### PR TITLE
fix: strip hop-by-hop response headers on the close path

### DIFF
--- a/src/net/proxy.zig
+++ b/src/net/proxy.zig
@@ -2260,17 +2260,20 @@ pub const ProxyConn = struct {
             !connection.overflow and
             !connection.names("close");
         var head_len = response.head_len;
-        if (conn.response_reusable) {
-            // The upstream's connection-management headers (a close
-            // announcement, keep-alive hints) are hop semantics between it
-            // and us; a keep-alive client must not see them and close on us.
+        // A real (>= 200) response: strip the upstream's connection-management
+        // headers (Connection + what it names, Keep-Alive, Proxy-Connection)
+        // in BOTH directions. A reused keep-alive client must not see them and
+        // close on us; a closing head must not carry the upstream's stale
+        // Connection line beside the `Connection: close` we inject below (RFC
+        // 9110 §7.6.1). Interim (1xx) heads are relayed untouched.
+        if (response.status >= 200) {
             head_len -= conn.strip_response_head(response, &connection);
-        } else if (response.status >= 200 and !connection.names("close")) {
-            // We will close the downstream connection after this response;
-            // the head must say so (RFC 9112 §9.6) or an HTTP/1.1 client
-            // assumes keep-alive and reads our close as a failure. Interim
-            // (1xx) heads are relayed untouched — they are not the response.
-            head_len += conn.inject_response_close(head_len);
+            if (!conn.response_reusable) {
+                // We will close the downstream after this response; the head
+                // must say so (RFC 9112 §9.6) or an HTTP/1.1 client assumes
+                // keep-alive and reads our close as a failure.
+                head_len += conn.inject_response_close(head_len);
+            }
         }
         pipe.framer = h1.BodyFramer.init(framing);
         const body = pipe.buf[head_len..pipe.filled];
@@ -4649,8 +4652,42 @@ test "proxy: does not reuse the connection for an HTTP/1.0 client" {
     c.go();
 
     try h.io.run_until_done(&c.eof);
-    // No reuse means no stripping either: the head passes through verbatim.
-    try std.testing.expectEqualStrings(response, c.buf[0..c.total]);
+    // The proxy closes on a 1.0 client (no keep-alive) and strips the
+    // upstream's hop-by-hop Connection header, re-announcing a single
+    // Connection: close in its place (RFC 9110 §7.6.1) — never duplicated.
+    const expected = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHELLO";
+    try std.testing.expectEqualStrings(expected, c.buf[0..c.total]);
+    while (h.pool.free_count != h.pool.capacity) try h.io.run_once();
+}
+
+test "proxy: a closing head replaces the upstream keep-alive Connection, never duplicates it" {
+    const gpa = std.testing.allocator;
+    // The upstream announces keep-alive; the proxy will close on this client
+    // and must strip that stale header, not emit it beside Connection: close
+    // (the regression: two conflicting Connection lines, RFC 9110 §7.6.1).
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nhi";
+    var h: TestHarness = undefined;
+    try h.init(gpa, .{ .response = response });
+    defer h.deinit(gpa);
+
+    const client = try h.connect();
+    defer _ = linux.close(client);
+
+    // The client asks to close, so the proxy closes after the response.
+    var c = OneShotClient{
+        .io = &h.io,
+        .fd = client,
+        .request = "GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n",
+    };
+    c.go();
+
+    try h.io.run_until_done(&c.done);
+    const received = c.buf[0..c.len];
+    // The upstream's keep-alive is gone, and exactly one Connection: close remains.
+    try std.testing.expect(std.mem.indexOf(u8, received, "keep-alive") == null);
+    try std.testing.expect(std.mem.indexOf(u8, received, "Connection: close\r\n") != null);
+    const first = std.mem.indexOf(u8, received, "Connection:").?;
+    try std.testing.expect(std.mem.indexOf(u8, received[first + 1 ..], "Connection:") == null);
     while (h.pool.free_count != h.pool.capacity) try h.io.run_once();
 }
 

--- a/src/sim.zig
+++ b/src/sim.zig
@@ -102,6 +102,29 @@ fn sim_panic(message: []const u8, first_trace_address: ?usize) noreturn {
     std.debug.defaultPanic(message, first_trace_address);
 }
 
+/// Header hygiene the proxy owes the client (RFC 9110 §7.6.1): the upstream's
+/// hop-by-hop connection headers must be stripped, so the forwarded response
+/// carries at most one Connection line and no Keep-Alive / Proxy-Connection.
+fn check_response_hygiene(response: *const h1.Response) void {
+    var connection_lines: u32 = 0;
+    for (response.headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "connection")) {
+            connection_lines += 1;
+        }
+        if (is_hop_by_hop_response_leak(header.name)) {
+            fail("proxy leaked hop-by-hop header '{s}' to the client", .{header.name});
+        }
+    }
+    if (connection_lines > 1) {
+        fail("proxy emitted {d} Connection headers (RFC 9110 §7.6.1)", .{connection_lines});
+    }
+}
+
+fn is_hop_by_hop_response_leak(name: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(name, "keep-alive") or
+        std.ascii.eqlIgnoreCase(name, "proxy-connection");
+}
+
 fn fail(comptime message: []const u8, extra: anytype) noreturn {
     std.debug.panic("sim: seed {d} FAILED: " ++ message, .{current_seed} ++ extra);
 }
@@ -591,6 +614,11 @@ const Origin = struct {
 
     const Behavior = enum {
         framed_keep_alive,
+        /// Like framed_keep_alive but the head carries a redundant
+        /// `Connection: keep-alive`. On a closing path (the client asked to
+        /// close, or the worker is draining) the proxy must strip it, never
+        /// emit it beside the injected `Connection: close` (RFC 9110 §7.6.1).
+        keep_alive_announced,
         framed_close,
         chunked_keep_alive,
         close_delimited,
@@ -700,6 +728,11 @@ const OriginConn = struct {
                 "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {d}\r\n\r\necho:{s}",
                 .{ echo_len, target },
             ) catch unreachable,
+            .keep_alive_announced => std.fmt.bufPrint(
+                &conn.response_buf,
+                "HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nContent-Length: {d}\r\n\r\necho:{s}",
+                .{ echo_len, target },
+            ) catch unreachable,
             .chunked_keep_alive => std.fmt.bufPrint(
                 &conn.response_buf,
                 "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{x}\r\necho:{s}\r\n0\r\n\r\n",
@@ -738,7 +771,10 @@ const OriginConn = struct {
         if (conn.sent < conn.response.len) return conn.arm_send();
         switch (conn.behavior) {
             .framed_close, .close_delimited, .garbage => conn.shutdown(),
-            .framed_keep_alive, .chunked_keep_alive => conn.next_request(),
+            .framed_keep_alive,
+            .chunked_keep_alive,
+            .keep_alive_announced,
+            => conn.next_request(),
             .linger_then_stale_close => {
                 // Serve, then close after a virtual delay — while the proxy
                 // has this connection parked in its pool: the stale-retry path.
@@ -1012,6 +1048,7 @@ const Client = struct {
                 .incomplete => return client.arm_recv(),
                 .complete => |response| response,
             };
+            check_response_hygiene(&response);
             const framing = h1.response_framing(client.method, &response) catch
                 fail("proxy emitted conflicting framing headers", .{});
             var framer = h1.BodyFramer.init(framing);


### PR DESCRIPTION
The one real correctness defect from the code review — verified against the source, then fixed and guarded with a regression test proven to fail on the pre-fix code.

## The bug
`begin_response_relay` stripped the upstream's connection-management headers **only** when reusing the downstream connection. On the close/drain path it injected `Connection: close` **without stripping first**, so an upstream response carrying a non-`close` Connection header (e.g. `Connection: keep-alive`) produced **two conflicting `Connection` lines** (RFC 9110 §7.6.1).

Reachable on any closing path: a **draining** worker, an **HTTP/1.0** client, or an **until-close** response, whenever the upstream sends a non-`close` Connection header.

## The fix
Strip in **both** directions for every real (≥200) response, then inject `Connection: close` only when the downstream won't be reused. `Connection`/`Keep-Alive`/`Proxy-Connection` are always classified hop-by-hop, so the upstream's line is removed regardless of its tokens (even under Connection-list overflow), leaving exactly one Connection line. Interim (1xx) heads stay untouched. This also makes response hop-by-hop stripping unconditional, as RFC 9110 §7.6.1 requires of intermediaries — previously it was skipped on the non-reuse path.

## Tests
- **New regression test** — upstream `Connection: keep-alive` on a closing path ⇒ exactly one `Connection: close`, no stray `keep-alive`. Temporarily reverting the fix makes it fail at `indexOf("keep-alive") == null`, confirming it guards the bug.
- **Updated the HTTP/1.0 test** — the head is now stripped + re-announced rather than passed through verbatim; its old "no stripping when not reusing" assertion had itself encoded the bug.

## Verification
- `zig build test` — **221/221 pass**
- `zig build sim -- 0 300` — OK, 3849 framed responses
- `zig fmt --check` + `zig build lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Simulator coverage (added)
This bug was invisible to the deterministic simulator on two counts: no virtual origin ever emitted a non-`close` Connection header (the only trigger), and the per-response invariant checked parse/framing/body-integrity but not header hygiene. Both closed:
- a **`keep_alive_announced`** origin behavior (selected uniformly, so every seed range exercises it), and
- a **`check_response_hygiene`** invariant: ≤1 Connection line, no Keep-Alive/Proxy-Connection to the client.

Reverting the proxy fix now makes the sim fail deterministically — `seed 6 FAILED: proxy emitted 2 Connection headers` — so this class of defect is caught at the simulator level, not just the unit test.