### PR TITLE
docs: adopt Zig reference naming convention over blanket snake_case

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,11 @@ that are actually enforced and easy to violate:
   `catch unreachable` on a reachable error.
 - **Explicitly-sized integers** (`u32`, `u63`, …); avoid `usize` except for real
   machine-word/index quantities.
-- `snake_case` for functions, variables, and **file names**. No abbreviations
+- **Naming follows the [Zig reference convention](https://ziglang.org/documentation/master/#Names):**
+  `TitleCase` for types and type-returning functions, `camelCase` for other
+  functions, `snake_case` for variables/constants/fields and namespace structs.
+  File names split the same way: `TitleCase.zig` for a struct-with-fields,
+  `snake_case.zig` for a namespace; directories `snake_case`. No abbreviations
   (`source`/`target`, not `src`/`dest`). Units/qualifiers last (`connections_max`,
   `header_bytes_max`). Struct order: fields, then types, then methods.
 - **Zero dependencies beyond the Zig toolchain, with one deliberate exception:** the

--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -51,8 +51,21 @@ and the **proxy-specific deltas**. When in doubt, read the original.
 
 ## Naming
 
-- `snake_case` for functions, variables, **and file names** (no `CamelCase.zig`).
-  Acronyms keep case: `IpAddress`, `HttpReader`.
+- **Follow the [Zig reference naming conventions](https://ziglang.org/documentation/master/#Names)**
+  — case encodes what a name *is*:
+  - `TitleCase` for types and for any function that returns a type
+    (`IpAddress`, `HttpReader`, `Pool(T)`, `Padded(T)`).
+  - `camelCase` for every other function (`readHead`, `beginDrain`).
+  - `snake_case` for variables, non-type constants, and struct fields
+    (`latency_ms_max`, `header_bytes_max`, `connections_max`).
+  - A field-less struct used purely as a namespace is `snake_case`.
+  - **File names follow the same type/namespace split:** a file whose
+    top-level struct has fields is a type → `TitleCase.zig`; a file that is
+    just a namespace of declarations → `snake_case.zig`. Directories are
+    `snake_case`.
+  - Acronyms and initialisms are ordinary words under these rules, even
+    two-letter ones: `IpAddress`/`HttpReader` (not `IPAddress`/`HTTPReader`),
+    `Tcp`, `Io`.
 - **No abbreviations** (except primitive indices in tight math). `source`/`target`
   over `src`/`dest` so `source_offset`/`target_offset` align.
 - **Units/qualifiers last, most-significant word first:** `latency_ms_max`,
@@ -60,7 +73,7 @@ and the **proxy-specific deltas**. When in doubt, read the original.
 - Give allocators meaning: `gpa: Allocator` vs `arena: Allocator` signals whether
   `deinit` is needed.
 - **Callbacks are the last parameter.** Helper naming shows call history:
-  `read_head()` + `read_head_callback()`.
+  `readHead()` + `readHeadCallback()`.
 - File order top-down, important first; `main` first. Struct order:
   **fields, then types (decls), then methods.** When unsure, sort alphabetically.
 - Comments are complete sentences (capital, full stop) — say **why** and **how**,
@@ -69,7 +82,7 @@ and the **proxy-specific deltas**. When in doubt, read the original.
 ## Off-by-one & correctness hygiene (DX)
 
 - Treat `index` (0-based), `count` (1-based), `size` (count × unit) as distinct;
-  cast explicitly. Show division intent: `@divExact` / `@divFloor` / `div_ceil`.
+  cast explicitly. Show division intent: `@divExact` / `@divFloor` / `divCeil`.
 - Pass args > 16 bytes as `*const` to catch accidental stack copies.
 - In-place init via out-pointer (`fn init(target: *T) !void`) for pointer
   stability and no intermediate copies.


### PR DESCRIPTION
## What

Replace the blanket **`snake_case` for functions, variables, and file names** rule in both `docs/TIGER_STYLE.md` and `CLAUDE.md` with the [Zig reference naming convention](https://ziglang.org/documentation/master/#Names), where case encodes what a name *is*:

- `TitleCase` — types and any function that returns a type (`Pool(T)`, `Padded(T)`, `IpAddress`)
- `camelCase` — every other function (`readHead`, `beginDrain`)
- `snake_case` — variables, non-type constants, struct fields, and namespace structs
- File names split the same way: `TitleCase.zig` for a struct-with-fields, `snake_case.zig` for a namespace; directories `snake_case`
- Acronyms are ordinary words even at two letters (`IpAddress`/`HttpReader`, not `IPAddress`/`HTTPReader`)

Downstream doc examples updated for internal consistency: the callback example (`readHead()` / `readHeadCallback()`) and the division-intent example (`divCeil`).

## Scope

**Docs only.** No code changes. The module table in `CLAUDE.md` still names real current symbols (`begin_drain`, `now_ns`, `send_headers`, …) and is left accurate. Migrating the code to the new convention is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)