### PR TITLE
feat(config): JSON Schema export + strict parsing (Phase 6 slice 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,21 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Check formatting
-        run: nix develop --command zig fmt --check src build.zig scripts/check_line_length.zig
+        run: >-
+          nix develop --command zig fmt --check
+          src build.zig scripts/check_line_length.zig scripts/config_tool.zig
 
       # zig fmt does not enforce line width; TigerStyle mandates a hard 100-column
       # limit (docs/TIGER_STYLE.md). Enforced by a Zig tool so local
       # `zig build lint` and CI share one implementation (scripts/check_line_length.zig).
       - name: Check line length (100-column hard limit)
         run: nix develop --command zig build lint
+
+      # The config JSON Schema is derived from the DTO; this gate fails if it was
+      # not regenerated (`zig build schema`) and strict-parses zoxy.json
+      # (docs/DESIGN.md §7 Phase 6, slice 1).
+      - name: Check config (schema drift + strict parse)
+        run: nix develop --command zig build check-config
 
       - name: Build
         run: nix develop --command zig build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ zig build test --summary all
 zig build run          # run using ./zoxy.json
 zig build sim -- 0 500 # deterministic simulator: [seed] [iterations]
 zig build sim -- fuzz  # random seeds forever (Ctrl-C; each seed replayable)
+zig build schema       # regenerate config.schema.json from the config DTO
+zig build check-config # CI gate: schema not stale + zoxy.json strict-parses
 zig fmt --check src build.zig   # lint (CI gate)
 scripts/coverage.sh    # kcov line coverage (tests + sim), HTML + cobertura
 ```
@@ -101,7 +103,8 @@ Consequences that bite if you forget them:
 | `src/http/h2_translate.zig` | H2 ↔ H1 translation (Phase 5, slice 4): `request_head` synthesizes an H1 head from decoded H2 fields (pseudo-header validation per RFC 9113 §8.3, §8.2.2 connection-specific rejects, cookie rejoining, CR/LF/NUL value hardening, content-length vs chunked framing choice); `response_block` hpack-encodes a parsed H1 response head (`:status` first, names lowercased, hop-by-hop + Connection-named strip) |
 | `src/net/h2_proxy.zig` | the H2-downstream data path (Phase 5): `H2Conn` drives the engine from ring completions (staged recv/send, one op per direction, ticking deadline scanning per-stream deadlines), pooled `StreamLeg`s run one H1 upstream transaction per stream (route→admit→pool checkout/dial→synthesized head→send-time chunk framing→response translate→window-paced DATA relay→pool checkin); WINDOW_UPDATE credit only after the upstream write (§1.4); legs release to their pool only op-quiescent (seed-1693 rule); **downstream TLS**: `H2Conn` adopts the handshaker's `terminator.Channel` and drives the userspace BIO-pair relay inline (h2c = null tls); GOAWAY drain via `begin_drain`; retries/per-try/upstream-TLS/close_notify deferred (DESIGN §7 Phase 5) |
 | `src/proxy/upstream_pool.zig` | per-worker idle upstream connections, fixed slots keyed by endpoint |
-| `src/config.zig` | JSON config → immutable `Config` (owns an arena); the **only** place allocation is expected. Per-cluster resilience blocks resolve into a `ResiliencePolicy` here (ms→ns, validated) |
+| `src/config.zig` | JSON config → immutable `Config` (owns an arena); the **only** place allocation is expected. Per-cluster resilience blocks resolve into a `ResiliencePolicy` here (ms→ns, validated). **Strict**: unknown keys are rejected by a type-directed walk that names the offending path; the `Dto` + its co-located `schema_fields` metadata are the source of truth for the JSON Schema |
+| `src/config_schema.zig` | comptime JSON-Schema (draft 2020-12) generator reflected from `config.Dto` (docs/DESIGN.md §7 Phase 6, slice 1); `assert_meta_matches` pins descriptions to fields at comptime so the schema can't drift. Driven by the `scripts/config_tool.zig` host tool behind `zig build schema` / `check-config` |
 | `src/proxy/router.zig`, `src/proxy/balancer.zig` | first-match host/path routing; P2C least-request balancing over per-worker in-flight counts and the Maglev consistent-hash pick (`pick_hashed`: deterministic forward-walk fallback, soft retry exclusion), fail-open when no endpoint is available |
 | `src/proxy/maglev.zig` | Maglev lookup tables: built once at config time (prime-sized, `u8` entries), data path = one wyhash + one index; knows nothing of config or balancer |
 | `src/proxy/resilience.zig` | per-worker mutable resilience state (Phase 2): request/attempt/dial/connection accounting, circuit-breaker admission, retry budget, passive outlier ejection — the narrow API the data path calls at fixed points; the sim asserts every counter drains to zero |

--- a/build.zig
+++ b/build.zig
@@ -103,8 +103,44 @@ pub fn build(b: *std.Build) void {
     add_zig_sources(b, run_lint, "src");
     run_lint.addFileArg(b.path("build.zig"));
     run_lint.addFileArg(b.path("scripts/check_line_length.zig"));
+    run_lint.addFileArg(b.path("scripts/config_tool.zig"));
     const lint_step = b.step("lint", "Check the 100-column line-length limit");
     lint_step.dependOn(&run_lint.step);
+
+    // Config JSON Schema (docs/DESIGN.md §7 Phase 6, slice 1). A host tool
+    // reflects the schema from the config DTO — config.zig is FFI-free, so this
+    // links no OpenSSL. `schema` regenerates the committed file; `check-config`
+    // guards it against drift and strict-parses zoxy.json.
+    const config_schema_mod = b.createModule(.{
+        .root_source_file = b.path("src/config_schema.zig"),
+        .target = b.graph.host,
+    });
+    const config_tool = b.addExecutable(.{
+        .name = "config_tool",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("scripts/config_tool.zig"),
+            .target = b.graph.host,
+            .imports = &.{.{ .name = "config_schema", .module = config_schema_mod }},
+        }),
+    });
+
+    const emit_schema = b.addRunArtifact(config_tool);
+    emit_schema.addArg("emit");
+    const generated_schema = emit_schema.captureStdOut(.{ .basename = "config.schema.json" });
+    const write_schema = b.addUpdateSourceFiles();
+    write_schema.addCopyFileToSource(generated_schema, "config.schema.json");
+    const schema_step = b.step("schema", "Regenerate config.schema.json from the config DTO");
+    schema_step.dependOn(&write_schema.step);
+
+    const check_config = b.addRunArtifact(config_tool);
+    check_config.addArg("check");
+    check_config.addFileArg(b.path("config.schema.json"));
+    check_config.addFileArg(b.path("zoxy.json"));
+    const check_config_step = b.step(
+        "check-config",
+        "Verify config.schema.json is current and zoxy.json is valid",
+    );
+    check_config_step.dependOn(&check_config.step);
 }
 
 /// Add every `.zig` file under `dir_path` (recursively) to `run` as a file

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "zoxy configuration",
+  "type": "object",
+  "description": "Static zoxy proxy configuration, parsed once at startup.",
+  "properties": {
+    "$schema": {
+      "description": "JSON Schema URL for editor completion; ignored by zoxy.",
+      "type": ["string", "null"]
+    },
+    "listen": {
+      "description": "Address the proxy accepts connections on.",
+      "type": "string",
+      "format": "hostport",
+      "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}:\\d{1,5}$",
+      "examples": ["0.0.0.0:8080"]
+    },
+    "admin": {
+      "description": "Address of the admin/metrics endpoint; null disables it.",
+      "type": ["string", "null"],
+      "format": "hostport",
+      "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}:\\d{1,5}$",
+      "examples": ["127.0.0.1:9901"]
+    },
+    "handoff": {
+      "description": "Unix-socket path for hot-restart listener handoff; null disables it.",
+      "type": ["string", "null"],
+      "examples": ["/run/zoxy-handoff.sock"]
+    },
+    "accept_mode": {
+      "description": "How accepted connections spread across workers.",
+      "type": "string",
+      "enum": ["reuseport", "shared"],
+      "x-enumDescriptions": { "reuseport": "One SO_REUSEPORT listener per worker; the kernel hashes.", "shared": "One listener; every worker holds a pending accept." },
+      "default": "reuseport"
+    },
+    "tls": {
+      "description": "TLS termination on the listener; null = plaintext.",
+      "anyOf": [
+        {
+          "type": "object",
+          "description": "TLS termination identity and options for the listener.",
+          "properties": {
+            "certificate_file": {
+              "description": "Path to the PEM certificate (chain) for the default identity.",
+              "type": "string",
+              "examples": ["cert.pem"]
+            },
+            "private_key_file": {
+              "description": "Path to the PEM private key for the default identity.",
+              "type": "string",
+              "examples": ["key.pem"]
+            },
+            "kernel_offload": {
+              "description": "Hand completed handshakes to kernel TLS; off forces the userspace relay.",
+              "type": "boolean",
+              "default": true
+            },
+            "http2": {
+              "description": "Offer HTTP/2 in ALPN; h2-negotiating clients use the HTTP/2 data path.",
+              "type": "boolean",
+              "default": false
+            },
+            "additional_identities": {
+              "description": "Extra SNI-selected server identities beyond the default certificate.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "An additional TLS identity, selected when the client's SNI matches.",
+                "properties": {
+                  "server_names": {
+                    "description": "SNI names this identity serves (exact, or single-label \"*.\" wildcards).",
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "certificate_file": {
+                    "description": "Path to this identity's PEM certificate (chain).",
+                    "type": "string"
+                  },
+                  "private_key_file": {
+                    "description": "Path to this identity's PEM private key.",
+                    "type": "string"
+                  }
+                },
+                "required": ["server_names", "certificate_file", "private_key_file"],
+                "additionalProperties": false
+              },
+              "default": []
+            }
+          },
+          "required": ["certificate_file", "private_key_file"],
+          "additionalProperties": false
+        },
+        { "type": "null" }
+      ]
+    },
+    "routes": {
+      "description": "Host/path routing rules, evaluated first-match-wins.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "A routing rule: match a host and path prefix, forward to a cluster.",
+        "properties": {
+          "host": {
+            "description": "Host to match; \"*\" matches any Host header.",
+            "type": "string",
+            "examples": ["api.example.com"],
+            "default": "*"
+          },
+          "path_prefix": {
+            "description": "Prefix matched against the request target; \"/\" matches everything.",
+            "type": "string",
+            "examples": ["/v1"],
+            "default": "/"
+          },
+          "cluster": {
+            "description": "Name of the cluster to route matching requests to.",
+            "type": "string"
+          }
+        },
+        "required": ["cluster"],
+        "additionalProperties": false
+      }
+    },
+    "clusters": {
+      "description": "Upstream clusters that routes target.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "An upstream cluster: endpoints plus optional resilience policy.",
+        "properties": {
+          "name": {
+            "description": "Unique cluster name referenced by routes.",
+            "type": "string"
+          },
+          "endpoints": {
+            "description": "Upstream endpoint addresses, each host:port.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tls": {
+            "description": "Re-encrypt traffic to this cluster's endpoints; null = plaintext.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Upstream re-encryption for a cluster; pick a verification posture explicitly.",
+                "properties": {
+                  "server_name": {
+                    "description": "Certificate hostname to require and offer as SNI; required unless insecure.",
+                    "type": ["string", "null"]
+                  },
+                  "ca_file": {
+                    "description": "PEM trust-store bundle path; required unless insecure.",
+                    "type": ["string", "null"]
+                  },
+                  "insecure": {
+                    "description": "Skip upstream verification; mutually exclusive with server_name/ca_file.",
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "lb": {
+            "description": "Load-balancing policy; absent = P2C least-request.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Load-balancer selection for a cluster.",
+                "properties": {
+                  "policy": {
+                    "description": "Balancing policy.",
+                    "type": "string",
+                    "enum": ["least_request", "maglev"],
+                    "x-enumDescriptions": { "least_request": "Power-of-two-choices least-request over in-flight counts.", "maglev": "Maglev consistent hashing (see hash); falls back to least-request." }
+                  },
+                  "hash": {
+                    "description": "What the consistent hash keys on (maglev only).",
+                    "type": "string",
+                    "enum": ["target", "header"],
+                    "x-enumDescriptions": { "target": "Hash the request target.", "header": "Hash a named request header (see header)." },
+                    "default": "target"
+                  },
+                  "header": {
+                    "description": "Header name to hash on when hash = header.",
+                    "type": ["string", "null"],
+                    "examples": ["x-user-id"]
+                  }
+                },
+                "required": ["policy"],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "retry": {
+            "description": "Retry policy for failed attempts; absent = retries off.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Retry policy: bounded attempts with jittered exponential backoff and a budget.",
+                "properties": {
+                  "max": {
+                    "description": "Retry attempts after the first try.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5
+                  },
+                  "backoff_base_ms": {
+                    "description": "Base backoff before the first retry (jittered exponential).",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295,
+                    "x-units": "milliseconds"
+                  },
+                  "backoff_cap_ms": {
+                    "description": "Maximum backoff between retries (must be >= backoff_base_ms).",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295,
+                    "x-units": "milliseconds"
+                  },
+                  "budget_percent": {
+                    "description": "Retry budget as a percent of active requests.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "budget_min": {
+                    "description": "Minimum concurrent retries allowed regardless of the budget percent.",
+                    "type": ["integer", "null"],
+                    "minimum": 0,
+                    "maximum": 4294967295
+                  }
+                },
+                "required": ["max"],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "circuit_breaker": {
+            "description": "Per-worker admission limits; absent = unbounded.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Per-worker circuit-breaker admission limits.",
+                "properties": {
+                  "max_connections": {
+                    "description": "Max concurrent upstream connections per worker.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295
+                  },
+                  "max_pending": {
+                    "description": "Max requests queued awaiting a connection per worker.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295
+                  },
+                  "max_requests": {
+                    "description": "Max concurrent upstream requests per worker.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295
+                  },
+                  "max_retries": {
+                    "description": "Max concurrent retries per worker.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "outlier": {
+            "description": "Passive outlier ejection; absent = off.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Passive outlier detection: eject endpoints that fail repeatedly.",
+                "properties": {
+                  "consecutive_failures": {
+                    "description": "Consecutive attempt failures before an endpoint is ejected.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295
+                  },
+                  "ejection_ms": {
+                    "description": "How long an ejected endpoint stays out.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295,
+                    "x-units": "milliseconds"
+                  },
+                  "max_ejection_percent": {
+                    "description": "Ceiling on the ejected share of a cluster.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "health_check": {
+            "description": "Active TCP health probes; absent = off.",
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Active TCP health probing for a cluster's endpoints.",
+                "properties": {
+                  "interval_ms": {
+                    "description": "Interval between active TCP-connect probes.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295,
+                    "x-units": "milliseconds"
+                  },
+                  "timeout_ms": {
+                    "description": "Per-probe connect timeout.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 4294967295,
+                    "x-units": "milliseconds"
+                  },
+                  "healthy_threshold": {
+                    "description": "Consecutive successes to mark an endpoint healthy.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "unhealthy_threshold": {
+                    "description": "Consecutive failures to mark an endpoint unhealthy.",
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": 65535
+                  }
+                },
+                "required": [],
+                "additionalProperties": false
+              },
+              { "type": "null" }
+            ]
+          },
+          "per_try_timeout_ms": {
+            "description": "Deadline per upstream attempt (connect to first byte); 0 = disabled.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295,
+            "x-units": "milliseconds",
+            "default": 0
+          }
+        },
+        "required": ["name", "endpoints"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["listen", "routes", "clusters"],
+  "additionalProperties": false
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -453,7 +453,7 @@ Deferred to later slices:
 - **Client-side flow-control stall coverage in the sim** — bodies beyond the
   initial window, needing a window-accounting test client.
 
-### Phase 6 — config: JSON schema + file-watch reload (planned)
+### Phase 6 — config: JSON schema (slice 1 done) + file-watch reload (planned)
 Decided 2026-07-04. Keep JSON as the canonical, machine-facing format (Caddy's
 model): the format was never the problem — `config.zig` already lowers a wire
 DTO into an immutable, arena-owned `Config`, and the allocation island absorbs
@@ -470,14 +470,25 @@ existing Envoy/Istio mesh" becomes a real requirement.
 
 Slices, each behind the usual gates:
 
-1. **Schema + strictness.** The Zig DTO stays the single source of truth; a
-   comptime reflection over its fields emits a JSON Schema, shipped for editor
-   completion and a `zig build check-config` CI gate (the schema can't drift —
-   it is derived from the parser). **Stop ignoring unknown fields**
-   (`ignore_unknown_fields = true` today): a misspelled `"circuit_breaker"`
-   silently disables the feature you thought you set — the worst property an
-   ops-facing config can have. Unknown keys become a parse error naming the
-   offending path.
+1. **Schema + strictness (done).** The Zig DTO (`config.zig`) stays the single
+   source of truth; a comptime reflection (`config_schema.zig`) emits a JSON
+   Schema (draft 2020-12). `zig build schema` regenerates the committed
+   `config.schema.json`; `zig build check-config` byte-diffs a fresh generation
+   against it — a drift gate, since the schema is derived from the parser — and
+   strict-parses `zoxy.json`; both run in CI. Rich descriptions, enum values,
+   and formats live in per-struct `schema_fields` metadata co-located with the
+   fields and pinned to them by a comptime cross-check (`assert_meta_matches`):
+   a stray or missing entry fails compilation, so the *prose* can't drift from
+   the shape either. **Unknown fields are now rejected** (`ignore_unknown_fields`
+   is gone): a misspelled `"circuit_breaker"` used to silently disable the
+   feature you thought you set — the worst property an ops-facing config can
+   have. Parsing now decodes to a dynamic tree, a comptime type-directed walk
+   reports the first unknown key by path
+   (`clusters[2].circuit_breaker.max_requsts`), then decodes strictly into the
+   DTO. A `$schema` key is accepted (and emitted) so editor completion coexists
+   with strictness. Lesson: reflecting the schema from the parser makes the
+   schema *and its documentation* a byproduct of the DTO, so "can't drift"
+   covers every description and enum value, not just the field shape.
 2. **File-watch reload → RCU swap.** A dedicated thread (off every data path)
    watches the config file, parses + validates a *complete* new `Config` in a
    fresh arena, and publishes only on success — a bad edit is logged and the

--- a/scripts/config_tool.zig
+++ b/scripts/config_tool.zig
@@ -1,0 +1,75 @@
+//! Host-tool CLI for the config JSON Schema (docs/DESIGN.md §7 Phase 6, slice 1):
+//!
+//!   config_tool emit                            → write the schema to stdout
+//!   config_tool check <schema.json> [config…]   → drift gate + strict parse
+//!
+//! `check` regenerates the schema in memory and byte-compares it to the
+//! committed <schema.json> (a stale file fails, prompting `zig build schema`),
+//! then strict-parses each config file. Rooted at `b.graph.host` and importing
+//! only `config_schema` (which pulls in `config.zig`) — no OpenSSL, since the
+//! config graph is FFI-free.
+
+const std = @import("std");
+const schema = @import("config_schema");
+const config = schema.config_zig;
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(gpa);
+    if (args.len >= 2 and std.mem.eql(u8, args[1], "emit")) return emit(init.io);
+    if (args.len >= 3 and std.mem.eql(u8, args[1], "check")) return check(init.io, gpa, args[2..]);
+    std.log.err("usage: config_tool <emit | check <schema.json> [config.json ...]>", .{});
+    return error.Usage;
+}
+
+/// Write the generated schema to stdout (captured by `zig build schema`).
+fn emit(io: std.Io) !void {
+    var buf: [64 * 1024]u8 = undefined;
+    var file_writer = std.Io.File.stdout().writer(io, &buf);
+    try schema.write(&file_writer.interface);
+    try file_writer.flush();
+}
+
+/// Fail if the committed schema is stale, then strict-parse each config file.
+fn check(io: std.Io, gpa: std.mem.Allocator, paths: []const [:0]const u8) !void {
+    assert_paths(paths);
+
+    var buf: [64 * 1024]u8 = undefined; // the generated schema is a few KiB
+    var generated = std.Io.Writer.fixed(&buf);
+    try schema.write(&generated);
+    const want = generated.buffered();
+
+    const committed = std.Io.Dir.cwd().readFileAlloc(io, paths[0], gpa, .unlimited) catch |err| {
+        std.log.err("config_tool: cannot read schema {s}: {s}", .{ paths[0], @errorName(err) });
+        return err;
+    };
+    if (!std.mem.eql(u8, want, committed)) {
+        std.log.err("config_tool: {s} is stale — run `zig build schema`", .{paths[0]});
+        return error.SchemaStale;
+    }
+
+    for (paths[1..]) |config_path| {
+        const text = std.Io.Dir.cwd().readFileAlloc(io, config_path, gpa, .unlimited) catch |err| {
+            std.log.err(
+                "config_tool: cannot read config {s}: {s}",
+                .{ config_path, @errorName(err) },
+            );
+            return err;
+        };
+        var diagnostic: config.Diagnostic = .{};
+        var parsed = config.parse_diagnostic(gpa, text, &diagnostic) catch |err| {
+            if (diagnostic.unknown_field) |field| {
+                std.log.err("config_tool: {s}: unknown field {s}", .{ config_path, field });
+            } else {
+                std.log.err("config_tool: {s}: {s}", .{ config_path, @errorName(err) });
+            }
+            return err;
+        };
+        parsed.deinit();
+    }
+}
+
+fn assert_paths(paths: []const [:0]const u8) void {
+    std.debug.assert(paths.len >= 1); // check requires at least a schema path
+    std.debug.assert(paths[0].len > 0);
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -88,6 +88,11 @@ pub const Cluster = struct {
 
 pub const HashOn = enum { target, header };
 
+/// Balancing policy for a cluster's `lb` block. The accepted policy strings
+/// are these enum names — sourced here so both the parser (`lower_lb`) and the
+/// generated JSON Schema draw the value set from one place.
+pub const LbPolicy = enum { least_request, maglev };
+
 pub const Route = struct {
     /// "*" matches any Host.
     host: []const u8,
@@ -170,8 +175,17 @@ pub const ParseError = error{
 
 pub const AcceptMode = enum { reuseport, shared };
 
-/// JSON shape mirrored 1:1 for decoding, then lowered into `Config`.
-const Dto = struct {
+/// A JSON Schema `pattern`/example hint for "host:port" IPv4 address strings
+/// (validated for real by `parse_address`; the pattern is a docs/editor hint).
+const hostport_pattern = "^(\\d{1,3}\\.){3}\\d{1,3}:\\d{1,5}$";
+
+/// JSON shape mirrored 1:1 for decoding, then lowered into `Config`. Public so
+/// `config_schema.zig` can reflect over it to emit the JSON Schema. Each struct
+/// carries `schema_doc` (object prose) and `schema_fields` (per-field docs);
+/// `assert_meta_matches` cross-checks the metadata against the fields at
+/// comptime, so the two can never drift.
+pub const Dto = struct {
+    @"$schema": ?[]const u8 = null,
     listen: []const u8,
     admin: ?[]const u8 = null,
     handoff: ?[]const u8 = null,
@@ -180,29 +194,119 @@ const Dto = struct {
     routes: []const RouteDto,
     clusters: []const ClusterDto,
 
-    const TlsDto = struct {
+    pub const schema_doc = "Static zoxy proxy configuration, parsed once at startup.";
+    pub const schema_fields = .{
+        .@"$schema" = .{ .desc = "JSON Schema URL for editor completion; ignored by zoxy." },
+        .listen = .{
+            .desc = "Address the proxy accepts connections on.",
+            .format = "hostport",
+            .pattern = hostport_pattern,
+            .example = "0.0.0.0:8080",
+        },
+        .admin = .{
+            .desc = "Address of the admin/metrics endpoint; null disables it.",
+            .format = "hostport",
+            .pattern = hostport_pattern,
+            .example = "127.0.0.1:9901",
+        },
+        .handoff = .{
+            .desc = "Unix-socket path for hot-restart listener handoff; null disables it.",
+            .example = "/run/zoxy-handoff.sock",
+        },
+        .accept_mode = .{
+            .desc = "How accepted connections spread across workers.",
+            .enum_type = AcceptMode,
+            .enum_docs = .{
+                .reuseport = "One SO_REUSEPORT listener per worker; the kernel hashes.",
+                .shared = "One listener; every worker holds a pending accept.",
+            },
+        },
+        .tls = .{ .desc = "TLS termination on the listener; null = plaintext." },
+        .routes = .{ .desc = "Host/path routing rules, evaluated first-match-wins." },
+        .clusters = .{ .desc = "Upstream clusters that routes target." },
+    };
+
+    pub const TlsDto = struct {
         certificate_file: []const u8,
         private_key_file: []const u8,
         kernel_offload: bool = true,
         http2: bool = false,
         additional_identities: []const TlsIdentityDto = &.{},
+
+        pub const schema_doc = "TLS termination identity and options for the listener.";
+        pub const schema_fields = .{
+            .certificate_file = .{
+                .desc = "Path to the PEM certificate (chain) for the default identity.",
+                .example = "cert.pem",
+            },
+            .private_key_file = .{
+                .desc = "Path to the PEM private key for the default identity.",
+                .example = "key.pem",
+            },
+            .kernel_offload = .{
+                .desc = "Hand completed handshakes to kernel TLS; off forces the userspace relay.",
+            },
+            .http2 = .{
+                .desc = "Offer HTTP/2 in ALPN; h2-negotiating clients use the HTTP/2 data path.",
+            },
+            .additional_identities = .{
+                .desc = "Extra SNI-selected server identities beyond the default certificate.",
+            },
+        };
     };
-    const TlsIdentityDto = struct {
+    pub const TlsIdentityDto = struct {
         server_names: []const []const u8,
         certificate_file: []const u8,
         private_key_file: []const u8,
+
+        pub const schema_doc =
+            "An additional TLS identity, selected when the client's SNI matches.";
+        pub const schema_fields = .{
+            .server_names = .{
+                .desc = "SNI names this identity serves (exact, or single-label \"*.\" wildcards).",
+            },
+            .certificate_file = .{ .desc = "Path to this identity's PEM certificate (chain)." },
+            .private_key_file = .{ .desc = "Path to this identity's PEM private key." },
+        };
     };
-    const ClusterTlsDto = struct {
+    pub const ClusterTlsDto = struct {
         server_name: ?[]const u8 = null,
         ca_file: ?[]const u8 = null,
         insecure: bool = false,
+
+        pub const schema_doc =
+            "Upstream re-encryption for a cluster; pick a verification posture explicitly.";
+        pub const schema_fields = .{
+            .server_name = .{
+                .desc = "Certificate hostname to require and offer as SNI; " ++
+                    "required unless insecure.",
+            },
+            .ca_file = .{ .desc = "PEM trust-store bundle path; required unless insecure." },
+            .insecure = .{
+                .desc = "Skip upstream verification; mutually exclusive with server_name/ca_file.",
+            },
+        };
     };
-    const RouteDto = struct {
+    pub const RouteDto = struct {
         host: []const u8 = "*",
         path_prefix: []const u8 = "/",
         cluster: []const u8,
+
+        pub const schema_doc =
+            "A routing rule: match a host and path prefix, forward to a cluster.";
+        pub const schema_fields = .{
+            .host = .{
+                .desc = "Host to match; \"*\" matches any Host header.",
+                .example = "api.example.com",
+            },
+            .path_prefix = .{
+                .desc = "Prefix matched against the request target; \"/\" matches everything.",
+                .example = "/v1",
+            },
+            .cluster = .{ .desc = "Name of the cluster to route matching requests to." },
+        };
     };
-    const ClusterDto = struct {
+    pub const ClusterDto = struct {
         name: []const u8,
         endpoints: []const []const u8,
         tls: ?ClusterTlsDto = null,
@@ -212,49 +316,366 @@ const Dto = struct {
         outlier: ?OutlierDto = null,
         health_check: ?HealthCheckDto = null,
         per_try_timeout_ms: u32 = 0,
+
+        pub const schema_doc = "An upstream cluster: endpoints plus optional resilience policy.";
+        pub const schema_fields = .{
+            .name = .{ .desc = "Unique cluster name referenced by routes." },
+            .endpoints = .{ .desc = "Upstream endpoint addresses, each host:port." },
+            .tls = .{ .desc = "Re-encrypt traffic to this cluster's endpoints; null = plaintext." },
+            .lb = .{ .desc = "Load-balancing policy; absent = P2C least-request." },
+            .retry = .{ .desc = "Retry policy for failed attempts; absent = retries off." },
+            .circuit_breaker = .{ .desc = "Per-worker admission limits; absent = unbounded." },
+            .outlier = .{ .desc = "Passive outlier ejection; absent = off." },
+            .health_check = .{ .desc = "Active TCP health probes; absent = off." },
+            .per_try_timeout_ms = .{
+                .desc = "Deadline per upstream attempt (connect to first byte); 0 = disabled.",
+                .units = "milliseconds",
+            },
+        };
     };
     // Absent per-field values fall back to `constants` defaults during
     // lowering (kept out of the DTO so the defaults live in one place).
-    const LbDto = struct {
+    pub const LbDto = struct {
         policy: []const u8,
         hash: []const u8 = "target",
         header: ?[]const u8 = null,
+
+        pub const schema_doc = "Load-balancer selection for a cluster.";
+        pub const schema_fields = .{
+            .policy = .{
+                .desc = "Balancing policy.",
+                .enum_type = LbPolicy,
+                .enum_docs = .{
+                    .least_request = "Power-of-two-choices least-request over in-flight counts.",
+                    .maglev = "Maglev consistent hashing (see hash); falls back to least-request.",
+                },
+            },
+            .hash = .{
+                .desc = "What the consistent hash keys on (maglev only).",
+                .enum_type = HashOn,
+                .enum_docs = .{
+                    .target = "Hash the request target.",
+                    .header = "Hash a named request header (see header).",
+                },
+            },
+            .header = .{
+                .desc = "Header name to hash on when hash = header.",
+                .example = "x-user-id",
+            },
+        };
     };
-    const RetryDto = struct {
+    pub const RetryDto = struct {
         max: u8,
         backoff_base_ms: ?u32 = null,
         backoff_cap_ms: ?u32 = null,
         budget_percent: ?u8 = null,
         budget_min: ?u32 = null,
+
+        pub const schema_doc =
+            "Retry policy: bounded attempts with jittered exponential backoff and a budget.";
+        pub const schema_fields = .{
+            .max = .{
+                .desc = "Retry attempts after the first try.",
+                .minimum = 1,
+                .maximum = constants.retry_attempts_max,
+            },
+            .backoff_base_ms = .{
+                .desc = "Base backoff before the first retry (jittered exponential).",
+                .units = "milliseconds",
+                .minimum = 1,
+            },
+            .backoff_cap_ms = .{
+                .desc = "Maximum backoff between retries (must be >= backoff_base_ms).",
+                .units = "milliseconds",
+                .minimum = 1,
+            },
+            .budget_percent = .{
+                .desc = "Retry budget as a percent of active requests.",
+                .minimum = 1,
+                .maximum = 100,
+            },
+            .budget_min = .{
+                .desc = "Minimum concurrent retries allowed regardless of the budget percent.",
+            },
+        };
     };
-    const CircuitBreakerDto = struct {
+    pub const CircuitBreakerDto = struct {
         max_connections: ?u32 = null,
         max_pending: ?u32 = null,
         max_requests: ?u32 = null,
         max_retries: ?u32 = null,
+
+        pub const schema_doc = "Per-worker circuit-breaker admission limits.";
+        pub const schema_fields = .{
+            .max_connections = .{
+                .desc = "Max concurrent upstream connections per worker.",
+                .minimum = 1,
+            },
+            .max_pending = .{
+                .desc = "Max requests queued awaiting a connection per worker.",
+                .minimum = 1,
+            },
+            .max_requests = .{
+                .desc = "Max concurrent upstream requests per worker.",
+                .minimum = 1,
+            },
+            .max_retries = .{ .desc = "Max concurrent retries per worker.", .minimum = 1 },
+        };
     };
-    const OutlierDto = struct {
+    pub const OutlierDto = struct {
         consecutive_failures: ?u32 = null,
         ejection_ms: ?u32 = null,
         max_ejection_percent: ?u8 = null,
+
+        pub const schema_doc = "Passive outlier detection: eject endpoints that fail repeatedly.";
+        pub const schema_fields = .{
+            .consecutive_failures = .{
+                .desc = "Consecutive attempt failures before an endpoint is ejected.",
+                .minimum = 1,
+            },
+            .ejection_ms = .{
+                .desc = "How long an ejected endpoint stays out.",
+                .units = "milliseconds",
+                .minimum = 1,
+            },
+            .max_ejection_percent = .{
+                .desc = "Ceiling on the ejected share of a cluster.",
+                .minimum = 1,
+                .maximum = 100,
+            },
+        };
     };
-    const HealthCheckDto = struct {
+    pub const HealthCheckDto = struct {
         interval_ms: ?u32 = null,
         timeout_ms: ?u32 = null,
         healthy_threshold: ?u16 = null,
         unhealthy_threshold: ?u16 = null,
+
+        pub const schema_doc = "Active TCP health probing for a cluster's endpoints.";
+        pub const schema_fields = .{
+            .interval_ms = .{
+                .desc = "Interval between active TCP-connect probes.",
+                .units = "milliseconds",
+                .minimum = 1,
+            },
+            .timeout_ms = .{
+                .desc = "Per-probe connect timeout.",
+                .units = "milliseconds",
+                .minimum = 1,
+            },
+            .healthy_threshold = .{
+                .desc = "Consecutive successes to mark an endpoint healthy.",
+                .minimum = 1,
+            },
+            .unhealthy_threshold = .{
+                .desc = "Consecutive failures to mark an endpoint unhealthy.",
+                .minimum = 1,
+            },
+        };
     };
 };
 
+/// The attribute keys a `schema_fields` entry may carry — the vocabulary the
+/// generator reads. A key outside this set would be silently ignored (dropping
+/// the annotation or widening a constraint), so `assert_meta_matches` rejects it.
+const schema_attributes = .{
+    "desc",      "format",    "pattern", "units",
+    "enum_type", "enum_docs", "example", "minimum",
+    "maximum",
+};
+
+/// Cross-check a DTO struct's `schema_fields` metadata against its actual fields
+/// at comptime, so the JSON Schema (shape *and* prose) can never drift from the
+/// parsed shape: (1) every field has exactly one metadata entry and vice versa;
+/// (2) every entry carries a `.desc`; (3) every attribute key is in
+/// `schema_attributes` (a typo like `.minimu` is a compile error, not a silent
+/// drop). Called from the container-scope block below (every build) and
+/// per-object by the generator (catches a nested struct missing from the list).
+pub fn assert_meta_matches(comptime T: type) void {
+    @setEvalBranchQuota(50_000); // the attribute-vocabulary cross-check is string-compare heavy
+    const meta = T.schema_fields;
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (!@hasField(@TypeOf(meta), field.name)) {
+            @compileError(@typeName(T) ++ ": schema_fields missing '" ++ field.name ++ "'");
+        }
+    }
+    inline for (@typeInfo(@TypeOf(meta)).@"struct".fields) |meta_field| {
+        if (!@hasField(T, meta_field.name)) {
+            @compileError(@typeName(T) ++ ": schema_fields has stray '" ++ meta_field.name ++ "'");
+        }
+        const entry = @field(meta, meta_field.name);
+        if (!@hasField(@TypeOf(entry), "desc")) {
+            @compileError(@typeName(T) ++ "." ++ meta_field.name ++ ": entry needs a .desc");
+        }
+        inline for (@typeInfo(@TypeOf(entry)).@"struct".fields) |attribute| {
+            comptime var known = false;
+            inline for (schema_attributes) |name| {
+                if (comptime std.mem.eql(u8, attribute.name, name)) known = true;
+            }
+            if (!known) @compileError(@typeName(T) ++ "." ++ meta_field.name ++
+                ": unknown schema attribute '" ++ attribute.name ++ "'");
+        }
+    }
+}
+
+/// Every DTO struct, checked on every build (config.zig is always compiled).
+pub const dto_types = .{
+    Dto,                   Dto.TlsDto,     Dto.TlsIdentityDto, Dto.ClusterTlsDto,
+    Dto.RouteDto,          Dto.ClusterDto, Dto.LbDto,          Dto.RetryDto,
+    Dto.CircuitBreakerDto, Dto.OutlierDto, Dto.HealthCheckDto,
+};
+
+comptime {
+    for (dto_types) |T| assert_meta_matches(T);
+}
+
+/// Longest config field path rendered in an unknown-field error.
+const config_path_bytes_max: usize = 256;
+/// Loop bounds for the strict-field walk (TigerStyle: bound every loop). Keys or
+/// array items past these fall through to the strict `parseFromValue`, which
+/// still rejects the unknown — just without the pretty path.
+const object_keys_max: u32 = 128;
+const array_items_max: u32 = 1024;
+
+/// Accumulates a dotted/indexed JSON path (e.g. `clusters[2].circuit_breaker`)
+/// into a caller-owned fixed buffer; silently truncates at the buffer end.
+const PathBuilder = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn mark(self: *const PathBuilder) usize {
+        return self.len;
+    }
+    fn rewind(self: *PathBuilder, to: usize) void {
+        assert(to <= self.len);
+        self.len = to;
+    }
+    fn push_key(self: *PathBuilder, name: []const u8) void {
+        if (self.len != 0) self.push_byte('.');
+        self.push_bytes(name);
+    }
+    fn push_index(self: *PathBuilder, index: usize) void {
+        var digits: [24]u8 = undefined;
+        const text = std.fmt.bufPrint(&digits, "[{d}]", .{index}) catch return;
+        self.push_bytes(text);
+    }
+    fn push_byte(self: *PathBuilder, byte: u8) void {
+        if (self.len >= self.buf.len) return;
+        self.buf[self.len] = byte;
+        self.len += 1;
+    }
+    fn push_bytes(self: *PathBuilder, bytes: []const u8) void {
+        assert(self.len <= self.buf.len);
+        const take = @min(bytes.len, self.buf.len - self.len);
+        @memcpy(self.buf[self.len..][0..take], bytes[0..take]);
+        self.len += take;
+    }
+    fn path(self: *const PathBuilder) []const u8 {
+        assert(self.len <= self.buf.len);
+        return self.buf[0..self.len];
+    }
+};
+
+fn field_known(comptime T: type, key: []const u8) bool {
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (std.mem.eql(u8, field.name, key)) return true;
+    }
+    return false;
+}
+
+/// Walk a decoded JSON object against DTO struct `T`, returning the path of the
+/// first key `T` does not declare, or null. Comptime-monomorphized per DTO type
+/// (Dto → ClusterDto → ClusterTlsDto …): each level is a distinct function over
+/// a distinct type and no type contains itself, so the descent is statically
+/// bounded at the DTO's nesting depth — it terminates and is not runtime
+/// recursion (the same shape as the comptime parsers elsewhere in the tree).
+fn check_object(comptime T: type, value: std.json.Value, pb: *PathBuilder) ?[]const u8 {
+    if (value != .object) return null; // shape mismatches are parseFromValue's job
+    var seen: u32 = 0;
+    var it = value.object.iterator();
+    while (it.next()) |entry| : (seen += 1) {
+        if (seen >= object_keys_max) break;
+        if (!field_known(T, entry.key_ptr.*)) {
+            pb.push_key(entry.key_ptr.*);
+            return pb.path();
+        }
+    }
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (value.object.get(field.name)) |child| {
+            const at = pb.mark();
+            pb.push_key(field.name);
+            if (check_value(field.type, child, pb)) |bad| return bad;
+            pb.rewind(at);
+        }
+    }
+    return null;
+}
+
+fn check_value(comptime T: type, value: std.json.Value, pb: *PathBuilder) ?[]const u8 {
+    switch (@typeInfo(T)) {
+        .optional => |opt| return if (value == .null) null else check_value(opt.child, value, pb),
+        .@"struct" => return check_object(T, value, pb),
+        .pointer => |ptr| {
+            if (ptr.size != .slice) return null;
+            if (@typeInfo(ptr.child) != .@"struct") return null; // strings, []const []const u8
+            if (value != .array) return null;
+            for (value.array.items, 0..) |item, index| {
+                if (index >= array_items_max) break;
+                const at = pb.mark();
+                pb.push_index(index);
+                if (check_object(ptr.child, item, pb)) |bad| return bad;
+                pb.rewind(at);
+            }
+            return null;
+        },
+        else => return null,
+    }
+}
+
+/// Returns the path of the first unknown config key (into `buf`), or null when
+/// every key maps to a DTO field. Backs the strict rejection in `parse`.
+pub fn find_unknown_field(root: std.json.Value, buf: []u8) ?[]const u8 {
+    var pb = PathBuilder{ .buf = buf };
+    return check_object(Dto, root, &pb);
+}
+
+/// Surfaced from `parse_diagnostic`: on `error.UnknownField`, `unknown_field`
+/// is the offending dotted path (`clusters[2].circuit_breaker`), backed by
+/// `path_buf`. Kept caller-owned so the library never logs on the parse path.
+pub const Diagnostic = struct {
+    unknown_field: ?[]const u8 = null,
+    path_buf: [config_path_bytes_max]u8 = undefined,
+};
+
+/// Parse without surfacing a diagnostic — the library stays quiet. Callers that
+/// want the offending field path (main, the config tool) use `parse_diagnostic`.
 pub fn parse(gpa: std.mem.Allocator, text: []const u8) ParseError!Config {
+    var diag: Diagnostic = .{};
+    return parse_diagnostic(gpa, text, &diag);
+}
+
+pub fn parse_diagnostic(
+    gpa: std.mem.Allocator,
+    text: []const u8,
+    diag: *Diagnostic,
+) ParseError!Config {
     const arena = try gpa.create(std.heap.ArenaAllocator);
     errdefer gpa.destroy(arena);
     arena.* = std.heap.ArenaAllocator.init(gpa);
     errdefer arena.deinit();
     const a = arena.allocator();
 
-    // Decode into the DTO with a throwaway arena, then dupe what we keep.
-    const parsed = try std.json.parseFromSlice(Dto, gpa, text, .{ .ignore_unknown_fields = true });
+    // Decode to a dynamic tree first so a misspelled key can be reported with
+    // its full path — std.json's UnknownField error carries none. Then decode
+    // strictly into the DTO (rejecting unknowns again, defense in depth) and
+    // dupe what we keep into the arena.
+    const tree = try std.json.parseFromSlice(std.json.Value, gpa, text, .{});
+    defer tree.deinit();
+    if (find_unknown_field(tree.value, &diag.path_buf)) |bad_path| {
+        diag.unknown_field = bad_path;
+        return error.UnknownField;
+    }
+    const parsed = try std.json.parseFromValue(Dto, gpa, tree.value, .{});
     defer parsed.deinit();
     const dto = parsed.value;
 
@@ -374,13 +795,14 @@ fn lower_lb(
 ) (error{InvalidLb} || std.mem.Allocator.Error)!void {
     const lb = dc.lb orelse return;
     assert(cluster.maglev_table.len == 0); // lowered exactly once per cluster
-    if (std.mem.eql(u8, lb.policy, "least_request")) {
+    const policy = std.meta.stringToEnum(LbPolicy, lb.policy) orelse return error.InvalidLb;
+    if (policy == .least_request) {
         // The default spelled out; hash knobs belong to maglev only.
         if (lb.header != null) return error.InvalidLb;
         if (!std.mem.eql(u8, lb.hash, "target")) return error.InvalidLb;
         return;
     }
-    if (!std.mem.eql(u8, lb.policy, "maglev")) return error.InvalidLb;
+    assert(policy == .maglev);
     if (cluster.endpoints.len == 0) return error.InvalidLb; // nothing to hash onto
     if (std.mem.eql(u8, lb.hash, "target")) {
         if (lb.header != null) return error.InvalidLb;
@@ -913,4 +1335,73 @@ test "config: rejects out-of-range resilience limits" {
             parse(std.testing.allocator, w.buffered()),
         );
     }
+}
+
+test "config: strict parsing rejects an unknown field" {
+    const bad =
+        \\{ "listen": "0.0.0.0:80", "typo_here": 1, "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    ;
+    try std.testing.expectError(error.UnknownField, parse(std.testing.allocator, bad));
+}
+
+test "config: strict parsing accepts a known $schema key" {
+    var config = try parse(std.testing.allocator,
+        \\{ "$schema": "./config.schema.json", "listen": "0.0.0.0:80",
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    defer config.deinit();
+    try std.testing.expectEqual(@as(u16, 80), config.listen.port);
+}
+
+test "config: find_unknown_field names the offending path" {
+    const Case = struct { json: []const u8, path: []const u8 };
+    const cases = [_]Case{
+        .{
+            .json =
+            \\{ "listen": "0.0.0.0:80", "nope": 1, "routes": [], "clusters": [] }
+            ,
+            .path = "nope",
+        },
+        .{
+            .json =
+            \\{ "listen": "0.0.0.0:80", "routes": [{ "cluster": "c", "hostt": "*" }],
+            \\  "clusters": [] }
+            ,
+            .path = "routes[0].hostt",
+        },
+        .{
+            .json =
+            \\{ "listen": "0.0.0.0:80", "routes": [],
+            \\  "clusters": [{ "name": "c", "endpoints": [],
+            \\    "circuit_breaker": { "max_requsts": 1 } }] }
+            ,
+            .path = "clusters[0].circuit_breaker.max_requsts",
+        },
+    };
+    for (cases) |case| {
+        var tree = try std.json.parseFromSlice(
+            std.json.Value,
+            std.testing.allocator,
+            case.json,
+            .{},
+        );
+        defer tree.deinit();
+        var buf: [config_path_bytes_max]u8 = undefined;
+        const found = find_unknown_field(tree.value, &buf);
+        try std.testing.expect(found != null);
+        try std.testing.expectEqualStrings(case.path, found.?);
+    }
+
+    // A fully valid document has no unknown field.
+    var ok = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        test_config,
+        .{},
+    );
+    defer ok.deinit();
+    var buf: [config_path_bytes_max]u8 = undefined;
+    try std.testing.expect(find_unknown_field(ok.value, &buf) == null);
 }

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -1,0 +1,377 @@
+//! JSON Schema (draft 2020-12) generator for the proxy config, derived by
+//! comptime reflection from `config.Dto` — the single source of truth, so the
+//! schema can never drift from the parser (docs/DESIGN.md §7 Phase 6, slice 1).
+//! Descriptions/enum values/formats come from each DTO struct's co-located
+//! `schema_doc`/`schema_fields` metadata, which `config.assert_meta_matches`
+//! pins to the field set at comptime. The output is deterministic (declaration
+//! field order, no maps, fixed 2-space indent, LF newlines) so a byte-compare
+//! against the committed `config.schema.json` is a stable drift gate.
+//!
+//! Emits the object schema for every DTO struct: `type`/`properties`/`required`
+//! (fields with no default)/`additionalProperties:false`, integer `minimum`/
+//! `maximum` from the exact Zig int type (or a metadata override), string/array
+//! shapes, `?T` as a nullable `type` array or an `anyOf` with `{"type":"null"}`,
+//! and `default` from the field's default value.
+
+const std = @import("std");
+const config = @import("config.zig");
+
+const Dto = config.Dto;
+const Error = std.Io.Writer.Error;
+
+/// Re-export so a CLI that imports only this module can still parse/validate a
+/// config file (`config_schema.config_zig.parse_diagnostic`).
+pub const config_zig = config;
+
+/// Write the full JSON Schema document for the proxy config to `w`.
+pub fn write(w: *std.Io.Writer) Error!void {
+    try w.writeAll("{\n");
+    try pad(w, 1);
+    try w.writeAll("\"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n");
+    try pad(w, 1);
+    try w.writeAll("\"title\": \"zoxy configuration\",\n");
+    try write_object_body(w, Dto, 1);
+    try w.writeAll("\n}\n");
+}
+
+/// A complete object schema `{ … }` (used for nested objects and array items).
+fn write_object(w: *std.Io.Writer, comptime T: type, comptime indent: usize) Error!void {
+    try w.writeAll("{\n");
+    try write_object_body(w, T, indent + 1);
+    try w.writeAll("\n");
+    try pad(w, indent);
+    try w.writeAll("}");
+}
+
+/// The keys of an object schema (no enclosing braces), each indented at
+/// `indent`. Calls the metadata drift check so a nested struct forgotten in
+/// `config.dto_types` is still caught the moment it is emitted.
+fn write_object_body(w: *std.Io.Writer, comptime T: type, comptime indent: usize) Error!void {
+    comptime config.assert_meta_matches(T);
+    const fields = @typeInfo(T).@"struct".fields;
+
+    try pad(w, indent);
+    try w.writeAll("\"type\": \"object\",\n");
+    if (@hasDecl(T, "schema_doc")) {
+        try pad(w, indent);
+        try w.writeAll("\"description\": ");
+        try json_string(w, T.schema_doc);
+        try w.writeAll(",\n");
+    }
+    try pad(w, indent);
+    try w.writeAll("\"properties\": {\n");
+    inline for (fields, 0..) |field, i| {
+        try pad(w, indent + 1);
+        try json_string(w, field.name);
+        try w.writeAll(": ");
+        try write_field(w, T, field, indent + 1);
+        if (i + 1 < fields.len) try w.writeAll(",");
+        try w.writeAll("\n");
+    }
+    try pad(w, indent);
+    try w.writeAll("},\n");
+
+    try pad(w, indent);
+    try w.writeAll("\"required\": [");
+    comptime var wrote_required = false;
+    inline for (fields) |field| {
+        if (field.defaultValue() == null) {
+            if (wrote_required) try w.writeAll(", ");
+            try json_string(w, field.name);
+            wrote_required = true;
+        }
+    }
+    try w.writeAll("],\n");
+
+    try pad(w, indent);
+    try w.writeAll("\"additionalProperties\": false");
+}
+
+/// One field's schema value: shape from the type, overlaid with metadata, then
+/// a `default` from the field's default value (null defaults are elided).
+fn write_field(
+    w: *std.Io.Writer,
+    comptime T: type,
+    comptime field: std.builtin.Type.StructField,
+    comptime indent: usize,
+) Error!void {
+    const meta = @field(T.schema_fields, field.name);
+    const Meta = @TypeOf(meta);
+    const info = @typeInfo(field.type);
+    const nullable = info == .optional;
+    const Base = if (nullable) info.optional.child else field.type;
+
+    try w.writeAll("{");
+    var first = true;
+
+    if (@hasField(Meta, "desc")) {
+        try key(w, indent, &first, "description");
+        try json_string(w, meta.desc);
+    }
+    try write_shape(w, Base, nullable, meta, indent, &first);
+    if (@hasField(Meta, "format")) {
+        try key(w, indent, &first, "format");
+        try json_string(w, meta.format);
+    }
+    if (@hasField(Meta, "pattern")) {
+        try key(w, indent, &first, "pattern");
+        try json_string(w, meta.pattern);
+    }
+    if (@hasField(Meta, "units")) {
+        try key(w, indent, &first, "x-units");
+        try json_string(w, meta.units);
+    }
+    if (@hasField(Meta, "enum_type")) try write_enum(w, meta, indent, &first);
+    if (@hasField(Meta, "example")) {
+        try key(w, indent, &first, "examples");
+        try w.writeAll("[");
+        try json_string(w, meta.example);
+        try w.writeAll("]");
+    }
+    if (field.defaultValue()) |default| {
+        const is_null = nullable and default == null;
+        if (!is_null) {
+            try key(w, indent, &first, "default");
+            try write_default(w, field.type, default);
+        }
+    }
+
+    if (!first) {
+        try w.writeAll("\n");
+        try pad(w, indent);
+    }
+    try w.writeAll("}");
+}
+
+/// The `type` (and `minimum`/`maximum` or `items`/`anyOf`) keys for `Base`.
+fn write_shape(
+    w: *std.Io.Writer,
+    comptime Base: type,
+    comptime nullable: bool,
+    meta: anytype,
+    comptime indent: usize,
+    first: *bool,
+) Error!void {
+    const Meta = @TypeOf(meta);
+    switch (@typeInfo(Base)) {
+        .bool => try type_key(w, indent, first, "boolean", nullable),
+        .int => {
+            try type_key(w, indent, first, "integer", nullable);
+            const lo = if (@hasField(Meta, "minimum")) meta.minimum else std.math.minInt(Base);
+            const hi = if (@hasField(Meta, "maximum")) meta.maximum else std.math.maxInt(Base);
+            try key(w, indent, first, "minimum");
+            try w.print("{d}", .{lo});
+            try key(w, indent, first, "maximum");
+            try w.print("{d}", .{hi});
+        },
+        .pointer => |ptr| {
+            if (ptr.child == u8) {
+                try type_key(w, indent, first, "string", nullable);
+            } else {
+                try type_key(w, indent, first, "array", nullable);
+                try key(w, indent, first, "items");
+                try write_items(w, ptr.child, indent + 1);
+            }
+        },
+        .@"struct" => {
+            try key(w, indent, first, if (nullable) "anyOf" else "allOf");
+            try w.writeAll("[\n");
+            try pad(w, indent + 2);
+            try write_object(w, Base, indent + 2);
+            if (nullable) {
+                try w.writeAll(",\n");
+                try pad(w, indent + 2);
+                try w.writeAll("{ \"type\": \"null\" }");
+            }
+            try w.writeAll("\n");
+            try pad(w, indent + 1);
+            try w.writeAll("]");
+        },
+        else => @compileError("config_schema: unsupported field type " ++ @typeName(Base)),
+    }
+}
+
+/// The `items` schema of an array: an object for struct elements, a plain
+/// string schema for `[]const []const u8`.
+fn write_items(w: *std.Io.Writer, comptime Child: type, comptime indent: usize) Error!void {
+    switch (@typeInfo(Child)) {
+        .@"struct" => try write_object(w, Child, indent),
+        .pointer => |ptr| {
+            if (ptr.child != u8) @compileError("config_schema: unsupported array element");
+            try w.writeAll("{ \"type\": \"string\" }");
+        },
+        else => @compileError("config_schema: unsupported array element " ++ @typeName(Child)),
+    }
+}
+
+/// `"enum": [...]` from the metadata's `enum_type`, plus a per-value
+/// `x-enumDescriptions` object when `enum_docs` is present. Values come from the
+/// real enum, and `@field(enum_docs, name)` forces a doc for every value — both
+/// drift-proof against the enum.
+fn write_enum(w: *std.Io.Writer, meta: anytype, comptime indent: usize, first: *bool) Error!void {
+    const E = meta.enum_type;
+    const values = @typeInfo(E).@"enum".fields;
+    try key(w, indent, first, "enum");
+    try w.writeAll("[");
+    inline for (values, 0..) |value, i| {
+        if (i != 0) try w.writeAll(", ");
+        try json_string(w, value.name);
+    }
+    try w.writeAll("]");
+    if (@hasField(@TypeOf(meta), "enum_docs")) {
+        try key(w, indent, first, "x-enumDescriptions");
+        try w.writeAll("{");
+        inline for (values, 0..) |value, i| {
+            if (i != 0) try w.writeAll(",");
+            try w.writeAll(" ");
+            try json_string(w, value.name);
+            try w.writeAll(": ");
+            try json_string(w, @field(meta.enum_docs, value.name));
+        }
+        try w.writeAll(" }");
+    }
+}
+
+/// Emit a field's default value as JSON.
+fn write_default(w: *std.Io.Writer, comptime T: type, value: T) Error!void {
+    switch (@typeInfo(T)) {
+        .bool => try w.writeAll(if (value) "true" else "false"),
+        .int => try w.print("{d}", .{value}),
+        .optional => |opt| if (value) |inner|
+            try write_default(w, opt.child, inner)
+        else
+            try w.writeAll("null"),
+        .pointer => |ptr| if (ptr.child == u8)
+            try json_string(w, value)
+        else
+            try w.writeAll("[]"), // the only slice default is an empty list
+        else => @compileError("config_schema: unsupported default type " ++ @typeName(T)),
+    }
+}
+
+/// Open a new key line inside a field object: newline for the first key,
+/// comma-newline for the rest, then indent and `"name": `.
+fn key(
+    w: *std.Io.Writer,
+    comptime indent: usize,
+    first: *bool,
+    comptime name: []const u8,
+) Error!void {
+    if (first.*) {
+        try w.writeAll("\n");
+        first.* = false;
+    } else {
+        try w.writeAll(",\n");
+    }
+    try pad(w, indent + 1);
+    try json_string(w, name);
+    try w.writeAll(": ");
+}
+
+/// The `type` key, as a bare string or a `["<name>", "null"]` union.
+fn type_key(
+    w: *std.Io.Writer,
+    comptime indent: usize,
+    first: *bool,
+    comptime name: []const u8,
+    comptime nullable: bool,
+) Error!void {
+    try key(w, indent, first, "type");
+    if (nullable) {
+        try w.writeAll("[");
+        try json_string(w, name);
+        try w.writeAll(", ");
+        try json_string(w, "null");
+        try w.writeAll("]");
+    } else {
+        try json_string(w, name);
+    }
+}
+
+fn pad(w: *std.Io.Writer, comptime indent: usize) Error!void {
+    const spaces = " " ** 40;
+    var remaining: usize = indent * 2;
+    while (remaining > 0) {
+        const take = @min(remaining, spaces.len);
+        try w.writeAll(spaces[0..take]);
+        remaining -= take;
+    }
+}
+
+/// Write `bytes` as a JSON string literal, escaping per RFC 8259.
+fn json_string(w: *std.Io.Writer, bytes: []const u8) Error!void {
+    const hex = "0123456789abcdef";
+    try w.writeByte('"');
+    for (bytes) |c| switch (c) {
+        '"' => try w.writeAll("\\\""),
+        '\\' => try w.writeAll("\\\\"),
+        '\n' => try w.writeAll("\\n"),
+        '\r' => try w.writeAll("\\r"),
+        '\t' => try w.writeAll("\\t"),
+        else => if (c < 0x20) {
+            try w.writeAll("\\u00");
+            try w.writeByte(hex[(c >> 4) & 0xf]);
+            try w.writeByte(hex[c & 0xf]);
+        } else try w.writeByte(c),
+    };
+    try w.writeByte('"');
+}
+
+// ---- tests ----------------------------------------------------------------
+
+test "config_schema: emits valid, strict, documented JSON Schema" {
+    var buf: [64 * 1024]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&buf);
+    try write(&writer);
+    const out = writer.buffered();
+
+    // Structural spot-checks on the raw text.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"additionalProperties\": false") != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\"",
+    ) != null);
+    // Enum values are sourced from the real enums, and units annotate ms fields.
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"reuseport\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"maglev\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"milliseconds\"") != null);
+
+    // The output must be valid JSON, and required-ness must follow field defaults.
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, out, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try std.testing.expectEqualStrings("object", root.get("type").?.string);
+    try std.testing.expectEqual(false, root.get("additionalProperties").?.bool);
+
+    const properties = root.get("properties").?.object;
+    try std.testing.expect(properties.get("listen") != null);
+    try std.testing.expect(properties.get("admin") != null);
+
+    var required_listen = false;
+    var required_admin = false;
+    for (root.get("required").?.array.items) |item| {
+        if (std.mem.eql(u8, item.string, "listen")) required_listen = true;
+        if (std.mem.eql(u8, item.string, "admin")) required_admin = true;
+    }
+    try std.testing.expect(required_listen); // no default
+    try std.testing.expect(!required_admin); // defaults to null
+
+    // accept_mode carries the enum drawn from `config.AcceptMode`.
+    const accept_mode = properties.get("accept_mode").?.object;
+    var saw_shared = false;
+    for (accept_mode.get("enum").?.array.items) |item| {
+        if (std.mem.eql(u8, item.string, "shared")) saw_shared = true;
+    }
+    try std.testing.expect(saw_shared);
+}
+
+test "config_schema: generated schema is deterministic" {
+    var buf_a: [64 * 1024]u8 = undefined;
+    var buf_b: [64 * 1024]u8 = undefined;
+    var writer_a = std.Io.Writer.fixed(&buf_a);
+    var writer_b = std.Io.Writer.fixed(&buf_b);
+    try write(&writer_a);
+    try write(&writer_b);
+    try std.testing.expectEqualStrings(writer_a.buffered(), writer_b.buffered());
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -35,8 +35,13 @@ pub fn main(init: std.process.Init) !void {
         std.log.err("zoxy: cannot read config {s}: {s}", .{ config_path, @errorName(err) });
         return err;
     };
-    var cfg = zoxy.config.parse(gpa, text) catch |err| {
-        std.log.err("zoxy: invalid config {s}: {s}", .{ config_path, @errorName(err) });
+    var diagnostic: zoxy.config.Diagnostic = .{};
+    var cfg = zoxy.config.parse_diagnostic(gpa, text, &diagnostic) catch |err| {
+        if (diagnostic.unknown_field) |field| {
+            std.log.err("zoxy: invalid config {s}: unknown field {s}", .{ config_path, field });
+        } else {
+            std.log.err("zoxy: invalid config {s}: {s}", .{ config_path, @errorName(err) });
+        }
         return err;
     };
     const router = Router.init(&cfg);

--- a/src/root.zig
+++ b/src/root.zig
@@ -99,6 +99,7 @@ test {
     _ = h2_translate;
     _ = h2_proxy;
     _ = config;
+    _ = @import("config_schema.zig");
     _ = @import("proxy/router.zig");
     _ = balancer;
     _ = maglev;

--- a/zoxy.json
+++ b/zoxy.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json",
   "listen": "127.0.0.1:8080",
   "admin": "127.0.0.1:9901",
   "handoff": "/tmp/zoxy-handoff.sock",


### PR DESCRIPTION
## Phase 6 · Slice 1 — Config JSON Schema + strict parsing

Implements the first slice of `docs/DESIGN.md` §7 Phase 6: an exported JSON
Schema derived from the config parser (for site docs + editor completion) and
strict parsing that rejects unknown fields. Reload (slice 2) and a
human-readable DSL (slice 3) remain deferred.

### What changed

- **Exported JSON Schema, drift-proof.** `src/config_schema.zig` reflects a
  draft-2020-12 schema from `config.Dto` at comptime. Descriptions, enum
  values, `host:port` formats, ms-unit notes, and examples live in per-struct
  `schema_fields` metadata co-located with the fields. `assert_meta_matches`
  pins the metadata to the fields at comptime — a missing/stray entry, a
  missing `.desc`, or a misspelled attribute key (`.minimu`) is a **compile
  error**, so the schema (shape *and* prose) can never drift from the parser.
  Output is deterministic, so `config.schema.json` byte-diffs cleanly.
- **Strict parsing with named paths.** Parsing decodes to a dynamic tree, a
  comptime type-directed walk reports the first unknown key by path
  (`clusters[2].circuit_breaker.max_requsts`), then decodes strictly into the
  DTO. `ignore_unknown_fields` is gone — a misspelled `"circuit_breaker"` no
  longer silently disables the feature. A `$schema` key is accepted (and
  emitted) so editor completion coexists with strictness.
- **Gates.** `zig build schema` regenerates the committed `config.schema.json`;
  `zig build check-config` byte-diffs a fresh generation against it (drift
  gate) and strict-parses `zoxy.json`. Both wired into CI.
- `LbPolicy` enum hoisted so `lower_lb` and the schema draw policy values from
  one source. The reflecting host tool links no OpenSSL (the config graph is
  FFI-free).

### Review

Ran a 4-dimension adversarial review (comptime correctness, schema semantics,
strict-parse safety, build/CI/determinism) with independent verification of
each finding. Two confirmed, both fixed:

- Schema false-accepted `0` on fields the parser rejects at `0`
  (`circuit_breaker.max_*`, `outlier.*`, `health_check.*`, `retry.backoff_*_ms`)
  → added `.minimum = 1` (kept `budget_min`/`per_try_timeout_ms`, where `0` is
  valid).
- Unvalidated metadata attribute keys → the `assert_meta_matches` typo-guard
  above.

### Verification

- `230/230` tests pass; sim seeds 0..300 clean (3898 framed responses verified).
- `zig fmt`, `zig build lint`, `zig build`, `zig build check-config` all green.
- Drift gate correctly fails on a stale schema; the attribute typo-guard fires
  on a misspelled metadata key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
