### PR TITLE
feat(nix): package zoxy as a flake for NixOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,34 @@ jobs:
       - name: Run simulator (seeds 0..300)
         run: nix develop --command zig build sim -- 0 300
 
+  nix-flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The NixOS VM test (checks.*.nixos-module) boots a real VM, which needs
+      # hardware virtualisation. GitHub's Linux runners expose /dev/kvm; this
+      # grants the unprivileged Nix build user access to it.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Builds the package hermetically (packages.<system>.zoxy) and runs the
+      # NixOS VM test (checks.<system>.nixos-module: nginx origin behind zoxy,
+      # asserting a proxied request and a live /metrics endpoint).
+      - name: nix flake check
+        run: nix flake check -L
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 zig-cache
 zig-out
 zig-pkg
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zoxy
 
-[![CI](https://github.com/floatdrop/zoxy/actions/workflows/ci.yml/badge.svg)](https://github.com/floatdrop/zoxy/actions/workflows/ci.yml)
-[![Coverage Status](https://coveralls.io/repos/github/floatdrop/zoxy/badge.svg?branch=main)](https://coveralls.io/github/floatdrop/zoxy?branch=main)
+[![CI](https://github.com/zoxy-io/zoxy/actions/workflows/ci.yml/badge.svg)](https://github.com/zoxy-io/zoxy/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/zoxy-io/zoxy/badge.svg?branch=main)](https://coveralls.io/github/zoxy-io/zoxy?branch=main)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A zero-allocation L7 edge proxy in Zig, in the spirit of Envoy and Linkerd.
@@ -84,6 +84,58 @@ zoxy logs a startup line and per-request access lines to stderr:
 info: zoxy listening on 127.0.0.1:8080 across 8 worker(s)
 GET /api/thing proxied 70
 ```
+
+### As a package / on NixOS
+
+The flake also exposes zoxy as a package (`packages.<system>.zoxy`), a runnable
+app, a `pkgs` overlay, and a NixOS module:
+
+```sh
+nix build github:zoxy-io/zoxy#zoxy            # -> ./result/bin/zoxy
+nix run   github:zoxy-io/zoxy -- config.json  # run it directly
+```
+
+The package build is fully offline. The one network dependency — the vendored
+OpenSSL *source* (built from source, see `third_party/openssl`) — is fetched by
+a fixed-output derivation (`nix/package.nix`), and the real build runs against
+it with `zig build --system`, so the Nix sandbox never needs the network. After
+bumping the OpenSSL ref in `third_party/openssl/build.zig.zon`, reset
+`outputHash` to `lib.fakeHash`, run `nix build`, and copy back the reported hash.
+
+Run it as a service on NixOS via `nixosModules.default`:
+
+```nix
+{
+  inputs.zoxy.url = "github:zoxy-io/zoxy";
+
+  outputs = { nixpkgs, zoxy, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        zoxy.nixosModules.default
+        {
+          services.zoxy = {
+            enable = true;
+            settings = {
+              listen = "0.0.0.0:8080";
+              admin = "127.0.0.1:9901";
+              routes = [ { cluster = "origin"; } ];
+              clusters = [ { name = "origin"; endpoints = [ "127.0.0.1:9000" ]; } ];
+            };
+            openFirewall = true;
+            ports = [ 8080 ];
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+The service runs as a hardened, dynamically-allocated user with the io_uring
+syscalls explicitly allowed (systemd excludes them from `@system-service`). Set
+`services.zoxy.configFile` instead of `settings` to hand zoxy a config file
+verbatim — e.g. one holding TLS material managed outside Nix.
 
 ## Configuration
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,38 +1,118 @@
 {
+  description = "zoxy — a zero-allocation L7 edge proxy in Zig (Linux only)";
+
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
   outputs =
     { self, nixpkgs }:
     let
-      supportedSystems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin"
+      inherit (nixpkgs) lib;
+
+      # zoxy is Linux-only (io_uring + raw linux syscalls, see CLAUDE.md).
+      # The package/app/NixOS module therefore only exist on Linux; the dev
+      # shell additionally covers darwin so the code can be edited there.
+      linuxSystems = [
         "x86_64-linux"
+        "aarch64-linux"
+      ];
+      allSystems = linuxSystems ++ [
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
-      defaultForEachSupportedSystem = (
-        func:
-        nixpkgs.lib.genAttrs supportedSystems (system: {
-          default = func system;
-        })
-      );
+      forSystems = systems: func: lib.genAttrs systems (system: func nixpkgs.legacyPackages.${system});
     in
     {
-      devShells = defaultForEachSupportedSystem (
-        system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-          };
-        in
-        pkgs.mkShell {
-          packages = with pkgs; [
-            zig_0_16
-            zls
-            nghttp2 # provides h2load, the bench load generator
-          ] ++ (if pkgs.stdenv.hostPlatform.isLinux then [ pkgs.kcov ] else []);
-        }
-      );
+      # nix build .#zoxy / nix run .#zoxy
+      packages = forSystems linuxSystems (pkgs: rec {
+        zoxy = pkgs.callPackage ./nix/package.nix { };
+        default = zoxy;
+      });
+
+      # A pkgs overlay so downstream flakes can `pkgs.zoxy` after adding it.
+      overlays.default = final: _prev: {
+        zoxy = final.callPackage ./nix/package.nix { };
+      };
+
+      # NixOS service: `services.zoxy.enable = true;`
+      nixosModules.zoxy = import ./nix/module.nix self;
+      nixosModules.default = self.nixosModules.zoxy;
+
+      apps = forSystems linuxSystems (pkgs: rec {
+        zoxy = {
+          type = "app";
+          program = "${self.packages.${pkgs.stdenv.hostPlatform.system}.zoxy}/bin/zoxy";
+          meta.description = "Run zoxy: zoxy <config.json>";
+        };
+        default = zoxy;
+      });
+
+      devShells = forSystems allSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages =
+            with pkgs;
+            [
+              zig_0_16
+              zls
+              nghttp2 # provides h2load, the bench load generator
+            ]
+            ++ lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.kcov;
+        };
+      });
+
+      # `nix flake check` boots a VM: nginx origin behind zoxy, proxied request
+      # must return the origin body. Also proves the systemd unit starts — i.e.
+      # the io_uring syscalls survive the sandbox's SystemCallFilter.
+      checks = forSystems linuxSystems (pkgs: {
+        nixos-module = pkgs.testers.nixosTest {
+          name = "zoxy-nixos-module";
+          nodes.machine =
+            { pkgs, ... }:
+            {
+              imports = [ self.nixosModules.zoxy ];
+
+              services.nginx = {
+                enable = true;
+                virtualHosts."origin" = {
+                  listen = [
+                    {
+                      addr = "127.0.0.1";
+                      port = 9000;
+                    }
+                  ];
+                  locations."/".extraConfig = "return 200 'hello from origin';";
+                };
+              };
+
+              services.zoxy = {
+                enable = true;
+                settings = {
+                  listen = "127.0.0.1:8080";
+                  admin = "127.0.0.1:9901";
+                  routes = [ { cluster = "origin"; } ];
+                  clusters = [
+                    {
+                      name = "origin";
+                      endpoints = [ "127.0.0.1:9000" ];
+                    }
+                  ];
+                };
+              };
+
+              environment.systemPackages = [ pkgs.curl ];
+            };
+
+          testScript = ''
+            machine.wait_for_unit("nginx.service")
+            machine.wait_for_unit("zoxy.service")
+            machine.wait_for_open_port(9000)
+            machine.wait_for_open_port(8080)
+            machine.succeed("curl -sf http://127.0.0.1:8080/ | grep 'hello from origin'")
+            machine.succeed("curl -sf http://127.0.0.1:9901/metrics")
+          '';
+        };
+      });
+
+      formatter = forSystems allSystems (pkgs: pkgs.nixfmt-rfc-style);
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,152 @@
+# NixOS module for zoxy. Wired from the flake as `nixosModules.zoxy`; the flake
+# passes `self` so the service can default to the flake's own package.
+#
+# Usage:
+#   services.zoxy = {
+#     enable = true;
+#     settings = {
+#       listen = "0.0.0.0:8080";
+#       admin = "127.0.0.1:9901";
+#       routes = [ { cluster = "origin"; } ];
+#       clusters = [ { name = "origin"; endpoints = [ "127.0.0.1:9000" ]; } ];
+#     };
+#   };
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.zoxy;
+  jsonFormat = pkgs.formats.json { };
+
+  # A caller may hand us a ready-made config file, otherwise we render one from
+  # `settings` (the schema zoxy's JSON config expects — see zoxy.json).
+  configFile =
+    if cfg.configFile != null then cfg.configFile else jsonFormat.generate "zoxy.json" cfg.settings;
+in
+{
+  options.services.zoxy = {
+    enable = lib.mkEnableOption "the zoxy L7 edge proxy";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.zoxy;
+      defaultText = lib.literalExpression "zoxy.packages.\${system}.zoxy";
+      description = "The zoxy package to run.";
+    };
+
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          listen = "0.0.0.0:8080";
+          admin = "127.0.0.1:9901";
+          routes = [ { cluster = "origin"; } ];
+          clusters = [ { name = "origin"; endpoints = [ "127.0.0.1:9000" ]; } ];
+        }
+      '';
+      description = ''
+        zoxy configuration, serialized to JSON and passed as the config file.
+        Ignored when {option}`services.zoxy.configFile` is set. See the project
+        README for the full schema.
+      '';
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/etc/zoxy/zoxy.json";
+      description = ''
+        Path to a config file to use verbatim. Overrides
+        {option}`services.zoxy.settings`. Useful when the config carries TLS
+        material or is managed outside Nix.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the TCP ports in {option}`services.zoxy.ports` in the firewall.";
+    };
+
+    ports = lib.mkOption {
+      type = lib.types.listOf lib.types.port;
+      default = [ ];
+      example = [ 8080 ];
+      description = ''
+        TCP ports to open when {option}`services.zoxy.openFirewall` is set.
+        zoxy's listen ports live inside the config, so they cannot be derived
+        automatically — list here whichever should be reachable.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.configFile != null || cfg.settings != { };
+        message = "services.zoxy: set either `settings` or `configFile`.";
+      }
+    ];
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall cfg.ports;
+
+    systemd.services.zoxy = {
+      description = "zoxy L7 edge proxy";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 1;
+
+        # Unprivileged, per-boot user; /run/zoxy is available for e.g. the
+        # hot-restart handoff socket ("handoff": "/run/zoxy/handoff.sock").
+        DynamicUser = true;
+        RuntimeDirectory = "zoxy";
+        RuntimeDirectoryMode = "0750";
+
+        # Binding ports < 1024 needs this; harmless otherwise.
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+
+        # A busy proxy: many fds, and io_uring may pin memory.
+        LimitNOFILE = 1048576;
+        LimitMEMLOCK = "infinity";
+
+        # Sandboxing. io_uring is deliberately excluded from systemd's
+        # @system-service set (security history), so it is allowed explicitly —
+        # without it every worker's ring setup fails.
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "io_uring_setup"
+          "io_uring_enter"
+          "io_uring_register"
+        ];
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,137 @@
+# zoxy package: a static, hermetic Zig build.
+#
+# The only thing zoxy fetches from the network is the vendored OpenSSL *source*
+# (third_party/openssl builds it from source — see third_party/openssl/README.md
+# and CLAUDE.md). Nix builds have no network, so the fetch is split out into a
+# fixed-output derivation (`zigDepsCache`) that mirrors what `zig fetch` would
+# put in the global cache; the real build then runs offline against it with
+# `zig build --system`.
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  zig_0_16,
+  cacert,
+}:
+
+let
+  # The single URL dependency in the tree, declared in
+  # third_party/openssl/build.zig.zon. Keep both fields in sync with it.
+  # `zig fetch <url>` prints the .hash; that hash is the p/<hash> cache key.
+  opensslSource = {
+    url = "git+https://github.com/openssl/openssl?ref=openssl-3.3.2#fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4";
+    zigHash = "N-V-__8AAB4K3gN87j2XVRV4lWznICWpINb_g79iOtl4Cl30";
+  };
+
+  # Only the files the build actually reads — keeps the source hash (and thus
+  # rebuilds) independent of docs/, bench/, README, CI config, etc.
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../build.zig
+      ../build.zig.zon
+      ../src
+      ../third_party
+      ../LICENSE
+    ];
+  };
+
+  # Fixed-output derivation: populate a Zig package directory (the layout
+  # `zig build --system` expects: one extracted <hash>/ subtree per package)
+  # by fetching every URL dependency, then extracting the cached tarballs.
+  #
+  # `zig build --fetch` does NOT descend into a *path* dependency's manifest
+  # (third_party/openssl is a path dep), so we fetch its URL dep explicitly.
+  zigDepsCache = stdenvNoCC.mkDerivation {
+    name = "zoxy-zig-deps";
+    nativeBuildInputs = [
+      zig_0_16
+      cacert
+    ];
+    dontUnpack = true;
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+      export HOME="$TMPDIR"
+      export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global"
+      # This zig's `zig fetch` insists on a build.zig in the current directory
+      # even when fetching a bare URL — give it an empty one to satisfy that.
+      : > build.zig
+      zig fetch "${opensslSource.url}"
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      # Each cached tarball's internal root is its own <hash>/ directory, so
+      # extracting at $out yields $out/<hash>/... — exactly the --system layout.
+      for tarball in "$ZIG_GLOBAL_CACHE_DIR"/p/*.tar.gz; do
+        tar -xf "$tarball" -C "$out"
+      done
+      test -d "$out/${opensslSource.zigHash}"
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    # Recompute after bumping the OpenSSL ref: set to lib.fakeHash, run
+    # `nix build .#zoxy`, and copy the "got:" value it reports.
+    outputHash = "sha256-OSNJqk2ZycD8HOaR4aSrxaya9+D5732RbWVeGTALMx0=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zoxy";
+  version = "0.0.0"; # tracks build.zig.zon .version
+
+  inherit src;
+
+  nativeBuildInputs = [ zig_0_16 ];
+
+  # Drive `zig build` from an explicit buildPhase rather than zig_0_16's setup
+  # hook: the hook can't express `--system <depsdir>`, which is what makes the
+  # build hermetic. Opt out of every hook phase so the manual phase is the only
+  # thing that runs. `zig build --prefix` installs; there is no ./configure.
+  dontUseZigConfigure = true;
+  dontUseZigBuild = true;
+  dontUseZigCheck = true;
+  dontUseZigInstall = true;
+  dontConfigure = true;
+  dontInstall = true;
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME="$TMPDIR"
+    export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-global"
+    mkdir -p "$ZIG_GLOBAL_CACHE_DIR"
+
+    # --system disables fetching and resolves deps from the FOD; -Dcpu=baseline
+    # keeps the binary portable across the target arch (no build-host tuning).
+    zig build \
+      --system "${finalAttrs.passthru.zigDepsCache}" \
+      --cache-dir "$TMPDIR/zig-local" \
+      --prefix "$out" \
+      -Doptimize=ReleaseSafe \
+      -Dcpu=baseline
+
+    runHook postBuild
+  '';
+
+  # build.zig also installs the standalone libopenssl.a and its headers (for
+  # coverage builds that bypass the build graph). OpenSSL is already statically
+  # linked into the zoxy binary, so keep only bin/ in the package output.
+  postBuild = ''
+    rm -rf "$out/lib" "$out/include"
+  '';
+
+  passthru = { inherit zigDepsCache; };
+
+  meta = {
+    description = "Zero-allocation L7 edge proxy in Zig (io_uring, thread-per-core)";
+    homepage = "https://github.com/zoxy-io/zoxy";
+    license = lib.licenses.mit;
+    mainProgram = "zoxy";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packages zoxy as a Nix flake so it can be installed and run on NixOS, and wires a `nix flake check` job into CI.

## What's added

- **`nix/package.nix`** — a hermetic build. zoxy's only network dependency is the vendored OpenSSL *source* (built from source), which the Nix sandbox can't fetch. A fixed-output derivation pre-fetches it into the layout `zig build --system` expects; the real build then compiles fully offline against it. Output is `bin/zoxy` only (OpenSSL is statically linked in).
- **`nix/module.nix`** — `services.zoxy` with `settings` (attrset → JSON) or `configFile`, `openFirewall`/`ports`, and a hardened `DynamicUser` unit. Notably, it allowlists the three `io_uring_*` syscalls that systemd deliberately excludes from `@system-service` — without them every worker's ring setup fails.
- **`flake.nix`** — new `packages` / `apps` / `overlays.default` / `nixosModules.{zoxy,default}` outputs alongside the existing dev shell, plus a `formatter`.
- **`checks.<system>.nixos-module`** — a NixOS VM test: boots a VM with an nginx origin behind zoxy, asserts a proxied request returns the origin body and that `/metrics` is live.
- **CI** — a `nix flake check` job (builds the package + runs the VM test; KVM enabled on the runner).
- **README** — an "As a package / on NixOS" section; repo URL updated to `github:zoxy-io/zoxy`.

## Usage

```sh
nix build github:zoxy-io/zoxy#zoxy            # -> ./result/bin/zoxy
nix run   github:zoxy-io/zoxy -- config.json
```

```nix
# NixOS
imports = [ zoxy.nixosModules.default ];
services.zoxy = {
  enable = true;
  settings = {
    listen = "0.0.0.0:8080";
    routes = [ { cluster = "origin"; } ];
    clusters = [ { name = "origin"; endpoints = [ "127.0.0.1:9000" ]; } ];
  };
};
```

## Verification (local)

- `nix build .#zoxy` → 25 MB binary; starts, listens across workers, drains on signal.
- `nix flake check` → **all checks passed**; the NixOS VM test boots, `zoxy.service` starts (io_uring survives the syscall filter), proxies `GET /` to nginx, `/metrics` responds.
- `nixfmt --check` clean on all Nix files.

## Notes

- The package builds with `-Dcpu=baseline` for a portable, cache-substitutable binary rather than build-host-tuned codegen.
- After bumping the OpenSSL ref in `third_party/openssl/build.zig.zon`, reset `outputHash` in `nix/package.nix` to `lib.fakeHash`, run `nix build`, and paste back the reported hash (documented inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)