### PR TITLE
feat(config): add worker count option for reproducible benchmarks

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -34,6 +34,12 @@
       "x-enumDescriptions": { "reuseport": "One SO_REUSEPORT listener per worker; the kernel hashes.", "shared": "One listener; every worker holds a pending accept." },
       "default": "reuseport"
     },
+    "workers": {
+      "description": "Fixed worker count; null uses one worker per online CPU (capped).",
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "maximum": 64
+    },
     "tls": {
       "description": "TLS termination on the listener; null = plaintext.",
       "anyOf": [

--- a/src/config.zig
+++ b/src/config.zig
@@ -406,6 +406,10 @@ pub const Config = struct {
     /// small-sample variance. `shared`: one listener, every worker holds a
     /// pending accept — idle workers naturally pull more.
     accept_mode: AcceptMode,
+    /// Fixed worker count; null lets the process spawn one worker per online
+    /// CPU (clamped to `constants.workers_max`). Pin it to make benchmarks
+    /// reproducible across machines (docs/DESIGN.md §3, thread-per-core).
+    workers: ?u16,
     /// TLS termination on the listener; null = plaintext.
     tls: ?TlsConfig,
     routes: []const Route,
@@ -456,6 +460,7 @@ pub const Dto = struct {
     admin: ?[]const u8 = null,
     handoff: ?[]const u8 = null,
     accept_mode: []const u8 = "reuseport",
+    workers: ?u16 = null,
     tls: ?TlsDto = null,
     routes: []const RouteDto,
     clusters: []const ClusterDto,
@@ -486,6 +491,11 @@ pub const Dto = struct {
                 .reuseport = "One SO_REUSEPORT listener per worker; the kernel hashes.",
                 .shared = "One listener; every worker holds a pending accept.",
             },
+        },
+        .workers = .{
+            .desc = "Fixed worker count; null uses one worker per online CPU (capped).",
+            .minimum = 1,
+            .maximum = constants.workers_max,
         },
         .tls = .{ .desc = "TLS termination on the listener; null = plaintext." },
         .routes = .{ .desc = "Host/path routing rules, evaluated first-match-wins." },
@@ -1030,6 +1040,10 @@ pub fn parse_resolved(
         } else null,
         .accept_mode = std.meta.stringToEnum(AcceptMode, dto.accept_mode) orelse
             return error.InvalidAcceptMode,
+        .workers = if (dto.workers) |w| blk: {
+            if (w < 1 or w > constants.workers_max) return error.InvalidLimit;
+            break :blk w;
+        } else null,
         .tls = tls,
         .routes = routes,
         .clusters = clusters,
@@ -1681,6 +1695,34 @@ test "config: accept_mode defaults to reuseport, parses shared, rejects junk" {
         \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
     );
     try std.testing.expectError(error.InvalidAcceptMode, junk);
+}
+
+test "config: workers defaults to null, parses a fixed count, rejects out-of-range" {
+    var auto = try parse(std.testing.allocator, test_config);
+    defer auto.deinit();
+    try std.testing.expectEqual(@as(?u16, null), auto.workers);
+
+    var pinned = try parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "workers": 4,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    defer pinned.deinit();
+    try std.testing.expectEqual(@as(?u16, 4), pinned.workers);
+
+    const zero = parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "workers": 0,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    try std.testing.expectError(error.InvalidLimit, zero);
+
+    const too_many = parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "workers": 65,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    try std.testing.expectError(error.InvalidLimit, too_many);
 }
 
 test "config: lb block — maglev builds a table, knobs validated strictly" {

--- a/src/config_adapter.zig
+++ b/src/config_adapter.zig
@@ -24,6 +24,7 @@
 //!   admin  127.0.0.1:9901
 //!   handoff /run/zoxy.sock
 //!   accept_mode shared            # reuseport | shared
+//!   workers 4                     # fixed worker count; omit = one per CPU
 //!
 //!   tls {
 //!       certificate cert.pem
@@ -259,6 +260,8 @@ const Parser = struct {
                 try p.scalar(line, &p.scalars, dto_field(Dto, "handoff"));
             } else if (eq(d, "accept_mode")) {
                 try p.scalar(line, &p.scalars, dto_field(Dto, "accept_mode"));
+            } else if (eq(d, "workers")) {
+                try p.scalar_integer(line, &p.scalars, dto_field(Dto, "workers"));
             } else if (eq(d, "tls")) {
                 try p.top_tls(line);
             } else if (eq(d, "route")) {
@@ -281,6 +284,18 @@ const Parser = struct {
         }
         try emit.field(name);
         try emit_string(emit.w, line.tokens[1]);
+    }
+
+    /// A `name value` scalar integer field into the given emitter (unquoted).
+    fn scalar_integer(p: *Parser, line: Line, emit: *Emit, name: []const u8) Error!void {
+        if (line.opens_block()) {
+            return p.fail(error.UnexpectedToken, "directive takes a value, not a block");
+        }
+        if (line.tokens.len != 2) {
+            return p.fail(error.MissingValue, "directive needs exactly one value");
+        }
+        try emit.field(name);
+        try p.emit_integer(emit.w, line.tokens[1]);
     }
 
     /// `tls { … }` on the listener → the `tls` object; `identity` sub-blocks
@@ -819,6 +834,7 @@ test "adapter: scalars, comments, and blank lines" {
         \\admin 127.0.0.1:9901
         \\handoff /run/zoxy.sock
         \\accept_mode shared
+        \\workers 4
         \\
         \\route -> c
         \\cluster c {
@@ -831,6 +847,7 @@ test "adapter: scalars, comments, and blank lines" {
     try testing.expectEqualStrings("127.0.0.1:9901", root.get("admin").?.string);
     try testing.expectEqualStrings("/run/zoxy.sock", root.get("handoff").?.string);
     try testing.expectEqualStrings("shared", root.get("accept_mode").?.string);
+    try testing.expectEqual(@as(i64, 4), root.get("workers").?.integer);
 }
 
 test "adapter: route arrow match forms" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -67,8 +67,13 @@ pub fn main(init: std.process.Init) !void {
     };
     const router = Router.init(&cfg);
 
-    const worker_count = std.Thread.getCpuCount() catch 1;
+    // A pinned `workers` in the config wins (reproducible benchmarks); otherwise
+    // one worker per online CPU. Clamp both to workers_max so the fixed-size
+    // per-worker arrays (listeners, metrics shards) never overflow.
+    const detected: usize = if (cfg.workers) |w| w else (std.Thread.getCpuCount() catch 1);
+    const worker_count = @min(detected, constants.workers_max);
     assert(worker_count >= 1); // one worker thread is spawned even if the count fails
+    assert(worker_count <= constants.workers_max);
 
     // TLS (docs/DESIGN.md §6): install the memory hook first — it must precede
     // any other OpenSSL call, so it runs before either context is built.


### PR DESCRIPTION
## What

Adds an optional `workers` config field that pins the thread-per-core worker count. When absent (`null`), the existing behavior is unchanged: one worker per online CPU.

## Why

Worker count has always tracked the online CPU count, so benchmark numbers aren't comparable across machines. Pinning `workers` makes benchmark runs reproducible.

## Details

- **`src/config.zig`** — new `workers: ?u16` on `Config`/`Dto` with schema metadata (`minimum: 1`, `maximum: constants.workers_max`). Validated in `parse_resolved` (rejects `0` and `> 64` with `error.InvalidLimit`).
- **`src/main.zig`** — worker count is `cfg.workers` if set, else `getCpuCount()`, then `@min`-clamped to `workers_max`. The clamp also closes a latent overflow of the fixed-size per-worker arrays (listeners, metrics shards) on >64-CPU hosts. Invariant asserted.
- **`src/config_adapter.zig`** — new `workers N` Zoxyfile directive (unquoted integer emit) so the DSL stays symmetric with the JSON surface.
- **`config.schema.json`** — regenerated via `zig build schema`.

Usage: `{ "listen": "127.0.0.1:8080", "workers": 4, ... }` or, in a Zoxyfile, `workers 4`.

## Testing

- `zig build`, `zig fmt --check`, `zig build check-config` — pass
- `zig build test` — 256/259 pass, 3 skipped (kTLS tests skip: host lacks the `tls` kernel ULP module; unrelated)
- `zig build sim -- 0 200` — OK
- Added config tests (default-null, fixed count, both out-of-range rejections) and an adapter scalar test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)