### PR TITLE
feat(config): gate all logging behind an opt-in flag

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,6 +40,11 @@
       "minimum": 1,
       "maximum": 64
     },
+    "logging": {
+      "description": "Emit diagnostics and per-request access logs; off keeps workers silent.",
+      "type": "boolean",
+      "default": false
+    },
     "tls": {
       "description": "TLS termination on the listener; null = plaintext.",
       "anyOf": [

--- a/src/config.zig
+++ b/src/config.zig
@@ -410,6 +410,11 @@ pub const Config = struct {
     /// CPU (clamped to `constants.workers_max`). Pin it to make benchmarks
     /// reproducible across machines (docs/DESIGN.md §3, thread-per-core).
     workers: ?u16,
+    /// Emit diagnostics (`std.log`) and per-request access logs. Off by
+    /// default so worker threads never serialize on the shared stderr fd — a
+    /// benchmark stays silent unless it opts in. Fatal config-load errors log
+    /// regardless (main only lowers to this once the config parses).
+    logging: bool,
     /// TLS termination on the listener; null = plaintext.
     tls: ?TlsConfig,
     routes: []const Route,
@@ -461,6 +466,7 @@ pub const Dto = struct {
     handoff: ?[]const u8 = null,
     accept_mode: []const u8 = "reuseport",
     workers: ?u16 = null,
+    logging: bool = false,
     tls: ?TlsDto = null,
     routes: []const RouteDto,
     clusters: []const ClusterDto,
@@ -496,6 +502,9 @@ pub const Dto = struct {
             .desc = "Fixed worker count; null uses one worker per online CPU (capped).",
             .minimum = 1,
             .maximum = constants.workers_max,
+        },
+        .logging = .{
+            .desc = "Emit diagnostics and per-request access logs; off keeps workers silent.",
         },
         .tls = .{ .desc = "TLS termination on the listener; null = plaintext." },
         .routes = .{ .desc = "Host/path routing rules, evaluated first-match-wins." },
@@ -1044,6 +1053,7 @@ pub fn parse_resolved(
             if (w < 1 or w > constants.workers_max) return error.InvalidLimit;
             break :blk w;
         } else null,
+        .logging = dto.logging,
         .tls = tls,
         .routes = routes,
         .clusters = clusters,
@@ -1723,6 +1733,20 @@ test "config: workers defaults to null, parses a fixed count, rejects out-of-ran
         \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
     );
     try std.testing.expectError(error.InvalidLimit, too_many);
+}
+
+test "config: logging defaults off and parses on" {
+    var off = try parse(std.testing.allocator, test_config);
+    defer off.deinit();
+    try std.testing.expectEqual(false, off.logging);
+
+    var on = try parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "logging": true,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    defer on.deinit();
+    try std.testing.expectEqual(true, on.logging);
 }
 
 test "config: lb block — maglev builds a table, knobs validated strictly" {

--- a/src/config_adapter.zig
+++ b/src/config_adapter.zig
@@ -25,6 +25,7 @@
 //!   handoff /run/zoxy.sock
 //!   accept_mode shared            # reuseport | shared
 //!   workers 4                     # fixed worker count; omit = one per CPU
+//!   logging                       # flag: presence enables diagnostics + access logs
 //!
 //!   tls {
 //!       certificate cert.pem
@@ -262,6 +263,8 @@ const Parser = struct {
                 try p.scalar(line, &p.scalars, dto_field(Dto, "accept_mode"));
             } else if (eq(d, "workers")) {
                 try p.scalar_integer(line, &p.scalars, dto_field(Dto, "workers"));
+            } else if (eq(d, "logging")) {
+                try p.scalar_flag(line, &p.scalars, dto_field(Dto, "logging"));
             } else if (eq(d, "tls")) {
                 try p.top_tls(line);
             } else if (eq(d, "route")) {
@@ -296,6 +299,14 @@ const Parser = struct {
         }
         try emit.field(name);
         try p.emit_integer(emit.w, line.tokens[1]);
+    }
+
+    /// A bare top-level boolean flag: its presence emits `true` (opt-in switch,
+    /// like the tls `http2` flag). Absence keeps the DTO default.
+    fn scalar_flag(p: *Parser, line: Line, emit: *Emit, name: []const u8) Error!void {
+        if (line.tokens.len != 1) return p.fail(error.UnexpectedToken, "flag takes no value");
+        try emit.field(name);
+        try emit.w.writeAll("true");
     }
 
     /// `tls { … }` on the listener → the `tls` object; `identity` sub-blocks
@@ -835,6 +846,7 @@ test "adapter: scalars, comments, and blank lines" {
         \\handoff /run/zoxy.sock
         \\accept_mode shared
         \\workers 4
+        \\logging
         \\
         \\route -> c
         \\cluster c {
@@ -848,6 +860,7 @@ test "adapter: scalars, comments, and blank lines" {
     try testing.expectEqualStrings("/run/zoxy.sock", root.get("handoff").?.string);
     try testing.expectEqualStrings("shared", root.get("accept_mode").?.string);
     try testing.expectEqual(@as(i64, 4), root.get("workers").?.integer);
+    try testing.expectEqual(true, root.get("logging").?.bool);
 }
 
 test "adapter: route arrow match forms" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,25 @@ const Ip4Address = std.Io.net.Ip4Address;
 
 const stderr_fd = 2;
 
+/// Diagnostics are gated on a runtime flag so a `logging: false` config keeps
+/// worker threads from serializing on the process-global stderr lock (every
+/// `std.log` call takes it) during a benchmark. It starts true so a config
+/// that fails to load still reports why; `main` lowers it to `cfg.logging` the
+/// moment the config parses, before anything past startup logs.
+var logging_enabled: std.atomic.Value(bool) = .init(true);
+
+pub const std_options: std.Options = .{ .logFn = gated_log };
+
+fn gated_log(
+    comptime level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    if (!logging_enabled.load(.monotonic)) return;
+    std.log.defaultLog(level, scope, format, args);
+}
+
 pub fn main(init: std.process.Init) !void {
     // All allocation here is startup-only; it lives in the process arena.
     const gpa = init.arena.allocator();
@@ -66,6 +85,12 @@ pub fn main(init: std.process.Init) !void {
         return err;
     };
     const router = Router.init(&cfg);
+
+    // Config parsed: from here on, honor its `logging` choice. Startup errors
+    // above always logged (the flag started true); everything past this point —
+    // the listening banner, worker errors, reload notices — stays silent when
+    // logging is off, and no worker touches the shared stderr lock.
+    logging_enabled.store(cfg.logging, .monotonic);
 
     // A pinned `workers` in the config wins (reproducible benchmarks); otherwise
     // one worker per online CPU. Clamp both to workers_max so the fixed-size
@@ -380,7 +405,7 @@ fn reserve_worker_pools(
     upstream_tls: []const ?*const zoxy.terminator.Context,
 ) !WorkerPools {
     const accesses = try gpa.alloc(cache_line.Padded(AccessLog), worker_count);
-    for (accesses) |*slot| slot.value = .{ .fd = stderr_fd };
+    for (accesses) |*slot| slot.value = .{ .fd = stderr_fd, .enabled = cfg.logging };
 
     const pools = try gpa.alloc(cache_line.Padded(Pool), worker_count);
     for (pools) |*slot| slot.value = try Pool.init(gpa, constants.connections_max);

--- a/src/obs/access_log.zig
+++ b/src/obs/access_log.zig
@@ -71,6 +71,9 @@ pub fn format_line(out: []u8, entry: Entry) []const u8 {
 
 pub const AccessLog = struct {
     fd: linux.fd_t,
+    /// When false, `record` is a no-op: the request path neither formats a line
+    /// nor writes, so workers never touch the shared log fd (config `logging`).
+    enabled: bool = true,
     used: usize = 0,
     buf: [buf_bytes]u8 = undefined,
 
@@ -82,6 +85,10 @@ pub const AccessLog = struct {
     }
 
     pub fn record(log: *AccessLog, entry: Entry) void {
+        if (!log.enabled) {
+            assert(log.used == 0); // disabled logs never accumulate
+            return;
+        }
         assert(log.used <= log.buf.len);
         if (log.used + line_max > log.buf.len) log.flush();
         assert(log.used + line_max <= log.buf.len); // flush guaranteed room
@@ -144,4 +151,11 @@ test "access_log: accumulates records in the buffer" {
     const out = log.buf[0..log.used];
     try std.testing.expect(std.mem.indexOf(u8, out, "GET /a proxied 5\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "POST /b 502 0\n") != null);
+}
+
+test "access_log: disabled log records nothing" {
+    var log = AccessLog{ .fd = -1, .enabled = false };
+    log.record(.{ .method = "GET", .target = "/a", .outcome = .proxied, .bytes_to_client = 5 });
+    log.record(.{ .method = "POST", .target = "/b", .outcome = .aborted, .bytes_to_client = 0 });
+    try std.testing.expectEqual(@as(usize, 0), log.used); // no format, no accumulation
 }


### PR DESCRIPTION
## What

Adds a `logging` config option (boolean, default `false`). When off — the default — zoxy emits no diagnostics and no per-request access logs.

## Why

Two things write to the shared stderr fd on every worker:
- Every `std.log` call takes the **process-global stderr lock** (`std.debug.lockStderr`), so any steady-state log serializes threads.
- Every proxied request writes an **access-log line** to `stderr_fd` (all workers, same fd).

During a benchmark that's pure overhead. This flag lets a run stay silent so the numbers reflect the proxy, not log I/O.

## How

- **`std.log` gate** — a custom `std_options.logFn` checks a runtime atomic. It starts `true` so a config that fails to load still reports why; `main` lowers it to `cfg.logging` the instant the config parses. So with logging off you still get fatal config-load errors, but the listening banner, worker errors, and reload notices are suppressed.
- **Access-log gate** — `AccessLog` gains an `enabled` field; when off, `record()` short-circuits before formatting, so the request path never touches the log buffer or fd.
- Mirrored in the Zoxyfile DSL as a bare `logging` flag (presence = true, like the tls `http2` flag) and reflected into `config.schema.json`.

## Verification

Ran the built binary:
- Bad config path → error still logs (flag starts true) ✅
- Valid config, `logging` omitted → completely silent ✅
- `logging: true` → `info: zoxy listening on ...` banner appears ✅

Plus: `zig build`, `zig fmt --check`, `zig build check-config`, `zig build test` (257/260 pass, 3 skipped — kTLS tests, host lacks the `tls` ULP module; unrelated), `zig build sim -- 0 200` OK. Added config-parse, adapter, and disabled-access-log tests.

Usage: `{ "listen": "...", "logging": true, ... }`, or in a Zoxyfile just `logging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)