### PR TITLE
feat(config): make connections_max a tunable config knob

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -45,6 +45,13 @@
       "type": "boolean",
       "default": false
     },
+    "connections_max": {
+      "description": "Concurrent downstream connections reserved per worker.",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 4096,
+      "default": 256
+    },
     "tls": {
       "description": "TLS termination on the listener; null = plaintext.",
       "anyOf": [

--- a/src/config.zig
+++ b/src/config.zig
@@ -415,6 +415,11 @@ pub const Config = struct {
     /// benchmark stays silent unless it opts in. Fatal config-load errors log
     /// regardless (main only lowers to this once the config parses).
     logging: bool,
+    /// Concurrent downstream connections reserved per worker. Sizes the
+    /// per-worker connection pool (and TLS-leg pool / TLS heap when terminating)
+    /// up front — raise it to push benchmark concurrency past the default,
+    /// bounded by `constants.connections_max_ceiling`.
+    connections_max: u32,
     /// TLS termination on the listener; null = plaintext.
     tls: ?TlsConfig,
     routes: []const Route,
@@ -467,6 +472,7 @@ pub const Dto = struct {
     accept_mode: []const u8 = "reuseport",
     workers: ?u16 = null,
     logging: bool = false,
+    connections_max: u32 = constants.connections_max,
     tls: ?TlsDto = null,
     routes: []const RouteDto,
     clusters: []const ClusterDto,
@@ -505,6 +511,11 @@ pub const Dto = struct {
         },
         .logging = .{
             .desc = "Emit diagnostics and per-request access logs; off keeps workers silent.",
+        },
+        .connections_max = .{
+            .desc = "Concurrent downstream connections reserved per worker.",
+            .minimum = 1,
+            .maximum = constants.connections_max_ceiling,
         },
         .tls = .{ .desc = "TLS termination on the listener; null = plaintext." },
         .routes = .{ .desc = "Host/path routing rules, evaluated first-match-wins." },
@@ -1054,6 +1065,12 @@ pub fn parse_resolved(
             break :blk w;
         } else null,
         .logging = dto.logging,
+        .connections_max = blk: {
+            if (dto.connections_max == 0 or
+                dto.connections_max > constants.connections_max_ceiling)
+                return error.InvalidLimit;
+            break :blk dto.connections_max;
+        },
         .tls = tls,
         .routes = routes,
         .clusters = clusters,
@@ -1747,6 +1764,34 @@ test "config: logging defaults off and parses on" {
     );
     defer on.deinit();
     try std.testing.expectEqual(true, on.logging);
+}
+
+test "config: connections_max defaults, parses a raise, rejects zero and over-ceiling" {
+    var dflt = try parse(std.testing.allocator, test_config);
+    defer dflt.deinit();
+    try std.testing.expectEqual(constants.connections_max, dflt.connections_max);
+
+    var raised = try parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "connections_max": 1024,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    defer raised.deinit();
+    try std.testing.expectEqual(@as(u32, 1024), raised.connections_max);
+
+    const zero = parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "connections_max": 0,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    try std.testing.expectError(error.InvalidLimit, zero);
+
+    const over = parse(std.testing.allocator,
+        \\{ "listen": "0.0.0.0:80", "connections_max": 4097,
+        \\  "routes": [{ "cluster": "c" }],
+        \\  "clusters": [{ "name": "c", "endpoints": ["127.0.0.1:9000"] }] }
+    );
+    try std.testing.expectError(error.InvalidLimit, over);
 }
 
 test "config: lb block — maglev builds a table, knobs validated strictly" {

--- a/src/config_adapter.zig
+++ b/src/config_adapter.zig
@@ -26,6 +26,7 @@
 //!   accept_mode shared            # reuseport | shared
 //!   workers 4                     # fixed worker count; omit = one per CPU
 //!   logging                       # flag: presence enables diagnostics + access logs
+//!   connections_max 512           # downstream connections reserved per worker
 //!
 //!   tls {
 //!       certificate cert.pem
@@ -265,6 +266,8 @@ const Parser = struct {
                 try p.scalar_integer(line, &p.scalars, dto_field(Dto, "workers"));
             } else if (eq(d, "logging")) {
                 try p.scalar_flag(line, &p.scalars, dto_field(Dto, "logging"));
+            } else if (eq(d, "connections_max")) {
+                try p.scalar_integer(line, &p.scalars, dto_field(Dto, "connections_max"));
             } else if (eq(d, "tls")) {
                 try p.top_tls(line);
             } else if (eq(d, "route")) {
@@ -847,6 +850,7 @@ test "adapter: scalars, comments, and blank lines" {
         \\accept_mode shared
         \\workers 4
         \\logging
+        \\connections_max 512
         \\
         \\route -> c
         \\cluster c {
@@ -861,6 +865,7 @@ test "adapter: scalars, comments, and blank lines" {
     try testing.expectEqualStrings("shared", root.get("accept_mode").?.string);
     try testing.expectEqual(@as(i64, 4), root.get("workers").?.integer);
     try testing.expectEqual(true, root.get("logging").?.bool);
+    try testing.expectEqual(@as(i64, 512), root.get("connections_max").?.integer);
 }
 
 test "adapter: route arrow match forms" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -4,9 +4,18 @@
 
 const std = @import("std");
 
-/// Maximum concurrent downstream connections per worker. Beyond this, new
-/// connections are rejected (backpressure), never queued via allocation.
+/// Default concurrent downstream connections per worker when the config omits
+/// `connections_max`. The config knob overrides it (benchmarks tune here);
+/// beyond the effective limit, new connections are rejected (backpressure),
+/// never queued via allocation.
 pub const connections_max: u32 = 256;
+
+/// Hard ceiling the config's `connections_max` may request — the largest
+/// per-worker pool (and thus reserved memory) a benchmark can ask for. Sized
+/// at the submission-queue depth: one pending recv per connection fits the ring
+/// here, and past it the SQ-full path (io/linux.zig) just flushes more eagerly,
+/// so this bounds reservation rather than marking a correctness edge.
+pub const connections_max_ceiling: u32 = io_ring_entries;
 
 /// Per-connection read buffer. Must hold a full HTTP request head (see later
 /// `head_bytes_max`) plus a useful chunk of body.

--- a/src/main.zig
+++ b/src/main.zig
@@ -177,7 +177,7 @@ fn reserve_tls_heap(
     const parked: usize = if (clusters_with_tls > 0) constants.upstream_idle_max else 0;
     const tls_heap_bytes = constants.tls_heap_base_bytes +
         constants.tls_heap_per_connection_bytes * worker_count *
-            (constants.connections_max * hops + parked);
+            (@as(usize, cfg.connections_max) * hops + parked);
     const alignment = comptime std.mem.Alignment.fromByteUnits(zoxy.tls.Heap.block_align);
     const region = try gpa.alignedAlloc(u8, alignment, tls_heap_bytes);
     try zoxy.tls.install_memory_hook(region);
@@ -408,7 +408,7 @@ fn reserve_worker_pools(
     for (accesses) |*slot| slot.value = .{ .fd = stderr_fd, .enabled = cfg.logging };
 
     const pools = try gpa.alloc(cache_line.Padded(Pool), worker_count);
-    for (pools) |*slot| slot.value = try Pool.init(gpa, constants.connections_max);
+    for (pools) |*slot| slot.value = try Pool.init(gpa, cfg.connections_max);
 
     // TLS legs live in their own per-worker pool, sized one leg per connection
     // per TLS-speaking side — a plaintext config reserves none.
@@ -423,7 +423,7 @@ fn reserve_worker_pools(
     const leg_pools: []cache_line.Padded(TlsLegPool) = if (tls_sides > 0) pools: {
         const leg_pools = try gpa.alloc(cache_line.Padded(TlsLegPool), worker_count);
         for (leg_pools) |*slot| {
-            slot.value = try TlsLegPool.init(gpa, constants.connections_max * tls_sides);
+            slot.value = try TlsLegPool.init(gpa, cfg.connections_max * tls_sides);
         }
         break :pools leg_pools;
     } else &.{};
@@ -855,6 +855,9 @@ fn run_worker(
     server.h2_leg_pool = h2_leg_pool;
     server.drain_trigger_fd = drain_trigger_fd;
     server.listener_refs = listener_refs;
+    // Resilience's active-count invariants are bounded by the real pool size
+    // (one request/attempt per connection slot), which the config sized.
+    server.resilience.connections_max = pool.capacity;
     server.start();
 
     // Active health checks ride the same ring; arms only when configured.

--- a/src/proxy/resilience.zig
+++ b/src/proxy/resilience.zig
@@ -61,6 +61,11 @@ pub const ClusterState = struct {
 
 pub const Resilience = struct {
     clusters: [constants.clusters_max]ClusterState = @splat(.{}),
+    /// Upper bound on per-worker active counts (one request/attempt/dial per
+    /// connection slot): the pool size main reserved from `config.connections_max`.
+    /// Defaults to the compile-time default — a safe over-estimate for the
+    /// sim/tests, whose pools never exceed it.
+    connections_max: u32 = constants.connections_max,
 
     pub fn cluster_state(resilience: *Resilience, cluster_index: u32) *ClusterState {
         assert(cluster_index < constants.clusters_max); // enforced by config.parse
@@ -131,7 +136,7 @@ pub const Resilience = struct {
         const cluster = resilience.cluster_state(cluster_index);
         cluster.retries_active += 1;
         // At most one scheduled retry per request, one request per slot.
-        assert(cluster.retries_active <= constants.connections_max);
+        assert(cluster.retries_active <= resilience.connections_max);
     }
 
     pub fn retry_finish(resilience: *Resilience, cluster_index: u32) void {
@@ -144,7 +149,7 @@ pub const Resilience = struct {
         const cluster = resilience.cluster_state(cluster_index);
         cluster.requests_active += 1;
         // Bounded by the downstream connection pool: one request per slot.
-        assert(cluster.requests_active <= constants.connections_max);
+        assert(cluster.requests_active <= resilience.connections_max);
     }
 
     pub fn request_finish(resilience: *Resilience, cluster_index: u32) void {
@@ -157,7 +162,7 @@ pub const Resilience = struct {
         const endpoint = resilience.endpoint_state(cluster_index, endpoint_index);
         endpoint.in_flight += 1;
         // One attempt at a time per request, one request per connection slot.
-        assert(endpoint.in_flight <= constants.connections_max);
+        assert(endpoint.in_flight <= resilience.connections_max);
     }
 
     /// Settle an attempt and run passive outlier detection on its outcome:
@@ -232,7 +237,7 @@ pub const Resilience = struct {
     pub fn dial_start(resilience: *Resilience, cluster_index: u32) void {
         const cluster = resilience.cluster_state(cluster_index);
         cluster.pending_dials += 1;
-        assert(cluster.pending_dials <= constants.connections_max);
+        assert(cluster.pending_dials <= resilience.connections_max);
     }
 
     pub fn dial_finish(resilience: *Resilience, cluster_index: u32) void {
@@ -244,7 +249,7 @@ pub const Resilience = struct {
     pub fn connection_open(resilience: *Resilience, cluster_index: u32) void {
         const cluster = resilience.cluster_state(cluster_index);
         cluster.connections_active += 1;
-        assert(cluster.connections_active <= constants.connections_max);
+        assert(cluster.connections_active <= resilience.connections_max);
     }
 
     pub fn connection_close(resilience: *Resilience, cluster_index: u32) void {


### PR DESCRIPTION
## What

Adds a `connections_max` config option (default 256) that sizes the per-worker connection pool at startup, so benchmarks can scale downstream concurrency up without recompiling.

## Why

Per-worker connection concurrency was the fixed compile-time constant `constants.connections_max = 256`. With SO_REUSEPORT spreading connections across workers, a serious throughput benchmark can saturate a worker's 256 slots — and the only way to raise it was a recompile. This makes it a config knob, consistent with the recent `workers` and `logging` knobs.

## How

- `constants.connections_max` is now documented as the **default**; a new `constants.connections_max_ceiling` (= `io_ring_entries`, 4096) hard-caps what the config may request so reserved memory stays bounded. Values outside `[1, ceiling]` are rejected at parse with `InvalidLimit`.
- `main` sizes every per-worker connection pool, the TLS-leg pool, and the TLS heap reservation from `cfg.connections_max`.
- **Resilience assertions**: the five active-count invariants (`requests_active`, `retries_active`, `in_flight`, `pending_dials`, `connections_active` ≤ pool size) previously bounded by the compile-time constant now bound by the effective pool size, threaded via `server.resilience.connections_max = pool.capacity`. The field defaults to the compile-time constant, so the sim/tests (whose pools stay ≤ 256) are unaffected.
- Mirrored in the Zoxyfile DSL as a `connections_max N` directive and reflected into `config.schema.json`.

Nothing uses `connections_max` as a comptime array size, and the io_uring layer already handles a full submission queue by flushing and retrying — so raising it is safe; the ceiling just bounds reserved memory.

## Verification

Ran the built binary:
- `connections_max: 1024` → starts, reserves the larger pool, `info: zoxy listening ...` ✅
- `connections_max: 99999` → rejected at parse with `InvalidLimit` ✅
- omitted → defaults to 256 ✅

Plus: `zig build`, `zig fmt --check`, `zig build check-config`, `zig build test` (259/262 pass, 3 skipped kTLS — unrelated), `zig build sim -- 0 300` OK. Added config-parse (default / raise / zero / over-ceiling) and adapter tests.

Usage: `{ "listen": "...", "connections_max": 1024, ... }`, or in a Zoxyfile `connections_max 1024`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)