### PR TITLE
feat: relay-buffer pressure watermark shrinks idle timeouts before the wall

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -37,6 +37,11 @@ pub fn Server(comptime IoType: type) type {
         endpoints_next: []u64,
         counters: counters_module.Counters,
         draining: bool,
+        /// §8 watermark state for the relay-buffer pool: set once the pool
+        /// crosses its high watermark, cleared once it drains back below
+        /// the low one (hysteresis). Biases idle timeouts shorter so quiet
+        /// connections return their buffers before the wall is reached.
+        relay_pressure: bool,
         drain_deadline_completion: IoType.Completion,
 
         const Self = @This();
@@ -83,6 +88,7 @@ pub fn Server(comptime IoType: type) type {
             @memset(server.endpoints_next, 0);
             server.counters = .{};
             server.draining = false;
+            server.relay_pressure = false;
             server.drain_deadline_completion = .{};
         }
 
@@ -250,6 +256,7 @@ pub fn Server(comptime IoType: type) type {
                 return;
             };
             server.counters.increment("admitted");
+            server.updateRelayPressure();
             conn.prepare(server, client_socket, buffer);
             server.io.setNodelay(client_socket) catch {
                 server.counters.increment("kernel_pressure_errors");
@@ -300,7 +307,7 @@ pub fn Server(comptime IoType: type) type {
                 server.counters.increment("kernel_pressure_errors");
             };
             conn.state = .relaying;
-            server.storeDeadline(conn, server.config.idle_timeout_ms);
+            server.storeDeadline(conn, server.idleTimeoutMs());
             relay.Relay(IoType).start(server, conn);
         }
 
@@ -379,9 +386,40 @@ pub fn Server(comptime IoType: type) type {
             if (conn.state != .closing) return;
             if (conn.armedCount() != 0) return;
             server.relay_buffers.release(conn.relay_buffer);
+            server.updateRelayPressure();
             server.conns.release(conn);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
+        }
+
+        /// §8 watermarks before walls: recompute the relay-buffer pressure
+        /// flag with hysteresis after every acquire/release. The engage
+        /// crossing is witnessed; the wall (admit-time shed) still backs it
+        /// up if pressure fails to relieve the load in time.
+        fn updateRelayPressure(server: *Self) void {
+            const held = server.relay_buffers.acquired_count;
+            const capacity: u32 = @intCast(server.relay_buffers.slots.len);
+            if (server.relay_pressure) {
+                if (held <= constants.relayPressureOff(capacity)) {
+                    server.relay_pressure = false;
+                }
+            } else if (held >= constants.relayPressureOn(capacity)) {
+                server.relay_pressure = true;
+                server.counters.increment("relay_pressure_engaged");
+            }
+        }
+
+        /// The idle timeout to apply now, shortened under relay-buffer
+        /// pressure so quiet connections return their buffers sooner (§8).
+        /// Only the idle deadline is biased — the connect deadline is a
+        /// correctness bound and stays fixed. Because a timer never moves
+        /// *earlier* once armed (§4), this reaches a connection at its next
+        /// deadline store (activity or half-close), not retroactively; the
+        /// admit-time wall covers connections that never transact again.
+        pub fn idleTimeoutMs(server: *const Self) u32 {
+            const configured = server.config.idle_timeout_ms;
+            if (!server.relay_pressure) return configured;
+            return @max(configured / constants.relay_pressure_idle_divisor, 1);
         }
 
         /// Public for the relay: activity pushes the idle deadline out;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -23,6 +23,28 @@ pub const relay_buffers_max: u32 = 1024;
 /// Bytes per relay direction; a `RelayBuffer` is a pair of these.
 pub const relay_buffer_bytes: u32 = 16 * 1024;
 
+/// §8 "watermarks before walls": the relay-buffer pool flips a pressure
+/// flag before it hits the wall so the proxy sheds *idle* capacity —
+/// shorter idle timeouts — before it must shed *work*. Hysteresis keeps
+/// the flag from flapping around a single threshold: engage at the high
+/// watermark, release only after draining back to the low one. Both are
+/// fractions of the *live* pool capacity, so an injected test pool and the
+/// production pool obey one rule. `On` uses ceil so a full pool always
+/// counts as pressured; `Off` uses floor so the gap is non-empty for every
+/// capacity >= 1.
+pub fn relayPressureOn(capacity: u32) u32 {
+    return (capacity * 3 + 3) / 4;
+}
+pub fn relayPressureOff(capacity: u32) u32 {
+    return capacity / 2;
+}
+
+/// Under relay-buffer pressure the idle timeout is divided by this, reaping
+/// quiet connections sooner to return their buffers (§8). The result is
+/// clamped to >= 1 ms so `storeDeadline`'s invariant holds even when the
+/// configured idle timeout is already small.
+pub const relay_pressure_idle_divisor: u32 = 4;
+
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
 
@@ -95,6 +117,11 @@ comptime {
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);
     assert(accept_retry_delay_ms >= 1);
+    assert(relay_pressure_idle_divisor >= 2);
+    // The watermarks must leave a hysteresis gap and never engage above
+    // the pool's own capacity, checked at the production size.
+    assert(relayPressureOn(relay_buffers_max) > relayPressureOff(relay_buffers_max));
+    assert(relayPressureOn(relay_buffers_max) <= relay_buffers_max);
 }
 
 /// Total pool memory as a closed-form function of the limits. Slot sizes
@@ -115,6 +142,19 @@ test "budgets: in-flight ops fit the completion queue with headroom" {
     // Headroom is deliberate: at least a quarter of the CQ stays free for
     // completion bursts even at the worst-case armed-op count.
     try std.testing.expect(in_flight_ops_max <= completion_queue_entries * 3 / 4);
+}
+
+test "pressure: relay watermarks have a hysteresis gap at every capacity" {
+    // On > Off (a non-empty gap) and On <= capacity for the small pools
+    // tests inject as well as the production size — no flapping, never a
+    // threshold the pool cannot reach.
+    for ([_]u32{ 1, 2, 3, 4, 8, relay_buffers_max }) |capacity| {
+        try std.testing.expect(relayPressureOn(capacity) > relayPressureOff(capacity));
+        try std.testing.expect(relayPressureOn(capacity) <= capacity);
+    }
+    // A full pool is always pressured; an empty pool never is.
+    try std.testing.expectEqual(@as(u32, 3), relayPressureOn(4));
+    try std.testing.expectEqual(@as(u32, 2), relayPressureOff(4));
 }
 
 test "budgets: memory total matches the closed form" {

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -19,6 +19,10 @@ pub const Counters = struct {
     shed_conn_slots: Value = Value.init(0),
     /// §8 rung: relay buffers exhausted at admission → close.
     shed_relay_buffers: Value = Value.init(0),
+    /// §8 "watermarks before walls": relay-buffer pressure engaged
+    /// (false→true crossings of the high watermark). Not a shed — a bias
+    /// that precedes the wall — so it stays out of `reconcile`.
+    relay_pressure_engaged: Value = Value.init(0),
     /// §8 rung: request/idle deadline fired → teardown.
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -102,7 +102,7 @@ pub fn Relay(comptime IoType: type) type {
                     // direction relaying under the deadline.
                     state.phase = .finished;
                     server.io.shutdown(targetSocket(conn, direction), .write);
-                    server.storeDeadline(conn, server.config.idle_timeout_ms);
+                    server.storeDeadline(conn, server.idleTimeoutMs());
                     maybeFinish(server, conn);
                     return;
                 }
@@ -142,7 +142,7 @@ pub fn Relay(comptime IoType: type) type {
             } else {
                 // A full exchange moved: this is activity — push the idle
                 // deadline out (§6); the armed timer op is not touched.
-                server.storeDeadline(conn, server.config.idle_timeout_ms);
+                server.storeDeadline(conn, server.idleTimeoutMs());
                 armRecv(server, conn, direction);
             }
         }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -448,6 +448,52 @@ test "server: relay-buffer exhaustion sheds with a quiet close" {
     try bed.expectDrained();
 }
 
+test "server: relay-buffer pressure engages before the wall and drains clean" {
+    // Four connections hold all four relay buffers at once (their upstream
+    // dials are black-holed, so each keeps its buffer until the connect
+    // deadline reaps it). Crossing the 3/4 high watermark flips the
+    // pressure flag exactly once; the flag clears again as the pool drains,
+    // and every counter still reconciles with the pools empty.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .server = .{ .conn_slots = 4, .relay_buffers = 4 },
+        .sim = .{ .seed = 71 },
+    });
+    defer bed.tearDown();
+
+    bed.sim_io.blackholeAddress(TestBed.originAddress());
+    bed.startClients(4, false);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 4), bed.server.counters.get("admitted"));
+    try std.testing.expect(bed.server.counters.get("relay_pressure_engaged") >= 1);
+    // Pressure is a transient bias, not a terminal state: it clears as the
+    // pool drains back below the low watermark.
+    try std.testing.expect(!bed.server.relay_pressure);
+    try std.testing.expectEqual(@as(u64, 4), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "server: idle timeout shortens under pressure, is full otherwise" {
+    // The pure selection rule the pressure flag drives: full timeout when
+    // relaxed, divided (floored at 1 ms) when pressured.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 72 },
+        .idle_timeout_ms = 1000,
+    });
+    defer bed.tearDown();
+
+    try std.testing.expect(!bed.server.relay_pressure);
+    try std.testing.expectEqual(@as(u32, 1000), bed.server.idleTimeoutMs());
+    bed.server.relay_pressure = true;
+    try std.testing.expectEqual(
+        @as(u32, 1000 / 4),
+        bed.server.idleTimeoutMs(),
+    );
+    bed.server.relay_pressure = false;
+}
+
 test "server: refused upstream tears the connection down and is counted" {
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{


### PR DESCRIPTION
## What

Implements the Phase-0 slice of §8 **"watermarks before walls"**: the relay-buffer pool flips a **pressure flag** before it hits the exhaustion wall, so the proxy sheds *idle* capacity (shorter idle timeouts) before it must shed *admitted work*.

## How

- **`constants`** — `relayPressureOn/Off(capacity)` high/low watermarks as fractions of the **live** pool capacity, so an injected test pool and the production pool share one rule. Comptime-asserted: the hysteresis gap is non-empty and `On` never exceeds capacity. `relay_pressure_idle_divisor` sets how hard the timeout is cut.
- **`Server`** — a `relay_pressure` flag recomputed with hysteresis after every relay-buffer acquire (`admit`) and release (`maybeRelease`). `idleTimeoutMs()` returns the configured idle timeout, divided (floored at 1 ms) while pressured. The **connect** deadline is a correctness bound and is *not* biased.
- **`relay`** — the two idle-deadline stores (half-close, full-exchange) route through `idleTimeoutMs()`, so activity under pressure re-arms nearer.
- **`counters`** — `relay_pressure_engaged` witnesses each false→true crossing. It's a bias, not a shed, so it stays **out of `reconcile()`**.

## Known limitation (documented in code)

Because an armed timer never moves *earlier* once set (§4), the shorter timeout reaches a connection at its **next** deadline store (activity / half-close), not retroactively. The admit-time wall still covers connections that never transact again. A pressure-triggered **sweep** of already-idle connections, plus conn-slot / keep-alive pressure, are deferred to Phase 1.

## Tests

- `zig build ci` green: **49 tests + lint + 64-seed sim sweep**.
- New: watermark hysteresis is a pure-function test; a 4-connection scenario witnesses pressure engaging before the wall and clearing as the pool drains; the idle-timeout selection rule is asserted both relaxed and pressured.
- `reconcile()` holds under every seed with the new counter present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)