### PR TITLE
feat: set SO_REUSEPORT on listen sockets for process-per-port scale-out

### DIFF
--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -135,6 +135,26 @@ pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
         return error.AddressUnavailable;
     }
     const tcp = xev.TCP.init(address) catch return error.Unexpected;
+    // SO_REUSEPORT before bind is what makes horizontal scale-out real
+    // (§1, §3): N independent zoxy processes bind the same port and the
+    // kernel load-balances new connections across them, with share-nothing
+    // isolation at the process boundary. The intra-process accept imbalance
+    // that made SO_REUSEPORT a liability in the previous iteration (§2)
+    // cannot arise here — each process still has exactly one accepting loop,
+    // so the kernel balances between processes, never between contending
+    // loops. Must precede bind; libxev sets SO_REUSEADDR inside bind, so the
+    // two options compose. On the io_uring kernels zoxy targets REUSEPORT is
+    // always available, so a failure here is genuinely unexpected.
+    const reuse: i32 = 1;
+    posix.setsockopt(
+        tcp.fd,
+        posix.SOL.SOCKET,
+        posix.SO.REUSEPORT,
+        std.mem.asBytes(&reuse),
+    ) catch {
+        closeFd(tcp.fd);
+        return error.Unexpected;
+    };
     tcp.bind(address) catch |err| {
         closeFd(tcp.fd);
         // Distinct failures get distinct diagnoses: "address in use" sends

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -263,3 +263,31 @@ test "xevio: bind failures are diagnosed distinctly, not all AddressInUse" {
     const unavailable = std.Io.net.IpAddress.parseLiteral("203.0.113.1:0") catch unreachable;
     try std.testing.expectError(error.AddressUnavailable, xev_io.listen(unavailable));
 }
+
+test "xevio: SO_REUSEPORT lets two listeners share one port" {
+    // Process-per-port scale-out (§1, §3): several zoxy instances bind the
+    // same port and the kernel load-balances across them. Proven in-process
+    // by binding two listeners to one concrete port — without SO_REUSEPORT
+    // the second bind fails EADDRINUSE. SO_REUSEADDR alone (which libxev
+    // sets inside bind) does not permit two live listeners on one port, so
+    // this test fails if the REUSEPORT option is dropped.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var xev_io: XevIo = undefined;
+    try xev_io.init(arena_state.allocator());
+    defer xev_io.deinit();
+
+    // First listener takes an ephemeral port; read the concrete port back.
+    const first = try xev_io.listen(
+        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+    );
+    const port = xev_io.listenerAddress(first).getPort();
+    try std.testing.expect(port != 0);
+
+    // A second listener on the very same port must also succeed.
+    var shared = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable;
+    shared.setPort(port);
+    const second = try xev_io.listen(shared);
+    try std.testing.expectEqual(port, xev_io.listenerAddress(second).getPort());
+}


### PR DESCRIPTION
## What

Sets `SO_REUSEPORT` on the listen fd (before bind) so **N independent zoxy processes can bind the same port** and the kernel load-balances new connections across them.

## Why

Horizontal scaling in zoxy is *"N independent processes behind SO_REUSEPORT — share-nothing at the process boundary, not N loops in one process"* (§1, §3, §NUMA). But the option was never set, so a second instance on the same port failed `EADDRINUSE`. This closes that gap — process-per-port scale-out and restart-as-reload now work.

## Not the old footgun

The previous iteration recorded SO_REUSEPORT as a liability because of **intra-process** accept imbalance across contending loops (§2). That can't arise here: each process still has exactly **one** accepting loop, so the kernel balances *between processes*, never between loops in one process — the design's whole point.

## Details

- Set before `bind` (REUSEPORT must precede bind). libxev already sets `SO_REUSEADDR` inside `bind`; the two compose.
- On the io_uring kernels zoxy targets, REUSEPORT is always available, so a `setsockopt` failure is treated as `Unexpected` (fd closed, error returned) — consistent with the rest of the listen path.
- SimIo is virtual (no real ports), so this is an XevIo-only change; the `Io` seam is unchanged.

## Test

New `xevio:` contract test binds **two real listeners to one concrete port** and asserts both succeed. Without SO_REUSEPORT the second bind returns `AddressInUse` (SO_REUSEADDR alone does not permit two live listeners on one port), so the test fails if the option is ever dropped.

`zig build ci` green: 48 tests (incl. real-loopback XevIo binds) + lint + 64-seed sim sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)