### PR TITLE
feat: cap connection age with a max-lifetime deadline

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -8,6 +8,7 @@
     "timeouts": {
         "connect_ms": 5000,
         "idle_ms": 60000,
-        "drain_deadline_ms": 10000
+        "drain_deadline_ms": 10000,
+        "max_lifetime_ms": 0
     }
 }

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -148,6 +148,14 @@ const Harness = struct {
             .connect_timeout_ms = 20 + random.uintAtMost(u32, 40),
             .idle_timeout_ms = 30 + random.uintAtMost(u32, 70),
             .drain_deadline_ms = 100,
+            // A third of seeds arm the max-lifetime cap (§6). The range
+            // straddles the idle timeout so the clamp sometimes reaps an
+            // actively-relaying connection and sometimes never bites —
+            // both paths under the adversary. 0 leaves it disabled.
+            .max_lifetime_ms = if (random.uintLessThan(u8, 3) == 0)
+                10 + random.uintAtMost(u32, 90)
+            else
+                0,
         };
 
         // A quarter of seeds shrink the pools to force the §8 rungs.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -426,7 +426,20 @@ pub fn Server(comptime IoType: type) type {
         /// only the stored value moves, never the armed timer op (§4).
         pub fn storeDeadline(server: *Self, conn: *ConnType, timeout_ms: u32) void {
             assert(timeout_ms >= 1);
-            conn.deadline_ns = server.io.nowNs() + @as(u64, timeout_ms) * std.time.ns_per_ms;
+            var deadline_ns = server.io.nowNs() + @as(u64, timeout_ms) * std.time.ns_per_ms;
+            // Max-lifetime rides the same deadline (§6): clamp the
+            // activity-driven value to the absolute age cap so a
+            // continuously busy connection is still reaped. 0 disables it.
+            // The clamp only ever moves the deadline *earlier*, which the
+            // lazy re-arm in onDeadline handles for free — deadline_ns stays
+            // <= cap, so every arm targets <= cap and the connection dies at
+            // the cap even though the armed timer never moves earlier (§4).
+            if (server.config.max_lifetime_ms != 0) {
+                const cap_ns = conn.birth_ns +
+                    @as(u64, server.config.max_lifetime_ms) * std.time.ns_per_ms;
+                deadline_ns = @min(deadline_ns, cap_ns);
+            }
+            conn.deadline_ns = deadline_ns;
         }
 
         fn armDeadline(server: *Self, conn: *ConnType) void {

--- a/src/config.zig
+++ b/src/config.zig
@@ -20,6 +20,13 @@ pub const Config = struct {
     connect_timeout_ms: u32,
     idle_timeout_ms: u32,
     drain_deadline_ms: u32,
+    /// Absolute cap on a connection's age, regardless of activity (§6): it
+    /// rides the same per-connection deadline timer as the idle timeout,
+    /// clamping the activity-refreshed deadline so a continuously busy
+    /// connection is still reaped. `0` disables the cap — the one timeout
+    /// where zero is legal (an unbounded connection age), so it is optional
+    /// in the JSON and defaults off.
+    max_lifetime_ms: u32,
 
     pub const Listener = struct {
         bind_address: std.Io.net.IpAddress,
@@ -74,6 +81,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .connect_timeout_ms = parsed.timeouts.connect_ms,
         .idle_timeout_ms = parsed.timeouts.idle_ms,
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
+        .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
     };
 }
 
@@ -96,6 +104,9 @@ const TimeoutsJson = struct {
     connect_ms: u32,
     idle_ms: u32,
     drain_deadline_ms: u32,
+    /// Optional: absent or `0` means "no cap" (§6). The default keeps every
+    /// pre-existing config valid and leaves max-lifetime opt-in.
+    max_lifetime_ms: u32 = 0,
 };
 
 /// JSON object map of cluster name → cluster, parsed into a bounded array
@@ -250,14 +261,21 @@ fn clusterIndexOf(
 }
 
 fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
-    const values = [_]u32{ timeouts.connect_ms, timeouts.idle_ms, timeouts.drain_deadline_ms };
-    for (values) |value| {
+    // The three lifecycle timeouts are correctness bounds — a 0 ms connect,
+    // idle, or drain deadline would reap instantly, so zero is a mistake.
+    const required = [_]u32{ timeouts.connect_ms, timeouts.idle_ms, timeouts.drain_deadline_ms };
+    for (required) |value| {
         if (value == 0) {
             return error.TimeoutZero;
         }
         if (value > constants.timeout_ms_max) {
             return error.TimeoutOverLimit;
         }
+    }
+    // max_lifetime_ms is the one optional bound (§6): 0 means "no cap", so
+    // only the shared ceiling is enforced — zero stays legal.
+    if (timeouts.max_lifetime_ms > constants.timeout_ms_max) {
+        return error.TimeoutOverLimit;
     }
 }
 
@@ -277,6 +295,53 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(@as(u32, 5000), parsed.connect_timeout_ms);
     try std.testing.expectEqual(@as(u32, 60000), parsed.idle_timeout_ms);
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+}
+
+test "config: max_lifetime_ms is optional and defaults to disabled" {
+    // The field is absent here — pre-existing configs stay valid and the
+    // cap defaults off (§6).
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+}
+
+test "config: max_lifetime_ms accepts zero (the one legal zero timeout) and real values" {
+    // Explicit 0 is legal — it is *not* a TimeoutZero, unlike the other
+    // three timeouts (§6).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,"max_lifetime_ms":0}}
+        );
+        try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+    }
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,"max_lifetime_ms":1800000}}
+        );
+        try std.testing.expectEqual(@as(u32, 1_800_000), parsed.max_lifetime_ms);
+    }
+}
+
+test "config: max_lifetime_ms still obeys the shared ceiling" {
+    try expectParseError(error.TimeoutOverLimit,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,"max_lifetime_ms":3600001}}
+    );
 }
 
 fn expectParseError(expected: ParseError, json_bytes: []const u8) !void {

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -29,6 +29,10 @@ pub fn Conn(comptime IoType: type) type {
         /// Absolute deadline; state transitions only store a new value —
         /// the armed timer op is never touched (§4).
         deadline_ns: u64,
+        /// Admission timestamp. The max-lifetime cap is `birth_ns +
+        /// max_lifetime_ms`; `storeDeadline` clamps every deadline to it so
+        /// an always-active connection is still reaped (§6).
+        birth_ns: u64,
         armed: Armed,
         directions: [2]DirectionState,
 
@@ -109,6 +113,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.upstream_socket = null;
             conn.relay_buffer = buffer;
             conn.deadline_ns = 0;
+            conn.birth_ns = server.io.nowNs();
             conn.armed = .{};
             conn.directions = .{ .{}, .{} };
             conn.op_data_client_to_upstream = .{};

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -199,6 +199,7 @@ pub const TestBed = struct {
         sim: SimIo.Options,
         origin_listens: bool = true,
         idle_timeout_ms: u32 = 1000,
+        max_lifetime_ms: u32 = 0,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -224,6 +225,7 @@ pub const TestBed = struct {
             .connect_timeout_ms = 50,
             .idle_timeout_ms = options.idle_timeout_ms,
             .drain_deadline_ms = 1000,
+            .max_lifetime_ms = options.max_lifetime_ms,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, options.server);
         try bed.server.start();
@@ -304,6 +306,37 @@ test "relay: idle timeout reaps a silent connection" {
     try std.testing.expectEqual(@as(u8, 1), bed.scenario.outcomeCount(.eof));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "relay: the max-lifetime cap reaps a connection before its idle timeout" {
+    // The idle timeout is set far in the future (10 s) so it cannot be the
+    // reaper; only the 40 ms lifetime cap (§6) can end the connection. The
+    // discriminator is the virtual clock: if the cap fired, the run ends
+    // near 40 ms, nowhere near the idle deadline.
+    const idle_ms: u32 = 10_000;
+    const lifetime_ms: u32 = 40;
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 41, .adversary = .{ .partial_io = false } },
+        .idle_timeout_ms = idle_ms,
+        .max_lifetime_ms = lifetime_ms,
+    });
+    defer bed.tearDown();
+
+    const start_ns = bed.sim_io.nowNs();
+    bed.startClients(1, false);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u8, 1), bed.scenario.outcomeCount(.eof));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+
+    // Reaped at the cap, not the idle deadline: at least the cap elapsed
+    // (never early), and far short of the idle timeout.
+    const elapsed_ns = bed.sim_io.nowNs() - start_ns;
+    try std.testing.expect(elapsed_ns >= @as(u64, lifetime_ms) * std.time.ns_per_ms);
+    try std.testing.expect(elapsed_ns < @as(u64, idle_ms) * std.time.ns_per_ms);
     try bed.expectDrained();
 }
 


### PR DESCRIPTION
## What

Completes the last spec gap in **Phase 0 (L4)**. DESIGN.md §6 lists max-lifetime in Phase 0's deliverable — *"idle timeout and max-lifetime ride the single deadline timer"* — but only the idle timeout existed. A continuously-active L4 tunnel refreshes its idle deadline on every exchange, so it could live forever; only *quiet* connections were ever reaped.

This adds an absolute connection-age cap that rides the **same** per-connection deadline timer.

## How

- `Conn.birth_ns` is stamped at admission (`prepare`).
- `Server.storeDeadline` clamps every computed deadline to `birth_ns + max_lifetime_ms`.
- The clamp only ever moves the deadline **earlier** and keeps `deadline_ns <= cap`, so the existing lazy re-arm in `onDeadline` reaps at the cap with **no new op** — and the §4 *"a timer never moves earlier once armed"* hazard is sidestepped because every re-arm already targets `<= cap`.

## Config

`max_lifetime_ms` is the **one timeout where `0` is legal** (`0` = no cap) and is **optional** in the JSON (defaults to `0`):

- every pre-existing config stays valid; the cap is opt-in;
- `validateTimeouts` keeps the zero-check for the three required timeouts and enforces only the shared ceiling on the cap.

The benchmark harness is deliberately unaffected — it omits the field → cap disabled → k6's long-lived VU tunnels are never reaped mid-run.

## Tests

- **config**: optional/default-0, explicit-0 legal, non-zero parsed, over-limit rejected.
- **behavioral (SimIo)**: a silent connection with a far-future idle timeout (10 s) and a 40 ms cap is reaped by the cap — proven via the virtual clock (run ends near 40 ms, nowhere near idle).
- **simulator**: the cap is armed on a third of seeds with a range straddling the idle timeout, so the clamp is exercised mid-relay under the adversary across the whole sweep.

## Gates

`zig fmt --check` ✓ · `zig build ci` ✓ (55 tests, fd-boundary lint, 64 sim seeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)