### PR TITLE
feat: witness kernel pressure on the relay data path

### DIFF
--- a/sim/main.zig
+++ b/sim/main.zig
@@ -136,6 +136,7 @@ const Harness = struct {
             .connect_delay_ns_max = random.uintAtMost(u64, 5_000_000),
             .connect_refuse_percent = random.uintAtMost(u8, 20),
             .reset_percent = random.uintAtMost(u8, 10),
+            .kernel_pressure_percent = random.uintAtMost(u8, 8),
         };
         try harness.io.init(arena, .{ .seed = seed, .adversary = adversary });
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -27,7 +27,9 @@ pub const Counters = struct {
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).
     upstream_connect_failed: Value = Value.init(0),
-    /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op.
+    /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
+    /// across every completion (accept, connect, setNodelay, and the relay
+    /// recv/send data path).
     kernel_pressure_errors: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -65,6 +65,10 @@ pub const Adversary = struct {
     connect_blackhole_percent: u8 = 0,
     /// Chance per batch to reset one random live connection.
     reset_percent: u8 = 0,
+    /// Chance per batch to fail one random live socket's next data op with
+    /// `error.Unexpected` (ENOBUFS/ENOMEM-class, §8) — local to that
+    /// socket, so the relay witnesses it and tears the connection down.
+    kernel_pressure_percent: u8 = 0,
     batch_max: u32 = constants.loop_completions_per_tick_max,
 };
 
@@ -171,6 +175,11 @@ const SocketEntry = struct {
     read_shutdown: bool,
     write_shutdown: bool,
     reset: bool,
+    /// One-shot: the next recv/send on this socket fails with
+    /// `error.Unexpected`, modeling a transient ENOBUFS/ENOMEM op failure
+    /// (§8 "any completion" kernel-pressure rung). Local to this socket —
+    /// the peer is untouched, unlike `reset`.
+    kernel_pressure: bool,
     linger_rst: bool,
     nodelay: bool,
     inbox: Ring,
@@ -235,6 +244,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     assert(@as(u16, options.adversary.connect_refuse_percent) +
         options.adversary.connect_blackhole_percent <= 100);
     assert(options.adversary.reset_percent <= 100);
+    assert(options.adversary.kernel_pressure_percent <= 100);
     assert(options.adversary.batch_max >= 1);
 
     io.listeners = try arena.alloc(ListenerEntry, listeners_max);
@@ -622,6 +632,7 @@ pub fn run(io: *SimIo) Io.RunError!void {
         }
         io.deliverBatch(ready);
         io.maybeInjectReset();
+        io.maybeInjectKernelPressure();
     }
     // The loop was stopped (a completed drain). A raced accept whose CQE
     // beat the listener close but was never delivered before stop() is an
@@ -705,12 +716,14 @@ fn opReady(io: *SimIo, completion: *Completion) bool {
         .connect => |op| op.canceled or io.now_ns_value >= completion.ready_at_ns,
         .recv => |op| ready: {
             const entry = io.socketEntry(op.socket);
-            break :ready entry.reset or entry.inbox.count > 0 or
+            break :ready entry.kernel_pressure or entry.reset or entry.inbox.count > 0 or
                 entry.read_shutdown or entry.fin_received;
         },
         .send => |op| ready: {
             const entry = io.socketEntry(op.socket);
-            if (entry.reset or entry.write_shutdown or entry.peer == peer_none) {
+            if (entry.kernel_pressure or entry.reset or
+                entry.write_shutdown or entry.peer == peer_none)
+            {
                 break :ready true;
             }
             break :ready io.peerEntry(entry).inbox.freeSpace() > 0;
@@ -820,6 +833,11 @@ fn finishConnect(
 
 fn finishRecv(io: *SimIo, socket: Socket, buffer: []u8) Io.RecvError!u32 {
     const entry = io.socketEntry(socket);
+    if (entry.kernel_pressure) {
+        // Transient op failure: consume the flag, leave the socket usable.
+        entry.kernel_pressure = false;
+        return error.Unexpected;
+    }
     if (entry.reset) {
         return error.Reset;
     }
@@ -837,6 +855,11 @@ fn finishRecv(io: *SimIo, socket: Socket, buffer: []u8) Io.RecvError!u32 {
 
 fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
     const entry = io.socketEntry(socket);
+    if (entry.kernel_pressure) {
+        // Transient op failure: consume the flag, leave the socket usable.
+        entry.kernel_pressure = false;
+        return error.Unexpected;
+    }
     if (entry.reset) {
         return error.Reset;
     }
@@ -913,6 +936,29 @@ fn maybeInjectReset(io: *SimIo) void {
     }
 }
 
+/// §8 kernel-pressure rung on the data path: flag one random live
+/// socket's next recv/send to fail with `error.Unexpected` (ENOBUFS/
+/// ENOMEM-class). Unlike a reset it is local and one-shot — only the
+/// picked socket's next op fails, the peer is untouched — so the relay
+/// witnesses it and tears the connection down.
+fn maybeInjectKernelPressure(io: *SimIo) void {
+    if (io.adversary.kernel_pressure_percent == 0) return;
+    const random = io.prng.random();
+    if (random.uintLessThan(u8, 100) >= io.adversary.kernel_pressure_percent) return;
+    if (io.sockets.acquired_count == 0) return;
+
+    var probe: u8 = 0;
+    while (probe < 8) : (probe += 1) {
+        const index = random.uintLessThan(u16, sockets_max);
+        const entry = &io.sockets.slots[index];
+        if (io.sockets.isAcquired(entry) and entry.peer != peer_none) {
+            entry.kernel_pressure = true;
+            io.mix(@as(u64, index) +% 0x454e4f42); // "ENOB"
+            return;
+        }
+    }
+}
+
 fn partialLen(io: *SimIo, available: u32) u32 {
     assert(available >= 1);
     if (!io.adversary.partial_io) return available;
@@ -971,6 +1017,7 @@ fn initSocketEntry(entry: *SocketEntry) void {
     entry.read_shutdown = false;
     entry.write_shutdown = false;
     entry.reset = false;
+    entry.kernel_pressure = false;
     entry.linger_rst = false;
     entry.nodelay = false;
     entry.inbox.head = 0;

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -106,6 +106,7 @@ pub fn Relay(comptime IoType: type) type {
                     maybeFinish(server, conn);
                     return;
                 }
+                witnessKernelPressure(server, err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -130,7 +131,8 @@ pub fn Relay(comptime IoType: type) type {
             assert(conn.state == .relaying);
             const state = directionState(conn, direction);
             assert(state.phase == .sending);
-            const sent = result catch {
+            const sent = result catch |err| {
+                witnessKernelPressure(server, err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -144,6 +146,20 @@ pub fn Relay(comptime IoType: type) type {
                 // deadline out (§6); the armed timer op is not touched.
                 server.storeDeadline(conn, server.idleTimeoutMs());
                 armRecv(server, conn, direction);
+            }
+        }
+
+        /// §8 kernel-pressure rung on the data path. On an established
+        /// relay socket the orderly failures are EndOfStream (peeled off by
+        /// the caller) and Reset — a normal RST. Anything else is a
+        /// non-orderly op failure, which on a live socket is resource
+        /// exhaustion (ENOBUFS/ENOMEM), so witness it before the teardown,
+        /// matching how the accept/connect/setNodelay sites count kernel
+        /// pressure. The teardown itself is unchanged. (`Canceled` never
+        /// reaches the relay: data ops are never canceled, §5.)
+        fn witnessKernelPressure(server: *ServerType, err: anyerror) void {
+            if (err == error.Unexpected) {
+                server.counters.increment("kernel_pressure_errors");
             }
         }
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -324,6 +324,32 @@ test "relay: an origin reset mid-exchange tears the connection down" {
     try bed.expectDrained();
 }
 
+test "relay: a kernel-pressure data-op failure is witnessed and tears down" {
+    // ENOBUFS/ENOMEM on a relay recv/send surfaces as error.Unexpected;
+    // the relay counts it (§8 "any completion" rung) and tears the
+    // connection down. The injection is certain every batch, so at least
+    // one relay data op takes the hit before the exchange completes.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{
+            .seed = 2,
+            .adversary = .{ .partial_io = true, .kernel_pressure_percent = 100 },
+        },
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, true);
+    try bed.sim_io.run();
+
+    // Witnessed on the data path, and the connection still tore down
+    // cleanly — a kernel-pressure teardown is an ordinary teardown that
+    // reconciles (it is a failure, not a shed).
+    try std.testing.expect(bed.server.counters.get("kernel_pressure_errors") >= 1);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("shed_relay_buffers"));
+    try bed.expectDrained();
+}
+
 test "server: kernel-pressure accept failure backs off and recovers" {
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 51 } });


### PR DESCRIPTION
## What

Closes the last minor gap from the Phase 0 §8 audit. The exhaustion ladder is supposed to count ENOBUFS/ENOMEM-class failures on **any completion**, but `kernel_pressure_errors` was only incremented at the **accept**, **connect**, and **setNodelay** sites. On the relay data path such a failure was torn down correctly but **silently** — counted as a plain teardown, so the ladder was blind there.

## Why categorical, not precise

libxev collapses ENOBUFS/ENOMEM into `error.Unexpected` (`posix.unexpectedErrno`) **before XevIo sees it** — for both recv (`readResult`) and send. The specific errno is gone, so a precise "only true ENOBUFS" counter would require a **libxev fork change + re-audit**, which is out of scope for this minor fix.

Instead this matches how the existing sites already categorize kernel pressure: on an *established* relay socket the orderly failures are `EndOfStream` (FIN) and `Reset` (RST); **any other failure — `error.Unexpected` — is non-orderly resource pressure**, so the relay witnesses it before tearing down. The teardown itself is unchanged.

Trade-off, stated plainly: this counts the data-path `Unexpected` bucket, which in practice is ENOBUFS/ENOMEM on a live socket (bug-class errno are asserted unreachable elsewhere). A precise version is a future libxev-fork slice if that distinction ever matters.

## How

- **`relay.zig`**: `onRecv`/`onSend` call a small `witnessKernelPressure` helper that increments `kernel_pressure_errors` on `error.Unexpected` before `beginTeardown`. `Reset`/`Canceled` stay uncounted (`Canceled` never reaches the relay — data ops aren't canceled, §5).
- **`counters.zig`**: doc note that the counter now spans the data path.
- **`SimIo`**: a one-shot, **local** `kernel_pressure` fault on `SocketEntry` + a `kernel_pressure_percent` adversary knob. It flags a random live socket's next recv/send to fail with `error.Unexpected` (peer untouched, unlike `reset`), wired into op-readiness and `finishRecv`/`finishSend`.

## Tests

- **directed** (`server_test.zig`, pinned seed, injection certain every batch): the counter fires and the connection still **reconciles + drains** — a kernel-pressure teardown is a failure, not a shed.
- **simulator sweep** (`sim/main.zig`): the knob is armed at 0–8% per seed, so the new path is exercised under the adversary across all 64 seeds with the reconcile/leak invariants holding.

## Gates

`zig fmt --check` ✓ · `zig build ci` ✓ (52 tests, fd-boundary lint, 64 sim seeds)

Independent of #34 (max-lifetime); both branch off `main` and touch disjoint code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)