### PR TITLE
refactor: extract the round-robin endpoint pick into a load-balancing policy

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 
+const Balancer = @import("balancer.zig").Balancer;
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
 const counters_module = @import("counters.zig");
@@ -30,11 +31,10 @@ pub fn Server(comptime IoType: type) type {
         relay_buffers: Pool(relay.RelayBuffer),
         listeners: []ListenerState,
         listeners_count: u16,
-        /// Per-cluster round-robin cursor. u64 so it never wraps in any
-        /// realistic process lifetime — a u16 wrap reset the rotation
-        /// phase and double-picked one endpoint for non-power-of-two
-        /// cluster sizes.
-        endpoints_next: []u64,
+        /// The load-balancing policy: resolves a cluster to the endpoint to
+        /// dial. Owns its own per-cluster state so the serving path never
+        /// hardcodes how an endpoint is chosen (§7).
+        balancer: Balancer,
         counters: counters_module.Counters,
         draining: bool,
         /// §8 watermark state for the relay-buffer pool: set once the pool
@@ -84,8 +84,7 @@ pub fn Server(comptime IoType: type) type {
             try server.relay_buffers.init(arena, options.relay_buffers);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
             server.listeners_count = @intCast(config.listeners.len);
-            server.endpoints_next = try arena.alloc(u64, config.clusters.len);
-            @memset(server.endpoints_next, 0);
+            try server.balancer.init(arena, config);
             server.counters = .{};
             server.draining = false;
             server.relay_pressure = false;
@@ -268,14 +267,9 @@ pub fn Server(comptime IoType: type) type {
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
             assert(conn.state == .connecting);
-            assert(cluster_index < server.config.clusters.len);
-            const cluster = &server.config.clusters[cluster_index];
-            const endpoint_index: usize =
-                @intCast(server.endpoints_next[cluster_index] % cluster.endpoints.len);
-            server.endpoints_next[cluster_index] += 1;
             conn.arm(&conn.op_connect, "connect");
             server.io.connect(
-                cluster.endpoints[endpoint_index],
+                server.balancer.pick(cluster_index),
                 &conn.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -1,0 +1,84 @@
+//! Upstream endpoint selection (DESIGN.md §7): the load-balancing policy
+//! kept behind a seam so the serving path never hardcodes *how* an
+//! endpoint is chosen — it only asks "which endpoint for this cluster?".
+//! Today's policy is round-robin; the design's trajectory is round-robin
+//! → P2C (§7), and that evolution lands as a change here, not in Server.
+//! The policy owns whatever per-cluster state it needs — a round-robin
+//! cursor now — and resolves a cluster index to the endpoint to dial.
+
+const std = @import("std");
+
+const config_module = @import("config.zig");
+
+const assert = std.debug.assert;
+
+pub const Balancer = struct {
+    config: *const config_module.Config,
+    /// Per-cluster round-robin cursor. u64 so it never wraps in any
+    /// realistic process lifetime — a u16 wrap reset the rotation phase
+    /// and double-picked one endpoint for non-power-of-two cluster sizes.
+    cursors: []u64,
+
+    /// Cursors are arena-owned and sized to the cluster count, so a pick
+    /// is a bounds-checked index, never an allocation on the loop.
+    pub fn init(
+        balancer: *Balancer,
+        arena: std.mem.Allocator,
+        config: *const config_module.Config,
+    ) error{OutOfMemory}!void {
+        balancer.config = config;
+        balancer.cursors = try arena.alloc(u64, config.clusters.len);
+        @memset(balancer.cursors, 0);
+    }
+
+    /// Choose the next endpoint to dial for `cluster_index`, advancing the
+    /// policy's state. Round-robin: the cursor modulo the endpoint count,
+    /// then incremented — a validated config guarantees at least one
+    /// endpoint, so the modulo is always defined.
+    pub fn pick(balancer: *Balancer, cluster_index: u16) std.Io.net.IpAddress {
+        assert(cluster_index < balancer.cursors.len);
+        const cluster = &balancer.config.clusters[cluster_index];
+        assert(cluster.endpoints.len >= 1);
+        const endpoint_index: usize =
+            @intCast(balancer.cursors[cluster_index] % cluster.endpoints.len);
+        balancer.cursors[cluster_index] += 1;
+        return cluster.endpoints[endpoint_index];
+    }
+};
+
+test "balancer: round-robin cycles endpoints and wraps per cluster" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
+
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const one = [_]std.Io.net.IpAddress{solo};
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio },
+        .{ .name = "one", .endpoints = &one },
+    };
+    const config: config_module.Config = .{
+        .listeners = &.{},
+        .clusters = &clusters,
+        .connect_timeout_ms = 1,
+        .idle_timeout_ms = 1,
+        .drain_deadline_ms = 1,
+        .max_lifetime_ms = 0,
+    };
+
+    var balancer: Balancer = undefined;
+    try balancer.init(arena, &config);
+
+    // Cluster 0 rotates a → b → c and wraps back to a; cluster 1 keeps
+    // its own cursor and always returns its single endpoint.
+    const expected = [_]std.Io.net.IpAddress{ a, b, c, a, b };
+    for (expected) |want| {
+        try std.testing.expectEqual(want, balancer.pick(0));
+        try std.testing.expectEqual(solo, balancer.pick(1));
+    }
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,6 +4,7 @@
 
 const std = @import("std");
 
+pub const balancer = @import("balancer.zig");
 pub const config = @import("config.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
@@ -19,6 +20,7 @@ pub const testing = struct {
 };
 
 test {
+    _ = balancer;
     _ = config;
     _ = constants;
     _ = counters;


### PR DESCRIPTION
## What

Extracts the inlined round-robin endpoint selection out of the serving path into a standalone `Balancer` load-balancing policy (`src/balancer.zig`).

Before, `armConnect` did the cursor arithmetic and `Server` held the per-cluster `endpoints_next: []u64` state directly. Adding a second policy (the design's round-robin → P2C trajectory, §7) would have meant more branching in the connection path.

## How

- **New `src/balancer.zig`** — a `Balancer` struct that owns its own per-cluster round-robin cursors and exposes `pick(cluster_index) -> IpAddress`. The serving path asks "which endpoint for this cluster?" and never sees *how* the choice is made. It holds a `*const Config` so the modulo bound is guaranteed by config validation.
- **`src/Server.zig`** — dropped the `endpoints_next` field + its alloc/memset; added a `balancer: Balancer` field initialized in `init`. `armConnect` collapses to `server.balancer.pick(cluster_index)`.
- **`src/root.zig`** — registered the module so its test compiles and runs.

Placed at top level alongside `config.zig`/`counters.zig` because, unlike `net/Conn.zig`/`net/relay.zig`, it's pure logic with no `Io` dependency. A future P2C policy lands as a change inside the balancer, not in `Server`.

## Testing

- Added a unit test covering rotation, wrap, and independent per-cluster cursors — the existing test bed only had single-endpoint clusters, so nothing exercised the rotation before.
- `zig build test`, `zig fmt --check`, and `zig build lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)