### PR TITLE
ci: bump cachix-action to v17 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       # replaced (net slower), and on Linux it was a wash — the fast
       # single-user install plus this cache already do the work.
       - name: Set up devenv binary cache
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: devenv
           skipPush: true
@@ -84,7 +84,7 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Set up devenv binary cache
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: devenv
           skipPush: true


### PR DESCRIPTION
Bumps `cachix/cachix-action` **v15 → v17**. v15 targets Node 20, which the GitHub runner now force-runs on Node 24 with a deprecation warning on every job; v17 ships as a native `node24` action, clearing the warning. No behavior change — still a pull-only devenv binary cache.

Follow-up to #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)