### PR TITLE
docs: record the CQE-reaping null result in DESIGN §4

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -304,17 +304,23 @@ unmerged behind it, so the pin moves only after re-audit.
 - **Plain ops only, at first.** Multishot accept/recv, buffer rings,
   `send_zc`, `splice` are deferred optimizations behind measurement — the
   previous iteration never became CPU-bound without them.
-- **Measured libxev-fork target: CQE reaping.** The pinned `zig build
-  profile` (§9) shows that once CPU-bound (~100k req/s loopback), libxev's
-  `copy_cqes` — `memcpy`-ing completions out of the io_uring CQ into a stack
-  array before dispatch — is the largest userspace cost after the loop body
-  (~17% of on-CPU cycles, the second-hottest symbol). Reaping CQEs in place
-  is the first fork optimization to reach for; deferred behind the same gate
-  as the op upgrades — it must dominate a *real* workload, not just a
-  loopback microbench, before the pin moves (§4 re-audit). The clock read on
-  the same path was the cheap win taken first: the idle-deadline refresh used
-  `CLOCK_MONOTONIC`, ~7% of on-CPU, cut to <1% by reading the coarse clock in
-  `XevIo.nowNs` (every deadline here is second-scale) — no fork change.
+- **Profiled and shelved: CQE reaping.** The pinned `zig build profile` (§9)
+  flags libxev's `copy_cqes` — `memcpy`-ing completions out of the io_uring CQ
+  into a stack array before dispatch — as ~17% of on-CPU under load (~100k
+  req/s loopback), the second-hottest symbol. Reaping in place (liburing's
+  `io_uring_for_each_cqe`: peek `cq.head` → acquire-loaded `tail`, invoke from
+  ring memory, `cq_advance` once) is a ~25-line fork change and passes libxev's
+  suite — but an A/B at a fixed ~99.8k req/s measured **no win**: total on-CPU
+  samples held at ~74k either way, the `memcpy` symbol vanishing only to
+  reappear inlined in the loop body. The 17% was an attribution artifact — the
+  `memcpy` call/setup plus the unavoidable per-CQE touch, not removable copy
+  work — so the pin stays put; a §4 re-audit is not spent on a non-win.
+  Revisit only under genuine CPU saturation with large CQE batches, never
+  loopback. Recorded so the profiler's headline symbol is not re-chased. The
+  clock read on the same path *was* a real cheap win: the idle-deadline
+  refresh used `CLOCK_MONOTONIC` (~7% of on-CPU), cut to <1% by reading the
+  coarse clock in `XevIo.nowNs` (every deadline here is second-scale) — no
+  fork change.
 
 ## 5. Memory — shared pools, fixed at startup
 


### PR DESCRIPTION
Follow-up to the profiling work (#39): I actually implemented the `copy_cqes` in-place reaping in the libxev fork and measured it. It's a **null result**, so the DESIGN note is rewritten from "first fork target to reach for" → "profiled and shelved."

## What the experiment found

- **Change:** in-place `io_uring_for_each_cqe` (peek `cq.head` → acquire-loaded `tail`, invoke from ring memory, `cq_advance` once) — ~25 lines in `Loop.tick_`, libxev suite green (142/146, pre-existing skips).
- **A/B at fixed ~99.8k req/s, 20s, zoxy pinned to a P-core (total on-CPU samples ∝ CPU time):**

  | libxev | on-CPU samples | req/s |
  |---|--:|--:|
  | baseline (`copy_cqes`) | 74,084 | 99,848 |
  | patched (in-place) | 74,614 | 99,844 |

  Dead heat. The `memcpyFast` symbol vanished (was ~17%) but `main.main` rose by the same amount — the reap work just inlined into the loop body. The 17% was an **attribution artifact** (memcpy call/setup + the unavoidable per-CQE touch), not removable copy work.

## Why record it

This is exactly the outcome the §4 gate anticipated ("must dominate a *real* workload, not a loopback microbench"). Writing down the null result stops the profiler's headline symbol from being re-chased, and keeps the pin/re-audit unspent. The experiment branch was dropped. The coarse-clock win on the same path (already merged) stands.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)