### PR TITLE
chore: point the libxev pin at zoxy-io/libxev

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // libxev is pinned by content hash to the floatdrop fork's
+    // libxev is pinned by content hash to the zoxy-io fork's
     // zoxy-ring-flags branch: the audited upstream snapshot plus the
     // setup-flags commit (DESIGN.md §4); see build.zig.zon. The pin moves
     // only after re-audit.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,13 +32,13 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        // Audited fork: floatdrop/libxev branch zoxy-ring-flags = upstream
+        // Audited fork: zoxy-io/libxev branch zoxy-ring-flags = upstream
         // 9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf (the audited snapshot)
         // plus one commit exposing io_uring setup flags through Options.
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
         .libxev = .{
-            .url = "git+https://github.com/floatdrop/libxev#c369817ab8bd529432047107967d88fd5674eae0",
+            .url = "git+https://github.com/zoxy-io/libxev#c369817ab8bd529432047107967d88fd5674eae0",
             .hash = "libxev-0.0.0-86vtc1cTFACGErSvTkJp2mZSFDLCgOHl7R45UZwS5wBZ",
         },
         .zrk = .{


### PR DESCRIPTION
The audited fork moved from `github.com/floatdrop/libxev` → `github.com/zoxy-io/libxev`. Updates the dependency URL and the two prose references (`build.zig`, `build.zig.zon`).

**Content-identical move — hash unchanged.** Same commit `c369817` serves the same content hash `libxev-0.0.0-86vtc1c...`, verified with a fresh `zig fetch` against the new host (into a throwaway cache). No re-audit implied; the pin's `.hash` is untouched.

This matters because CI fetches deps fresh from the URL each run (the zig package cache isn't persisted), so the new host must serve the commit — confirmed. `zrk` still points at `floatdrop/zrk` (only libxev moved).

`zig build` + `zig fmt --check` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)