### PR TITLE
ci: keep perf/flamegraph for developers, drop them from the CI closure

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,6 +5,16 @@
 # `zig build profile` (all Linux only). Activated automatically by
 # `.envrc` via direnv, or manually with `devenv shell`.
 { pkgs, lib, ... }:
+let
+  # `zig build profile` (Tier-0, §9) needs perf + flamegraph, so developers get
+  # them — but that pair drags in pkgs.linuxPackages_latest.perf, whose closure
+  # is often uncached, and building it falls back to the stdenv source-bootstrap
+  # which fails intermittently (the `ldexpl.c is not valid` coverage flake). CI
+  # never runs `zig build profile`, so skip them there and keep its closure
+  # cache-only. GitHub Actions sets CI=true; a CI checkout is always fresh, so
+  # this re-evaluates every run and never serves a stale (perf-included) shell.
+  in_ci = (builtins.getEnv "CI") == "true";
+in
 {
   packages =
     [
@@ -13,10 +23,14 @@
       pkgs.nginx
       pkgs.haproxy
     ]
-    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-      pkgs.kcov
-      pkgs.poop
-      pkgs.linuxPackages_latest.perf
-      pkgs.flamegraph
-    ];
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+      [
+        pkgs.kcov
+        pkgs.poop
+      ]
+      ++ lib.optionals (!in_ci) [
+        pkgs.linuxPackages_latest.perf
+        pkgs.flamegraph
+      ]
+    );
 }


### PR DESCRIPTION
## Problem

The `coverage` job fails intermittently on `main` with:
```
error: path '/nix/store/kwyjpvvi26l18qn9zc9mhshcjpg7d9c9-ldexpl.c' is not valid
```
— the *same* store path every time. `ldexpl.c` is a `mes-libc` / stage0 **full-source-bootstrap** path that nixpkgs normally never builds.

## Root cause

PR #39 added `pkgs.linuxPackages_latest.perf` + `pkgs.flamegraph` to `devenv.nix` (for `zig build profile`). `linuxPackages_latest` tracks the newest kernel and its closure is frequently **not in `cache.nixos.org`**. When a runner can't substitute a path in that closure, Nix falls back to building from source, which drags in the stdenv source-bootstrap and fails to realise the `ldexpl.c` source derivation. It's intermittent (depends on cache state at fetch time) and **began exactly at the #39 merge** — every `main` coverage run before it passed.

## Fix

`zig build profile` is a manual Tier-0 tool that **never runs in CI**, so the profiling tools don't belong in the CI closure. Gate them on the `CI` env var (GitHub sets `CI=true`):

```nix
in_ci = (builtins.getEnv "CI") == "true";
...
++ lib.optionals (!in_ci) [ pkgs.linuxPackages_latest.perf pkgs.flamegraph ]
```

Developers keep `perf` + `flamegraph`; CI evaluates a lean, cache-only shell. A CI checkout is always fresh (no persisted `.devenv`), so the gate re-evaluates every run and can't serve a stale shell.

## Verified locally

| shell | `perf` present? |
|---|---|
| `CI=true devenv shell` | **no** (lean CI closure) |
| `devenv shell` (developer) | **yes** (+ `flamegraph.pl`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)