### PR TITLE
ci: gate zls/nginx/haproxy/poop out of the CI closure

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,34 +1,38 @@
-# Dev environment (https://devenv.sh): the pinned toolchain — zig 0.16 +
-# zls, kcov (Linux, coverage), nginx (the Tier-1 bench origin, §9),
-# haproxy (the Tier-1 state-of-the-art reference proxy, §9), poop
-# (Tier-0 hardware-counter A/B) and perf + flamegraph for the pinned
-# `zig build profile` (all Linux only). Activated automatically by
-# `.envrc` via direnv, or manually with `devenv shell`.
+# Dev environment (https://devenv.sh): the pinned toolchain. Only two packages
+# are used by CI — zig (every job) and kcov (the Linux `zig build coverage`
+# job) — so everything else is developer/bench/profile tooling gated out of the
+# CI closure: zls (editor LSP), nginx + haproxy (Tier-1 bench origins, §9), poop
+# (Tier-0 hardware-counter A/B) and perf + flamegraph (the pinned
+# `zig build profile`). CI runs none of them (`zig fmt`, `zig build`,
+# `zig build ci`, `zig build coverage` only), and keeping its closure cache-only
+# both trims fetch time and dodges the uncached-source-bootstrap flake that
+# pkgs.linuxPackages_latest.perf triggered (the `ldexpl.c is not valid`
+# coverage failure). Activated automatically by `.envrc` via direnv, or manually
+# with `devenv shell`.
 { pkgs, lib, ... }:
 let
-  # `zig build profile` (Tier-0, §9) needs perf + flamegraph, so developers get
-  # them — but that pair drags in pkgs.linuxPackages_latest.perf, whose closure
-  # is often uncached, and building it falls back to the stdenv source-bootstrap
-  # which fails intermittently (the `ldexpl.c is not valid` coverage flake). CI
-  # never runs `zig build profile`, so skip them there and keep its closure
-  # cache-only. GitHub Actions sets CI=true; a CI checkout is always fresh, so
-  # this re-evaluates every run and never serves a stale (perf-included) shell.
+  # GitHub Actions sets CI=true; a CI checkout is always fresh, so this
+  # re-evaluates every run and never serves a stale (dev-tool-included) shell.
   in_ci = (builtins.getEnv "CI") == "true";
 in
 {
   packages =
     [
       pkgs.zig_0_16
-      pkgs.zls
-      pkgs.nginx
-      pkgs.haproxy
     ]
-    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux (
+    # kcov drives the Linux `zig build coverage` job.
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      pkgs.kcov
+    ]
+    # Developer/bench/profile tooling — no CI command runs it.
+    ++ lib.optionals (!in_ci) (
       [
-        pkgs.kcov
-        pkgs.poop
+        pkgs.zls
+        pkgs.nginx
+        pkgs.haproxy
       ]
-      ++ lib.optionals (!in_ci) [
+      ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+        pkgs.poop
         pkgs.linuxPackages_latest.perf
         pkgs.flamegraph
       ]


### PR DESCRIPTION
## Question this answers

*"Do we need zls, nginx and haproxy in CI?"* — **No.** CI runs only `zig fmt`, `zig build`, `zig build ci`, and `zig build coverage`, which need exactly two packages:

- **`zig`** — every job
- **`kcov`** — the Linux `zig build coverage` job

Everything else is developer/bench/profile tooling that no CI command invokes:

| package | used by | in CI? |
|---|---|---|
| `zls` | editor LSP | no |
| `nginx`, `haproxy` | `zig build bench` / `zig build profile` (spawned at runtime) | no |
| `poop` | manual Tier-0 A/B | no |
| `perf`, `flamegraph` | `zig build profile` | no (already gated in #42) |

## Change

Move `zls`/`nginx`/`haproxy`/`poop` into the same `!in_ci` gate as `perf`/`flamegraph` (from #42). Every CI job now fetches a minimal, cache-only closure — leaner + faster, and one less surface for an uncached-path source build.

## Verified

| shell | tools present |
|---|---|
| `CI=true devenv shell` | `zig`, `kcov` only (nginx/haproxy/poop/perf/flamegraph absent) |
| `devenv shell` (developer) | full set |

(Locally `zls` still resolves under `CI=true` because my machine has a *system* zls on PATH; a GH runner has none.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)