### PR TITLE
ci: pin devenv to v2.1.2 (deterministic install)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,11 @@ jobs:
           name: devenv
           skipPush: true
 
-      # The same pinned toolchain as local dev (devenv.nix: zig_0_16),
-      # resolved through devenv.lock and served by the Nix binary cache.
+      # Pin devenv to a fixed release (matches local dev, 2.1.2) instead of the
+      # drifting `nixpkgs#devenv`, so every run resolves the same devenv binary;
+      # --accept-flake-config lets it pull prebuilt from devenv.cachix.org.
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        run: nix profile install --accept-flake-config github:cachix/devenv/v2.1.2
 
       # zig-pkg (vendored, hash-pinned deps) is deliberately not checked.
       - name: Check formatting
@@ -90,7 +91,7 @@ jobs:
           skipPush: true
 
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        run: nix profile install --accept-flake-config github:cachix/devenv/v2.1.2
 
       - name: Measure coverage (kcov)
         run: devenv shell -- zig build coverage


### PR DESCRIPTION
Chosen fix (option 2) for the intermittent coverage flake.

## What

Replace `nix profile install nixpkgs#devenv` (both jobs) with `nix profile install --accept-flake-config github:cachix/devenv/v2.1.2`.

## Why

`nixpkgs#devenv` resolves devenv from the runner's nixpkgs registry, so the devenv **binary drifts run-to-run** and can differ from what developers use locally (2.1.2). Pinning makes every CI job resolve the same devenv; `--accept-flake-config` pulls it prebuilt from `devenv.cachix.org`.

## Relation to the coverage flake — honest framing

The flake is `mes-libc → error: path '.../ldexpl.c' is not valid`. Root cause (corrected from #42, which did **not** fix it — it was luck): devenv **2.x's** per-package bootstrap-provenance check (`bootstrapLib.nix` `isFromBootstrapFiles`) realises a nixpkgs `minimal-bootstrap` source via import-from-derivation at shell-eval, and that content-addressed source substitutes flakily from `cache.nixos.org`. It's ~1-in-3 runs, on **any** `devenv shell` job, independent of the package list (proven: #43 failed with `perf` absent).

Pinning removes the **devenv version** as a variable and, if the bootstrap resolves through devenv's own nixpkgs, clears the trigger. If it instead comes from the project's `devenv.lock`, the pin won't fully clear it — in which case the fallback is a retry wrapper. **I'll run this PR's CI several times to gauge before claiming it's fixed** (one green run ≠ proof for a 1-in-3 flake).

Verified the ref resolves: `github:cachix/devenv/v2.1.2#packages.x86_64-linux.default` → `devenv-wrapped-2.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)