### PR TITLE
ci: persist the Nix store on the coverage job (kill the ldexpl.c flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,22 @@ jobs:
           nix_conf: |
             experimental-features = nix-command flakes
 
+      # Persist /nix/store across runs so the realised nixpkgs bootstrap paths
+      # — including the `ldexpl.c` source that devenv 2.x's shell-eval IFD
+      # flakily re-substitutes from cache.nixos.org — survive between runs.
+      # That kills the intermittent `path '...ldexpl.c' is not valid` coverage
+      # failure at its root (a restored path is already valid) and skips the
+      # re-fetch, so the job gets faster, not slower. Coverage-only: Linux +
+      # single-user Nix (nix-quick-install-action), where restore works — the
+      # daemon install's permission problem that broke it is gone. Keyed on
+      # devenv.lock (the nixpkgs pin that fixes the bootstrap paths); the prefix
+      # restores the newest store on a miss so the bootstrap survives a bump.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-coverage-v1-${{ hashFiles('devenv.lock') }}
+          restore-prefixes-first-match: nix-coverage-v1-
+
       - name: Set up devenv binary cache
         uses: cachix/cachix-action@v17
         with:


### PR DESCRIPTION
The chosen root-cause fix for the intermittent coverage flake — and it *speeds up* the job rather than slowing it (unlike a retry).

## Problem

`error: path '/nix/store/…-ldexpl.c' is not valid` — a `cache.nixos.org` substituter transient on a nixpkgs `minimal-bootstrap` source that devenv 2.x's shell-eval import-from-derivation forces to realise. ~1-in-6 runs. Ruled out as *not* the cause: the package list (#42/#43 still failed) and the devenv version (#44 still failed, validated over 6 runs). The variable is that path's substitution.

## Fix

Add `nix-community/cache-nix-action` to the **coverage job** so `/nix/store` persists across runs. Once `ldexpl.c` is realised it stays — restored runs never re-substitute it, so the flake's root is gone. And restoring the store is faster than re-fetching devenv + the shell closure, so the job gets **faster**.

- **Coverage-only** for now — the job where the flake lands.
- **Linux + single-user Nix** (`nix-quick-install-action`), where cache-nix-action's restore works; the daemon-install permission problem that broke it in #37 is gone.
- Keyed on `devenv.lock` (the nixpkgs pin that fixes the bootstrap paths); prefix-restore keeps the bootstrap across a lock bump.

## Validation plan

First run is a cache **miss** (populates the store — may still flake during population; I'll re-run until it saves). Subsequent runs are **hits** → `ldexpl.c` already valid → no re-substitution. I'll run several times to confirm no recurrence + cache-hit speedup before calling it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)