### PR TITLE
docs: split DESIGN.md into design, plans, and implementation notes

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -13,6 +13,10 @@ L7-only, share-nothing, thread-per-core proxy directly on `io_uring`; its
 measured lessons are carried forward here (§2) and its dead ends are not
 revisited.
 
+This document is the settled design. Phasing and future work live in
+[`PLANS.md`](PLANS.md); measured findings and shelved experiments in
+[`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md).
+
 ---
 
 ## 1. Goals and non-goals
@@ -46,7 +50,7 @@ Non-goals (deliberate, recorded so they are decisions rather than drift):
   when they do).
 - Config reload. Config is parse-once immutable (§5); a change is a
   process restart — consistent with process-per-port scale-out (§3). Hot
-  restart / drain-to-successor stays deferred (§10).
+  restart / drain-to-successor stays deferred ([PLANS.md](PLANS.md)).
 - Dynamic DNS for upstreams. Cluster endpoints are static socket
   addresses resolved once at config load (§7); re-resolution waits for a
   demonstrated need.
@@ -236,7 +240,7 @@ takes its recorded exceptions here, and both are pure Zig, vendored by
 content hash in `build.zig.zon`: **libxev** (this section) and **hparse**
 (the HTTP/1.1 head parser — as a hardened fork, §7). No C-FFI dependency
 exists in the codebase; any future one (a TLS stack is the known
-candidate, §10 Phase 3) is a
+Phase-3 candidate — [PLANS.md](PLANS.md)) is a
 separate deliberate decision, not a default. The pinned hash is an
 *audited commit*, never a branch tip — libxev's Zig 0.16 support is a
 self-described compatibility shim (PR #220) with real fixes still
@@ -254,6 +258,15 @@ unmerged behind it, so the pin moves only after re-audit.
   which live in pool slots — so the no-unbounded-queue rule holds by
   construction. The in-flight op budget that keeps CQ overflow
   unreachable is part of the startup printout (§8).
+- **Ring setup flags.** The ring is created with `SINGLE_ISSUER`,
+  `COOP_TASKRUN`, and `DEFER_TASKRUN`: completion task-work stays on
+  the loop thread and is batched at the reap point instead of
+  interrupting it. Sound by construction here — the loop thread is the
+  only submitter (§3), and the loop always enters the kernel waiting
+  (GETEVENTS), which is where deferred task-work is flushed. Kernels
+  older than 6.1 reject the flags with EINVAL; startup degrades to a
+  plain ring rather than refuse to start. (Measured win:
+  `IMPLEMENTATION_NOTES.md`.)
 - **Backend selection.** Production: `io_uring` (Linux ≥ 5.11). Dev box:
   kqueue (macOS) — same API, same callbacks, so day-to-day development
   does not need a VM. Correctness claims are only made for Linux.
@@ -288,7 +301,10 @@ unmerged behind it, so the pin moves only after re-audit.
   callback inline.
 - **Clock.** `Io.now_ns` is refreshed once per loop tick (the previous
   iteration measured per-callback `clock_gettime` at ~3% of data-path CPU)
-  and is the seam the simulator's virtual clock replaces. Anything
+  and is the seam the simulator's virtual clock replaces. The refresh
+  reads the *coarse* monotonic clock — every consumer is a second-scale
+  deadline, and the precise read was measured at ~7% of on-CPU
+  (`IMPLEMENTATION_NOTES.md`). Anything
   computed from it may be stale by up to one tick's completion batch —
   deadline logic must stay correct under that bound, and the simulator
   makes the staleness adversarial (§9).
@@ -301,26 +317,12 @@ unmerged behind it, so the pin moves only after re-audit.
   **Teardown is the one place a timer is canceled** (§5 release rule).
   libxev cancellation is internally cancel+resubmit and consumes its own
   caller-owned completion, embedded in the slot like every other op.
-- **Plain ops only, at first.** Multishot accept/recv, buffer rings,
-  `send_zc`, `splice` are deferred optimizations behind measurement — the
-  previous iteration never became CPU-bound without them.
-- **Profiled and shelved: CQE reaping.** The pinned `zig build profile` (§9)
-  flags libxev's `copy_cqes` — `memcpy`-ing completions out of the io_uring CQ
-  into a stack array before dispatch — as ~17% of on-CPU under load (~100k
-  req/s loopback), the second-hottest symbol. Reaping in place (liburing's
-  `io_uring_for_each_cqe`: peek `cq.head` → acquire-loaded `tail`, invoke from
-  ring memory, `cq_advance` once) is a ~25-line fork change and passes libxev's
-  suite — but an A/B at a fixed ~99.8k req/s measured **no win**: total on-CPU
-  samples held at ~74k either way, the `memcpy` symbol vanishing only to
-  reappear inlined in the loop body. The 17% was an attribution artifact — the
-  `memcpy` call/setup plus the unavoidable per-CQE touch, not removable copy
-  work — so the pin stays put; a §4 re-audit is not spent on a non-win.
-  Revisit only under genuine CPU saturation with large CQE batches, never
-  loopback. Recorded so the profiler's headline symbol is not re-chased. The
-  clock read on the same path *was* a real cheap win: the idle-deadline
-  refresh used `CLOCK_MONOTONIC` (~7% of on-CPU), cut to <1% by reading the
-  coarse clock in `XevIo.nowNs` (every deadline here is second-scale) — no
-  fork change.
+- **Plain ops only.** Multishot accept/recv, buffer rings, `send_zc`,
+  `splice` stay behind measurement — the previous iteration never became
+  CPU-bound without them, and this one is latency-bound with CPU
+  headroom. Each has since been evaluated: verdicts and revisit
+  conditions live in [`PLANS.md`](PLANS.md), the measurements behind
+  them in [`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md).
 
 ## 5. Memory — shared pools, fixed at startup
 
@@ -354,8 +356,8 @@ Three shared pools, all owned and touched only by the loop thread:
    as an idle timeout (kept below typical origin keep-alive windows, so
    most origin-side closes are pre-empted), a close that slips through is
    detected at checkout and absorbed by the stale-replay rung (§7), and
-   active health checks — when they land (§10) — close the parked
-   connections of ejected endpoints.
+   active health checks — when they land ([PLANS.md](PLANS.md)) — close
+   the parked connections of ejected endpoints.
 
 Sizing shape (illustrative defaults, all tunable):
 
@@ -539,9 +541,9 @@ the loop thread.
   readers, so a metrics/admin thread can read without a data race and
   single-writer stays intact. The simulator asserts counters reconcile
   (admitted = completed + shed + in-flight) under every seed. Counters
-  live in `counters.zig` (§11); Phase 0 exposure is a SIGUSR1-triggered
+  live in `counters.zig` (§10); Phase 0 exposure is a SIGUSR1-triggered
   dump (through the seam's `signal` primitive, §4) — the admin plane
-  stays deferred (§10).
+  stays deferred ([PLANS.md](PLANS.md)).
 - **File descriptors are pre-budgeted, not shed.** Worst-case fd count is
   closed-form — listeners + connection slots + upstream slots + ring,
   async and signal fds — computed from `src/constants.zig` and asserted
@@ -644,62 +646,7 @@ explicit allowlist for `main.zig` startup work (the `RLIMIT_NOFILE`
 assert, `sigaction`). Cheap, and it turns "no direct syscalls on the
 data path" from prose into CI.
 
-## 10. Phasing
-
-Each phase ships behind all four gates of §9.
-
-- **Phase 0 — skeleton + L4.** `Io` seam with `XevIo` + `SimIo`,
-  `Pool(T)`, `constants.zig`, config (strict JSON, arena, parse-once),
-  accept gate, TCP relay, deadline timer, SIGTERM drain, the exhaustion
-  ladder rungs that exist so far, all four test gates, static-memory and
-  fd-budget printout.
-- **Phase 1 — L7 HTTP/1.1.** Head parser + framing, routing, upstream
-  pool + keep-alive both sides, relay-buffer decoupling (idle costs no
-  relay memory), static error responses, remaining ladder rungs.
-- **Phase 2 — shedding hardening + minimal resilience.** Pressure
-  watermarks, P2C pick, stale-replay, per-try deadline, counter
-  reconciliation invariants in the sim, overload benchmark scenario
-  (offered load ≫ capacity: assert flat memory, bounded latency for
-  admitted work, all excess shed with correct status).
-- **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
-  activates). The stack is an **open decision under the Zig-first policy**
-  (§4). Leading candidate (surveyed 2026-07-12): **ztls**
-  (github.com/mattrobenolt/ztls) — a sans-I/O TLS 1.3 state machine in
-  Zig. The fit is almost point-for-point: caller-owned buffers and zero
-  allocations in library code (its own claim, matching §5), both server
-  and client roles (termination + upstream re-encryption), ALPN,
-  handshake randomness injected by the caller (drivable from the
-  simulator without sockets), kTLS key-packing helpers matching the
-  proven switchover recipe, CI gated on Zig 0.16, and TLS-Anvil
-  conformance runs. Two eyes-open costs, re-check both at adoption time:
-  (1) pre-alpha — version 0.0.0, API explicitly unstable; no session
-  resumption, 0-RTT, HelloRetryRequest, or client certs yet; TLS 1.3
-  only. (2) Not pure Zig at the bottom: crypto primitives are libcrypto
-  via `@cImport` (OpenSSL/AWS-LC/BoringSSL; no pure-Zig backend), so
-  adopting it is still a deliberate C-FFI exception (§4) — though far
-  narrower than libssl, since the protocol layer stays in Zig and only
-  primitives cross the boundary; the fixed FFI heap behind
-  `CRYPTO_set_mem_functions` still applies to keep the zero-alloc
-  promise. If ztls hasn't matured by Phase 3, the fallback ladder
-  (surveyed 2026-07-12) is: **picotls** (h2o/picotls) — sans-I/O like
-  ztls, battle-tested in H2O/quicly at Fastly, feature-complete where
-  ztls is not (resumption, 0-RTT, HRR, client certs, ECH), injectable
-  `random_bytes`/`get_time` (sim-drivable), kTLS-ready via
-  `ptls_export_secret`/`update_traffic_key`, and its minicrypto backend
-  even drops the system-library link for termination — but the protocol
-  layer itself is C (the §4 exception swallows the whole TLS layer) and
-  it mallocs internally with no allocator hook, so the zero-alloc
-  promise needs link-time interposition or a documented carve-out. Last
-  rung: the previous iteration's full OpenSSL/libssl recipe (sans-io BIO
-  pair + fixed FFI heap, kTLS switchover) — proven by us, heaviest, and
-  now likely displaced by picotls even as a fallback.
-- **Deferred, revisit on evidence:** HTTP/2, richer resilience (breakers,
-  outlier ejection, budgets, health checks), hot restart + drain-to-
-  successor, config DSL, metrics/admin plane beyond counters-on-a-thread,
-  io_uring op upgrades (multishot, buffer rings, `send_zc`, `splice`,
-  `SINGLE_ISSUER`/`DEFER_TASKRUN` flags).
-
-## 11. Module map (target)
+## 10. Module map (target)
 
 ```
 src/
@@ -729,7 +676,7 @@ sim/                  // simulator harness + invariants
 bench/                // micro benches (poop) + loopback harness (zrk), §9
 ```
 
-## 12. Key references
+## 11. Key references
 
 - [libxev](https://github.com/mitchellh/libxev) — proactor event loop,
   io_uring/kqueue backends, caller-owned completions.

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,155 @@
+# zoxy — implementation notes
+
+Measured findings and shelved experiments, recorded so they are not
+re-chased. The settled design lives in [`DESIGN.md`](DESIGN.md) — bare
+section references (§) point there — and future work in
+[`PLANS.md`](PLANS.md). All numbers are from the 8-core hybrid dev box
+over loopback unless stated otherwise; read "Bench hygiene" at the
+bottom before comparing any of them. The detailed perf write-ups from
+2026-07-12 were deliberately removed from history — this file carries
+the durable conclusions.
+
+## Loop profile at the Tier-1 band (2026-07-12)
+
+`zig build profile` (pinned-core perf → flamegraph, §9) under load:
+
+- Single-loop saturation ceiling ~165 k req/s (h2load `--h1 -m1`,
+  connection-count-invariant) at only ~55% of its core — latency-bound
+  with CPU headroom, not compute-bound. The ~45% off-CPU residue at the
+  ceiling is unexplained; `perf sched` is the follow-up.
+- 98.6% of cycles sit inside the one `io_uring_enter` (io_send ~79% —
+  the loopback sender pays the receiver's TCP stack too). zoxy user
+  code is **1.26% of cycles**: do not optimize the Zig side.
+- Syscall shape: ~3.2 syscalls/request at 20 k req/s, batching to ~122
+  ring ops per enter at the ceiling.
+- Box tax ~12–15% of the profile: nft+conntrack ~6%, systemd BPF
+  firewall ~5.6%, kernel alloc-tagging ~2.4%. An nft loopback bypass
+  would clean the bench bands — environmental work, not zoxy work.
+
+All three candidates this profile ranked have since been measured (ring
+flags: landed; multishot recv: parked; pre-block spin: rejected — all
+below). Remaining wins are environmental (nft bypass) or workload-level
+(`splice`/`send_zc` for large bodies — PLANS.md).
+
+## Ring setup flags — landed 2026-07-12 (196ffbf)
+
+`SINGLE_ISSUER | COOP_TASKRUN | DEFER_TASKRUN`, exposed through the
+fork's `Options.io_uring_flags` (branch `zoxy-ring-flags`, c369817).
+Measured: interrupt-driven task_work eliminated (`tctx_task_work` 10.8%
+→ 0, re-batched as `__io_run_local_work` in the wait path), steady loop
+CPU −3.4%, p90 improved within overlapping bands, saturation unchanged.
+Verify it is active: `perf -e io_uring:io_uring_create` → flags
+`0x3100`. Kernels < 6.1 reject the flags; `XevIo.init` degrades to a
+plain ring on EINVAL rather than refusing to start.
+
+## Coarse deadline clock — landed (#39)
+
+The idle-deadline refresh's `CLOCK_MONOTONIC` read was ~7% of on-CPU
+under load. `XevIo.nowNs` now reads `CLOCK_MONOTONIC_COARSE` (a
+vvar-page vDSO load, no TSC access): <1%. Sound because every consumer
+of that clock is a second-scale deadline, so ~ms resolution is ample.
+No fork change; `nowNs` documents the field-layout reach-in that the
+hash pin fixes.
+
+## CQE reaping — profiled and shelved (#40)
+
+The pinned `zig build profile` flagged libxev's `copy_cqes` —
+`memcpy`-ing completions out of the io_uring CQ into a stack array
+before dispatch — at ~17% of on-CPU under load (~100 k req/s loopback),
+the second-hottest symbol. Reaping in place (liburing's
+`io_uring_for_each_cqe` shape: peek `cq.head` → acquire-loaded `tail`,
+invoke from ring memory, `cq_advance` once) is a ~25-line fork change
+and passes libxev's suite — but an A/B at a fixed ~99.8 k req/s measured
+**no win**: total on-CPU samples held at ~74 k either way, the `memcpy`
+symbol vanishing only to reappear inlined in the loop body. The 17% was
+an attribution artifact — the `memcpy` call/setup plus the unavoidable
+per-CQE touch, not removable copy work — so the pin stays put; a §4
+re-audit is not spent on a non-win. Revisit only under genuine CPU
+saturation with large CQE batches, never loopback. Recorded so the
+profiler's headline symbol is not re-chased.
+
+## Multishot recv — measured and parked (2026-07-12)
+
+Best-case echo microbench (pinned cores, ABBA, single-shot vs multishot
+recv): only ~2–4% CPU and 15–20% fewer enters — does not pay for the
+relay redesign it demands (buffer-group lifecycle, ENOBUFS coupling,
+SimIo emulation). The libxev `recv_ms` patch and the echo harness were
+erased with the perf write-ups; re-derive if ever needed: `recv_ms` op
+= `RECV_MULTISHOT` + `IOSQE_BUFFER_SELECT` over a std `BufferGroup`,
+`F_MORE` keeps the completion armed, `cqe_flags` carries the buffer id;
+harness = pinned-core echo, single-shot vs multishot, ABBA. Do not
+re-propose without a recv-submission-bound workload (many mostly-idle
+connections) — PLANS.md holds the standing verdict.
+
+## Pre-block spin — rejected (2026-07-12)
+
+Spinning before the loop blocks: p50 +15–25 µs *worse* and CPU ×2. The
+loop only blocks when its pipeline is empty and the next arrival is
+~50 µs out, so the spin budget expires empty every time. Reverted; do
+not re-propose.
+
+## The concurrency ceiling is CQ-bound (95d1f8f)
+
+Concurrent L4 connections are bound by the io_uring completion queue,
+not fds or memory: each admitted connection holds up to
+`conn_ops_max = 5` armed ops, the ring is pre-budgeted and never shed
+(§8), and in-flight ops must stay under ¾ of the CQ. At the usable ring
+maximum (`ring_entries = 4096`, CQ = 8192) that caps
+`relay_buffers_max` at `(6144 − 18) / 5 = 1225`. `constants.zig` owns
+the arithmetic and comptime-asserts it; fds and memory both have
+headroom (`fds_max = 2464` against a typical 4096 hard limit). The
+levers that lift the ceiling are fork work — PLANS.md, "c10k".
+
+## libxev error surfacing is lossy
+
+The io_uring backend keeps only a few named errnos on data ops:
+`readResult` maps CANCELED/CONNRESET/EOF and the send path maps
+CANCELED/CONNRESET/PIPE — everything else, including ENOBUFS/ENOMEM,
+funnels through `posix.unexpectedErrno` → `error.Unexpected` before the
+seam ever sees it. The specific errno is gone at the boundary, and this
+generalizes: any future feature needing a particular errno on a data op
+hits the same wall (fork queue: PLANS.md). What shipped instead
+(0a4c0bb): a categorical witness — `relay.zig` counts a data-path
+`error.Unexpected` as `kernel_pressure_errors`, matching the
+accept/connect/setNodelay sites, since on an established relay socket
+the orderly failures (EOF, RST) are peeled off first. SimIo grew a
+one-shot `kernel_pressure` fault and a `kernel_pressure_percent`
+adversary knob to exercise the rung.
+
+## Phase 0 baselines (2026-07-10/11)
+
+- Debug-build zoxy over loopback (`zig build bench`, nginx origin, rate
+  20 k, c=32): 20 k req/s sustained, hop +259 µs p50 (426 µs proxied vs
+  167 µs direct). RSS byte-identical across ~200 k requests — the
+  process-level zero-alloc witness. Clean SIGTERM drain, exit 0.
+- haproxy 3.4.1 reference band in the same harness (mode tcp,
+  nbthread 1 to match the single loop): zoxy hop +214 µs p50 vs haproxy
+  +199 µs, p90/p99 bands overlapping — parity with the state of the art
+  on this setup. Another run's pair read +128 vs +123 µs: compare within
+  one run, never across runs. haproxy never gates (§9).
+
+## Bench hygiene (hard-won)
+
+- **Bands, not numbers.** p50 swings up to ~3× between identical
+  back-to-back runs; a regression verdict needs alternating runs of
+  both binaries in one session (§9 Tier 1).
+- **Thermals.** The first saturation run after idle reads ~165 k req/s;
+  the P-core then settles to ~117 k at identical CPU share. Only
+  adjacent within-session A/B pairs are comparable; set the performance
+  governor for A/Bs and restore powersave after.
+- **Stale proxies.** Killing `$ZOXY_PID` does not kill an
+  strace-wrapped zoxy (that pid is strace's) — stale instances stay in
+  the SO_REUSEPORT group and silently absorb load from later runs.
+  Before any bench: `pgrep -af zoxy` and `ss -tln` on the bench ports.
+  An afternoon of tail-latency forensics was lost to this.
+- **strace is unusable** for latency work (tracer writeback freezes
+  tracees 8–12 ms and mangles timestamps); bpftrace on the io_uring
+  tracepoints (submit/complete keyed by `user_data` = Completion
+  pointer) works well.
+- **Generator limits.** zrk saturates at ~25–27 k req/s on this box
+  regardless of cores — use h2load (`--h1 -m1`) above that. And
+  closed-loop `-m1` measures *latency*: a proxy hop lowers its req/s by
+  construction; saturating zoxy's core needs high `-c` or real RTT.
+- **Zig 0.16 `Child`.** `kill()` reaps; a `wait()` after it is UB
+  (SEGV'd the ReleaseFast bench harness and leaked nginx onto a bench
+  port — d3000f5).

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,0 +1,148 @@
+# zoxy — plans
+
+Future work, in dependency order. The settled design lives in
+[`DESIGN.md`](DESIGN.md) — bare section references (§) point there —
+and the measurements behind the verdicts below live in
+[`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md). Every phase ships
+behind all four gates of §9.
+
+## Phasing
+
+- **Phase 0 — skeleton + L4. Shipped.** `Io` seam with `XevIo` + `SimIo`,
+  `Pool(T)`, `constants.zig`, config (strict JSON, arena, parse-once),
+  accept gate, TCP relay, deadline timer, SIGTERM drain, the exhaustion
+  ladder rungs that exist so far, all four test gates, static-memory and
+  fd-budget printout. Spec-complete 2026-07-13: the kernel-pressure
+  witness on the relay data path (0a4c0bb) closed the last §8 audit gap.
+- **Phase 1 — L7 HTTP/1.1. Next.** Head parser + framing, routing,
+  upstream pool + keep-alive both sides, relay-buffer decoupling (idle
+  costs no relay memory), static error responses, remaining ladder
+  rungs. Entry gate: the hparse fork must clear the hardening list
+  recorded in §7 before this phase lands.
+- **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
+  stale-replay, per-try deadline, counter reconciliation invariants in
+  the sim, overload benchmark scenario (offered load ≫ capacity: assert
+  flat memory, bounded latency for admitted work, all excess shed with
+  correct status). The relay-buffer pressure watermark shipped early
+  (361213f); the remaining watermarks land here.
+- **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
+  activates). The stack is an **open decision under the Zig-first policy**
+  (§4). Leading candidate (surveyed 2026-07-12): **ztls**
+  (github.com/mattrobenolt/ztls) — a sans-I/O TLS 1.3 state machine in
+  Zig. The fit is almost point-for-point: caller-owned buffers and zero
+  allocations in library code (its own claim, matching §5), both server
+  and client roles (termination + upstream re-encryption), ALPN,
+  handshake randomness injected by the caller (drivable from the
+  simulator without sockets), kTLS key-packing helpers matching the
+  proven switchover recipe, CI gated on Zig 0.16, and TLS-Anvil
+  conformance runs. Two eyes-open costs, re-check both at adoption time:
+  (1) pre-alpha — version 0.0.0, API explicitly unstable; no session
+  resumption, 0-RTT, HelloRetryRequest, or client certs yet; TLS 1.3
+  only. (2) Not pure Zig at the bottom: crypto primitives are libcrypto
+  via `@cImport` (OpenSSL/AWS-LC/BoringSSL; no pure-Zig backend), so
+  adopting it is still a deliberate C-FFI exception (§4) — though far
+  narrower than libssl, since the protocol layer stays in Zig and only
+  primitives cross the boundary; the fixed FFI heap behind
+  `CRYPTO_set_mem_functions` still applies to keep the zero-alloc
+  promise. If ztls hasn't matured by Phase 3, the fallback ladder
+  (surveyed 2026-07-12) is: **picotls** (h2o/picotls) — sans-I/O like
+  ztls, battle-tested in H2O/quicly at Fastly, feature-complete where
+  ztls is not (resumption, 0-RTT, HRR, client certs, ECH), injectable
+  `random_bytes`/`get_time` (sim-drivable), kTLS-ready via
+  `ptls_export_secret`/`update_traffic_key`, and its minicrypto backend
+  even drops the system-library link for termination — but the protocol
+  layer itself is C (the §4 exception swallows the whole TLS layer) and
+  it mallocs internally with no allocator hook, so the zero-alloc
+  promise needs link-time interposition or a documented carve-out. Last
+  rung: the previous iteration's full OpenSSL/libssl recipe (sans-io BIO
+  pair + fixed FFI heap, kTLS switchover) — proven by us, heaviest, and
+  now likely displaced by picotls even as a fallback.
+
+## io_uring op upgrades — evaluated, all deferred (2026-07-16)
+
+§4's "plain ops only" policy holds: on the measured profile —
+latency-bound with CPU headroom, zoxy user code ~1.3% of cycles
+(IMPLEMENTATION_NOTES.md) — none of the deferred ops pays for itself.
+Verdicts, so they are not re-litigated:
+
+| op | verdict | revisit when |
+|---|---|---|
+| multishot accept | parked (unmeasured) | connection-churn workload (`Connection: close` storms) |
+| multishot recv + buffer rings | measured, parked (2026-07-12) | recv-submission-bound workload: many mostly-idle conns |
+| `send_zc` | rejected at 4 KiB buffers | large-body workload with ≥16 KiB sends |
+| `splice` | deferred | genuine CPU/memory-bandwidth saturation |
+
+- **Multishot accept** saves only the userspace re-arm (one SQE prep per
+  connection), invisible under keep-alive; it also needs a fork op and a
+  documented exception to XevIo's every-callback-disarms discipline.
+  Decide with a Tier-0 churn A/B if a churn-heavy workload shows up.
+- **Multishot recv / buffer rings.** The best-case echo microbench gave
+  only ~2–4% CPU and 15–20% fewer enters — it does not pay for the relay
+  redesign it demands (IMPLEMENTATION_NOTES.md). Buffer rings' real
+  payoff is Phase-1 memory shape — idle keep-alive connections arming a
+  recv without a dedicated posted buffer — but multishot recv *is*
+  read-ahead, which the strict §6 relay exists to forbid; single-shot
+  buffer-select keeps the discipline and forfeits most of the syscall
+  win. Revisit only if Phase-1 idle-connection memory is measured as a
+  problem.
+- **`send_zc`.** Below ~10–32 KiB the kernel copy is cheaper than page
+  pinning, and the extra notification CQE per send doubles CQE
+  consumption — eroding the CQ budget that already caps concurrency
+  (next section). At the deliberate 4 KiB relay buffer it is a strict
+  loss.
+- **`splice`.** The only op that removes the userspace copy, and it
+  preserves §6 backpressure naturally (a bounded pipe). But the copy is
+  not the bottleneck (§3's envelope; the profile above), and the costs
+  are real: two pipes per L4 connection (+4 fds — the fd budget
+  triples), a `Pool(Pipe)`, a SimIo virtual-pipe primitive, and a bigger
+  per-connection op budget against the CQ. Shares the fork prerequisite
+  with c10k below; TLS and chunked L7 bodies fall back to copy
+  regardless.
+
+## c10k — lifting the 1225-connection ceiling
+
+Concurrent L4 connections are CQ-bound, not memory- or fd-bound:
+`relay_buffers_max = (6144 − 18) / 5 = 1225` (derivation in
+`constants.zig`). Two levers, both fork work:
+
+1. **Deeper CQ** — `IORING_SETUP_CQSIZE`; libxev fixes the CQ at 2 × SQ
+   today, and exposing it needs `IoUring.init_params` plumbing in the
+   fork, not just a flag OR. This directly lifts the ceiling. Past it,
+   fds bind next: `fds_max = 14 + 2·relay_buffers`, so true c10k (~10 k
+   buffers → ~20 k fds) also raises the documented `RLIMIT_NOFILE`
+   assumption.
+2. **`splice`** (above) — an independent win at saturation, same
+   fork/re-audit cost.
+
+Entry gate: demonstrate a workload that actually hits the 1225 wall
+before spending a fork re-audit on it.
+
+## libxev fork queue
+
+The §4 pin policy (audited commit, moves only after re-audit) makes fork
+changes deliberate, batched work. Landed so far: `Options.io_uring_flags`
+(branch `zoxy-ring-flags`, c369817 — the §4 ring setup flags). Known
+queue, in rough value order:
+
+1. `IORING_SETUP_CQSIZE` exposure (c10k lever #1).
+2. Per-errno surfacing on data ops: the backend collapses ENOBUFS/ENOMEM
+   — and every uncommon errno — into `error.Unexpected`
+   (IMPLEMENTATION_NOTES.md), so zoxy ships a categorical
+   kernel-pressure witness instead. Fork change: map
+   `.NOBUFS`/`.NOMEM => error.SystemResources` and widen
+   ReadError/WriteError.
+3. `IORING_OP_SPLICE` (the op union is closed today).
+4. Multishot accept/recv ops — only behind the workloads in the verdict
+   table above.
+
+## Deferred, revisit on evidence
+
+- HTTP/2, HTTP/3, gRPC, WebSocket — after the L4/L7 core is proven (§1).
+- Richer resilience: circuit breakers, outlier ejection, retry budgets,
+  active health checks (§7).
+- Hot restart + drain-to-successor (§1).
+- Config DSL (§1 keeps config parse-once immutable).
+- Metrics/admin plane beyond loop-written counters + the SIGUSR1 dump
+  (§8).
+- Dynamic DNS for upstream endpoints (§1).
+- io_uring op upgrades — the verdict table above.

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -49,7 +49,7 @@ pub const Counters = struct {
     }
 
     /// Phase 0 exposure (§8): SIGUSR1 dumps to stderr through the signal
-    /// seam; the admin plane stays deferred (§10).
+    /// seam; the admin plane stays deferred (docs/PLANS.md).
     pub fn dump(counters: *const Counters) void {
         std.debug.print("zoxy counters:", .{});
         inline for (@typeInfo(Counters).@"struct".fields) |field| {


### PR DESCRIPTION
## What

`DESIGN.md` becomes design-only; two new files take the rest:

- **`docs/PLANS.md`** — future work: phasing with status (Phase 0 shipped, Phase 1 next behind the hparse hardening gate), the io_uring op-upgrade verdict table (multishot accept parked-unmeasured, multishot recv/buffer rings measured-and-parked, `send_zc` rejected at 4 KiB buffers, `splice` deferred — each with its revisit condition), the c10k section (CQ-bound 1225 ceiling, `IORING_SETUP_CQSIZE` + splice as the fork levers), and the libxev fork queue in value order.
- **`docs/IMPLEMENTATION_NOTES.md`** — measured findings, dated, recorded so they are not re-chased: the 2026-07-12 loop profile (~165k ceiling at ~55% of one core, zoxy user code 1.26% of cycles), ring setup flags (−3.4% loop CPU), coarse deadline clock (#39), the CQE-reaping null result (#40), multishot-recv park (with the re-derivation recipe), pre-block-spin rejection, libxev's lossy errno surfacing, Phase 0 baselines (haproxy parity band), and the bench-hygiene list.

## DESIGN.md changes

- §10 Phasing removed; intro points at the two new files.
- §4 gains a **ring setup flags** bullet — the `SINGLE_ISSUER | COOP_TASKRUN | DEFER_TASKRUN` choice was landed code but undocumented design — and the Clock bullet records the coarse-clock decision.
- The "Profiled and shelved: CQE reaping" narrative moves to IMPLEMENTATION_NOTES.md; "Plain ops only, at first" becomes "Plain ops only" pointing at the PLANS.md verdicts.
- §11/§12 renumber to §10/§11; all cross-references re-pointed, including the one `§10` citation in `src/counters.zig` (comment-only code change).

§2 (lessons from the previous iteration) deliberately stays in DESIGN.md: those are load-bearing design constraints cited throughout, not findings of this iteration.

Note: the condensed perf findings restored into IMPLEMENTATION_NOTES.md were previously erased from history; this makes them durable in-repo again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)