### PR TITLE
Phase 1: the L7 HTTP/1.1 reverse proxy — trust boundary, state machine, and simulation gate

### DIFF
--- a/bench/affinity.zig
+++ b/bench/affinity.zig
@@ -1,0 +1,103 @@
+//! CPU-affinity helpers shared by the bench harnesses (DESIGN.md §9):
+//! dedicate one core to the process under test and pin the load
+//! generator and origin off it, so the latency bands and the hardware
+//! PMU measure the proxy — not contention with the generator — and match
+//! zoxy's one-loop-per-core deployment (§3). Pure Zig, Linux-only; every
+//! entry point is a no-op on other targets so the harnesses still build
+//! and run (unpinned) on a macOS dev box.
+
+const builtin = @import("builtin");
+const std = @import("std");
+const Io = std.Io;
+const linux = std.os.linux;
+
+const assert = std.debug.assert;
+
+pub const CpuSet = linux.cpu_set_t;
+const cpu_bits = @bitSizeOf(usize);
+const cpu_set_words = @typeInfo(CpuSet).array.len;
+
+/// Choose the dedicated core (`override`, else the last P-core, else the
+/// last cpu), pin the calling process to every *other* core so its
+/// threads and any children it spawns inherit that mask, and return the
+/// dedicated core. Null on non-Linux: the caller runs unpinned. Pin
+/// children onto the returned core with `pinChildTo`.
+pub fn dedicate(io: Io, override: ?u16) ?u16 {
+    if (comptime builtin.os.tag != .linux) {
+        return null;
+    }
+    var universe: CpuSet = undefined;
+    _ = linux.sched_getaffinity(0, @sizeOf(CpuSet), &universe);
+    const cpu = override orelse detectPCore(io) orelse maxCpu(&universe);
+    assert(cpu < cpu_set_words * cpu_bits);
+    var others = universe;
+    cpuClear(&others, cpu);
+    // A failed pin only makes the bench less isolated (bands noisier), it
+    // never stops it running — benchmarking is best-effort, not a gate.
+    linux.sched_setaffinity(0, &others) catch {};
+    return cpu;
+}
+
+/// Pin a spawned child (the proxy under test) to the dedicated core.
+pub fn pinChildTo(pid: std.process.Child.Id, cpu: u16) void {
+    if (comptime builtin.os.tag != .linux) {
+        return;
+    }
+    assert(cpu < cpu_set_words * cpu_bits);
+    var only = cpuZero();
+    cpuSet(&only, cpu);
+    // Best-effort like `dedicate`: a failed pin degrades isolation, not
+    // correctness.
+    linux.sched_setaffinity(pid, &only) catch {};
+}
+
+fn cpuZero() CpuSet {
+    return @splat(0);
+}
+
+fn cpuSet(set: *CpuSet, cpu: u16) void {
+    set[cpu / cpu_bits] |= @as(usize, 1) << @intCast(cpu % cpu_bits);
+}
+
+fn cpuClear(set: *CpuSet, cpu: u16) void {
+    set[cpu / cpu_bits] &= ~(@as(usize, 1) << @intCast(cpu % cpu_bits));
+}
+
+fn cpuIsSet(set: *const CpuSet, cpu: u16) bool {
+    return set[cpu / cpu_bits] & (@as(usize, 1) << @intCast(cpu % cpu_bits)) != 0;
+}
+
+fn maxCpu(set: *const CpuSet) u16 {
+    var cpu: u16 = cpu_set_words * cpu_bits;
+    while (cpu > 0) {
+        cpu -= 1;
+        if (cpuIsSet(set, cpu)) return cpu;
+    }
+    return 0;
+}
+
+/// Last cpu id listed in the hybrid P-core sysfs mask (e.g. "0-3" -> 3),
+/// so the process under test lands on a performance core. Null when the
+/// file is absent (not hybrid, or an older kernel) — the caller falls
+/// back to the last available cpu.
+fn detectPCore(io: Io) ?u16 {
+    const file = Io.Dir.cwd().openFile(io, "/sys/devices/cpu_core/cpus", .{}) catch return null;
+    defer file.close(io);
+    var read_buffer: [256]u8 = undefined;
+    var file_reader = file.reader(io, &read_buffer);
+    var content: [256]u8 = undefined;
+    const len = file_reader.interface.readSliceShort(&content) catch return null;
+    // Take the last run of digits: the highest cpu id in the mask.
+    var last: ?u16 = null;
+    var current: ?u32 = null;
+    for (content[0..len]) |char| {
+        if (char >= '0' and char <= '9') {
+            current = (current orelse 0) * 10 + (char - '0');
+        } else if (current) |value| {
+            last = std.math.cast(u16, value) orelse last;
+            current = null;
+        }
+    }
+    if (current) |value| last = std.math.cast(u16, value) orelse last;
+    return last;
+}

--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -1,0 +1,53 @@
+//! Tier-0 micro bench (§9): the per-request L7 head CPU — parse the
+//! request head, render it upstream, parse the origin response head,
+//! render it downstream — the work an L7 exchange does that an L4 relay
+//! does not. Realistic small-GET heads (what the Tier-1 loopback bench
+//! drives). poop A/B on hardware counters; decision tool, not a CI gate.
+//!
+//! Run: `zig build bench-micro` then
+//! `poop ./zig-out/bin/zoxy-bench-l7_head_pipeline` for the absolute
+//! per-iteration cost, or poop two builds to A/B a candidate change.
+
+const std = @import("std");
+
+const zoxy = @import("zoxy");
+
+const parser = zoxy.http.parser;
+const render = zoxy.http.render;
+
+const iterations: u64 = 1_000_000;
+
+const request_head =
+    "GET / HTTP/1.1\r\n" ++
+    "Host: 127.0.0.1:18181\r\n" ++
+    "User-Agent: zrk/0.1\r\n" ++
+    "Accept: */*\r\n\r\n";
+
+const response_head =
+    "HTTP/1.1 200 OK\r\n" ++
+    "Server: nginx\r\n" ++
+    "Content-Type: text/plain\r\n" ++
+    "Content-Length: 18\r\n\r\n";
+
+pub fn main() void {
+    var request_storage: parser.HeaderStorage = undefined;
+    var response_storage: parser.HeaderStorage = undefined;
+    var upstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
+    var downstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
+
+    var checksum: u64 = 0;
+    var index: u64 = 0;
+    while (index < iterations) : (index += 1) {
+        const request = parser.parseRequestHead(request_head, false, &request_storage) catch unreachable;
+        const upstream = render.renderRequestHead(&request, false, &upstream_head) catch unreachable;
+        const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
+        const downstream = render.renderResponseHead(&response, true, &downstream_head) catch unreachable;
+
+        // Consume the outputs so nothing is dead-code-eliminated.
+        checksum +%= upstream[upstream.len - 1];
+        checksum +%= downstream[downstream.len - 1];
+        checksum +%= @intFromEnum(request.method);
+        checksum +%= response.status;
+    }
+    std.debug.print("checksum {d}\n", .{checksum});
+}

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -16,8 +16,8 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const Io = std.Io;
-const linux = std.os.linux;
 
+const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
 
 const assert = std.debug.assert;
@@ -69,12 +69,9 @@ pub fn main(init: std.process.Init) !u8 {
     // Topology: dedicate one core to zoxy, run everything else off it. Pin
     // ourselves first so the nginx/zoxy/perf children and the zrk load threads
     // all inherit the "everything else" mask; zoxy is then re-pinned alone.
-    var universe: CpuSet = undefined;
-    _ = linux.sched_getaffinity(0, @sizeOf(CpuSet), &universe);
-    const zoxy_cpu = flags.zoxy_cpu orelse detectPCore(io) orelse maxCpu(&universe);
-    var others = universe;
-    cpuClear(&others, zoxy_cpu);
-    linux.sched_setaffinity(0, &others) catch {};
+    // Non-null: `main` already returned above on non-Linux, the only case
+    // `dedicate` yields null.
+    const zoxy_cpu = affinity.dedicate(io, flags.zoxy_cpu).?;
 
     var origin_child = try spawnNginx(arena, io);
     defer origin_child.kill(io);
@@ -83,9 +80,7 @@ pub fn main(init: std.process.Init) !u8 {
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
     const zoxy_pid = zoxy_child.id orelse return error.NoZoxyPid;
-    var zoxy_only = cpuZero();
-    cpuSet(&zoxy_only, zoxy_cpu);
-    linux.sched_setaffinity(zoxy_pid, &zoxy_only) catch {};
+    affinity.pinChildTo(zoxy_pid, zoxy_cpu);
 
     // Warm up and prove the path serves before spending a measured run on it.
     try awaitResponsive(arena, io, &flags);
@@ -169,62 +164,6 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
     assert(flags.connections >= 1);
     assert(flags.duration_s >= 1);
     return flags;
-}
-
-// --- CPU affinity (pure Zig; the whole point is single-PMU pinning) ---------
-
-const CpuSet = linux.cpu_set_t;
-const cpu_bits = @bitSizeOf(usize);
-const cpu_set_words = @typeInfo(CpuSet).array.len;
-
-fn cpuZero() CpuSet {
-    return @splat(0);
-}
-
-fn cpuSet(set: *CpuSet, cpu: u16) void {
-    set[cpu / cpu_bits] |= @as(usize, 1) << @intCast(cpu % cpu_bits);
-}
-
-fn cpuClear(set: *CpuSet, cpu: u16) void {
-    set[cpu / cpu_bits] &= ~(@as(usize, 1) << @intCast(cpu % cpu_bits));
-}
-
-fn cpuIsSet(set: *const CpuSet, cpu: u16) bool {
-    return set[cpu / cpu_bits] & (@as(usize, 1) << @intCast(cpu % cpu_bits)) != 0;
-}
-
-fn maxCpu(set: *const CpuSet) u16 {
-    var cpu: u16 = cpu_set_words * cpu_bits;
-    while (cpu > 0) {
-        cpu -= 1;
-        if (cpuIsSet(set, cpu)) return cpu;
-    }
-    return 0;
-}
-
-/// Last cpu id listed in the hybrid P-core sysfs mask (e.g. "0-3" -> 3), so
-/// zoxy lands on a performance core. Null when the file is absent (not hybrid,
-/// or an older kernel) — the caller falls back to the last available cpu.
-fn detectPCore(io: Io) ?u16 {
-    const file = Io.Dir.cwd().openFile(io, "/sys/devices/cpu_core/cpus", .{}) catch return null;
-    defer file.close(io);
-    var read_buffer: [256]u8 = undefined;
-    var file_reader = file.reader(io, &read_buffer);
-    var content: [256]u8 = undefined;
-    const len = file_reader.interface.readSliceShort(&content) catch return null;
-    // Take the last run of digits: the highest cpu id in the mask.
-    var last: ?u16 = null;
-    var current: ?u32 = null;
-    for (content[0..len]) |char| {
-        if (char >= '0' and char <= '9') {
-            current = (current orelse 0) * 10 + (char - '0');
-        } else if (current) |value| {
-            last = std.math.cast(u16, value) orelse last;
-            current = null;
-        }
-    }
-    if (current) |value| last = std.math.cast(u16, value) orelse last;
-    return last;
 }
 
 // --- process orchestration --------------------------------------------------

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -77,7 +77,7 @@ pub fn main(init: std.process.Init) !u8 {
     var origin_child = try spawnNginx(arena, io);
     defer origin_child.kill(io);
 
-    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path, &flags);
+    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path);
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
     const zoxy_pid = zoxy_child.id orelse return error.NoZoxyPid;
@@ -201,7 +201,6 @@ fn spawnZoxy(
     arena: std.mem.Allocator,
     io: Io,
     zoxy_path: []const u8,
-    flags: *const Flags,
 ) !std.process.Child {
     // Both listeners always exist so the flag only picks which one zrk
     // drives; the idle one adds no load.
@@ -217,7 +216,6 @@ fn spawnZoxy(
         \\}}
         \\
     , .{ zoxy_l4_port, zoxy_http_port, origin_port });
-    _ = flags;
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     return std.process.spawn(io, .{

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -34,8 +34,9 @@ const report_path = work_directory ++ "/zoxy.report";
 
 const Flags = struct {
     rate: u64 = 100_000,
+    // zrk serves one thread per connection, so this is both the
+    // connection count and the load-thread count.
     connections: u32 = 64,
-    threads: u32 = 4,
     duration_s: u64 = 30,
     freq: u32 = 4000,
     /// Core to dedicate to zoxy; null auto-picks the last P-core (or last cpu).
@@ -125,9 +126,6 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
         } else if (std.mem.eql(u8, arg, "--connections")) {
             index += 1;
             flags.connections = try std.fmt.parseUnsigned(u32, args[index], 10);
-        } else if (std.mem.eql(u8, arg, "--threads")) {
-            index += 1;
-            flags.threads = try std.fmt.parseUnsigned(u32, args[index], 10);
         } else if (std.mem.eql(u8, arg, "--seconds")) {
             index += 1;
             flags.duration_s = try std.fmt.parseUnsigned(u64, args[index], 10);
@@ -154,7 +152,7 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
         } else {
             std.debug.print(
                 "usage: profile [zoxy-path] [--rate N] [--connections N] " ++
-                    "[--threads N] [--seconds N] [--freq N] [--cpu N]\n",
+                    "[--seconds N] [--freq N] [--cpu N]\n",
                 .{},
             );
             return error.InvalidArguments;
@@ -260,10 +258,9 @@ fn spawnPerf(
 
 // --- load (zrk, in-process, like bench/run.zig) -----------------------------
 
-fn benchConfig(port: u16, rate: u64, connections: u32, threads: u32) zrk.cli.Config {
+fn benchConfig(port: u16, rate: u64, connections: u32) zrk.cli.Config {
     return .{
         .url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" },
-        .threads = threads,
         .connections = connections,
         .rate = rate,
         .timeout_ns = 2 * std.time.ns_per_s,
@@ -277,9 +274,9 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
     const retry_sleep = Io.Duration.fromNanoseconds(200 * std.time.ns_per_ms);
     var attempt: u8 = 0;
     while (attempt < attempts_max) : (attempt += 1) {
-        var config = benchConfig(flags.zoxyPort(), 20_000, 16, 2);
+        var config = benchConfig(flags.zoxyPort(), 20_000, 16);
         config.duration_ns = std.time.ns_per_s / 2;
-        const report = zrk.runner.run(arena, io, &config, null, null) catch {
+        const report = zrk.runner.run(arena, io, &config, 0, null, null) catch {
             if (attempt == attempts_max - 1) return error.TargetUnresponsive;
             io.sleep(retry_sleep, .awake) catch {};
             continue;
@@ -291,9 +288,9 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
 }
 
 fn loadTest(arena: std.mem.Allocator, io: Io, flags: *const Flags) !zrk.runner.Report {
-    var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections, flags.threads);
+    var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections);
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
-    return zrk.runner.run(arena, io, &config, null, null);
+    return zrk.runner.run(arena, io, &config, 0, null, null);
 }
 
 fn printReport(report: *const zrk.runner.Report) void {

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -23,7 +23,8 @@ const zrk = @import("zrk");
 const assert = std.debug.assert;
 
 const origin_port: u16 = 19190;
-const zoxy_port: u16 = 18190;
+const zoxy_l4_port: u16 = 18190;
+const zoxy_http_port: u16 = 18191;
 const work_directory = ".zig-cache/zoxy-profile";
 const perf_data_path = work_directory ++ "/zoxy.perf.data";
 const script_path = work_directory ++ "/zoxy.script";
@@ -39,7 +40,18 @@ const Flags = struct {
     freq: u32 = 4000,
     /// Core to dedicate to zoxy; null auto-picks the last P-core (or last cpu).
     zoxy_cpu: ?u16 = null,
+    /// Which listener to drive: the L4 relay or the L7 reverse proxy.
+    protocol: Protocol = .l4,
     zoxy_path: []const u8 = "zig-out/bin/zoxy-profile",
+
+    const Protocol = enum { l4, http };
+
+    fn zoxyPort(flags: *const Flags) u16 {
+        return switch (flags.protocol) {
+            .l4 => zoxy_l4_port,
+            .http => zoxy_http_port,
+        };
+    }
 };
 
 pub fn main(init: std.process.Init) !u8 {
@@ -67,7 +79,7 @@ pub fn main(init: std.process.Init) !u8 {
     var origin_child = try spawnNginx(arena, io);
     defer origin_child.kill(io);
 
-    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path);
+    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path, &flags);
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
     const zoxy_pid = zoxy_child.id orelse return error.NoZoxyPid;
@@ -76,10 +88,10 @@ pub fn main(init: std.process.Init) !u8 {
     linux.sched_setaffinity(zoxy_pid, &zoxy_only) catch {};
 
     // Warm up and prove the path serves before spending a measured run on it.
-    try awaitResponsive(arena, io);
+    try awaitResponsive(arena, io, &flags);
     std.debug.print(
-        "profile: zoxy pid {d} pinned to cpu {d}; origin + load pinned off it\n",
-        .{ zoxy_pid, zoxy_cpu },
+        "profile: zoxy pid {d} pinned to cpu {d}; driving {s} listener; origin + load pinned off it\n",
+        .{ zoxy_pid, zoxy_cpu, @tagName(flags.protocol) },
     );
 
     // Record only the zoxy pid for the load's duration while zrk saturates it.
@@ -130,6 +142,16 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
         } else if (std.mem.eql(u8, arg, "--cpu")) {
             index += 1;
             flags.zoxy_cpu = try std.fmt.parseUnsigned(u16, args[index], 10);
+        } else if (std.mem.eql(u8, arg, "--protocol")) {
+            index += 1;
+            if (std.mem.eql(u8, args[index], "l4")) {
+                flags.protocol = .l4;
+            } else if (std.mem.eql(u8, args[index], "http")) {
+                flags.protocol = .http;
+            } else {
+                std.debug.print("profile: --protocol must be l4 or http\n", .{});
+                return error.InvalidArguments;
+            }
         } else if (!zoxy_path_set and !std.mem.startsWith(u8, arg, "--")) {
             // First bare argument is the zoxy binary (passed by `zig build`).
             flags.zoxy_path = arg;
@@ -242,16 +264,23 @@ fn spawnZoxy(
     arena: std.mem.Allocator,
     io: Io,
     zoxy_path: []const u8,
+    flags: *const Flags,
 ) !std.process.Child {
+    // Both listeners always exist so the flag only picks which one zrk
+    // drives; the idle one adds no load.
     const config_path = work_directory ++ "/zoxy.json";
     const config_json = try std.fmt.allocPrint(arena,
         \\{{
-        \\    "listeners": [ {{ "bind": "127.0.0.1:{d}", "cluster": "origin" }} ],
+        \\    "listeners": [
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }}
+        \\    ],
         \\    "clusters": {{ "origin": {{ "endpoints": ["127.0.0.1:{d}"] }} }},
         \\    "timeouts": {{ "connect_ms": 5000, "idle_ms": 60000, "drain_deadline_ms": 5000 }}
         \\}}
         \\
-    , .{ zoxy_port, origin_port });
+    , .{ zoxy_l4_port, zoxy_http_port, origin_port });
+    _ = flags;
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     return std.process.spawn(io, .{
@@ -292,9 +321,9 @@ fn spawnPerf(
 
 // --- load (zrk, in-process, like bench/run.zig) -----------------------------
 
-fn benchConfig(rate: u64, connections: u32, threads: u32) zrk.cli.Config {
+fn benchConfig(port: u16, rate: u64, connections: u32, threads: u32) zrk.cli.Config {
     return .{
-        .url = .{ .scheme = .http, .host = "127.0.0.1", .port = zoxy_port, .target = "/" },
+        .url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" },
         .threads = threads,
         .connections = connections,
         .rate = rate,
@@ -304,12 +333,12 @@ fn benchConfig(rate: u64, connections: u32, threads: u32) zrk.cli.Config {
     };
 }
 
-fn awaitResponsive(arena: std.mem.Allocator, io: Io) !void {
+fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void {
     const attempts_max: u8 = 10;
     const retry_sleep = Io.Duration.fromNanoseconds(200 * std.time.ns_per_ms);
     var attempt: u8 = 0;
     while (attempt < attempts_max) : (attempt += 1) {
-        var config = benchConfig(20_000, 16, 2);
+        var config = benchConfig(flags.zoxyPort(), 20_000, 16, 2);
         config.duration_ns = std.time.ns_per_s / 2;
         const report = zrk.runner.run(arena, io, &config, null, null) catch {
             if (attempt == attempts_max - 1) return error.TargetUnresponsive;
@@ -323,7 +352,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io) !void {
 }
 
 fn loadTest(arena: std.mem.Allocator, io: Io, flags: *const Flags) !zrk.runner.Report {
-    var config = benchConfig(flags.rate, flags.connections, flags.threads);
+    var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections, flags.threads);
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
     return zrk.runner.run(arena, io, &config, null, null);
 }
@@ -351,8 +380,9 @@ fn generateFlamegraph(arena: std.mem.Allocator, io: Io) !void {
     try runToFile(io, &.{ "perf", "script", "-i", perf_data_path }, script_path);
     try runToFile(io, &.{ "stackcollapse-perf.pl", script_path }, folded_path);
     try runToFile(io, &.{
-        "flamegraph.pl",                                       "--title",
-        "zoxy L4 relay under load (cycles:u, LBR call-graph)", folded_path,
+        "flamegraph.pl", "--title",
+        "zoxy under load (cycles:u, LBR call-graph) — see run for path",
+        folded_path,
     }, svg_path);
     std.debug.print("profile: flamegraph -> {s}\n", .{svg_path});
 }

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -16,6 +16,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 const Io = std.Io;
 
+const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
 
 const assert = std.debug.assert;
@@ -43,6 +44,15 @@ pub fn main(init: std.process.Init) !u8 {
 
     try Io.Dir.cwd().createDirPath(io, work_directory);
 
+    // Dedicate one core to the proxy under test and pin this process (its
+    // zrk load threads) and the inherited origin off it, so the bands
+    // measure the proxy rather than its contention with the generator,
+    // and match zoxy's one-loop-per-core topology (§3). Both proxies are
+    // pinned to the same core: the scenarios run sequentially, so only
+    // one is ever under load, and the idle one burns no cycles. Pin self
+    // before spawning so children inherit the "everything else" mask.
+    const proxy_cpu = affinity.dedicate(io, null);
+
     var origin_child: ?std.process.Child = null;
     const origin_address = flags.origin orelse spawn_origin: {
         origin_child = try spawnNginx(arena, io);
@@ -59,6 +69,12 @@ pub fn main(init: std.process.Init) !u8 {
 
     var haproxy_child = try spawnHaproxy(arena, io, origin_address);
     defer haproxy_child.kill(io);
+
+    if (proxy_cpu) |cpu| {
+        affinity.pinChildTo(zoxy_child.id.?, cpu);
+        affinity.pinChildTo(haproxy_child.id.?, cpu);
+        std.debug.print("bench: proxy under test pinned to cpu {d}; origin + load off it\n", .{cpu});
+    }
 
     // Warm all paths up and prove they answer before measuring.
     _ = try awaitResponsive(arena, io, originPortOf(origin_address), "origin");

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -343,7 +343,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, port: u16, label: []const u
     while (attempt < probe_attempts_max) : (attempt += 1) {
         var config = benchConfig(port, 4, 100);
         config.duration_ns = std.time.ns_per_s / 2;
-        const report = zrk.runner.run(arena, io, &config, null, null) catch |err| {
+        const report = zrk.runner.run(arena, io, &config, 0, null, null) catch |err| {
             if (attempt == probe_attempts_max - 1) return err;
             io.sleep(retry_sleep, .awake) catch {};
             continue;
@@ -365,7 +365,7 @@ fn loadTest(
     assert(flags.duration_s >= 1);
     var config = benchConfig(port, flags.connections, flags.rate);
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
-    const report = try zrk.runner.run(arena, io, &config, null, null);
+    const report = try zrk.runner.run(arena, io, &config, 0, null, null);
     assert(report.launched >= 1);
     return report;
 }

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -21,8 +21,10 @@ const zrk = @import("zrk");
 const assert = std.debug.assert;
 
 const zoxy_port: u16 = 18180;
+const zoxy_http_port: u16 = 18181;
 const origin_port: u16 = 19180;
 const haproxy_port: u16 = 17180;
+const haproxy_http_port: u16 = 17181;
 const work_directory = ".zig-cache/zoxy-bench";
 
 const Flags = struct {
@@ -60,8 +62,10 @@ pub fn main(init: std.process.Init) !u8 {
 
     // Warm all paths up and prove they answer before measuring.
     _ = try awaitResponsive(arena, io, originPortOf(origin_address), "origin");
-    _ = try awaitResponsive(arena, io, zoxy_port, "zoxy");
-    _ = try awaitResponsive(arena, io, haproxy_port, "haproxy");
+    _ = try awaitResponsive(arena, io, zoxy_port, "zoxy L4");
+    _ = try awaitResponsive(arena, io, zoxy_http_port, "zoxy L7");
+    _ = try awaitResponsive(arena, io, haproxy_port, "haproxy tcp");
+    _ = try awaitResponsive(arena, io, haproxy_http_port, "haproxy http");
 
     const rss_before_kb = try readRssKb(arena, io, zoxy_child.id);
 
@@ -70,19 +74,23 @@ pub fn main(init: std.process.Init) !u8 {
         .{ flags.rate, flags.connections, flags.duration_s },
     );
     const direct = try loadTest(arena, io, originPortOf(origin_address), &flags);
-    const proxied = try loadTest(arena, io, zoxy_port, &flags);
+    const proxied_l4 = try loadTest(arena, io, zoxy_port, &flags);
+    const proxied_l7 = try loadTest(arena, io, zoxy_http_port, &flags);
 
+    // The RSS window closes after both zoxy runs, so the zero-alloc
+    // witness means "zoxy served L4 and L7 load", not "zoxy idled".
     const rss_after_kb = try readRssKb(arena, io, zoxy_child.id);
 
-    // The reference run happens outside the RSS window so the zero-alloc
-    // witness keeps meaning "zoxy sat under load", not "zoxy idled while
-    // haproxy was measured".
-    const reference = try loadTest(arena, io, haproxy_port, &flags);
+    // The reference runs happen outside the RSS window.
+    const reference_tcp = try loadTest(arena, io, haproxy_port, &flags);
+    const reference_http = try loadTest(arena, io, haproxy_http_port, &flags);
 
-    printReport("direct ", &direct);
-    printReport("proxied", &proxied);
-    printReport("haproxy", &reference);
-    printOverhead(&direct, &proxied, &reference);
+    printReport("direct      ", &direct);
+    printReport("zoxy L4     ", &proxied_l4);
+    printReport("zoxy L7     ", &proxied_l7);
+    printReport("haproxy tcp ", &reference_tcp);
+    printReport("haproxy http", &reference_http);
+    printOverhead(&direct, &proxied_l4, &proxied_l7, &reference_tcp, &reference_http);
 
     std.debug.print("zoxy RSS: {d} KiB -> {d} KiB\n", .{ rss_before_kb, rss_after_kb });
 
@@ -100,7 +108,8 @@ pub fn main(init: std.process.Init) !u8 {
         std.debug.print("FAIL: zoxy RSS grew under load\n", .{});
     }
     const completed = direct.snapshot.counters.completed > 0 and
-        proxied.snapshot.counters.completed > 0;
+        proxied_l4.snapshot.counters.completed > 0 and
+        proxied_l7.snapshot.counters.completed > 0;
     if (!completed) {
         std.debug.print("FAIL: a run completed zero requests\n", .{});
     }
@@ -109,12 +118,16 @@ pub fn main(init: std.process.Init) !u8 {
     // stay under 1% or a relay stall passes silently. Status errors are
     // excluded: a faithfully relayed 4xx/5xx is not a proxy failure (and
     // the loopback origin may legitimately answer non-2xx).
-    const proxied_socket_errors = proxied.snapshot.counters.socketErrors();
-    const errors_ok = proxied_socket_errors * 100 <= proxied.snapshot.counters.completed;
+    const l4_socket_errors = proxied_l4.snapshot.counters.socketErrors();
+    const l7_socket_errors = proxied_l7.snapshot.counters.socketErrors();
+    const errors_ok =
+        l4_socket_errors * 100 <= proxied_l4.snapshot.counters.completed and
+        l7_socket_errors * 100 <= proxied_l7.snapshot.counters.completed;
     if (!errors_ok) {
         std.debug.print(
-            "FAIL: proxied socket-error rate too high ({d} socket-errors, {d} completed)\n",
-            .{ proxied_socket_errors, proxied.snapshot.counters.completed },
+            "FAIL: proxied socket-error rate too high " ++
+                "(L4 {d}, L7 {d} socket-errors)\n",
+            .{ l4_socket_errors, l7_socket_errors },
         );
     }
     return if (rss_flat and completed and errors_ok and drained_cleanly) 0 else 1;
@@ -216,10 +229,16 @@ fn spawnZoxy(
     origin_address: []const u8,
 ) !std.process.Child {
     const config_path = work_directory ++ "/zoxy.json";
+    // Both protocols on one process (§6, §7): the L4 relay and the L7
+    // reverse proxy serve the same origin, so one run bands both paths.
+    // idle_ms stays below nginx's default 75 s keepalive_timeout so
+    // parked upstream connections are reaped before the origin closes
+    // them (§5).
     const config_json = try std.fmt.allocPrint(arena,
         \\{{
         \\    "listeners": [
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin" }}
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }}
         \\    ],
         \\    "clusters": {{
         \\        "origin": {{ "endpoints": ["{s}"] }}
@@ -231,7 +250,7 @@ fn spawnZoxy(
         \\    }}
         \\}}
         \\
-    , .{ zoxy_port, origin_address });
+    , .{ zoxy_port, zoxy_http_port, origin_address });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     return std.process.spawn(io, .{
@@ -272,7 +291,12 @@ fn spawnHaproxy(
         \\    bind 127.0.0.1:{d}
         \\    server origin {s}
         \\
-    , .{ haproxy_port, origin_address });
+        \\listen bench_http
+        \\    mode http
+        \\    bind 127.0.0.1:{d}
+        \\    server origin {s}
+        \\
+    , .{ haproxy_port, origin_address, haproxy_http_port, origin_address });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = conf_path, .data = conf });
 
     // -db keeps haproxy in the foreground so kill() reaches the process
@@ -374,16 +398,26 @@ fn printReport(label: []const u8, report: *const zrk.runner.Report) void {
 
 fn printOverhead(
     direct: *const zrk.runner.Report,
-    proxied: *const zrk.runner.Report,
-    reference: *const zrk.runner.Report,
+    proxied_l4: *const zrk.runner.Report,
+    proxied_l7: *const zrk.runner.Report,
+    reference_tcp: *const zrk.runner.Report,
+    reference_http: *const zrk.runner.Report,
 ) void {
     const direct_p50 = direct.snapshot.hist.valueAtPercentile(50.0);
-    const proxied_p50 = proxied.snapshot.hist.valueAtPercentile(50.0);
-    const reference_p50 = reference.snapshot.hist.valueAtPercentile(50.0);
+    const l4_p50 = proxied_l4.snapshot.hist.valueAtPercentile(50.0);
+    const l7_p50 = proxied_l7.snapshot.hist.valueAtPercentile(50.0);
+    const tcp_p50 = reference_tcp.snapshot.hist.valueAtPercentile(50.0);
+    const http_p50 = reference_http.snapshot.hist.valueAtPercentile(50.0);
     std.debug.print(
-        "hop overhead p50: zoxy +{d} us, haproxy +{d} us " ++
+        "hop overhead p50: zoxy L4 +{d} us, zoxy L7 +{d} us, " ++
+            "haproxy tcp +{d} us, haproxy http +{d} us " ++
             "(bands, not single numbers — §9)\n",
-        .{ proxied_p50 -| direct_p50, reference_p50 -| direct_p50 },
+        .{
+            l4_p50 -| direct_p50,
+            l7_p50 -| direct_p50,
+            tcp_p50 -| direct_p50,
+            http_p50 -| direct_p50,
+        },
     );
 }
 

--- a/build.zig
+++ b/build.zig
@@ -14,12 +14,23 @@ pub fn build(b: *std.Build) void {
     });
     const xev_module = xev_dependency.module("xev");
 
+    // hparse — the hardened head-parser fork — is pinned by content hash
+    // to an audited zoxy-io/hparse commit (DESIGN.md §7); the pin moves
+    // only after re-audit. Only src/http/parser.zig may import it (lint-
+    // enforced): that wrapper owns every strictness and framing decision.
+    const hparse_dependency = b.dependency("hparse", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const hparse_module = hparse_dependency.module("hparse");
+
     const zoxy_module = b.addModule("zoxy", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
         .imports = &.{
             .{ .name = "xev", .module = xev_module },
+            .{ .name = "hparse", .module = hparse_module },
         },
     });
     // The shipped example config is embedded so tests and the fuzz corpus
@@ -116,12 +127,20 @@ pub fn build(b: *std.Build) void {
 
     // §9 Tier 0: micro binaries for manual poop A/B; installed, never run
     // in CI (counter deltas on shared runners are noise).
+    // The fast module gets its own ReleaseFast hparse instance: hparse's
+    // SIMD paths scalarize under the Debug self-hosted backend, which
+    // would turn a Tier-0 parser A/B into a measurement of the wrong code.
+    const hparse_fast_dependency = b.dependency("hparse", .{
+        .target = target,
+        .optimize = std.builtin.OptimizeMode.ReleaseFast,
+    });
     const zoxy_fast_module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = .ReleaseFast,
         .imports = &.{
             .{ .name = "xev", .module = xev_module },
+            .{ .name = "hparse", .module = hparse_fast_dependency.module("hparse") },
         },
     });
     const micro_step = b.step("bench-micro", "Build Tier-0 micro binaries for poop A/B");

--- a/build.zig
+++ b/build.zig
@@ -97,39 +97,18 @@ pub fn build(b: *std.Build) void {
     const sim_step = b.step("sim", "Deterministic simulation: -- [seed] [iterations] | fuzz");
     sim_step.dependOn(&sim_run.step);
 
-    // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash)
-    // and always measures ReleaseFast, whatever -Doptimize says.
+    // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash),
+    // and the zoxy under test is a ReleaseFast build — matching the
+    // shipped binary — whatever -Doptimize says. ReleaseFast selects the
+    // LLVM backend (Zig 0.16's default for release modes), so hparse's
+    // SIMD paths are emitted; a Debug/self-hosted zoxy scalarizes them
+    // and would benchmark the wrong code.
     const zrk_dependency = b.dependency("zrk", .{
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseFast,
     });
-    const bench_exe = b.addExecutable(.{
-        .name = "zoxy-bench",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("bench/run.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zrk", .module = zrk_dependency.module("zrk") },
-            },
-        }),
-    });
-    const bench_run = b.addRunArtifact(bench_exe);
-    bench_run.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        bench_run.addArgs(args);
-    }
-    const bench_step = b.step(
-        "bench",
-        "Tier-1 loopback bands: -- [--rate N] [--seconds N] [--origin host:port]",
-    );
-    bench_step.dependOn(&bench_run.step);
-
-    // §9 Tier 0: micro binaries for manual poop A/B; installed, never run
-    // in CI (counter deltas on shared runners are noise).
-    // The fast module gets its own ReleaseFast hparse instance: hparse's
-    // SIMD paths scalarize under the Debug self-hosted backend, which
-    // would turn a Tier-0 parser A/B into a measurement of the wrong code.
+    // The ReleaseFast zoxy shared by the bench and the profiler, with its
+    // own ReleaseFast hparse instance (SIMD, not scalarized).
     const hparse_fast_dependency = b.dependency("hparse", .{
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseFast,
@@ -143,6 +122,47 @@ pub fn build(b: *std.Build) void {
             .{ .name = "hparse", .module = hparse_fast_dependency.module("hparse") },
         },
     });
+    const release_zoxy = b.addExecutable(.{
+        .name = "zoxy-release",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+            .imports = &.{
+                .{ .name = "zoxy", .module = zoxy_fast_module },
+            },
+        }),
+    });
+    const bench_exe = b.addExecutable(.{
+        .name = "zoxy-bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("bench/run.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+            .imports = &.{
+                .{ .name = "zrk", .module = zrk_dependency.module("zrk") },
+            },
+        }),
+    });
+    const bench_run = b.addRunArtifact(bench_exe);
+    // Drive the ReleaseFast zoxy, not the default-optimize install
+    // artifact — a Debug zoxy scalarizes hparse and benchmarks the wrong
+    // binary (§9). bench/run.zig takes it via --zoxy.
+    bench_run.addArg("--zoxy");
+    bench_run.addArtifactArg(release_zoxy);
+    if (b.args) |args| {
+        bench_run.addArgs(args);
+    }
+    const bench_step = b.step(
+        "bench",
+        "Tier-1 loopback bands: -- [--rate N] [--seconds N] [--origin host:port]",
+    );
+    bench_step.dependOn(&bench_run.step);
+
+    // §9 Tier 0: micro binaries for manual poop A/B; installed, never run
+    // in CI (counter deltas on shared runners are noise). They reuse the
+    // ReleaseFast `zoxy_fast_module` defined above so the SIMD parser is
+    // what gets measured.
     const micro_step = b.step("bench-micro", "Build Tier-0 micro binaries for poop A/B");
     for ([_][]const u8{ "pool_acquire_release", "relay_chunking", "l7_head_pipeline" }) |micro_name| {
         const micro_exe = b.addExecutable(.{
@@ -165,17 +185,6 @@ pub fn build(b: *std.Build) void {
     // the PMU and LBR call-graph stay on a single core type, drives zrk load,
     // and folds perf into a flamegraph. Linux-only — perf/flamegraph/nginx
     // live in the dev shell. Tooling in Zig, not bash (TIGER_STYLE §Tooling).
-    const profile_zoxy = b.addExecutable(.{
-        .name = "zoxy-profile",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zoxy", .module = zoxy_fast_module },
-            },
-        }),
-    });
     const profile_harness = b.addExecutable(.{
         .name = "zoxy-profile-harness",
         .root_module = b.createModule(.{
@@ -188,7 +197,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     const profile_run = b.addRunArtifact(profile_harness);
-    profile_run.addArtifactArg(profile_zoxy);
+    profile_run.addArtifactArg(release_zoxy);
     if (b.args) |args| profile_run.addArgs(args);
     const profile_step = b.step(
         "profile",

--- a/build.zig
+++ b/build.zig
@@ -144,7 +144,7 @@ pub fn build(b: *std.Build) void {
         },
     });
     const micro_step = b.step("bench-micro", "Build Tier-0 micro binaries for poop A/B");
-    for ([_][]const u8{ "pool_acquire_release", "relay_chunking" }) |micro_name| {
+    for ([_][]const u8{ "pool_acquire_release", "relay_chunking", "l7_head_pipeline" }) |micro_name| {
         const micro_exe = b.addExecutable(.{
             .name = b.fmt("zoxy-bench-{s}", .{micro_name}),
             .root_module = b.createModule(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -45,6 +45,10 @@
             .url = "git+https://github.com/floatdrop/zrk#e13a1fb1ed1278202c170def5502ca4ad37cd0bd",
             .hash = "zrk-0.1.0-WqdFO9erAQDo_HjVH3qPGzyGOC-7XJ_1k_Cc51HqJ52c",
         },
+        .hparse = .{
+            .url = "git+https://github.com/zoxy-io/hparse#33b42c617a84aff9c863ae672f94f20749aa2d0e",
+            .hash = "hparse-0.2.0-IukW0sBzAQDyDV7Yl4OIbPMKI3yQ8HyRzCH6-wmJFSOZ",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,8 +42,8 @@
             .hash = "libxev-0.0.0-86vtc1cTFACGErSvTkJp2mZSFDLCgOHl7R45UZwS5wBZ",
         },
         .zrk = .{
-            .url = "git+https://github.com/floatdrop/zrk#e13a1fb1ed1278202c170def5502ca4ad37cd0bd",
-            .hash = "zrk-0.1.0-WqdFO9erAQDo_HjVH3qPGzyGOC-7XJ_1k_Cc51HqJ52c",
+            .url = "git+https://github.com/floatdrop/zrk#dfab0b0e6bbe01c3db147b5025a0d6b38f37f830",
+            .hash = "zrk-0.3.6-WqdFO8JiAwCaTpT5YBAsjbn_73dLTDUA5-qtoX29FwET",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -45,9 +45,12 @@
             .url = "git+https://github.com/floatdrop/zrk#e13a1fb1ed1278202c170def5502ca4ad37cd0bd",
             .hash = "zrk-0.1.0-WqdFO9erAQDo_HjVH3qPGzyGOC-7XJ_1k_Cc51HqJ52c",
         },
+        // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
+        // hardening-gate merge (PR #3: CRLF-only line terminators +
+        // extension-method tokens). The pin moves only after re-audit.
         .hparse = .{
-            .url = "git+https://github.com/zoxy-io/hparse#33b42c617a84aff9c863ae672f94f20749aa2d0e",
-            .hash = "hparse-0.2.0-IukW0sBzAQDyDV7Yl4OIbPMKI3yQ8HyRzCH6-wmJFSOZ",
+            .url = "git+https://github.com/zoxy-io/hparse#65521edfc09f19c5574a3360e2ce236c6dbc3be3",
+            .hash = "hparse-0.2.0-IukW0rSOAQAmTPCaHzBakxuRRv6dfMds5OGdGU8nxlXw",
         },
     },
     .paths = .{

--- a/config/example.json
+++ b/config/example.json
@@ -1,6 +1,6 @@
 {
     "listeners": [
-        { "bind": "127.0.0.1:8080", "cluster": "origin" }
+        { "bind": "127.0.0.1:8080", "cluster": "origin", "protocol": "l4" }
     ],
     "clusters": {
         "origin": { "endpoints": ["127.0.0.1:9000"] }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -583,8 +583,19 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    sockets and a virtual clock under a seeded adversarial scheduler:
    partial reads/writes down to 1 byte, delayed/refused/black-holed
    connects, resets at every point in every exchange, misbehaving origins.
-   Every request carries a token echoed into the body and verified
-   byte-exact. Invariants per seed: no slot leaks (all pools drain to
+   Mixed L4 and L7 clients share one server. L4 clients carry a token
+   echoed into the body and verified byte-exact. L7 clients run HTTP
+   request scripts — the valid shapes, the §7 reject shapes, and the
+   keep-alive/pipelined/silent patterns — against scripted origins
+   (sized, chunked, until-close, truncated, reset, mute, and instant
+   origins that answer before the request finishes), and every byte they
+   receive must be a prefix of a legal transcript. A quarter of seeds run
+   clean — adversary off, origin well-behaved — hardening the L7 oracle
+   from prefix-legality to each script's exact golden outcome, so a
+   silently torn-down exchange that should have been answered fails the
+   seed instead of passing as a cut. The origins are oracles too: no
+   malformed byte (§7) ever reaches one. Invariants per seed: no slot
+   leaks (all pools drain to
    zero), no deadlock, counters reconcile, every shed is witnessed, no
    completion is delivered to a freed or reused slot (slot generations
    checked on every delivery, §5), and no loop-side write ever lands in

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -667,6 +667,7 @@ src/
     upstream.zig      // shared upstream pool + endpoint idle lists
   http/
     parser.zig        // hparse wrapper: strictness + framing + chunked decoder
+    render.zig        // §7 head rendering: hop-by-hop strip + close injection
     proxy.zig         // L7 state machine over phases
   phases.zig          // admit / route / upstream_pick / settle
   shed.zig            // exhaustion ladder: decisions + static responses

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -22,7 +22,9 @@ behind all four gates of §9.
   (zoxy-io/hparse PR #3: CRLF-only line terminators + extension-method
   tokens; pin at 65521ed).
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
-  stale-replay, per-try deadline, counter reconciliation invariants in
+  stale-replay (a checkout that fails on first use answers 502 today),
+  per-try deadline and the §8 request-deadline 504 verdict (an expired
+  exchange tears down today), counter reconciliation invariants in
   the sim, overload benchmark scenario (offered load ≫ capacity: assert
   flat memory, bounded latency for admitted work, all excess shed with
   correct status). The relay-buffer pressure watermark shipped early

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -18,7 +18,9 @@ behind all four gates of §9.
   upstream pool + keep-alive both sides, relay-buffer decoupling (idle
   costs no relay memory), static error responses, remaining ladder
   rungs. Entry gate: the hparse fork must clear the hardening list
-  recorded in §7 before this phase lands.
+  recorded in §7 before this phase lands — **cleared 2026-07-18**
+  (zoxy-io/hparse PR #3: CRLF-only line terminators + extension-method
+  tokens; pin at 65521ed).
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
   stale-replay, per-try deadline, counter reconciliation invariants in
   the sim, overload benchmark scenario (offered load ≫ capacity: assert

--- a/scripts/lint.zig
+++ b/scripts/lint.zig
@@ -1,9 +1,11 @@
 //! Build-time lint for the fd boundary of DESIGN.md §4/§9: raw syscall
 //! surfaces (`std.posix`, `std.os`, `os.linux`) and the `xev` import may be
 //! named only under `src/io/`, with an explicit allowlist for `main.zig`
-//! startup work (rlimits, sigaction). `@cImport` is forbidden everywhere —
-//! the codebase has no C-FFI dependency (§4). Runs as `zig build lint`
-//! with the source root as its single argument.
+//! startup work (rlimits, sigaction). The `hparse` import is likewise
+//! confined to `src/http/parser.zig` — the wrapper that owns the trust
+//! boundary (§7). `@cImport` is forbidden everywhere — the codebase has no
+//! C-FFI dependency (§4). Runs as `zig build lint` with the source root as
+//! its single argument.
 
 const std = @import("std");
 
@@ -77,6 +79,8 @@ fn lintFile(
     const in_io_directory = std.mem.startsWith(u8, path, "io/") or
         std.mem.startsWith(u8, path, "io" ++ std.fs.path.sep_str);
     const is_main = std.mem.eql(u8, path, "main.zig");
+    const is_http_parser = std.mem.eql(u8, path, "http/parser.zig") or
+        std.mem.eql(u8, path, "http" ++ std.fs.path.sep_str ++ "parser.zig");
 
     const contents = try root.readFileAlloc(io, path, arena, .limited(file_bytes_max));
     assert(contents.len < file_bytes_max);
@@ -86,7 +90,7 @@ fn lintFile(
     var lines = std.mem.splitScalar(u8, contents, '\n');
     while (lines.next()) |line| {
         line_number += 1;
-        if (lintLine(line, in_io_directory, is_main)) |message| {
+        if (lintLine(line, in_io_directory, is_main, is_http_parser)) |message| {
             std.debug.print("{s}:{d}: {s}\n", .{ path, line_number, message });
             violation_count += 1;
         }
@@ -96,9 +100,17 @@ fn lintFile(
 }
 
 /// Returns a violation message for the line, or null if the line is clean.
-fn lintLine(line: []const u8, in_io_directory: bool, is_main: bool) ?[]const u8 {
+fn lintLine(
+    line: []const u8,
+    in_io_directory: bool,
+    is_main: bool,
+    is_http_parser: bool,
+) ?[]const u8 {
     if (std.mem.indexOf(u8, line, "@cImport") != null) {
         return "@cImport is forbidden: no C-FFI dependency (DESIGN.md §4)";
+    }
+    if (!is_http_parser and std.mem.indexOf(u8, line, "@import(\"hparse\")") != null) {
+        return "hparse is imported only by src/http/parser.zig — the trust boundary (DESIGN.md §7)";
     }
     if (in_io_directory) {
         return null;
@@ -152,26 +164,33 @@ fn startsWithAllowedMember(member: []const u8) bool {
 }
 
 test "lintLine: raw syscalls flagged outside io, allowed inside" {
-    try std.testing.expect(lintLine("const x = std.posix.socket();", false, false) != null);
-    try std.testing.expect(lintLine("const x = std.os.linux.close(fd);", false, false) != null);
-    try std.testing.expect(lintLine("const x = std.posix.socket();", true, false) == null);
-    try std.testing.expect(lintLine("const clean = a + b;", false, false) == null);
+    try std.testing.expect(lintLine("const x = std.posix.socket();", false, false, false) != null);
+    try std.testing.expect(lintLine("const x = std.os.linux.close(fd);", false, false, false) != null);
+    try std.testing.expect(lintLine("const x = std.posix.socket();", true, false, false) == null);
+    try std.testing.expect(lintLine("const clean = a + b;", false, false, false) == null);
 }
 
 test "lintLine: main.zig allowlist admits rlimit and sigaction only" {
-    try std.testing.expect(lintLine("try std.posix.setrlimit(.NOFILE, limits);", false, true) == null);
-    try std.testing.expect(lintLine("std.posix.sigaction(.TERM, &action, null);", false, true) == null);
-    try std.testing.expect(lintLine("_ = std.posix.setsockopt(fd, 0, 0, &opt);", false, true) != null);
+    try std.testing.expect(lintLine("try std.posix.setrlimit(.NOFILE, limits);", false, true, false) == null);
+    try std.testing.expect(lintLine("std.posix.sigaction(.TERM, &action, null);", false, true, false) == null);
+    try std.testing.expect(lintLine("_ = std.posix.setsockopt(fd, 0, 0, &opt);", false, true, false) != null);
     // A comment mentioning SIG must not exempt a real forbidden call.
-    try std.testing.expect(lintLine("const s = std.posix.socket(); // closed on SIGTERM", false, true) != null);
+    try std.testing.expect(lintLine("const s = std.posix.socket(); // closed on SIGTERM", false, true, false) != null);
     // A forbidden call sharing a line with an allowed one is still caught.
-    try std.testing.expect(lintLine("std.posix.sigaction(x); std.posix.socket();", false, true) != null);
+    try std.testing.expect(lintLine("std.posix.sigaction(x); std.posix.socket();", false, true, false) != null);
     // std.os.linux.* is never allowlisted in main.zig.
-    try std.testing.expect(lintLine("_ = std.os.linux.close(fd);", false, true) != null);
+    try std.testing.expect(lintLine("_ = std.os.linux.close(fd);", false, true, false) != null);
 }
 
 test "lintLine: xev import and cImport boundaries" {
-    try std.testing.expect(lintLine("const xev = @import(\"xev\");", false, false) != null);
-    try std.testing.expect(lintLine("const xev = @import(\"xev\");", true, false) == null);
-    try std.testing.expect(lintLine("const c = @cImport({});", true, false) != null);
+    try std.testing.expect(lintLine("const xev = @import(\"xev\");", false, false, false) != null);
+    try std.testing.expect(lintLine("const xev = @import(\"xev\");", true, false, false) == null);
+    try std.testing.expect(lintLine("const c = @cImport({});", true, false, false) != null);
+}
+
+test "lintLine: hparse import is confined to the http parser wrapper" {
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", false, false, true) == null);
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", false, false, false) != null);
+    // Not even src/io/ may reach around the wrapper.
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", true, false, false) != null);
 }

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -308,14 +308,37 @@ pub fn HttpOrigin(comptime IoType: type) type {
     };
 }
 
-/// The client's request scripts. Slice 1 ships the valid single-exchange
-/// pair; the adversarial matrix (malformed, oversize, CONNECT, keep-alive,
-/// pipelined, silent) follows.
+/// The client's request scripts: the valid shapes, the §7 reject shapes
+/// (each pinned to its exact verdict on clean seeds), and the connection
+/// patterns (keep-alive reuse, pipelining, silence).
 pub const Script = enum(u8) {
     /// A bodyless GET; expects one canonical 200.
     get,
     /// A POST with a 24-byte sized body; expects one canonical 200.
     post_sized,
+    /// A POST with a valid chunked body; expects one canonical 200.
+    post_chunked,
+    /// A chunked POST whose first body byte violates chunk framing —
+    /// the silent-teardown-instead-of-400 shape (§7): clean seeds
+    /// demand the 400.
+    post_chunked_malformed,
+    /// A bare-LF head terminator (smuggling shape); 400.
+    malformed_head,
+    /// A request line alone overflowing the proxy's 8 KiB head buffer;
+    /// 414.
+    oversize_uri,
+    /// CONNECT is a §1 non-goal; 501.
+    connect_method,
+    /// Two sequential GETs on one connection: the §5 parking/checkout
+    /// path — the second is sent only after the first 200 settles
+    /// reusable.
+    keepalive_pair,
+    /// Two GETs in one send: the proxy answers the first, announces
+    /// close (§2), and never serves the second.
+    pipelined,
+    /// Connects and sends nothing: the head-read deadline reaps it;
+    /// any response byte is a violation.
+    silent,
 };
 
 /// A verify-time verdict over everything the client received.
@@ -361,6 +384,8 @@ pub fn Client(comptime IoType: type) type {
         connect_settled: bool = false,
         cancel_requested: bool = false,
         script_satisfied: bool = false,
+        /// The keep-alive pair's second request has been appended.
+        second_sent: bool = false,
         closed: bool = false,
         ended: bool = false,
         send_pending: bool = false,
@@ -375,8 +400,35 @@ pub fn Client(comptime IoType: type) type {
         const responses_max: u8 = 4;
 
         const post_body = "request-body-24-bytes-ab";
+        const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n\r\n";
         comptime {
             assert(post_body.len == 24);
+        }
+
+        fn requestBytes(script: Script) []const u8 {
+            return switch (script) {
+                .get => get_request,
+                .post_sized => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+                    "Content-Length: 24\r\n\r\n" ++ post_body,
+                .post_chunked => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+                    "Transfer-Encoding: chunked\r\n\r\n" ++ "8\r\nabcdefgh\r\n0\r\n\r\n",
+                // "Z" is no chunk-size digit: the framing violation is in
+                // the first body byte, coalesced with the head.
+                .post_chunked_malformed => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+                    "Transfer-Encoding: chunked\r\n\r\nZ",
+                // A bare LF terminating the request line (§7 smuggling
+                // shape).
+                .malformed_head => "GET /sim HTTP/1.1\nHost: sim\r\n\r\n",
+                // The request line alone must overflow the proxy's 8 KiB
+                // head buffer with no newline in sight: 414, not 431.
+                .oversize_uri => "GET /" ++ ("a" ** 8500) ++ " HTTP/1.1\r\nHost: sim\r\n\r\n",
+                .connect_method => "CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n",
+                // The second GET is appended at run time, only after the
+                // first 200 settles reusable.
+                .keepalive_pair => get_request,
+                .pipelined => get_request ++ get_request,
+                .silent => "",
+            };
         }
 
         pub fn prepare(
@@ -390,18 +442,14 @@ pub fn Client(comptime IoType: type) type {
             client.address = address;
             client.script = script;
             client.clean = clean;
-            const bytes: []const u8 = switch (script) {
-                .get => "GET /sim HTTP/1.1\r\nHost: sim\r\n\r\n",
-                .post_sized => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
-                    "Content-Length: 24\r\n\r\n" ++ post_body,
-            };
+            const bytes = requestBytes(script);
             assert(bytes.len <= client.request.len);
             @memcpy(client.request[0..bytes.len], bytes);
             client.request_len = @intCast(bytes.len);
         }
 
         pub fn begin(client: *Self) void {
-            assert(client.request_len >= 1);
+            assert(client.request_len >= 1 or client.script == .silent);
             client.io.connect(
                 client.address,
                 &client.connect_completion,
@@ -419,7 +467,9 @@ pub fn Client(comptime IoType: type) type {
             };
             client.connected = true;
             client.armRecv();
-            client.armSend();
+            if (client.request_len >= 1) {
+                client.armSend();
+            }
         }
 
         fn armSend(client: *Self) void {
@@ -485,7 +535,8 @@ pub fn Client(comptime IoType: type) type {
                 client.receive_buffer[0..client.received_len],
                 client.script,
             );
-            if (walk.violation == null and walk.complete_count >= expectedResponses(client.script)) {
+            client.maybeSendSecondRequest(&walk);
+            if (walk.violation == null and walk.complete_count >= responsesTarget(client.script, &walk)) {
                 // The script's transcript is fully in hand: close from
                 // this side — the proxy honors keep-alive, so waiting for
                 // its FIN would hang until the drain.
@@ -494,6 +545,46 @@ pub fn Client(comptime IoType: type) type {
                 return;
             }
             client.armRecv();
+        }
+
+        /// The first exchange settled as a reusable success: a 200 that
+        /// did not announce close.
+        fn firstExchangeReusable(walk: *const Walk) bool {
+            assert(walk.complete_count >= 1);
+            return walk.statuses[0] == 200 and walk.keep_alives[0];
+        }
+
+        /// The keep-alive pair's second exchange starts only after the
+        /// first 200 settles reusable — the §5 parked-connection checkout
+        /// under schedule fuzz.
+        fn maybeSendSecondRequest(client: *Self, walk: *const Walk) void {
+            if (client.script != .keepalive_pair or client.second_sent) return;
+            if (walk.violation != null) return;
+            if (walk.complete_count != 1) return;
+            if (!firstExchangeReusable(walk)) return;
+            // A complete first response implies the proxy consumed the
+            // whole first request, so the send op has settled.
+            assert(!client.send_pending);
+            assert(client.sent_len == client.request_len);
+            const second = get_request;
+            assert(client.request_len + second.len <= client.request.len);
+            @memcpy(client.request[client.request_len..][0..second.len], second);
+            client.request_len += @intCast(second.len);
+            client.second_sent = true;
+            client.armSend();
+        }
+
+        /// How many responses the script still legally expects, given
+        /// what has arrived: the keep-alive pair degrades to a single
+        /// exchange when its first response refuses reuse (an error
+        /// status, or an announced close under pressure or drain).
+        fn responsesTarget(script: Script, walk: *const Walk) u8 {
+            const static_target = expectedResponses(script);
+            if (script != .keepalive_pair) return static_target;
+            if (walk.complete_count >= 1 and !firstExchangeReusable(walk)) {
+                return 1;
+            }
+            return static_target;
         }
 
         /// Scenario end: a connect the adversary black-holed must still
@@ -565,6 +656,11 @@ pub fn Client(comptime IoType: type) type {
                         return ClientError.GoldenOutcomeMissed;
                     }
                 }
+                // §2: a pipelined first response must announce the close
+                // that follows it.
+                if (client.script == .pipelined and walk.keep_alives[0]) {
+                    return ClientError.GoldenOutcomeMissed;
+                }
             }
         }
 
@@ -572,6 +668,9 @@ pub fn Client(comptime IoType: type) type {
             complete_count: u8,
             offset: u32,
             statuses: [responses_max]u16,
+            /// Per-response persistence verdicts (§2): version defaults
+            /// plus Connection tokens, as the parser computed them.
+            keep_alives: [responses_max]bool,
             violation: ?ClientError,
         };
 
@@ -586,6 +685,7 @@ pub fn Client(comptime IoType: type) type {
                 .complete_count = 0,
                 .offset = 0,
                 .statuses = @splat(0),
+                .keep_alives = @splat(false),
                 .violation = null,
             };
             while (walk.complete_count < responses_max) {
@@ -616,11 +716,12 @@ pub fn Client(comptime IoType: type) type {
                 }
                 assert(verdict.body_len <= body.len);
                 walk.statuses[walk.complete_count] = response.status;
+                walk.keep_alives[walk.complete_count] = response.keep_alive;
                 walk.complete_count += 1;
                 walk.offset += response.head_len + verdict.body_len;
                 // A complete response beyond the script's transcript is a
                 // duplication bug, not a legal prefix.
-                if (walk.complete_count > expectedResponses(script)) {
+                if (walk.complete_count > transcriptCap(script)) {
                     walk.violation = ClientError.ResponseOverrun;
                     return walk;
                 }
@@ -680,30 +781,69 @@ pub fn Client(comptime IoType: type) type {
 
         fn expectedResponses(script: Script) u8 {
             return switch (script) {
-                .get, .post_sized => 1,
+                .get, .post_sized, .post_chunked => 1,
+                .post_chunked_malformed, .malformed_head => 1,
+                .oversize_uri, .connect_method, .pipelined => 1,
+                .keepalive_pair => 2,
+                .silent => 0,
             };
         }
 
-        /// The exact status a clean seed's script must produce.
+        /// The most complete responses ANY legal transcript can contain —
+        /// the walker's surplus bound. Pipelined admits one more than the
+        /// clean expectation: when adversarial fragmentation lands exactly
+        /// on the request boundary, the proxy never observes the pipelined
+        /// bytes and legally serves both requests as plain keep-alive.
+        /// The clean tier still pins pipelined to exactly one (detection
+        /// is deterministic there).
+        fn transcriptCap(script: Script) u8 {
+            return switch (script) {
+                .pipelined => 2,
+                else => expectedResponses(script),
+            };
+        }
+
+        /// The exact status a clean seed's script must produce. Silent
+        /// never produces one; its zero-response transcript makes the
+        /// value unread.
         fn goldenStatus(script: Script) u16 {
             return switch (script) {
-                .get, .post_sized => 200,
+                .get, .post_sized, .post_chunked, .keepalive_pair, .pipelined => 200,
+                .post_chunked_malformed, .malformed_head => 400,
+                .oversize_uri => 414,
+                .connect_method => 501,
+                .silent => 0,
             };
         }
 
+        /// The method context for response parsing (HEAD-shaped body
+        /// rules). CONNECT maps to GET: the parser refuses to represent a
+        /// CONNECT response (the proxy rejects the method before dialing),
+        /// and the 501 static carries no body either way.
         fn methodOf(script: Script) parser.Method {
             return switch (script) {
-                .get => .get,
-                .post_sized => .post,
+                .post_sized, .post_chunked, .post_chunked_malformed => .post,
+                .get, .malformed_head, .oversize_uri => .get,
+                .connect_method, .keepalive_pair, .pipelined, .silent => .get,
             };
         }
 
         /// Statuses a script may legally see. Valid requests meet the
         /// canonical 200, the §8 rungs (503), or an upstream that the
-        /// adversary killed (502) — anything else is a proxy bug.
+        /// adversary killed (502); parse verdicts precede routing, so the
+        /// reject scripts admit exactly their own verdict — and a silent
+        /// client may see nothing at all.
         fn statusAllowed(script: Script, status: u16) bool {
             return switch (script) {
-                .get, .post_sized => status == 200 or status == 502 or status == 503,
+                .get, .post_sized, .post_chunked, .keepalive_pair, .pipelined => //
+                status == 200 or status == 502 or status == 503,
+                // The head routes before its body is validated, so the §8
+                // rungs and a killed dial can still precede the 400.
+                .post_chunked_malformed => status == 400 or status == 502 or status == 503,
+                .malformed_head => status == 400,
+                .oversize_uri => status == 414,
+                .connect_method => status == 501,
+                .silent => false,
             };
         }
     };

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -1,0 +1,710 @@
+//! L7 pieces of the deterministic-simulation gate (§9): an HTTP/1.1
+//! scripted origin and a script-driven client, both generic over the Io
+//! backend. The sim mixes these with the L4 population in one scenario so
+//! the shared pools feel cross-protocol pressure.
+//!
+//! Oracles, not expectations: the origin asserts the §7 promise that no
+//! malformed byte is ever forwarded upstream (every request it receives
+//! must parse, every body must satisfy its own framing); the client
+//! asserts that whatever bytes it got back are a prefix of some legal
+//! transcript — parseable heads, statuses drawn from its script's allowed
+//! set, 200-bodies matching the origin's canonical wire bytes. On clean
+//! seeds (adversary off, origin well-behaved) the oracle hardens to
+//! exact: the scripted outcome must happen, byte-for-byte — a silently
+//! torn-down exchange that should have been answered is a failure, not
+//! an accepted cut.
+
+const std = @import("std");
+
+const zoxy = @import("zoxy");
+
+const Io = zoxy.Io;
+const parser = zoxy.http.parser;
+
+const assert = std.debug.assert;
+
+/// The canonical 200 the well-behaved origin serves: body bytes are fixed
+/// so the client can detect corruption without correlating connections.
+pub const sized_body = "canonical-sized-response-body-00";
+pub const sized_head = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n\r\n";
+const sized_response = sized_head ++ sized_body;
+
+comptime {
+    assert(sized_body.len == 32);
+}
+
+/// Per-connection origin behavior. Slice 1 ships the well-behaved mode;
+/// the misbehavior matrix (early, oversize, truncated, ...) follows.
+pub const OriginMode = enum(u8) {
+    /// Parse each request, wait for its full body, answer the canonical
+    /// sized 200, keep the connection open for reuse (§5 parking).
+    sized,
+};
+
+/// What the origin verifies about every byte the proxy forwards (§7):
+/// heads parse, bodies satisfy their own framing. A violation here means
+/// the proxy relayed something it was built to reject.
+pub fn HttpOrigin(comptime IoType: type) type {
+    return struct {
+        io: *IoType = undefined,
+        listener: IoType.Listener = undefined,
+        accept_completion: IoType.Completion = .{},
+        conns: [conns_max]Conn = @splat(.{}),
+        conns_count: u8 = 0,
+        listening: bool = false,
+        /// Optional per-accept mode picker (the sim randomizes modes).
+        mode_selector: ?*const fn (?*anyopaque) OriginMode = null,
+        context: ?*anyopaque = null,
+        /// Count of §7 violations observed: a malformed forwarded head,
+        /// a body that broke its framing. Checked by the harness verify.
+        violations: u32 = 0,
+
+        const Self = @This();
+        pub const conns_max: u8 = 32;
+        const request_buffer_bytes: u32 = 16384;
+
+        const Phase = enum(u8) { head, body, respond };
+        const FramingTag = enum(u8) { none, content_length, chunked };
+
+        pub const Conn = struct {
+            origin: *Self = undefined,
+            socket: IoType.Socket = undefined,
+            recv_completion: IoType.Completion = .{},
+            send_completion: IoType.Completion = .{},
+            /// Every request stays captured; the current one starts at
+            /// `request_offset` and parses from there.
+            request_buffer: [request_buffer_bytes]u8 = undefined,
+            request_len: u32 = 0,
+            request_offset: u32 = 0,
+            phase: Phase = .head,
+            framing_tag: FramingTag = .none,
+            content_remaining: u64 = 0,
+            chunk_scanner: parser.ChunkedScanner = .{},
+            mode: OriginMode = .sized,
+            response_sent: u32 = 0,
+            requests_served: u32 = 0,
+            done: bool = false,
+
+            fn armRecv(conn: *Conn) void {
+                assert(!conn.done);
+                assert(conn.request_len < conn.request_buffer.len);
+                conn.origin.io.recv(
+                    conn.socket,
+                    conn.request_buffer[conn.request_len..],
+                    &conn.recv_completion,
+                    Conn,
+                    conn,
+                    onRecv,
+                );
+            }
+
+            fn onRecv(conn: *Conn, result: Io.RecvError!u32) void {
+                const received = result catch {
+                    // Peer closed or scenario teardown: not a violation.
+                    conn.close();
+                    return;
+                };
+                assert(received >= 1);
+                conn.request_len += received;
+                assert(conn.request_len <= conn.request_buffer.len);
+                conn.advance();
+            }
+
+            /// Drive head → body → respond over the buffered bytes; arms
+            /// a recv when more are needed. No loop: each phase either
+            /// falls through or returns, and a finished response re-enters
+            /// from `onSend` for any already-buffered next request.
+            fn advance(conn: *Conn) void {
+                if (conn.phase == .head) {
+                    if (!conn.parseHead()) return;
+                }
+                if (conn.phase == .body) {
+                    if (!conn.consumeBody()) return;
+                }
+                assert(conn.phase == .respond);
+                conn.beginRespond();
+            }
+
+            /// Returns true when the head is parsed and the phase moved
+            /// on; false when it armed a recv or closed on a violation.
+            fn parseHead(conn: *Conn) bool {
+                assert(conn.phase == .head);
+                const bytes = conn.request_buffer[conn.request_offset..conn.request_len];
+                if (bytes.len == 0) {
+                    conn.recvMoreOrViolation();
+                    return false;
+                }
+                var storage: parser.HeaderStorage = undefined;
+                const request = parser.parseRequestHead(bytes, false, &storage) catch |err| {
+                    if (err == error.Incomplete and conn.request_len < conn.request_buffer.len) {
+                        conn.armRecv();
+                        return false;
+                    }
+                    // §7: the proxy never forwards a malformed head — and
+                    // never one bigger than its own 8 KiB cap, so a full
+                    // origin buffer is a violation too, not a shortfall.
+                    conn.origin.violations += 1;
+                    conn.close();
+                    return false;
+                };
+                switch (request.framing) {
+                    .none => conn.framing_tag = .none,
+                    .content_length => |length| {
+                        conn.framing_tag = .content_length;
+                        conn.content_remaining = length;
+                    },
+                    .chunked => {
+                        conn.framing_tag = .chunked;
+                        conn.chunk_scanner = .{};
+                    },
+                    // The parser asserts requests are length-delimited.
+                    .until_close => unreachable,
+                }
+                conn.request_offset += request.head_len;
+                assert(conn.request_offset <= conn.request_len);
+                conn.phase = .body;
+                return true;
+            }
+
+            /// Returns true when the body completed and the phase moved
+            /// on; false when it armed a recv or closed on a violation.
+            fn consumeBody(conn: *Conn) bool {
+                assert(conn.phase == .body);
+                const bytes = conn.request_buffer[conn.request_offset..conn.request_len];
+                switch (conn.framing_tag) {
+                    .none => {},
+                    .content_length => {
+                        const take: u32 = @intCast(@min(conn.content_remaining, bytes.len));
+                        conn.content_remaining -= take;
+                        conn.request_offset += take;
+                        if (conn.content_remaining > 0) {
+                            conn.recvMoreOrViolation();
+                            return false;
+                        }
+                    },
+                    .chunked => {
+                        if (bytes.len == 0) {
+                            conn.recvMoreOrViolation();
+                            return false;
+                        }
+                        const progress = conn.chunk_scanner.feed(bytes) catch {
+                            // §7: forwarded chunked bytes always satisfy
+                            // their own framing.
+                            conn.origin.violations += 1;
+                            conn.close();
+                            return false;
+                        };
+                        conn.request_offset += progress.consumed;
+                        if (!progress.done) {
+                            conn.recvMoreOrViolation();
+                            return false;
+                        }
+                    },
+                }
+                assert(conn.request_offset <= conn.request_len);
+                conn.phase = .respond;
+                return true;
+            }
+
+            /// A request still incomplete with the buffer full is
+            /// forwarded excess the scripts never produce — a violation,
+            /// not a capacity shortfall; otherwise read on.
+            fn recvMoreOrViolation(conn: *Conn) void {
+                assert(conn.phase == .head or conn.phase == .body);
+                if (conn.request_len == conn.request_buffer.len) {
+                    conn.origin.violations += 1;
+                    conn.close();
+                    return;
+                }
+                conn.armRecv();
+            }
+
+            fn beginRespond(conn: *Conn) void {
+                assert(conn.phase == .respond);
+                conn.response_sent = 0;
+                conn.armSend();
+            }
+
+            fn armSend(conn: *Conn) void {
+                assert(conn.response_sent < sized_response.len);
+                conn.origin.io.send(
+                    conn.socket,
+                    sized_response[conn.response_sent..],
+                    &conn.send_completion,
+                    Conn,
+                    conn,
+                    onSend,
+                );
+            }
+
+            fn onSend(conn: *Conn, result: Io.SendError!u32) void {
+                const sent = result catch {
+                    conn.close();
+                    return;
+                };
+                conn.response_sent += sent;
+                assert(conn.response_sent <= sized_response.len);
+                if (conn.response_sent < sized_response.len) {
+                    conn.armSend();
+                    return;
+                }
+                // Keep-alive: the next request parses from the new offset
+                // (its bytes may already be buffered).
+                conn.requests_served += 1;
+                conn.phase = .head;
+                conn.advance();
+            }
+
+            fn close(conn: *Conn) void {
+                if (conn.done) return;
+                conn.done = true;
+                conn.origin.io.closeNow(conn.socket);
+            }
+        };
+
+        pub fn start(origin: *Self, io: *IoType, address: std.Io.net.IpAddress) !void {
+            origin.io = io;
+            origin.listener = try io.listen(address);
+            origin.listening = true;
+            origin.armAccept();
+        }
+
+        fn armAccept(origin: *Self) void {
+            origin.io.accept(origin.listener, &origin.accept_completion, Self, origin, onAccept);
+        }
+
+        fn onAccept(origin: *Self, result: Io.AcceptError!IoType.Socket) void {
+            const socket = result catch |err| {
+                assert(err == error.Canceled);
+                return;
+            };
+            assert(origin.conns_count < origin.conns.len);
+            const conn = &origin.conns[origin.conns_count];
+            origin.conns_count += 1;
+            conn.origin = origin;
+            conn.socket = socket;
+            conn.mode = if (origin.mode_selector) |select|
+                select(origin.context)
+            else
+                .sized;
+            conn.armRecv();
+            origin.armAccept();
+        }
+
+        pub fn stopListening(origin: *Self) void {
+            if (origin.listening) {
+                origin.io.listenClose(origin.listener);
+                origin.listening = false;
+            }
+        }
+
+        /// Close any connection still open at scenario end so the socket
+        /// leak check is exact.
+        pub fn closeRemaining(origin: *Self) void {
+            for (origin.conns[0..origin.conns_count]) |*conn| {
+                conn.close();
+            }
+        }
+    };
+}
+
+/// The client's request scripts. Slice 1 ships the valid single-exchange
+/// pair; the adversarial matrix (malformed, oversize, CONNECT, keep-alive,
+/// pipelined, silent) follows.
+pub const Script = enum(u8) {
+    /// A bodyless GET; expects one canonical 200.
+    get,
+    /// A POST with a 24-byte sized body; expects one canonical 200.
+    post_sized,
+};
+
+/// A verify-time verdict over everything the client received.
+pub const ClientError = error{
+    /// Received bytes that no legal transcript starts with.
+    ResponseCorrupted,
+    /// A complete response carried a status outside the script's set.
+    ResponseStatusUnexpected,
+    /// A 200 body diverged from every canonical origin body.
+    ResponseBodyCorrupted,
+    /// More response bytes than any legal transcript contains.
+    ResponseOverrun,
+    /// A clean seed did not produce the script's exact golden outcome.
+    GoldenOutcomeMissed,
+};
+
+/// A script-driven HTTP client over the sim's virtual sockets. Sends its
+/// script's request bytes, reads until the expected responses complete
+/// (or the connection dies), and verifies the §9 oracles at scenario end.
+pub fn Client(comptime IoType: type) type {
+    return struct {
+        io: *IoType = undefined,
+        address: std.Io.net.IpAddress = undefined,
+        on_ended: ?*const fn (?*anyopaque) void = null,
+        context: ?*anyopaque = null,
+        script: Script = .get,
+        /// Clean seeds harden the prefix oracle to the exact golden
+        /// outcome — nothing may be cut, shed, or silently torn down.
+        clean: bool = false,
+        connect_completion: IoType.Completion = .{},
+        connect_cancel_completion: IoType.Completion = .{},
+        recv_completion: IoType.Completion = .{},
+        send_completion: IoType.Completion = .{},
+        request: [request_bytes_max]u8 = undefined,
+        request_len: u32 = 0,
+        receive_buffer: [receive_bytes_max]u8 = undefined,
+        received_len: u32 = 0,
+        /// Bytes past the buffer land here; any arrival is an overrun.
+        overrun_scratch: [1]u8 = undefined,
+        overrun: bool = false,
+        socket: IoType.Socket = undefined,
+        connected: bool = false,
+        connect_settled: bool = false,
+        cancel_requested: bool = false,
+        script_satisfied: bool = false,
+        closed: bool = false,
+        ended: bool = false,
+        send_pending: bool = false,
+        recv_terminal: bool = false,
+        sent_len: u32 = 0,
+
+        const Self = @This();
+        /// Room for the oversize-URI script, which must overflow the
+        /// proxy's 8 KiB head buffer to earn its 414.
+        pub const request_bytes_max: u32 = 9216;
+        pub const receive_bytes_max: u32 = 4096;
+        const responses_max: u8 = 4;
+
+        const post_body = "request-body-24-bytes-ab";
+        comptime {
+            assert(post_body.len == 24);
+        }
+
+        pub fn prepare(
+            client: *Self,
+            io: *IoType,
+            address: std.Io.net.IpAddress,
+            script: Script,
+            clean: bool,
+        ) void {
+            client.io = io;
+            client.address = address;
+            client.script = script;
+            client.clean = clean;
+            const bytes: []const u8 = switch (script) {
+                .get => "GET /sim HTTP/1.1\r\nHost: sim\r\n\r\n",
+                .post_sized => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+                    "Content-Length: 24\r\n\r\n" ++ post_body,
+            };
+            assert(bytes.len <= client.request.len);
+            @memcpy(client.request[0..bytes.len], bytes);
+            client.request_len = @intCast(bytes.len);
+        }
+
+        pub fn begin(client: *Self) void {
+            assert(client.request_len >= 1);
+            client.io.connect(
+                client.address,
+                &client.connect_completion,
+                Self,
+                client,
+                onConnect,
+            );
+        }
+
+        fn onConnect(client: *Self, result: Io.ConnectError!IoType.Socket) void {
+            client.connect_settled = true;
+            client.socket = result catch {
+                client.end();
+                return;
+            };
+            client.connected = true;
+            client.armRecv();
+            client.armSend();
+        }
+
+        fn armSend(client: *Self) void {
+            assert(client.sent_len < client.request_len);
+            assert(!client.send_pending);
+            client.send_pending = true;
+            client.io.send(
+                client.socket,
+                client.request[client.sent_len..client.request_len],
+                &client.send_completion,
+                Self,
+                client,
+                onSend,
+            );
+        }
+
+        fn onSend(client: *Self, result: Io.SendError!u32) void {
+            assert(client.send_pending);
+            client.send_pending = false;
+            const sent = result catch {
+                client.settleIfTerminal();
+                return;
+            };
+            client.sent_len += sent;
+            assert(client.sent_len <= client.request_len);
+            if (client.recv_terminal or client.script_satisfied) {
+                client.settleIfTerminal();
+            } else if (client.sent_len < client.request_len) {
+                client.armSend();
+            }
+        }
+
+        fn armRecv(client: *Self) void {
+            const buffer: []u8 = if (client.received_len == client.receive_buffer.len)
+                &client.overrun_scratch
+            else
+                client.receive_buffer[client.received_len..];
+            client.io.recv(
+                client.socket,
+                buffer,
+                &client.recv_completion,
+                Self,
+                client,
+                onRecv,
+            );
+        }
+
+        fn onRecv(client: *Self, result: Io.RecvError!u32) void {
+            const received = result catch {
+                client.recv_terminal = true;
+                client.settleIfTerminal();
+                return;
+            };
+            assert(received >= 1);
+            if (client.received_len == client.receive_buffer.len) {
+                client.overrun = true;
+                client.armRecv();
+                return;
+            }
+            client.received_len += received;
+            assert(client.received_len <= client.receive_buffer.len);
+            const walk = walkResponses(
+                client.receive_buffer[0..client.received_len],
+                client.script,
+            );
+            if (walk.violation == null and walk.complete_count >= expectedResponses(client.script)) {
+                // The script's transcript is fully in hand: close from
+                // this side — the proxy honors keep-alive, so waiting for
+                // its FIN would hang until the drain.
+                client.script_satisfied = true;
+                client.settleIfTerminal();
+                return;
+            }
+            client.armRecv();
+        }
+
+        /// Scenario end: a connect the adversary black-holed must still
+        /// be reaped, the same seam the proxy relies on (§5).
+        pub fn cancelIfStuck(client: *Self) void {
+            if (client.connect_settled or client.cancel_requested) return;
+            client.cancel_requested = true;
+            client.io.connectCancel(
+                &client.connect_completion,
+                &client.connect_cancel_completion,
+                Self,
+                client,
+                onConnectCanceled,
+            );
+        }
+
+        fn onConnectCanceled(client: *Self) void {
+            if (!client.connect_settled) {
+                client.connect_settled = true;
+                client.end();
+            }
+        }
+
+        fn settleIfTerminal(client: *Self) void {
+            assert(client.recv_terminal or client.script_satisfied or !client.send_pending);
+            if (client.send_pending) return;
+            if (client.recv_terminal or client.script_satisfied) {
+                client.closeIfOpen();
+                client.end();
+            }
+        }
+
+        pub fn closeIfOpen(client: *Self) void {
+            if (client.connected and !client.closed) {
+                client.closed = true;
+                client.io.closeNow(client.socket);
+            }
+        }
+
+        fn end(client: *Self) void {
+            if (client.ended) return;
+            client.ended = true;
+            if (client.on_ended) |ended| {
+                ended(client.context);
+            }
+        }
+
+        /// The §9 verdict over everything received. Adversarial seeds get
+        /// the prefix oracle; clean seeds additionally demand the exact
+        /// golden outcome — count, status, and byte coverage all pinned,
+        /// so a shed, a wrong verdict, or a silent teardown fails the
+        /// seed instead of passing as a "cut".
+        pub fn verify(client: *const Self) ClientError!void {
+            assert(client.received_len <= client.receive_buffer.len);
+            if (client.overrun) return ClientError.ResponseOverrun;
+            const bytes = client.receive_buffer[0..client.received_len];
+            const walk = walkResponses(bytes, client.script);
+            if (walk.violation) |violation| return violation;
+            assert(walk.offset <= client.received_len);
+            if (client.clean) {
+                if (walk.complete_count != expectedResponses(client.script)) {
+                    return ClientError.GoldenOutcomeMissed;
+                }
+                if (walk.offset != client.received_len) {
+                    return ClientError.GoldenOutcomeMissed;
+                }
+                for (walk.statuses[0..walk.complete_count]) |status| {
+                    if (status != goldenStatus(client.script)) {
+                        return ClientError.GoldenOutcomeMissed;
+                    }
+                }
+            }
+        }
+
+        const Walk = struct {
+            complete_count: u8,
+            offset: u32,
+            statuses: [responses_max]u16,
+            violation: ?ClientError,
+        };
+
+        /// Walk the received bytes as a sequence of responses, validating
+        /// each complete one: parseable head, status in the script's set,
+        /// 200-bodies matching a canonical origin body. A partial tail is
+        /// a legal prefix (the adversary cuts mid-anything); bytes that
+        /// can never extend to a legal transcript — or one complete
+        /// response more than the transcript contains — are a violation.
+        fn walkResponses(bytes: []const u8, script: Script) Walk {
+            var walk = Walk{
+                .complete_count = 0,
+                .offset = 0,
+                .statuses = @splat(0),
+                .violation = null,
+            };
+            while (walk.complete_count < responses_max) {
+                assert(walk.offset <= bytes.len);
+                if (walk.offset == bytes.len) return walk;
+                var storage: parser.HeaderStorage = undefined;
+                const response = parser.parseResponseHead(
+                    bytes[walk.offset..],
+                    false,
+                    &storage,
+                    methodOf(script),
+                ) catch |err| {
+                    if (err == error.Incomplete and tailAnchored(bytes[walk.offset..])) {
+                        return walk;
+                    }
+                    walk.violation = ClientError.ResponseCorrupted;
+                    return walk;
+                };
+                if (!statusAllowed(script, response.status)) {
+                    walk.violation = ClientError.ResponseStatusUnexpected;
+                    return walk;
+                }
+                const body = bytes[walk.offset + response.head_len ..];
+                const verdict = walkBody(response, body) orelse return walk;
+                if (verdict.violation) |violation| {
+                    walk.violation = violation;
+                    return walk;
+                }
+                assert(verdict.body_len <= body.len);
+                walk.statuses[walk.complete_count] = response.status;
+                walk.complete_count += 1;
+                walk.offset += response.head_len + verdict.body_len;
+                // A complete response beyond the script's transcript is a
+                // duplication bug, not a legal prefix.
+                if (walk.complete_count > expectedResponses(script)) {
+                    walk.violation = ClientError.ResponseOverrun;
+                    return walk;
+                }
+            }
+            return walk;
+        }
+
+        /// Every legal response starts "HTTP/1."; a partial tail that
+        /// already diverges from that anchor can never extend into one.
+        fn tailAnchored(tail: []const u8) bool {
+            assert(tail.len >= 1);
+            const anchor = "HTTP/1.";
+            const check_len = @min(tail.len, anchor.len);
+            assert(check_len >= 1);
+            return std.mem.eql(u8, tail[0..check_len], anchor[0..check_len]);
+        }
+
+        const BodyVerdict = struct {
+            body_len: u32,
+            violation: ?ClientError,
+        };
+
+        /// Null means the body is still incomplete (a legal partial
+        /// tail); otherwise the verdict carries the wire length consumed
+        /// and any corruption found. Framings are pinned before any byte
+        /// comparison: the canonical 200 is Content-Length 32, every
+        /// legal non-200 is a static with Content-Length 0 — so a
+        /// corrupted length fails even before its body arrives.
+        fn walkBody(response: parser.ResponseHead, body: []const u8) ?BodyVerdict {
+            switch (response.framing) {
+                .content_length => |length| {
+                    if (response.status == 200) {
+                        if (length != sized_body.len) {
+                            return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
+                        }
+                        const have: u32 = @intCast(@min(@as(u64, body.len), length));
+                        if (!std.mem.eql(u8, body[0..have], sized_body[0..have])) {
+                            return .{ .body_len = have, .violation = ClientError.ResponseBodyCorrupted };
+                        }
+                        if (body.len < length) return null;
+                        return .{ .body_len = @intCast(length), .violation = null };
+                    }
+                    if (length != 0) {
+                        return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
+                    }
+                    return .{ .body_len = 0, .violation = null };
+                },
+                // No legal transcript uses these framings yet: the sized
+                // origin frames by length and the statics are
+                // Content-Length 0. The misbehavior matrix widens this.
+                .none, .chunked, .until_close => return .{
+                    .body_len = 0,
+                    .violation = ClientError.ResponseCorrupted,
+                },
+            }
+        }
+
+        fn expectedResponses(script: Script) u8 {
+            return switch (script) {
+                .get, .post_sized => 1,
+            };
+        }
+
+        /// The exact status a clean seed's script must produce.
+        fn goldenStatus(script: Script) u16 {
+            return switch (script) {
+                .get, .post_sized => 200,
+            };
+        }
+
+        fn methodOf(script: Script) parser.Method {
+            return switch (script) {
+                .get => .get,
+                .post_sized => .post,
+            };
+        }
+
+        /// Statuses a script may legally see. Valid requests meet the
+        /// canonical 200, the §8 rungs (503), or an upstream that the
+        /// adversary killed (502) — anything else is a proxy bug.
+        fn statusAllowed(script: Script, status: u16) bool {
+            return switch (script) {
+                .get, .post_sized => status == 200 or status == 502 or status == 503,
+            };
+        }
+    };
+}

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -23,22 +23,65 @@ const parser = zoxy.http.parser;
 
 const assert = std.debug.assert;
 
-/// The canonical 200 the well-behaved origin serves: body bytes are fixed
-/// so the client can detect corruption without correlating connections.
+/// The canonical 200s the origin serves: bodies are fixed so the client
+/// can detect corruption without correlating connections. The proxy
+/// relays body wire bytes verbatim, so the client prefix-checks the raw
+/// framed forms.
 pub const sized_body = "canonical-sized-response-body-00";
 pub const sized_head = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n\r\n";
 const sized_response = sized_head ++ sized_body;
+pub const chunked_wire = "10\r\nchunked-body-16b\r\n0\r\n\r\n";
+pub const chunked_head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+const chunked_response = chunked_head ++ chunked_wire;
+pub const until_close_body = "until-close-stream";
+pub const until_close_head = "HTTP/1.1 200 OK\r\n\r\n";
+const until_close_response = until_close_head ++ until_close_body;
+const truncated_response = sized_head ++ sized_body[0..16];
+
+/// A parseable head that cannot survive the render: 8190 bytes fits the
+/// proxy's 8 KiB response buffer, but no Content-Length and no
+/// Transfer-Encoding makes it until-close framing, which forces a
+/// Connection: close injection — and 8190 plus that header overflows
+/// 8192. Sent at accept time, it races the request legs into the
+/// deferred-render path (§7 buffer rotation) and must die as a clean
+/// 502 or teardown, never a crash.
+const oversize_head = "HTTP/1.1 200 OK\r\nx-pad: " ++ ("p" ** 8162) ++ "\r\n\r\n";
 
 comptime {
     assert(sized_body.len == 32);
+    assert(chunked_wire[0] == '1' and chunked_wire[1] == '0');
+    assert(chunked_wire.len == 4 + 16 + 2 + 5);
+    assert(oversize_head.len == 8190);
 }
 
-/// Per-connection origin behavior. Slice 1 ships the well-behaved mode;
-/// the misbehavior matrix (early, oversize, truncated, ...) follows.
+/// Per-connection origin behavior: the well-behaved framings, then the
+/// misbehavior matrix (§9 adversarial-origin coverage). Clean seeds pin
+/// every connection to `sized`.
 pub const OriginMode = enum(u8) {
     /// Parse each request, wait for its full body, answer the canonical
     /// sized 200, keep the connection open for reuse (§5 parking).
     sized,
+    /// As `sized`, with the chunked canonical 200.
+    chunked,
+    /// Answer the until-close canonical 200 and close after it: the FIN
+    /// delimits the body, and the connection is never reusable.
+    until_close,
+    /// Send the sized head but only half its body, then close: a
+    /// truncated length-delimited response the proxy must cut, never
+    /// repair.
+    truncated,
+    /// RST on the first forwarded byte.
+    reset,
+    /// Read forever, never answer: the proxy's idle deadline reaps the
+    /// exchange.
+    mute,
+    /// Answer the canonical 200 at accept time — before any request
+    /// byte — then only drain. Early responses are legal (§7) and race
+    /// the request legs' buffer rotation.
+    instant_sized,
+    /// Send the oversize-after-edits head at accept time, then drain:
+    /// the render-failure race into the deferred-render path.
+    instant_oversize,
 };
 
 /// What the origin verifies about every byte the proxy forwards (§7):
@@ -81,6 +124,14 @@ pub fn HttpOrigin(comptime IoType: type) type {
             content_remaining: u64 = 0,
             chunk_scanner: parser.ChunkedScanner = .{},
             mode: OriginMode = .sized,
+            /// What this connection answers with, per its mode.
+            response_bytes: []const u8 = sized_response,
+            /// Close right after the response: until-close and truncated
+            /// bodies are delimited by the FIN itself.
+            close_after_response: bool = false,
+            /// Instant and mute modes never answer parsed requests; any
+            /// forwarded bytes are read and discarded.
+            drain_only: bool = false,
             response_sent: u32 = 0,
             requests_served: u32 = 0,
             done: bool = false,
@@ -105,9 +156,39 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     return;
                 };
                 assert(received >= 1);
+                if (conn.mode == .reset) {
+                    conn.origin.io.setLingerRst(conn.socket) catch unreachable;
+                    conn.close();
+                    return;
+                }
                 conn.request_len += received;
                 assert(conn.request_len <= conn.request_buffer.len);
                 conn.advance();
+            }
+
+            /// The drain loop for instant and mute modes: forwarded bytes
+            /// are legal but never answered — recv into the front of the
+            /// buffer and discard, so it can never fill.
+            fn armDrainRecv(conn: *Conn) void {
+                assert(!conn.done);
+                assert(conn.drain_only);
+                conn.origin.io.recv(
+                    conn.socket,
+                    conn.request_buffer[0..],
+                    &conn.recv_completion,
+                    Conn,
+                    conn,
+                    onDrainRecv,
+                );
+            }
+
+            fn onDrainRecv(conn: *Conn, result: Io.RecvError!u32) void {
+                assert(conn.drain_only);
+                _ = result catch {
+                    conn.close();
+                    return;
+                };
+                conn.armDrainRecv();
             }
 
             /// Drive head → body → respond over the buffered bytes; arms
@@ -226,10 +307,10 @@ pub fn HttpOrigin(comptime IoType: type) type {
             }
 
             fn armSend(conn: *Conn) void {
-                assert(conn.response_sent < sized_response.len);
+                assert(conn.response_sent < conn.response_bytes.len);
                 conn.origin.io.send(
                     conn.socket,
-                    sized_response[conn.response_sent..],
+                    conn.response_bytes[conn.response_sent..],
                     &conn.send_completion,
                     Conn,
                     conn,
@@ -243,16 +324,68 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     return;
                 };
                 conn.response_sent += sent;
-                assert(conn.response_sent <= sized_response.len);
-                if (conn.response_sent < sized_response.len) {
+                assert(conn.response_sent <= conn.response_bytes.len);
+                if (conn.response_sent < conn.response_bytes.len) {
                     conn.armSend();
+                    return;
+                }
+                conn.requests_served += 1;
+                if (conn.close_after_response) {
+                    // The FIN is the delimiter (until-close), or the
+                    // truncation itself (truncated).
+                    conn.close();
+                    return;
+                }
+                if (conn.drain_only) {
+                    // Instant modes answered at accept; whatever the
+                    // proxy still forwards is read and dropped.
+                    conn.armDrainRecv();
                     return;
                 }
                 // Keep-alive: the next request parses from the new offset
                 // (its bytes may already be buffered).
-                conn.requests_served += 1;
                 conn.phase = .head;
                 conn.advance();
+            }
+
+            /// Wire a fresh connection per its mode: pick the response,
+            /// decide whether the FIN delimits it, and for the instant
+            /// modes answer now — before any request byte arrives.
+            fn beginMode(conn: *Conn) void {
+                assert(!conn.done);
+                assert(conn.phase == .head);
+                switch (conn.mode) {
+                    .sized, .reset => conn.armRecv(),
+                    .chunked => {
+                        conn.response_bytes = chunked_response;
+                        conn.armRecv();
+                    },
+                    .until_close => {
+                        conn.response_bytes = until_close_response;
+                        conn.close_after_response = true;
+                        conn.armRecv();
+                    },
+                    .truncated => {
+                        conn.response_bytes = truncated_response;
+                        conn.close_after_response = true;
+                        conn.armRecv();
+                    },
+                    .mute => {
+                        conn.drain_only = true;
+                        conn.armDrainRecv();
+                    },
+                    .instant_sized => {
+                        conn.drain_only = true;
+                        conn.phase = .respond;
+                        conn.beginRespond();
+                    },
+                    .instant_oversize => {
+                        conn.response_bytes = oversize_head;
+                        conn.drain_only = true;
+                        conn.phase = .respond;
+                        conn.beginRespond();
+                    },
+                }
             }
 
             fn close(conn: *Conn) void {
@@ -287,7 +420,7 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 select(origin.context)
             else
                 .sized;
-            conn.armRecv();
+            conn.beginMode();
             origin.armAccept();
         }
 
@@ -316,6 +449,12 @@ pub const Script = enum(u8) {
     get,
     /// A POST with a 24-byte sized body; expects one canonical 200.
     post_sized,
+    /// A POST with a 6000-byte sized body: bigger than one virtual-socket
+    /// push, so the body spans multiple deliveries — the excess-forward
+    /// and body-pump paths race the response leg for the head buffer
+    /// (§7 buffer rotation), which is where a misbehaving instant origin
+    /// meets the deferred render.
+    post_big,
     /// A POST with a valid chunked body; expects one canonical 200.
     post_chunked,
     /// A chunked POST whose first body byte violates chunk framing —
@@ -401,8 +540,20 @@ pub fn Client(comptime IoType: type) type {
 
         const post_body = "request-body-24-bytes-ab";
         const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n\r\n";
+        /// Deterministic 6000-byte body for `post_big`, cycled so the
+        /// origin-side §7 oracle can spot any reordering.
+        const big_body = blk: {
+            @setEvalBranchQuota(30_000);
+            var bytes: [6000]u8 = undefined;
+            for (&bytes, 0..) |*byte, index| {
+                byte.* = 'a' + @as(u8, @intCast(index % 26));
+            }
+            const frozen = bytes;
+            break :blk frozen;
+        };
         comptime {
             assert(post_body.len == 24);
+            assert(big_body.len == 6000);
         }
 
         fn requestBytes(script: Script) []const u8 {
@@ -410,6 +561,8 @@ pub fn Client(comptime IoType: type) type {
                 .get => get_request,
                 .post_sized => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
                     "Content-Length: 24\r\n\r\n" ++ post_body,
+                .post_big => "POST /big HTTP/1.1\r\nHost: sim\r\n" ++
+                    "Content-Length: 6000\r\n\r\n" ++ big_body,
                 .post_chunked => "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
                     "Transfer-Encoding: chunked\r\n\r\n" ++ "8\r\nabcdefgh\r\n0\r\n\r\n",
                 // "Z" is no chunk-size digit: the framing violation is in
@@ -747,8 +900,9 @@ pub fn Client(comptime IoType: type) type {
         /// Null means the body is still incomplete (a legal partial
         /// tail); otherwise the verdict carries the wire length consumed
         /// and any corruption found. Framings are pinned before any byte
-        /// comparison: the canonical 200 is Content-Length 32, every
-        /// legal non-200 is a static with Content-Length 0 — so a
+        /// comparison: a 200 carries exactly one canonical body per
+        /// framing (the proxy relays body wire bytes verbatim), and
+        /// every legal non-200 is a static with Content-Length 0 — so a
         /// corrupted length fails even before its body arrives.
         fn walkBody(response: parser.ResponseHead, body: []const u8) ?BodyVerdict {
             switch (response.framing) {
@@ -757,31 +911,62 @@ pub fn Client(comptime IoType: type) type {
                         if (length != sized_body.len) {
                             return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
                         }
-                        const have: u32 = @intCast(@min(@as(u64, body.len), length));
-                        if (!std.mem.eql(u8, body[0..have], sized_body[0..have])) {
-                            return .{ .body_len = have, .violation = ClientError.ResponseBodyCorrupted };
-                        }
-                        if (body.len < length) return null;
-                        return .{ .body_len = @intCast(length), .violation = null };
+                        return prefixVerdict(body, sized_body, @intCast(length));
                     }
                     if (length != 0) {
                         return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
                     }
                     return .{ .body_len = 0, .violation = null };
                 },
-                // No legal transcript uses these framings yet: the sized
-                // origin frames by length and the statics are
-                // Content-Length 0. The misbehavior matrix widens this.
-                .none, .chunked, .until_close => return .{
+                .chunked => {
+                    if (response.status != 200) {
+                        return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
+                    }
+                    return prefixVerdict(body, chunked_wire, chunked_wire.len);
+                },
+                .until_close => {
+                    if (response.status != 200) {
+                        return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
+                    }
+                    // The FIN delimits this body, so it is transcript-
+                    // final: bytes beyond the canonical body — or past
+                    // where the close must fall — are corruption, and
+                    // whatever arrived counts as the (possibly cut)
+                    // complete response.
+                    if (body.len > until_close_body.len) {
+                        return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
+                    }
+                    const have: u32 = @intCast(body.len);
+                    if (!std.mem.eql(u8, body[0..have], until_close_body[0..have])) {
+                        return .{ .body_len = have, .violation = ClientError.ResponseBodyCorrupted };
+                    }
+                    return .{ .body_len = have, .violation = null };
+                },
+                // No canonical 200 is bodiless, and the statics carry an
+                // explicit Content-Length: 0.
+                .none => return .{
                     .body_len = 0,
                     .violation = ClientError.ResponseCorrupted,
                 },
             }
         }
 
+        /// Verdict for a wire-exact canonical body: the received prefix
+        /// must match byte-for-byte; short is incomplete (null), full is
+        /// complete at exactly `wire_len`.
+        fn prefixVerdict(body: []const u8, canonical: []const u8, wire_len: u32) ?BodyVerdict {
+            assert(canonical.len == wire_len);
+            const have: u32 = @intCast(@min(body.len, canonical.len));
+            if (!std.mem.eql(u8, body[0..have], canonical[0..have])) {
+                return .{ .body_len = have, .violation = ClientError.ResponseBodyCorrupted };
+            }
+            if (body.len < wire_len) return null;
+            return .{ .body_len = wire_len, .violation = null };
+        }
+
         fn expectedResponses(script: Script) u8 {
             return switch (script) {
-                .get, .post_sized, .post_chunked => 1,
+                .get, .post_sized, .post_big, .post_chunked => 1,
                 .post_chunked_malformed, .malformed_head => 1,
                 .oversize_uri, .connect_method, .pipelined => 1,
                 .keepalive_pair => 2,
@@ -808,7 +993,7 @@ pub fn Client(comptime IoType: type) type {
         /// value unread.
         fn goldenStatus(script: Script) u16 {
             return switch (script) {
-                .get, .post_sized, .post_chunked, .keepalive_pair, .pipelined => 200,
+                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined => 200,
                 .post_chunked_malformed, .malformed_head => 400,
                 .oversize_uri => 414,
                 .connect_method => 501,
@@ -822,7 +1007,7 @@ pub fn Client(comptime IoType: type) type {
         /// and the 501 static carries no body either way.
         fn methodOf(script: Script) parser.Method {
             return switch (script) {
-                .post_sized, .post_chunked, .post_chunked_malformed => .post,
+                .post_sized, .post_big, .post_chunked, .post_chunked_malformed => .post,
                 .get, .malformed_head, .oversize_uri => .get,
                 .connect_method, .keepalive_pair, .pipelined, .silent => .get,
             };
@@ -835,7 +1020,7 @@ pub fn Client(comptime IoType: type) type {
         /// client may see nothing at all.
         fn statusAllowed(script: Script, status: u16) bool {
             return switch (script) {
-                .get, .post_sized, .post_chunked, .keepalive_pair, .pipelined => //
+                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined => //
                 status == 200 or status == 502 or status == 503,
                 // The head routes before its body is validated, so the §8
                 // rungs and a killed dial can still precede the 400.

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -3,20 +3,29 @@
 //! seed-derived tokens, adversary knobs, pool sizes that force the §8
 //! rungs, misbehaving-origin scripts) and runs the *real* serving path
 //! over SimIo — twice, asserting the two trace hashes are identical, so
-//! replayability itself is gated. Invariants per seed: no deadlock,
-//! pools drain to zero, counters reconcile, every byte a client gets
-//! back is a prefix of what it sent (echo integrity), and every virtual
-//! socket is released. A failure prints its seed; the same seed replays
-//! the exact schedule.
+//! replayability itself is gated. Scenarios mix protocols: an L4 echo
+//! population and an L7 HTTP population share one server, so the pools
+//! feel cross-protocol pressure. A quarter of seeds run *clean* — the
+//! adversary off and the origin well-behaved — hardening the oracles
+//! from prefix-legality to the scripts' exact golden outcomes (sim/l7.zig).
+//! Invariants per seed: no deadlock, pools drain to zero, counters
+//! reconcile, every L4 echo byte is a prefix of what was sent, every L7
+//! response is a prefix of a legal transcript, no malformed byte ever
+//! reaches the origin (§7), and every virtual socket is released. A
+//! failure prints its seed; the same seed replays the exact schedule.
 
 const std = @import("std");
 
 const zoxy = @import("zoxy");
 
+const l7 = @import("l7.zig");
+
 const Io = zoxy.Io;
 const SimIo = zoxy.Io.SimIo;
 const ServerSim = zoxy.Server(SimIo);
 const Origin = zoxy.testing.Origin(SimIo);
+const HttpOrigin = l7.HttpOrigin(SimIo);
+const HttpClient = l7.Client(SimIo);
 
 const assert = std.debug.assert;
 
@@ -106,14 +115,22 @@ fn runSeed(arena_state: *std.heap.ArenaAllocator, seed: u64) !u64 {
 const Harness = struct {
     io: SimIo,
     server: ServerSim,
-    endpoints: [1]std.Io.net.IpAddress,
-    clusters: [1]zoxy.config.Config.Cluster,
-    listener_configs: [1]zoxy.config.Config.Listener,
+    endpoints_l4: [1]std.Io.net.IpAddress,
+    endpoints_http: [1]std.Io.net.IpAddress,
+    clusters: [2]zoxy.config.Config.Cluster,
+    listener_configs: [2]zoxy.config.Config.Listener,
     config: zoxy.config.Config,
     origin: Origin,
+    origin_http: HttpOrigin,
     clients: [clients_max]Client,
+    l7_clients: [clients_max]HttpClient,
+    l4_count: u8,
+    l7_count: u8,
     clients_count: u8,
     ended_count: u8,
+    /// Clean seeds run without the adversary and with a well-behaved
+    /// origin, so the L7 oracles demand exact golden outcomes.
+    clean: bool,
     end_timer_completion: SimIo.Completion,
     scenario_prng: std.Random.DefaultPrng,
 
@@ -121,8 +138,16 @@ const Harness = struct {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8080") catch unreachable;
     }
 
+    fn httpBindAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8081") catch unreachable;
+    }
+
     fn originAddress() std.Io.net.IpAddress {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
+    }
+
+    fn httpOriginAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9001") catch unreachable;
     }
 
     fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
@@ -131,18 +156,53 @@ const Harness = struct {
         harness.scenario_prng = std.Random.DefaultPrng.init(seed ^ 0x5a5a5a5a5a5a5a5a);
         const random = harness.scenario_prng.random();
 
-        const adversary: SimIo.Adversary = .{
+        // A quarter of seeds run clean: adversary off, origin
+        // well-behaved, so the L7 golden oracles demand each script's
+        // exact outcome — a silently dropped 400 or a shed that should
+        // not happen fails the seed instead of passing as a "cut".
+        harness.clean = random.uintLessThan(u8, 4) == 0;
+        try harness.io.init(arena, .{
+            .seed = seed,
+            .adversary = deriveAdversary(random, harness.clean),
+        });
+        harness.deriveTopology(random);
+        try harness.startServerAndOrigins(arena, random);
+        harness.populateClients(random);
+
+        harness.end_timer_completion = .{};
+        harness.io.timerStart(
+            &harness.end_timer_completion,
+            scenario_end_ns,
+            Harness,
+            harness,
+            onScenarioEnd,
+        );
+    }
+
+    fn deriveAdversary(random: std.Random, clean: bool) SimIo.Adversary {
+        if (clean) {
+            return .{ .partial_io = false };
+        }
+        return .{
             .partial_io = true,
             .connect_delay_ns_max = random.uintAtMost(u64, 5_000_000),
             .connect_refuse_percent = random.uintAtMost(u8, 20),
             .reset_percent = random.uintAtMost(u8, 10),
             .kernel_pressure_percent = random.uintAtMost(u8, 8),
         };
-        try harness.io.init(arena, .{ .seed = seed, .adversary = adversary });
+    }
 
-        harness.endpoints = .{originAddress()};
-        harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
-        harness.listener_configs = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 }};
+    fn deriveTopology(harness: *Harness, random: std.Random) void {
+        harness.endpoints_l4 = .{originAddress()};
+        harness.endpoints_http = .{httpOriginAddress()};
+        harness.clusters = .{
+            .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4 },
+            .{ .name = "origin-http", .endpoints = &harness.endpoints_http },
+        };
+        harness.listener_configs = .{
+            .{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 },
+            .{ .bind_address = httpBindAddress(), .cluster_index = 1, .protocol = .http },
+        };
         harness.config = .{
             .listeners = &harness.listener_configs,
             .clusters = &harness.clusters,
@@ -158,13 +218,25 @@ const Harness = struct {
             else
                 0,
         };
+    }
 
-        // A quarter of seeds shrink the pools to force the §8 rungs.
-        const force_exhaustion = random.uintLessThan(u8, 4) == 0;
+    fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: std.Random) !void {
+        // A quarter of adversarial seeds shrink the pools to force the
+        // §8 rungs; clean seeds keep ample pools so golden outcomes
+        // never meet a shed.
+        const force_exhaustion = !harness.clean and random.uintLessThan(u8, 4) == 0;
         const options: ServerSim.InitOptions = if (force_exhaustion)
-            .{ .conn_slots = 1 + random.uintLessThan(u32, 2), .relay_buffers = 1 }
+            .{
+                .conn_slots = 1 + random.uintLessThan(u32, 2),
+                .relay_buffers = 1,
+                .upstream_slots = 1,
+            }
         else
-            .{ .conn_slots = 2 * clients_max, .relay_buffers = clients_max };
+            .{
+                .conn_slots = 2 * clients_max,
+                .relay_buffers = clients_max,
+                .upstream_slots = 2 * clients_max,
+            };
         try harness.server.init(arena, &harness.io, &harness.config, options);
         try harness.server.start();
 
@@ -173,30 +245,51 @@ const Harness = struct {
             .context = harness,
         };
         try harness.origin.start(&harness.io, Harness.originAddress());
+        harness.origin_http = .{};
+        try harness.origin_http.start(&harness.io, Harness.httpOriginAddress());
+    }
 
+    fn populateClients(harness: *Harness, random: std.Random) void {
+        // Each client flips a protocol coin: mixed populations put both
+        // serving paths under one schedule and shared pools.
         harness.clients_count = 1 + random.uintLessThan(u8, clients_max);
+        harness.l4_count = 0;
+        harness.l7_count = 0;
         harness.ended_count = 0;
         harness.clients = @splat(.{});
-        for (harness.clients[0..harness.clients_count]) |*client| {
-            client.harness = harness;
-            client.token_len = 1 + random.uintLessThan(u8, token_bytes_max);
-            random.bytes(client.token[0..client.token_len]);
-            client.silent = random.uintLessThan(u8, 5) == 0;
+        harness.l7_clients = @splat(.{});
+        var index: u8 = 0;
+        while (index < harness.clients_count) : (index += 1) {
+            if (random.boolean()) {
+                const client = &harness.l7_clients[harness.l7_count];
+                harness.l7_count += 1;
+                client.prepare(
+                    &harness.io,
+                    httpBindAddress(),
+                    random.enumValue(l7.Script),
+                    harness.clean,
+                );
+                client.on_ended = l7ClientEnded;
+                client.context = harness;
+            } else {
+                const client = &harness.clients[harness.l4_count];
+                harness.l4_count += 1;
+                client.harness = harness;
+                client.token_len = 1 + random.uintLessThan(u8, token_bytes_max);
+                random.bytes(client.token[0..client.token_len]);
+                client.silent = random.uintLessThan(u8, 5) == 0;
+            }
         }
-
-        harness.end_timer_completion = .{};
-        harness.io.timerStart(
-            &harness.end_timer_completion,
-            scenario_end_ns,
-            Harness,
-            harness,
-            onScenarioEnd,
-        );
+        assert(harness.l4_count + harness.l7_count == harness.clients_count);
     }
 
     fn startClients(harness: *Harness) void {
         assert(harness.clients_count >= 1);
-        for (harness.clients[0..harness.clients_count]) |*client| {
+        assert(harness.l4_count + harness.l7_count == harness.clients_count);
+        for (harness.clients[0..harness.l4_count]) |*client| {
+            client.begin();
+        }
+        for (harness.l7_clients[0..harness.l7_count]) |*client| {
             client.begin();
         }
     }
@@ -217,29 +310,49 @@ const Harness = struct {
     }
 
     fn endScenario(harness: *Harness) void {
-        for (harness.clients[0..harness.clients_count]) |*client| {
+        for (harness.clients[0..harness.l4_count]) |*client| {
+            client.cancelIfStuck();
+        }
+        for (harness.l7_clients[0..harness.l7_count]) |*client| {
             client.cancelIfStuck();
         }
         harness.server.beginDrain();
         harness.origin.stopListening();
+        harness.origin_http.stopListening();
     }
 
     fn verify(harness: *Harness) !void {
         // The loop may stop before harness-side terminal completions
         // deliver; close what remains so the socket-leak check is exact.
-        for (harness.clients[0..harness.clients_count]) |*client| {
+        for (harness.clients[0..harness.l4_count]) |*client| {
+            client.closeIfOpen();
+        }
+        for (harness.l7_clients[0..harness.l7_count]) |*client| {
             client.closeIfOpen();
         }
         harness.origin.closeRemaining();
+        harness.origin_http.closeRemaining();
 
         if (!harness.server.isIdle()) return error.PoolLeak;
         if (!harness.server.reconcile()) return error.CountersDiverged;
         if (!harness.io.sockets.isFullyReleased()) return error.SocketLeak;
-        for (harness.clients[0..harness.clients_count]) |*client| {
+        // §7: no malformed byte may ever reach an origin.
+        if (harness.origin_http.violations != 0) return error.OriginSawMalformedBytes;
+        for (harness.clients[0..harness.l4_count]) |*client| {
             try client.verifyIntegrity();
+        }
+        for (harness.l7_clients[0..harness.l7_count]) |*client| {
+            try client.verify();
         }
     }
 };
+
+/// The L7 client's ended hook: type-erased because l7.zig cannot know the
+/// harness type.
+fn l7ClientEnded(context: ?*anyopaque) void {
+    const harness: *Harness = @ptrCast(@alignCast(context.?));
+    harness.clientEnded();
+}
 
 /// Per-accept origin behavior, drawn from the harness's scenario PRNG so
 /// each proxied connection meets a random misbehavior (echo / RST / mute /

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -234,7 +234,12 @@ const Harness = struct {
         else
             .{
                 .conn_slots = 2 * clients_max,
-                .relay_buffers = clients_max,
+                // Clean seeds size the pool so the §8 pressure watermark
+                // (ceil of 3/4 capacity) sits above the whole client
+                // population: a golden outcome must never meet a
+                // pressure-announced close, which is correct behavior
+                // but not the script's exact transcript.
+                .relay_buffers = if (harness.clean) 2 * clients_max else clients_max,
                 .upstream_slots = 2 * clients_max,
             };
         try harness.server.init(arena, &harness.io, &harness.config, options);

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -142,7 +142,7 @@ const Harness = struct {
 
         harness.endpoints = .{originAddress()};
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
-        harness.listener_configs = .{.{ .bind_address = bindAddress(), .cluster_index = 0 }};
+        harness.listener_configs = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 }};
         harness.config = .{
             .listeners = &harness.listener_configs,
             .clusters = &harness.clusters,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -250,7 +250,10 @@ const Harness = struct {
             .context = harness,
         };
         try harness.origin.start(&harness.io, Harness.originAddress());
-        harness.origin_http = .{};
+        harness.origin_http = .{
+            .mode_selector = pickHttpOriginMode,
+            .context = harness,
+        };
         try harness.origin_http.start(&harness.io, Harness.httpOriginAddress());
     }
 
@@ -365,6 +368,15 @@ fn l7ClientEnded(context: ?*anyopaque) void {
 fn pickOriginMode(context: ?*anyopaque) zoxy.testing.Mode {
     const harness: *Harness = @ptrCast(@alignCast(context.?));
     return harness.scenario_prng.random().enumValue(zoxy.testing.Mode);
+}
+
+/// Per-accept HTTP-origin misbehavior, drawn like the L4 origin's. Clean
+/// seeds pin every connection to the well-behaved sized mode so golden
+/// outcomes stay exact.
+fn pickHttpOriginMode(context: ?*anyopaque) l7.OriginMode {
+    const harness: *Harness = @ptrCast(@alignCast(context.?));
+    if (harness.clean) return .sized;
+    return harness.scenario_prng.random().enumValue(l7.OriginMode);
 }
 
 /// A scripted client with a seed-derived token. Sends the token, FINs

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -22,6 +22,7 @@ const Pool = @import("mem/Pool.zig").Pool;
 const proxy = @import("http/proxy.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
+const upstream_module = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
 
@@ -33,6 +34,9 @@ pub fn Server(comptime IoType: type) type {
         config: *const config_module.Config,
         conns: Pool(ConnType),
         relay_buffers: Pool(relay.RelayBuffer),
+        /// The shared upstream connection pool (§3, §5): leased per L7
+        /// exchange today; parking joins with keep-alive.
+        upstreams: upstream_module.UpstreamPool(IoType),
         listeners: []ListenerState,
         listeners_count: u16,
         /// The load-balancing policy: resolves a cluster to the endpoint to
@@ -58,6 +62,7 @@ pub fn Server(comptime IoType: type) type {
         pub const InitOptions = struct {
             conn_slots: u32 = constants.conn_slots_max,
             relay_buffers: u32 = constants.relay_buffers_max,
+            upstream_slots: u32 = constants.upstream_slots_max,
         };
 
         const ListenerState = struct {
@@ -90,6 +95,7 @@ pub fn Server(comptime IoType: type) type {
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
+            try server.upstreams.init(arena, options.upstream_slots);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
             server.listeners_count = @intCast(config.listeners.len);
             try server.balancer.init(arena, config);
@@ -165,13 +171,15 @@ pub fn Server(comptime IoType: type) type {
             if (!server.draining) return;
             if (!server.conns.isFullyReleased()) return;
             assert(server.relay_buffers.isFullyReleased());
+            assert(server.upstreams.isFullyReleased());
             server.io.stop();
         }
 
         /// The simulator's leak invariant (§9).
         pub fn isIdle(server: *const Self) bool {
             return server.conns.isFullyReleased() and
-                server.relay_buffers.isFullyReleased();
+                server.relay_buffers.isFullyReleased() and
+                server.upstreams.isFullyReleased();
         }
 
         pub fn activeCount(server: *const Self) u32 {
@@ -257,7 +265,7 @@ pub fn Server(comptime IoType: type) type {
             assert(!server.draining);
             switch (state.protocol) {
                 .l4 => server.admitL4(state, client_socket),
-                .http => server.admitHttp(client_socket),
+                .http => server.admitHttp(state, client_socket),
             }
         }
 
@@ -283,12 +291,13 @@ pub fn Server(comptime IoType: type) type {
             buffer: ?*relay.RelayBuffer,
             state: ConnType.State,
             timeout_ms: u32,
+            cluster_index: u16,
         ) void {
             assert(!server.draining);
             assert(state == .connecting or state == .l7_reading_head);
             assert(timeout_ms >= 1);
             server.counters.increment("admitted");
-            conn.prepare(server, client_socket, buffer, state);
+            conn.prepare(server, client_socket, buffer, state, cluster_index);
             server.io.setNodelay(client_socket) catch {
                 server.counters.increment("kernel_pressure_errors");
             };
@@ -313,6 +322,7 @@ pub fn Server(comptime IoType: type) type {
                 buffer,
                 .connecting,
                 server.config.connect_timeout_ms,
+                state.cluster_index,
             );
             server.armConnect(conn, state.cluster_index);
         }
@@ -321,7 +331,7 @@ pub fn Server(comptime IoType: type) type {
         /// holds no relay buffer, which is acquired when a body relay
         /// starts. The head-read deadline is armed so a slowloris meets
         /// the clock or `head_bytes_max` first (§7).
-        fn admitHttp(server: *Self, client_socket: IoType.Socket) void {
+        fn admitHttp(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
             const conn = server.admitConn(client_socket) orelse return;
             server.finishAdmission(
                 conn,
@@ -329,8 +339,18 @@ pub fn Server(comptime IoType: type) type {
                 null,
                 .l7_reading_head,
                 server.idleTimeoutMs(),
+                state.cluster_index,
             );
             Proxy.start(server, conn);
+        }
+
+        /// L7 body relays acquire their buffer mid-connection (§5), so
+        /// the proxy needs the acquire-with-pressure-update pair the L4
+        /// admission does inline. Null is the §8 relay-buffer rung.
+        pub fn acquireRelayBuffer(server: *Self) ?*relay.RelayBuffer {
+            const buffer = server.relay_buffers.acquire() orelse return null;
+            server.updateRelayPressure();
+            return buffer;
         }
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
@@ -452,6 +472,15 @@ pub fn Server(comptime IoType: type) type {
             if (conn.relay_buffer) |buffer| {
                 server.relay_buffers.release(buffer);
                 server.updateRelayPressure();
+                conn.relay_buffer = null;
+            }
+            // The leased upstream slot rides the same release rule: its
+            // socket (if any) was closed by this teardown's
+            // close_upstream, so the slot is inert by the time the armed
+            // set empties (§5). Parking replaces this with reuse later.
+            if (conn.upstream) |leased| {
+                server.upstreams.release(leased);
+                conn.upstream = null;
             }
             server.conns.release(conn);
             server.counters.increment("completed");

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2,10 +2,13 @@
 //! listeners, the counters, and the drain flag; generic over the Io
 //! backend so the simulator instantiates the whole serving path without
 //! main. All admission decisions happen here — the ladder's single
-//! choke point. Slice 7 scope: full connection lifecycle (accept gate →
-//! admission → upstream dial → deadline → teardown with armed-op-gated
-//! release); the bidirectional relay lands in slice 8, so a connected
-//! conn currently tears down immediately.
+//! choke point. Admission forks on the listener's protocol: an `l4`
+//! listener runs the strict TCP relay (`net/relay.zig`), an `http`
+//! listener runs the L7 state machine (`http/proxy.zig`); the shared
+//! accept gate, deadline, and teardown machinery serve both. The L7
+//! request path is filling in slice by slice — head ingestion and the
+//! static-response rejects are in; the upstream leg follows — so a valid
+//! L7 request currently tears down once its head is parsed.
 
 const std = @import("std");
 
@@ -16,6 +19,7 @@ const counters_module = @import("counters.zig");
 const conn_module = @import("net/Conn.zig");
 const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
+const proxy = @import("http/proxy.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
 
@@ -47,6 +51,7 @@ pub fn Server(comptime IoType: type) type {
         const Self = @This();
 
         pub const ConnType = conn_module.Conn(IoType);
+        const Proxy = proxy.Proxy(IoType);
 
         /// Pool sizes are injectable so tests and the simulator can force
         /// every exhaustion rung; production uses the §5 defaults.
@@ -64,6 +69,9 @@ pub fn Server(comptime IoType: type) type {
             /// ring budget stays one op (§8).
             retry_completion: IoType.Completion,
             cluster_index: u16,
+            /// Copied from config so admission forks without reaching back
+            /// through the listener index (§6, §7).
+            protocol: config_module.Config.Listener.Protocol,
             accepting: bool,
         };
 
@@ -73,19 +81,11 @@ pub fn Server(comptime IoType: type) type {
             io: *IoType,
             config: *const config_module.Config,
             options: InitOptions,
-        ) error{ OutOfMemory, HttpListenersUnimplemented }!void {
+        ) error{OutOfMemory}!void {
             assert(config.listeners.len >= 1);
             assert(config.listeners.len <= constants.listeners_max);
             assert(options.relay_buffers >= 1);
             assert(options.relay_buffers <= options.conn_slots);
-            // Phase-1 gate: until the L7 state machine lands, an http
-            // listener cannot be served — refuse at startup rather than
-            // silently relaying it as L4. The proxy slice removes this.
-            for (config.listeners) |listener| {
-                if (listener.protocol == .http) {
-                    return error.HttpListenersUnimplemented;
-                }
-            }
             server.io = io;
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
@@ -110,6 +110,7 @@ pub fn Server(comptime IoType: type) type {
                     .accept_completion = .{},
                     .retry_completion = .{},
                     .cluster_index = listener_config.cluster_index,
+                    .protocol = listener_config.protocol,
                     .accepting = false,
                 };
                 server.armAccept(state);
@@ -249,7 +250,18 @@ pub fn Server(comptime IoType: type) type {
             }
         }
 
+        /// The admission fork (§6, §7): every protocol shares the accept
+        /// gate, the conn slot, the deadline, and teardown; they diverge
+        /// only in what a fresh connection does next.
         fn admit(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
+            assert(!server.draining);
+            switch (state.protocol) {
+                .l4 => server.admitL4(state, client_socket),
+                .http => server.admitHttp(client_socket),
+            }
+        }
+
+        fn admitL4(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
             assert(!server.draining);
             const conn = server.conns.acquire() orelse {
                 server.counters.increment("shed_conn_slots");
@@ -264,13 +276,34 @@ pub fn Server(comptime IoType: type) type {
             };
             server.counters.increment("admitted");
             server.updateRelayPressure();
-            conn.prepare(server, client_socket, buffer);
+            conn.prepare(server, client_socket, buffer, .connecting);
             server.io.setNodelay(client_socket) catch {
                 server.counters.increment("kernel_pressure_errors");
             };
             server.storeDeadline(conn, server.config.connect_timeout_ms);
             server.armDeadline(conn);
             server.armConnect(conn, state.cluster_index);
+        }
+
+        /// L7 admission (§5, §7): a slot only — an idle L7 connection
+        /// holds no relay buffer, which is acquired when a body relay
+        /// starts (a later slice). The head-read deadline is armed so a
+        /// slowloris meets the clock or `head_bytes_max` first (§7).
+        fn admitHttp(server: *Self, client_socket: IoType.Socket) void {
+            assert(!server.draining);
+            const conn = server.conns.acquire() orelse {
+                server.counters.increment("shed_conn_slots");
+                shed.closeWithRst(IoType, server.io, client_socket);
+                return;
+            };
+            server.counters.increment("admitted");
+            conn.prepare(server, client_socket, null, .l7_reading_head);
+            server.io.setNodelay(client_socket) catch {
+                server.counters.increment("kernel_pressure_errors");
+            };
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            server.armDeadline(conn);
+            Proxy.start(server, conn);
         }
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
@@ -319,7 +352,7 @@ pub fn Server(comptime IoType: type) type {
         /// releases the slot.
         pub fn beginTeardown(server: *Self, conn: *ConnType) void {
             if (conn.isTearingDown()) return;
-            assert(conn.state == .connecting or conn.state == .relaying);
+            assert(conn.isLive());
             conn.state = .tearing_down;
             server.io.shutdown(conn.client_socket, .both);
             if (conn.upstream_socket) |socket| {
@@ -387,11 +420,28 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.isTearingDown());
             if (conn.state != .closing) return;
             if (conn.armedCount() != 0) return;
-            server.relay_buffers.release(conn.relay_buffer);
-            server.updateRelayPressure();
+            // An idle L7 connection holds no relay buffer (§5); only
+            // release one that was actually acquired.
+            if (conn.relay_buffer) |buffer| {
+                server.relay_buffers.release(buffer);
+                server.updateRelayPressure();
+            }
             server.conns.release(conn);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
+        }
+
+        /// §8 kernel-pressure rung on the data path: a non-orderly op
+        /// failure on a live socket is resource exhaustion (ENOBUFS/
+        /// ENOMEM), which the seam collapses to Unexpected. Orderly
+        /// failures (EndOfStream, Reset, Canceled) are peeled off by the
+        /// caller; only Unexpected is witnessed here, matching the
+        /// accept/connect/setNodelay sites. Shared by the L4 relay and the
+        /// L7 state machine.
+        pub fn witnessKernelPressure(server: *Self, err: anyerror) void {
+            if (err == error.Unexpected) {
+                server.counters.increment("kernel_pressure_errors");
+            }
         }
 
         /// §8 watermarks before walls: recompute the relay-buffer pressure

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -73,11 +73,19 @@ pub fn Server(comptime IoType: type) type {
             io: *IoType,
             config: *const config_module.Config,
             options: InitOptions,
-        ) error{OutOfMemory}!void {
+        ) error{ OutOfMemory, HttpListenersUnimplemented }!void {
             assert(config.listeners.len >= 1);
             assert(config.listeners.len <= constants.listeners_max);
             assert(options.relay_buffers >= 1);
             assert(options.relay_buffers <= options.conn_slots);
+            // Phase-1 gate: until the L7 state machine lands, an http
+            // listener cannot be served — refuse at startup rather than
+            // silently relaying it as L4. The proxy slice removes this.
+            for (config.listeners) |listener| {
+                if (listener.protocol == .http) {
+                    return error.HttpListenersUnimplemented;
+                }
+            }
             server.io = io;
             server.config = config;
             try server.conns.init(arena, options.conn_slots);

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -51,6 +51,14 @@ pub fn Server(comptime IoType: type) type {
         /// connections return their buffers before the wall is reached.
         relay_pressure: bool,
         drain_deadline_completion: IoType.Completion,
+        /// The one timer covering every parked upstream (§5): a parked
+        /// connection holds no armed op, so this sweep compares stored
+        /// deadlines against the clock and reaps overdue connections with
+        /// a synchronous close. Armed only while anything is parked, so
+        /// an idle process (and a quiescent simulator run) has no ticking
+        /// timer.
+        upstream_sweep_completion: IoType.Completion,
+        upstream_sweep_armed: bool,
 
         const Self = @This();
 
@@ -103,6 +111,8 @@ pub fn Server(comptime IoType: type) type {
             server.draining = false;
             server.relay_pressure = false;
             server.drain_deadline_completion = .{};
+            server.upstream_sweep_completion = .{};
+            server.upstream_sweep_armed = false;
         }
 
         pub fn start(server: *Self) Io.ListenError!void {
@@ -136,6 +146,9 @@ pub fn Server(comptime IoType: type) type {
             for (server.listeners[0..server.listeners_count]) |*state| {
                 server.io.listenClose(state.listener);
             }
+            // Parked upstreams are idle capacity; the drain sheds them
+            // first (§8). Synchronous closes: no armed op to wait for.
+            server.reapParked(true);
             server.io.timerStart(
                 &server.drain_deadline_completion,
                 @as(u64, server.config.drain_deadline_ms) * std.time.ns_per_ms,
@@ -171,8 +184,57 @@ pub fn Server(comptime IoType: type) type {
             if (!server.draining) return;
             if (!server.conns.isFullyReleased()) return;
             assert(server.relay_buffers.isFullyReleased());
+            // beginDrain reaped every parked slot synchronously and no
+            // conn is left to lease one, so the pool must be empty.
             assert(server.upstreams.isFullyReleased());
             server.io.stop();
+        }
+
+        /// Reap parked upstream connections: all of them (drain), or only
+        /// those past their stored idle deadline (the sweep). Bounded by
+        /// the pool capacity; closes are synchronous — a parked slot has
+        /// no armed op (§5), so unpark + close + release is one step.
+        fn reapParked(server: *Self, reap_all: bool) void {
+            const now = server.io.nowNs();
+            for (server.upstreams.slot_pool.slots) |*upstream| {
+                if (!server.upstreams.slot_pool.isAcquired(upstream)) continue;
+                if (!upstream.parked) continue;
+                if (!reap_all and upstream.deadline_ns > now) continue;
+                server.upstreams.unpark(upstream);
+                server.io.closeNow(upstream.socket);
+                server.upstreams.release(upstream);
+                if (!reap_all) {
+                    server.counters.increment("upstream_idle_reaped");
+                }
+            }
+        }
+
+        /// Arm the sweep if anything is parked and it is not ticking; the
+        /// half-interval keeps worst-case parked overstay under 1.5x the
+        /// idle timeout. The §8 pressure bias shortens the interval
+        /// lazily, at the next re-arm — an already-ticking sweep is never
+        /// touched, the same never-move-earlier rule as every timer (§4).
+        pub fn ensureUpstreamSweep(server: *Self) void {
+            if (server.upstream_sweep_armed) return;
+            if (server.upstreams.idle_count == 0) return;
+            server.upstream_sweep_armed = true;
+            const interval_ms = @max(server.idleTimeoutMs() / 2, 1);
+            server.io.timerStart(
+                &server.upstream_sweep_completion,
+                @as(u64, interval_ms) * std.time.ns_per_ms,
+                Self,
+                server,
+                onUpstreamSweep,
+            );
+        }
+
+        fn onUpstreamSweep(server: *Self, result: Io.TimerError!void) void {
+            assert(server.upstream_sweep_armed);
+            server.upstream_sweep_armed = false;
+            // Nothing ever cancels the sweep timer.
+            result catch unreachable;
+            server.reapParked(false);
+            server.ensureUpstreamSweep();
         }
 
         /// The simulator's leak invariant (§9).
@@ -351,6 +413,13 @@ pub fn Server(comptime IoType: type) type {
             const buffer = server.relay_buffers.acquire() orelse return null;
             server.updateRelayPressure();
             return buffer;
+        }
+
+        /// The release pair: an L7 connection going idle on keep-alive
+        /// returns its buffer so idle costs a slot + head buffer only (§5).
+        pub fn releaseRelayBuffer(server: *Self, buffer: *relay.RelayBuffer) void {
+            server.relay_buffers.release(buffer);
+            server.updateRelayPressure();
         }
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -261,48 +261,75 @@ pub fn Server(comptime IoType: type) type {
             }
         }
 
-        fn admitL4(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
+        /// The shared conn-slot rung (§8): both protocols shed the same
+        /// way when slots run out, so the rung lives in one place.
+        fn admitConn(server: *Self, client_socket: IoType.Socket) ?*ConnType {
             assert(!server.draining);
-            const conn = server.conns.acquire() orelse {
+            return server.conns.acquire() orelse {
                 server.counters.increment("shed_conn_slots");
                 shed.closeWithRst(IoType, server.io, client_socket);
-                return;
+                return null;
             };
+        }
+
+        /// The shared admission tail (§8 single choke point): counting,
+        /// slot prepare, socket options, and the first deadline are
+        /// identical across protocols; only the entry state, buffer, and
+        /// timeout differ.
+        fn finishAdmission(
+            server: *Self,
+            conn: *ConnType,
+            client_socket: IoType.Socket,
+            buffer: ?*relay.RelayBuffer,
+            state: ConnType.State,
+            timeout_ms: u32,
+        ) void {
+            assert(!server.draining);
+            assert(state == .connecting or state == .l7_reading_head);
+            assert(timeout_ms >= 1);
+            server.counters.increment("admitted");
+            conn.prepare(server, client_socket, buffer, state);
+            server.io.setNodelay(client_socket) catch {
+                server.counters.increment("kernel_pressure_errors");
+            };
+            server.storeDeadline(conn, timeout_ms);
+            server.armDeadline(conn);
+            assert(conn.deadline_ns > 0);
+            assert(conn.armed.deadline);
+        }
+
+        fn admitL4(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
+            const conn = server.admitConn(client_socket) orelse return;
             const buffer = server.relay_buffers.acquire() orelse {
                 server.conns.release(conn);
                 server.counters.increment("shed_relay_buffers");
                 shed.closeQuietly(IoType, server.io, client_socket);
                 return;
             };
-            server.counters.increment("admitted");
             server.updateRelayPressure();
-            conn.prepare(server, client_socket, buffer, .connecting);
-            server.io.setNodelay(client_socket) catch {
-                server.counters.increment("kernel_pressure_errors");
-            };
-            server.storeDeadline(conn, server.config.connect_timeout_ms);
-            server.armDeadline(conn);
+            server.finishAdmission(
+                conn,
+                client_socket,
+                buffer,
+                .connecting,
+                server.config.connect_timeout_ms,
+            );
             server.armConnect(conn, state.cluster_index);
         }
 
         /// L7 admission (§5, §7): a slot only — an idle L7 connection
         /// holds no relay buffer, which is acquired when a body relay
-        /// starts (a later slice). The head-read deadline is armed so a
-        /// slowloris meets the clock or `head_bytes_max` first (§7).
+        /// starts. The head-read deadline is armed so a slowloris meets
+        /// the clock or `head_bytes_max` first (§7).
         fn admitHttp(server: *Self, client_socket: IoType.Socket) void {
-            assert(!server.draining);
-            const conn = server.conns.acquire() orelse {
-                server.counters.increment("shed_conn_slots");
-                shed.closeWithRst(IoType, server.io, client_socket);
-                return;
-            };
-            server.counters.increment("admitted");
-            conn.prepare(server, client_socket, null, .l7_reading_head);
-            server.io.setNodelay(client_socket) catch {
-                server.counters.increment("kernel_pressure_errors");
-            };
-            server.storeDeadline(conn, server.idleTimeoutMs());
-            server.armDeadline(conn);
+            const conn = server.admitConn(client_socket) orelse return;
+            server.finishAdmission(
+                conn,
+                client_socket,
+                null,
+                .l7_reading_head,
+                server.idleTimeoutMs(),
+            );
             Proxy.start(server, conn);
         }
 
@@ -310,7 +337,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.state == .connecting);
             conn.arm(&conn.op_connect, "connect");
             server.io.connect(
-                server.balancer.pick(cluster_index),
+                server.balancer.pick(cluster_index).address,
                 &conn.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -31,18 +31,29 @@ pub const Balancer = struct {
         @memset(balancer.cursors, 0);
     }
 
+    /// A pick names the endpoint both ways: the address to dial and the
+    /// index the upstream pool keys its idle lists by (§5).
+    pub const Pick = struct {
+        address: std.Io.net.IpAddress,
+        endpoint_index: u16,
+    };
+
     /// Choose the next endpoint to dial for `cluster_index`, advancing the
     /// policy's state. Round-robin: the cursor modulo the endpoint count,
     /// then incremented — a validated config guarantees at least one
     /// endpoint, so the modulo is always defined.
-    pub fn pick(balancer: *Balancer, cluster_index: u16) std.Io.net.IpAddress {
+    pub fn pick(balancer: *Balancer, cluster_index: u16) Pick {
         assert(cluster_index < balancer.cursors.len);
         const cluster = &balancer.config.clusters[cluster_index];
         assert(cluster.endpoints.len >= 1);
-        const endpoint_index: usize =
+        const endpoint_index: u16 =
             @intCast(balancer.cursors[cluster_index] % cluster.endpoints.len);
         balancer.cursors[cluster_index] += 1;
-        return cluster.endpoints[endpoint_index];
+        assert(endpoint_index < cluster.endpoints.len);
+        return .{
+            .address = cluster.endpoints[endpoint_index],
+            .endpoint_index = endpoint_index,
+        };
     }
 };
 
@@ -75,10 +86,16 @@ test "balancer: round-robin cycles endpoints and wraps per cluster" {
     try balancer.init(arena, &config);
 
     // Cluster 0 rotates a → b → c and wraps back to a; cluster 1 keeps
-    // its own cursor and always returns its single endpoint.
+    // its own cursor and always returns its single endpoint. Address and
+    // index name the same endpoint.
     const expected = [_]std.Io.net.IpAddress{ a, b, c, a, b };
-    for (expected) |want| {
-        try std.testing.expectEqual(want, balancer.pick(0));
-        try std.testing.expectEqual(solo, balancer.pick(1));
+    const expected_indexes = [_]u16{ 0, 1, 2, 0, 1 };
+    for (expected, expected_indexes) |want, want_index| {
+        const picked = balancer.pick(0);
+        try std.testing.expectEqual(want, picked.address);
+        try std.testing.expectEqual(want_index, picked.endpoint_index);
+        const solo_picked = balancer.pick(1);
+        try std.testing.expectEqual(solo, solo_picked.address);
+        try std.testing.expectEqual(@as(u16, 0), solo_picked.endpoint_index);
     }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,6 +31,16 @@ pub const Config = struct {
     pub const Listener = struct {
         bind_address: std.Io.net.IpAddress,
         cluster_index: u16,
+        protocol: Protocol,
+
+        /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
+        /// `http` runs the HTTP/1.1 reverse-proxy state machine. The
+        /// JSON field is optional and defaults to `l4`, so pre-L7
+        /// configs stay valid.
+        pub const Protocol = enum(u1) {
+            l4,
+            http,
+        };
     };
 
     pub const Cluster = struct {
@@ -45,6 +55,7 @@ pub const ValidationError = error{
     ListenersOverLimit,
     ListenerBindInvalid,
     ListenerBindDuplicate,
+    ListenerProtocolUnknown,
     ClusterUnknown,
     ClustersEmpty,
     ClustersOverLimit,
@@ -94,6 +105,8 @@ const ConfigJson = struct {
 const ListenerJson = struct {
     bind: []const u8,
     cluster: []const u8,
+    /// Optional: absent means `l4`, keeping pre-L7 configs valid.
+    protocol: []const u8 = "l4",
 };
 
 const ClusterJson = struct {
@@ -240,10 +253,23 @@ fn resolveListeners(
         listeners[index] = .{
             .bind_address = bind_address,
             .cluster_index = try clusterIndexOf(clusters, listener_json.cluster),
+            .protocol = try protocolOf(listener_json.protocol),
         };
     }
     assert(listeners.len == listeners_json.len);
     return listeners;
+}
+
+/// The closed protocol vocabulary; anything else is its own error so a
+/// typo ("htpp") fails loudly instead of silently relaying as L4.
+fn protocolOf(literal: []const u8) error{ListenerProtocolUnknown}!Config.Listener.Protocol {
+    if (std.mem.eql(u8, literal, "l4")) {
+        return .l4;
+    }
+    if (std.mem.eql(u8, literal, "http")) {
+        return .http;
+    }
+    return error.ListenerProtocolUnknown;
 }
 
 fn clusterIndexOf(
@@ -289,6 +315,7 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(@as(usize, 1), parsed.listeners.len);
     try std.testing.expectEqual(@as(usize, 1), parsed.clusters.len);
     try std.testing.expectEqual(@as(u16, 0), parsed.listeners[0].cluster_index);
+    try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
     try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].getPort());
@@ -334,6 +361,39 @@ test "config: max_lifetime_ms accepts zero (the one legal zero timeout) and real
         );
         try std.testing.expectEqual(@as(u32, 1_800_000), parsed.max_lifetime_ms);
     }
+}
+
+test "config: listener protocol defaults to l4 and accepts http" {
+    // Absent field: pre-L7 configs stay valid.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
+    }
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(Config.Listener.Protocol.http, parsed.listeners[0].protocol);
+    }
+}
+
+test "config: unknown listener protocol fails loudly" {
+    // A typo must not silently relay as L4.
+    try expectParseError(error.ListenerProtocolUnknown,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"htpp"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
 }
 
 test "config: max_lifetime_ms still obeys the shared ceiling" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -58,6 +58,27 @@ pub fn relayPressureOff(capacity: u32) u32 {
 /// configured idle timeout is already small.
 pub const relay_pressure_idle_divisor: u32 = 4;
 
+/// Upper bound on one L7 request or response head, including the final
+/// CRLF — the size of a connection slot's head buffer (§5). A request
+/// head that cannot complete inside this budget is answered 414 (request
+/// line still open) or 431 (header section); an oversize origin response
+/// head tears the exchange down (§7).
+pub const head_bytes_max: u32 = 8 * 1024;
+
+/// Bounded per-head header array. Overflowing it is load, not malice: it
+/// maps to 431, distinguishable from malformed input's 400 (§7).
+pub const headers_max: u16 = 64;
+
+/// Upper bound on one chunk-size line (hex size, extensions, CRLF) in a
+/// chunked body (§7). Bounded so a hostile peer cannot stream an endless
+/// size line through the relay; kept under one relay buffer so a legal
+/// line never spans more than two buffer fills.
+pub const chunked_line_bytes_max: u32 = 256;
+
+/// Upper bound on a chunked trailer section, which is forwarded verbatim
+/// (§7). Same bounding argument as the size line.
+pub const chunked_trailer_bytes_max: u32 = 1024;
+
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
 
@@ -131,6 +152,11 @@ comptime {
     assert(timeout_ms_max >= 1000);
     assert(accept_retry_delay_ms >= 1);
     assert(relay_pressure_idle_divisor >= 2);
+    assert(head_bytes_max >= 1024);
+    assert(headers_max >= 8);
+    assert(chunked_line_bytes_max >= 32);
+    assert(chunked_line_bytes_max <= relay_buffer_bytes);
+    assert(chunked_trailer_bytes_max >= chunked_line_bytes_max);
     // The watermarks must leave a hysteresis gap and never engage above
     // the pool's own capacity, checked at the production size.
     assert(relayPressureOn(relay_buffers_max) > relayPressureOff(relay_buffers_max));

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -79,6 +79,13 @@ pub const chunked_line_bytes_max: u32 = 256;
 /// (§7). Same bounding argument as the size line.
 pub const chunked_trailer_bytes_max: u32 = 1024;
 
+/// Shared upstream connection slots (`Pool(Upstream)`) — one pool for
+/// the whole process, checked out by any request and parked per endpoint
+/// on keep-alive (§3, §5). The fd, ring, and memory budgets absorb this
+/// pool when the L7 state machine composes it into the Server; until
+/// then the constant only sizes the pool itself.
+pub const upstream_slots_max: u32 = 2048;
+
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
 
@@ -154,6 +161,7 @@ comptime {
     assert(relay_pressure_idle_divisor >= 2);
     assert(head_bytes_max >= 1024);
     assert(headers_max >= 8);
+    assert(upstream_slots_max >= 1);
     assert(chunked_line_bytes_max >= 32);
     assert(chunked_line_bytes_max <= relay_buffer_bytes);
     assert(chunked_trailer_bytes_max >= chunked_line_bytes_max);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -10,23 +10,26 @@ const assert = std.debug.assert;
 /// Upper bound on configured listeners.
 pub const listeners_max: u16 = 8;
 
-/// Connection slots (`Pool(Conn)`). In Phase 0 (L4 only) concurrency is
-/// bounded by `relay_buffers_max`, not this; the surplus slots are sized
-/// for Phase 1 keep-alive connections, which hold no relay buffer while
-/// idle (§5).
-pub const conn_slots_max: u32 = 4096;
+/// Connection slots (`Pool(Conn)`). The binding constraint is the
+/// io_uring completion queue, not fds or memory (§8): every admitted
+/// connection — L4 relaying or L7 in any phase — can hold up to
+/// `conn_ops_max` armed ops whether or not it holds a relay buffer
+/// (an L7 head read is a data op like any other), so every slot claims
+/// its worst-case share of the pre-budgeted ring. With the ring at its
+/// usable maximum (`ring_entries = 4096`, CQ = 8192, ¾ headroom = 6144)
+/// and the parked-upstream reservation carved out first, that caps this
+/// at `(6144 - 18 - upstream_slots_max) / conn_ops_max = 1020` —
+/// comptime-derived below. Keep-alive surplus beyond this ceiling waits
+/// for the deeper-CQ fork lever (`IORING_SETUP_CQSIZE`, docs/PLANS.md),
+/// the same prerequisite as c10k.
+pub const conn_slots_max: u32 = 1020;
 
-/// Relay buffer pairs (`Pool(RelayBuffer)`) — the true bound on concurrent
-/// L4 connections plus, in Phase 1, active L7 relays (§5, §6). The binding
-/// constraint is the io_uring completion queue, not fds or memory: every
-/// admitted connection can hold `conn_ops_max` armed ops at once, the ring
-/// is pre-budgeted and never shed (§8), and the budget keeps in-flight ops
-/// under ¾ of the completion queue. With the ring at its usable maximum
-/// (`ring_entries = 4096`, CQ = 8192) that caps this at
-/// `(6144 - 18) / 5 = 1225`. Lifting the ceiling toward c10k needs a
-/// deeper CQ (`IORING_SETUP_CQSIZE`), which the libxev fork does not yet
-/// expose — the same prerequisite as the splice fast path.
-pub const relay_buffers_max: u32 = 1225;
+/// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
+/// connections plus active L7 body relays (§5, §6). Sized to the
+/// conn-slot ceiling: the completion queue binds both (see
+/// `conn_slots_max`), and a buffer beyond the slot count could never be
+/// acquired.
+pub const relay_buffers_max: u32 = conn_slots_max;
 
 /// Bytes per relay direction; a `RelayBuffer` is a pair of these. Held to
 /// 4 KiB: the strict recv→send→recv relay (§6) is correct at any size, so
@@ -81,10 +84,13 @@ pub const chunked_trailer_bytes_max: u32 = 1024;
 
 /// Shared upstream connection slots (`Pool(Upstream)`) — one pool for
 /// the whole process, checked out by any request and parked per endpoint
-/// on keep-alive (§3, §5). The fd, ring, and memory budgets absorb this
-/// pool when the L7 state machine composes it into the Server; until
-/// then the constant only sizes the pool itself.
-pub const upstream_slots_max: u32 = 2048;
+/// on keep-alive (§3, §5). Counted in the §8 budgets below: a parked
+/// upstream holds a socket (fd budget) and, once keep-alive lands, one
+/// armed idle-timer op (ring budget) — both reserved now so composing
+/// keep-alive does not re-cut the budgets. Sized as the largest power of
+/// two the fd and CQ budgets accommodate alongside the conn-slot
+/// ceiling.
+pub const upstream_slots_max: u32 = 1024;
 
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
@@ -127,21 +133,27 @@ pub const endpoints_per_cluster_max: u16 = 64;
 pub const timeout_ms_max: u32 = 3_600_000;
 
 /// Worst-case in-flight ring ops (§8: the ring is pre-budgeted, not shed):
-/// every admitted connection at its op peak, two ops per listener (a
-/// draining listener holds its armed accept — or the accept-retry
-/// backoff timer — plus the async cancel that reaps it), the single
-/// async wakeup op for signals, and the server's one drain-deadline
-/// timer.
+/// every connection slot at its op peak (L7 slots hold armed ops with or
+/// without a relay buffer, so the term is per slot, not per buffer), one
+/// idle-timer op per parked upstream (§5/§8 — reserved ahead of the
+/// keep-alive slice), two ops per listener (a draining listener holds
+/// its armed accept — or the accept-retry backoff timer — plus the async
+/// cancel that reaps it), the single async wakeup op for signals, and
+/// the server's one drain-deadline timer.
 pub const in_flight_ops_max: u32 =
-    relay_buffers_max * conn_ops_max + 2 * @as(u32, listeners_max) + 1 + 1;
+    conn_slots_max * conn_ops_max + upstream_slots_max +
+    2 * @as(u32, listeners_max) + 1 + 1;
 
 /// Kernel completion queue capacity (io_uring fixes CQ at 2 × SQ).
 pub const completion_queue_entries: u32 = 2 * @as(u32, ring_entries);
 
 /// Worst-case fd count (§8: fds are pre-budgeted, not shed): stdio + ring
-/// + async eventfd + listeners + two sockets per admitted connection + the
-/// one transient just-accepted fd an admission decision is pending on.
-pub const fds_max: u32 = 3 + 1 + 1 + listeners_max + 2 * relay_buffers_max + 1;
+/// + async eventfd + listeners + two sockets per admitted connection
+/// (client plus the exchange's upstream) + the one transient
+/// just-accepted fd an admission decision is pending on + one socket per
+/// parked upstream, which belongs to no connection.
+pub const fds_max: u32 =
+    3 + 1 + 1 + listeners_max + 2 * conn_slots_max + 1 + upstream_slots_max;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -169,17 +181,31 @@ comptime {
     // the pool's own capacity, checked at the production size.
     assert(relayPressureOn(relay_buffers_max) > relayPressureOff(relay_buffers_max));
     assert(relayPressureOn(relay_buffers_max) <= relay_buffers_max);
+    // The conn-slot ceiling is derived, not chosen: the largest slot
+    // count whose worst-case ops fit the ¾-CQ budget after the fixed
+    // ops and the parked-upstream reservation are carved out (§8).
+    assert(conn_slots_max == @divFloor(
+        completion_queue_entries * 3 / 4 - 2 * @as(u32, listeners_max) - 1 - 1 -
+            upstream_slots_max,
+        conn_ops_max,
+    ));
 }
 
 /// Total pool memory as a closed-form function of the limits. Slot sizes
 /// are runtime parameters because `Conn` is generic over the Io backend;
 /// the composition site passes `@sizeOf` of the concrete types and
 /// main.zig prints the result at startup (§5).
-pub fn memoryBytesTotal(conn_bytes: u64, relay_buffer_pair_bytes: u64) u64 {
+pub fn memoryBytesTotal(
+    conn_bytes: u64,
+    relay_buffer_pair_bytes: u64,
+    upstream_bytes: u64,
+) u64 {
     assert(conn_bytes > 0);
     assert(relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
+    assert(upstream_bytes >= head_bytes_max);
     const total = conn_slots_max * conn_bytes +
-        relay_buffers_max * relay_buffer_pair_bytes;
+        relay_buffers_max * relay_buffer_pair_bytes +
+        upstream_slots_max * upstream_bytes;
     assert(total > 0);
     return total;
 }
@@ -205,29 +231,33 @@ test "pressure: relay watermarks have a hysteresis gap at every capacity" {
 }
 
 test "budgets: memory total matches the closed form" {
-    const conn_bytes: u64 = 2048;
+    const conn_bytes: u64 = 10240;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
+    const upstream_bytes: u64 = head_bytes_max + 64;
     const expected = @as(u64, conn_slots_max) * conn_bytes +
-        @as(u64, relay_buffers_max) * pair_bytes;
-    try std.testing.expectEqual(expected, memoryBytesTotal(conn_bytes, pair_bytes));
+        @as(u64, relay_buffers_max) * pair_bytes +
+        @as(u64, upstream_slots_max) * upstream_bytes;
+    try std.testing.expectEqual(
+        expected,
+        memoryBytesTotal(conn_bytes, pair_bytes, upstream_bytes),
+    );
 }
 
 test "budgets: fd count stays under a typical hard limit" {
     // 4096 is the common RLIMIT_NOFILE hard ceiling for unprivileged
     // processes; startup asserts against the real limit (§8), this test
-    // guards the defaults against drifting past the common case. The fd
-    // budget is not the binding ceiling — the completion queue is (see
-    // relay_buffers_max) — so fds_max has comfortable headroom here.
+    // guards the defaults against drifting past the common case.
     try std.testing.expect(fds_max <= 4096);
-    try std.testing.expectEqual(@as(u32, 2464), fds_max);
+    try std.testing.expectEqual(@as(u32, 3078), fds_max);
 }
 
-test "budgets: relay buffers sit at the completion-queue ceiling" {
-    // The ¾-CQ headroom rule is what actually caps concurrent L4
-    // connections; relay_buffers_max is set to the largest value that
-    // still satisfies it, so one more buffer would break the budget.
+test "budgets: conn slots sit at the completion-queue ceiling" {
+    // The ¾-CQ headroom rule is what actually caps concurrent
+    // connections; conn_slots_max is the largest value that still
+    // satisfies it after the parked-upstream reservation, so one more
+    // slot would break the budget.
     try std.testing.expect(in_flight_ops_max <= completion_queue_entries * 3 / 4);
-    const one_more = (relay_buffers_max + 1) * conn_ops_max +
+    const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
         2 * @as(u32, listeners_max) + 1 + 1;
     try std.testing.expect(one_more > completion_queue_entries * 3 / 4);
 }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -36,6 +36,17 @@ pub const Counters = struct {
     l7_uri_too_long: Value = Value.init(0),
     l7_headers_too_large: Value = Value.init(0),
     l7_not_implemented: Value = Value.init(0),
+    /// §8 rungs at the L7 request level, answered 503: relay buffers or
+    /// upstream slots exhausted when a valid request needed them. Like
+    /// the reject counters these connections complete normally, so they
+    /// stay out of `reconcile`'s shed sum.
+    l7_shed_relay_buffers: Value = Value.init(0),
+    l7_shed_upstream_slots: Value = Value.init(0),
+    /// Upstream leg failed before any response byte reached the client:
+    /// answered 502 (§7, §8).
+    l7_bad_gateway: Value = Value.init(0),
+    /// Completed L7 exchanges: a parsed origin response relayed back.
+    l7_responses: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path).

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -27,6 +27,15 @@ pub const Counters = struct {
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).
     upstream_connect_failed: Value = Value.init(0),
+    /// L7 reject responses (§7): a malformed head (400), an oversize
+    /// request line (414) or header section (431), or an unsupported
+    /// method/upgrade (501). Not sheds — the connection was admitted and
+    /// answered a static response, so it completes normally and stays out
+    /// of `reconcile`'s shed sum; these are pure observability.
+    l7_bad_request: Value = Value.init(0),
+    l7_uri_too_long: Value = Value.init(0),
+    l7_headers_too_large: Value = Value.init(0),
+    l7_not_implemented: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path).

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -43,10 +43,16 @@ pub const Counters = struct {
     l7_shed_relay_buffers: Value = Value.init(0),
     l7_shed_upstream_slots: Value = Value.init(0),
     /// Upstream leg failed before any response byte reached the client:
-    /// answered 502 (§7, §8).
+    /// answered 502 (§7, §8). A stale parked connection detected at
+    /// checkout lands here too until Phase 2's free replay.
     l7_bad_gateway: Value = Value.init(0),
     /// Completed L7 exchanges: a parsed origin response relayed back.
     l7_responses: Value = Value.init(0),
+    /// Exchanges served over a parked upstream connection instead of a
+    /// fresh dial — the §3 reuse win, witnessed.
+    upstream_reused: Value = Value.init(0),
+    /// Parked upstream connections reaped by the idle sweep (§5).
+    upstream_idle_reaped: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path).

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -616,12 +616,16 @@ fn analyzeHeaders(
 /// token pass — scanning the list twice (once per token) was a measured
 /// hot spot (§9). Tokens are OWS-trimmed and matched case-insensitively.
 fn scanConnectionTokens(value: []const u8, analysis: *HeaderAnalysis) void {
+    // The value is a slice of the parsed head (an empty value is legal:
+    // `Connection:` with nothing after it), so it is head-buffer bounded.
+    assert(value.len <= constants.head_bytes_max);
     var tokens = std.mem.splitScalar(u8, value, ',');
     while (tokens.next()) |raw_token| {
         const token = std.mem.trim(u8, raw_token, " \t");
         if (token.len == 0) {
             continue;
         }
+        assert(token.len >= 1); // Only real options are classified below.
         if (std.ascii.eqlIgnoreCase(token, "close")) {
             analysis.connection_close = true;
         } else if (std.ascii.eqlIgnoreCase(token, "keep-alive")) {

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -1,0 +1,1277 @@
+//! HTTP/1.1 head parsing and body framing for the L7 data path (DESIGN.md
+//! §7). hparse — the hardened zoxy-io fork, pinned by content hash in
+//! build.zig.zon — parses *syntax* only; every strictness, smuggling, and
+//! framing decision is made here, so the trust boundary sits at this
+//! wrapper, not at the dependency. A build-time lint confines the hparse
+//! import to this file.
+//!
+//! Nothing here allocates or copies payload bytes: heads parse zero-copy
+//! into caller-owned storage over the linear head buffer, and "streaming"
+//! is detect-and-retry — a partial head returns `error.Incomplete` and the
+//! caller re-parses from byte 0 once more bytes arrive, bounded by
+//! `constants.head_bytes_max`.
+//!
+//! Two §7 fork-gate items are still open against the current pin and are
+//! handled here until the pin moves: bare-LF line terminators are rejected
+//! by `rejectBareLineFeeds` (hparse still accepts them), and extension
+//! methods (PROPFIND, ...) surface as `error.Malformed` because hparse's
+//! method enum is still closed.
+
+const std = @import("std");
+const hparse = @import("hparse");
+const constants = @import("../constants.zig");
+
+const assert = std.debug.assert;
+
+/// The nine methods the pinned hparse recognizes. Owned here (not
+/// re-exported) so opening the fork's method enum to extension tokens
+/// changes only this file's mapping, not every consumer.
+pub const Method = enum(u8) {
+    get,
+    post,
+    head,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+};
+
+/// HTTP/1.0 and HTTP/1.1 are served; anything else is malformed (§1
+/// defers HTTP/2 and beyond).
+pub const Version = enum(u1) {
+    http_1_0,
+    http_1_1,
+};
+
+/// One parsed header. Both slices point into the head buffer the head was
+/// parsed from — zero-copy, valid only while that buffer holds this head.
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// Caller-owned header storage for one parsed head; the connection slot
+/// embeds one of these per direction it parses.
+pub const HeaderStorage = [constants.headers_max]Header;
+
+/// How the message body is delimited (RFC 9112 §6.3). `until_close` is
+/// legal only on responses; requests are always length-delimited.
+pub const BodyFraming = union(enum) {
+    /// No body bytes follow the head.
+    none,
+    /// Exactly this many body bytes follow the head.
+    content_length: u64,
+    /// The body is chunked; `ChunkedScanner` finds its end.
+    chunked,
+    /// The body runs until the origin closes (responses only). Forces the
+    /// upstream connection out of reuse.
+    until_close,
+};
+
+/// * `Incomplete` — the head is not finished; read more bytes and re-parse.
+/// * `Malformed` — protocol violation or smuggling shape; 400 downstream,
+///   teardown upstream.
+/// * `UriTooLong` — the request line alone overflowed the head buffer; 414.
+/// * `HeadTooLarge` — the header section overflowed the head buffer or the
+///   bounded header array; 431. Load, not malice — distinct from 400 (§7).
+pub const HeadError = error{
+    Incomplete,
+    Malformed,
+    UriTooLong,
+    HeadTooLarge,
+};
+
+/// A fully parsed and validated request head. All slices point into the
+/// head buffer; `head_len` is where the body (or the next pipelined head)
+/// begins.
+pub const RequestHead = struct {
+    method: Method,
+    target: []const u8,
+    version: Version,
+    headers: []const Header,
+    /// Non-null whenever `version == .http_1_1` (exactly-one-Host is
+    /// enforced); HTTP/1.0 may omit it.
+    host: ?[]const u8,
+    framing: BodyFraming,
+    /// Whether the downstream connection may serve another request after
+    /// this exchange, per version defaults and Connection tokens.
+    keep_alive: bool,
+    head_len: u32,
+};
+
+/// A fully parsed and validated response head. Same slice lifetime rules
+/// as `RequestHead`.
+pub const ResponseHead = struct {
+    status: u16,
+    version: Version,
+    headers: []const Header,
+    framing: BodyFraming,
+    /// Whether the upstream connection may be parked for reuse after this
+    /// exchange; always false for `until_close` framing.
+    keep_alive: bool,
+    head_len: u32,
+};
+
+/// Parses and validates one request head from `head`. `head_is_full` says
+/// the head buffer has no room left, turning a partial parse into the 414
+/// vs 431 oversize verdict instead of `error.Incomplete` (§7, §8).
+pub fn parseRequestHead(
+    head: []const u8,
+    head_is_full: bool,
+    headers_storage: *HeaderStorage,
+) HeadError!RequestHead {
+    assert(head.len <= constants.head_bytes_max);
+    if (head_is_full) {
+        assert(head.len >= 1);
+    }
+
+    var raw_method: hparse.Method = .unknown;
+    var raw_target: ?[]const u8 = null;
+    var raw_version: hparse.Version = .@"1.0";
+    var raw_headers: [constants.headers_max]hparse.Header = undefined;
+    var raw_header_count: usize = 0;
+    const head_len = hparse.parseRequest(
+        head,
+        &raw_method,
+        &raw_target,
+        &raw_version,
+        &raw_headers,
+        &raw_header_count,
+    ) catch |err| switch (err) {
+        // A head that cannot complete inside a full buffer is oversize,
+        // not partial (§7): request line still open → 414, else 431.
+        error.Incomplete => {
+            if (head_is_full) {
+                return oversizeRequestError(head);
+            }
+            return error.Incomplete;
+        },
+        error.Invalid => return error.Malformed,
+        // The bounded header array filling up is load, not malice (§7).
+        error.TooManyHeaders => return error.HeadTooLarge,
+    };
+    assert(head_len >= 1);
+    assert(head_len <= head.len);
+    assert(raw_header_count <= constants.headers_max);
+
+    try rejectBareLineFeeds(head[0..head_len]);
+    const target = raw_target.?; // A successful parse always sets the target.
+    const method = methodFromRaw(raw_method);
+    try validateTarget(target, method);
+    const version = versionFromRaw(raw_version);
+
+    const analysis = try analyzeHeaders(raw_headers[0..raw_header_count], headers_storage);
+    // An HTTP/1.1 request must carry exactly one Host (RFC 9112 §3.2);
+    // duplicates were already rejected during analysis.
+    if (version == .http_1_1) {
+        if (analysis.host == null) {
+            return error.Malformed;
+        }
+    }
+    const framing = try requestFraming(version, &analysis);
+    assert(framing != .until_close); // Requests are always length-delimited.
+
+    return .{
+        .method = method,
+        .target = target,
+        .version = version,
+        .headers = headers_storage[0..raw_header_count],
+        .host = analysis.host,
+        .framing = framing,
+        .keep_alive = keepAliveDefault(version, &analysis),
+        .head_len = @intCast(head_len),
+    };
+}
+
+/// Parses and validates one response head from `head`. Framing needs the
+/// request's method (HEAD responses carry no body regardless of headers).
+pub fn parseResponseHead(
+    head: []const u8,
+    head_is_full: bool,
+    headers_storage: *HeaderStorage,
+    request_method: Method,
+) HeadError!ResponseHead {
+    assert(head.len <= constants.head_bytes_max);
+    // The proxy rejects CONNECT before dialing (§7 keeps tunnels out), so
+    // a CONNECT response is unrepresentable here.
+    assert(request_method != .connect);
+
+    var raw_version: hparse.Version = .@"1.0";
+    var raw_status: u16 = 0;
+    var raw_status_message: ?[]const u8 = null;
+    var raw_headers: [constants.headers_max]hparse.Header = undefined;
+    var raw_header_count: usize = 0;
+    const head_len = hparse.parseResponse(
+        head,
+        &raw_version,
+        &raw_status,
+        &raw_status_message,
+        &raw_headers,
+        &raw_header_count,
+    ) catch |err| switch (err) {
+        // No 414-class verdict on the origin side: an oversize response
+        // head is simply too large, whatever line it stalled on.
+        error.Incomplete => {
+            if (head_is_full) {
+                return error.HeadTooLarge;
+            }
+            return error.Incomplete;
+        },
+        error.Invalid => return error.Malformed,
+        error.TooManyHeaders => return error.HeadTooLarge,
+    };
+    assert(head_len >= 1);
+    assert(head_len <= head.len);
+    assert(raw_header_count <= constants.headers_max);
+
+    try rejectBareLineFeeds(head[0..head_len]);
+    // hparse only checks for three digits; the status class is ours.
+    if (raw_status < 100) {
+        return error.Malformed;
+    }
+    if (raw_status > 599) {
+        return error.Malformed;
+    }
+    const version = versionFromRaw(raw_version);
+
+    const analysis = try analyzeHeaders(raw_headers[0..raw_header_count], headers_storage);
+    const framing = try responseFraming(request_method, raw_status, version, &analysis);
+
+    return .{
+        .status = raw_status,
+        .version = version,
+        .headers = headers_storage[0..raw_header_count],
+        .framing = framing,
+        .keep_alive = keepAliveDefault(version, &analysis) and framing != .until_close,
+        .head_len = @intCast(head_len),
+    };
+}
+
+/// Incremental delimiter for chunked bodies (RFC 9112 §7.1) relayed
+/// verbatim: zoxy forwards the encoded bytes untouched and only needs to
+/// know where the message ends, so this scanner validates framing and
+/// counts — it never decodes or copies. Feed it the exact bytes that will
+/// be forwarded, in any split; whole-buffer and byte-at-a-time feeding
+/// reach identical outcomes. CRLF-strict everywhere: a bare LF anywhere in
+/// the framing is malformed (§7's smuggling posture).
+pub const ChunkedScanner = struct {
+    state: State = .size,
+    /// Chunk-data bytes still to pass through in the current chunk.
+    data_remaining: u64 = 0,
+    /// Chunk-size value accumulating while in `.size`.
+    size: u64 = 0,
+    /// True once the current size line has at least one hex digit.
+    size_has_digit: bool = false,
+    /// Bytes consumed by the current size line, bounded by
+    /// `constants.chunked_line_bytes_max`.
+    line_bytes: u32 = 0,
+    /// Bytes consumed by the trailer section, bounded by
+    /// `constants.chunked_trailer_bytes_max`.
+    trailer_bytes: u32 = 0,
+
+    pub const State = enum(u8) {
+        size,
+        extension,
+        size_lf,
+        data,
+        data_cr,
+        data_lf,
+        trailer_start,
+        trailer_field,
+        trailer_lf,
+        final_lf,
+        done,
+    };
+
+    pub const Progress = struct {
+        consumed: u32,
+        done: bool,
+    };
+
+    /// * `Malformed` — framing violation; the message end is unknowable,
+    ///   so the connection is torn down.
+    /// * `Oversize` — a size line or trailer section exceeded its static
+    ///   bound; same teardown, distinct counter.
+    pub const Error = error{ Malformed, Oversize };
+
+    /// Consumes bytes until the message ends or `bytes` runs out. Bytes
+    /// past the terminating CRLF belong to the next message (or to
+    /// nothing) and are never consumed.
+    pub fn feed(scanner: *ChunkedScanner, bytes: []const u8) Error!Progress {
+        assert(bytes.len >= 1);
+        assert(bytes.len <= std.math.maxInt(u32));
+        assert(scanner.state != .done);
+
+        var index: u32 = 0;
+        while (index < bytes.len) {
+            const consumed = try scanner.step(bytes[index..]);
+            assert(consumed >= 1);
+            index += consumed;
+            assert(index <= bytes.len);
+            if (scanner.state == .done) {
+                break;
+            }
+        }
+        assert(index >= 1);
+        const done = scanner.state == .done;
+        if (!done) {
+            assert(index == bytes.len);
+        }
+        return .{ .consumed = index, .done = done };
+    }
+
+    /// Consumes at least one byte: a whole run of chunk data, or exactly
+    /// one framing byte.
+    fn step(scanner: *ChunkedScanner, bytes: []const u8) Error!u32 {
+        assert(bytes.len >= 1);
+        return switch (scanner.state) {
+            .size, .extension, .size_lf => scanner.stepSizeLine(bytes[0]),
+            .data => scanner.stepData(bytes),
+            .data_cr, .data_lf => scanner.stepDataEnd(bytes[0]),
+            .trailer_start, .trailer_field, .trailer_lf, .final_lf => scanner.stepTrailer(bytes[0]),
+            .done => unreachable, // feed() never steps a finished scanner.
+        };
+    }
+
+    fn stepSizeLine(scanner: *ChunkedScanner, byte: u8) Error!u32 {
+        try scanner.countLineByte();
+        switch (scanner.state) {
+            .size => switch (byte) {
+                '0'...'9', 'a'...'f', 'A'...'F' => {
+                    // A size whose next digit would overflow u64 is a
+                    // hostile stream, not a body anyone relays.
+                    if (scanner.size > comptime (std.math.maxInt(u64) >> 4)) {
+                        return error.Oversize;
+                    }
+                    scanner.size = scanner.size * 16 + hexDigitValue(byte);
+                    scanner.size_has_digit = true;
+                },
+                ';' => {
+                    if (!scanner.size_has_digit) {
+                        return error.Malformed;
+                    }
+                    scanner.state = .extension;
+                },
+                '\r' => {
+                    if (!scanner.size_has_digit) {
+                        return error.Malformed;
+                    }
+                    scanner.state = .size_lf;
+                },
+                else => return error.Malformed,
+            },
+            // Extensions are forwarded, not interpreted; only the byte
+            // alphabet is policed (bare LF and controls are malformed).
+            .extension => switch (byte) {
+                '\r' => scanner.state = .size_lf,
+                else => {
+                    if (!isForwardableByte(byte)) {
+                        return error.Malformed;
+                    }
+                },
+            },
+            .size_lf => {
+                if (byte != '\n') {
+                    return error.Malformed;
+                }
+                if (scanner.size == 0) {
+                    // last-chunk (a size of zero) ends the data phase.
+                    scanner.state = .trailer_start;
+                } else {
+                    scanner.data_remaining = scanner.size;
+                    scanner.state = .data;
+                }
+            },
+            else => unreachable, // step() dispatched a size-line state.
+        }
+        return 1;
+    }
+
+    fn stepData(scanner: *ChunkedScanner, bytes: []const u8) Error!u32 {
+        assert(bytes.len >= 1);
+        assert(scanner.data_remaining >= 1);
+        const wanted: u64 = @min(scanner.data_remaining, @as(u64, bytes.len));
+        const consumed: u32 = @intCast(wanted);
+        assert(consumed >= 1);
+        scanner.data_remaining -= wanted;
+        if (scanner.data_remaining == 0) {
+            scanner.state = .data_cr;
+        }
+        return consumed;
+    }
+
+    fn stepDataEnd(scanner: *ChunkedScanner, byte: u8) Error!u32 {
+        switch (scanner.state) {
+            .data_cr => {
+                if (byte != '\r') {
+                    return error.Malformed;
+                }
+                scanner.state = .data_lf;
+            },
+            .data_lf => {
+                if (byte != '\n') {
+                    return error.Malformed;
+                }
+                scanner.size = 0;
+                scanner.size_has_digit = false;
+                scanner.line_bytes = 0;
+                scanner.state = .size;
+            },
+            else => unreachable, // step() dispatched a data-end state.
+        }
+        return 1;
+    }
+
+    fn stepTrailer(scanner: *ChunkedScanner, byte: u8) Error!u32 {
+        try scanner.countTrailerByte();
+        switch (scanner.state) {
+            .trailer_start => switch (byte) {
+                '\r' => scanner.state = .final_lf,
+                else => {
+                    if (!isForwardableByte(byte)) {
+                        return error.Malformed;
+                    }
+                    scanner.state = .trailer_field;
+                },
+            },
+            .trailer_field => switch (byte) {
+                '\r' => scanner.state = .trailer_lf,
+                else => {
+                    if (!isForwardableByte(byte)) {
+                        return error.Malformed;
+                    }
+                },
+            },
+            .trailer_lf => {
+                if (byte != '\n') {
+                    return error.Malformed;
+                }
+                scanner.state = .trailer_start;
+            },
+            .final_lf => {
+                if (byte != '\n') {
+                    return error.Malformed;
+                }
+                scanner.state = .done;
+            },
+            else => unreachable, // step() dispatched a trailer state.
+        }
+        return 1;
+    }
+
+    fn countLineByte(scanner: *ChunkedScanner) Error!void {
+        assert(scanner.line_bytes < std.math.maxInt(u32));
+        scanner.line_bytes += 1;
+        if (scanner.line_bytes > constants.chunked_line_bytes_max) {
+            return error.Oversize;
+        }
+    }
+
+    fn countTrailerByte(scanner: *ChunkedScanner) Error!void {
+        assert(scanner.trailer_bytes < std.math.maxInt(u32));
+        scanner.trailer_bytes += 1;
+        if (scanner.trailer_bytes > constants.chunked_trailer_bytes_max) {
+            return error.Oversize;
+        }
+    }
+};
+
+/// First value for a header name, case-insensitively, or null. For the
+/// phase points and the renderer; framing decisions never use it (they
+/// need duplicate detection, which `analyzeHeaders` owns).
+pub fn headerValue(headers: []const Header, name: []const u8) ?[]const u8 {
+    assert(name.len >= 1);
+    for (headers) |header| {
+        assert(header.name.len >= 1);
+        if (std.ascii.eqlIgnoreCase(header.name, name)) {
+            return header.value;
+        }
+    }
+    return null;
+}
+
+/// True if a comma-separated token list (Connection, TE, ...) contains
+/// `token`, case-insensitively, with optional whitespace around tokens.
+pub fn tokenListHas(value: []const u8, token: []const u8) bool {
+    assert(token.len >= 1);
+    var tokens = std.mem.splitScalar(u8, value, ',');
+    // Bounded: the iterator yields at most value.len + 1 pieces.
+    while (tokens.next()) |raw_token| {
+        const trimmed = std.mem.trim(u8, raw_token, " \t");
+        if (trimmed.len == 0) {
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(trimmed, token)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// What one validation pass over the raw headers found. The pass also
+/// copies every header into the caller's storage — the copy rides the
+/// walk the analysis needs anyway, so consumers never see hparse's types.
+const HeaderAnalysis = struct {
+    host: ?[]const u8,
+    content_length: ?u64,
+    /// Transfer-Encoding present and exactly "chunked".
+    te_chunked: bool,
+    /// Transfer-Encoding present and anything else.
+    te_other: bool,
+    connection_close: bool,
+    connection_keep_alive: bool,
+};
+
+fn analyzeHeaders(
+    raw_headers: []const hparse.Header,
+    headers_storage: *HeaderStorage,
+) error{Malformed}!HeaderAnalysis {
+    assert(raw_headers.len <= headers_storage.len);
+    var analysis = HeaderAnalysis{
+        .host = null,
+        .content_length = null,
+        .te_chunked = false,
+        .te_other = false,
+        .connection_close = false,
+        .connection_keep_alive = false,
+    };
+    for (raw_headers, 0..) |raw_header, index| {
+        assert(raw_header.key.len >= 1);
+        headers_storage[index] = .{ .name = raw_header.key, .value = raw_header.value };
+        if (std.ascii.eqlIgnoreCase(raw_header.key, "host")) {
+            // A second Host changes routing depending on who reads which —
+            // a smuggling shape, like an empty one (RFC 9112 §3.2).
+            if (analysis.host != null) {
+                return error.Malformed;
+            }
+            if (raw_header.value.len == 0) {
+                return error.Malformed;
+            }
+            analysis.host = raw_header.value;
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(raw_header.key, "content-length")) {
+            // Duplicate Content-Length is rejected outright, identical
+            // values included (§7 "duplicate/garbage Content-Length").
+            if (analysis.content_length != null) {
+                return error.Malformed;
+            }
+            analysis.content_length = try parseContentLength(raw_header.value);
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(raw_header.key, "transfer-encoding")) {
+            // A second Transfer-Encoding header is the list form in
+            // disguise; only the single exact "chunked" is ever legal
+            // here, so any repeat is malformed.
+            if (analysis.te_chunked or analysis.te_other) {
+                return error.Malformed;
+            }
+            if (std.ascii.eqlIgnoreCase(raw_header.value, "chunked")) {
+                analysis.te_chunked = true;
+            } else {
+                analysis.te_other = true;
+            }
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(raw_header.key, "connection")) {
+            // Multiple Connection headers combine as one list (RFC 9110).
+            if (tokenListHas(raw_header.value, "close")) {
+                analysis.connection_close = true;
+            }
+            if (tokenListHas(raw_header.value, "keep-alive")) {
+                analysis.connection_keep_alive = true;
+            }
+            continue;
+        }
+    }
+    assert(!(analysis.te_chunked and analysis.te_other));
+    if (analysis.host) |host| {
+        assert(host.len >= 1);
+    }
+    return analysis;
+}
+
+/// Request-side framing (RFC 9112 §6.3): length-delimited or nothing.
+/// Every smuggling shape dies here, before any byte reaches an upstream.
+fn requestFraming(
+    version: Version,
+    analysis: *const HeaderAnalysis,
+) error{Malformed}!BodyFraming {
+    assert(!(analysis.te_chunked and analysis.te_other));
+    const te_present = analysis.te_chunked or analysis.te_other;
+    if (te_present) {
+        // Transfer-Encoding does not exist in HTTP/1.0.
+        if (version == .http_1_0) {
+            return error.Malformed;
+        }
+        // TE + CL is the classic smuggling shape (§7): reject, never pick.
+        if (analysis.content_length != null) {
+            return error.Malformed;
+        }
+        // Only the single exact "chunked" coding is accepted on requests
+        // (RFC 9112 §6.1 lets a server reject anything else).
+        if (analysis.te_other) {
+            return error.Malformed;
+        }
+        return .chunked;
+    }
+    if (analysis.content_length) |length| {
+        return .{ .content_length = length };
+    }
+    return .none;
+}
+
+/// Response-side framing (RFC 9112 §6.3), in the RFC's precedence order.
+fn responseFraming(
+    request_method: Method,
+    status: u16,
+    version: Version,
+    analysis: *const HeaderAnalysis,
+) error{Malformed}!BodyFraming {
+    assert(status >= 100);
+    assert(status <= 599);
+    assert(request_method != .connect);
+    const te_present = analysis.te_chunked or analysis.te_other;
+    // TE + CL "ought to be handled as an error" (RFC 9112 §6.3): an origin
+    // emitting the smuggling shape is torn down, not reinterpreted.
+    if (te_present) {
+        if (analysis.content_length != null) {
+            return error.Malformed;
+        }
+        if (version == .http_1_0) {
+            return error.Malformed;
+        }
+    }
+    // These carry no body bytes regardless of framing headers.
+    if (request_method == .head) {
+        return .none;
+    }
+    if (status < 200) {
+        return .none;
+    }
+    if (status == 204) {
+        return .none;
+    }
+    if (status == 304) {
+        return .none;
+    }
+    if (analysis.te_chunked) {
+        return .chunked;
+    }
+    if (analysis.te_other) {
+        // Chunked-not-final: the body runs to connection close
+        // (RFC 9112 §6.3 item 4) and the connection leaves reuse.
+        return .until_close;
+    }
+    if (analysis.content_length) |length| {
+        return .{ .content_length = length };
+    }
+    return .until_close;
+}
+
+/// Persistence per version defaults and Connection tokens (RFC 9112 §9).
+fn keepAliveDefault(version: Version, analysis: *const HeaderAnalysis) bool {
+    return switch (version) {
+        .http_1_1 => !analysis.connection_close,
+        .http_1_0 => analysis.connection_keep_alive and !analysis.connection_close,
+    };
+}
+
+/// A reverse proxy routes origin-form targets (§7 routes host/path);
+/// asterisk-form is legal for OPTIONS. CONNECT's authority-form passes
+/// through so the proxy can answer it with 501 rather than 400.
+fn validateTarget(target: []const u8, method: Method) error{Malformed}!void {
+    if (target.len == 0) {
+        return error.Malformed;
+    }
+    assert(target.len >= 1);
+    if (method == .connect) {
+        return;
+    }
+    if (target[0] == '/') {
+        return;
+    }
+    if (method == .options) {
+        if (std.mem.eql(u8, target, "*")) {
+            return;
+        }
+    }
+    return error.Malformed;
+}
+
+/// 1*DIGIT (RFC 9112 §6.2): digits only — no sign, no whitespace, no
+/// comma list. 19 digits bound the value below 10^19 < 2^64, so the
+/// accumulation cannot overflow.
+fn parseContentLength(value: []const u8) error{Malformed}!u64 {
+    if (value.len == 0) {
+        return error.Malformed;
+    }
+    if (value.len > 19) {
+        return error.Malformed;
+    }
+    var total: u64 = 0;
+    for (value) |byte| {
+        if (byte < '0') {
+            return error.Malformed;
+        }
+        if (byte > '9') {
+            return error.Malformed;
+        }
+        total = total * 10 + (byte - '0');
+    }
+    assert(total < 10_000_000_000_000_000_000);
+    return total;
+}
+
+/// §7 fork-gate item still open: the pinned hparse accepts a bare LF as a
+/// line terminator — a smuggling ingredient when intermediaries disagree
+/// on where lines end. Enforce CRLF-only here until the fork rejects it
+/// at parse time; this scan then becomes a redundant second witness.
+fn rejectBareLineFeeds(head: []const u8) error{Malformed}!void {
+    assert(head.len >= 1);
+    for (head, 0..) |byte, index| {
+        if (byte != '\n') {
+            continue;
+        }
+        if (index == 0) {
+            return error.Malformed;
+        }
+        if (head[index - 1] != '\r') {
+            return error.Malformed;
+        }
+    }
+}
+
+/// The 414 vs 431 verdict for a request head that cannot complete inside
+/// a full head buffer (§7): no line terminator at all means the request
+/// line itself overflowed.
+fn oversizeRequestError(head: []const u8) HeadError {
+    assert(head.len >= 1);
+    if (std.mem.indexOfScalar(u8, head, '\n') == null) {
+        return error.UriTooLong;
+    }
+    return error.HeadTooLarge;
+}
+
+fn methodFromRaw(raw_method: hparse.Method) Method {
+    assert(raw_method != .unknown);
+    return switch (raw_method) {
+        // A successful parse always overwrites the sentinel (hparse contract).
+        .unknown => unreachable,
+        .get => .get,
+        .post => .post,
+        .head => .head,
+        .put => .put,
+        .delete => .delete,
+        .connect => .connect,
+        .options => .options,
+        .trace => .trace,
+        .patch => .patch,
+    };
+}
+
+fn versionFromRaw(raw_version: hparse.Version) Version {
+    return switch (raw_version) {
+        .@"1.0" => .http_1_0,
+        .@"1.1" => .http_1_1,
+    };
+}
+
+fn isForwardableByte(byte: u8) bool {
+    return byte == '\t' or (byte >= ' ' and byte != 0x7f);
+}
+
+fn hexDigitValue(byte: u8) u4 {
+    return switch (byte) {
+        '0'...'9' => @intCast(byte - '0'),
+        'a'...'f' => @intCast(byte - 'a' + 10),
+        'A'...'F' => @intCast(byte - 'A' + 10),
+        else => unreachable, // Caller matched a hex digit.
+    };
+}
+
+// Tests. Head-parse cases go through the public wrapper only — hparse's
+// own behavior is covered in its repository; what is pinned down here is
+// the trust boundary's verdicts (§7).
+
+const testing = std.testing;
+
+fn expectRequestError(expected: HeadError, head: []const u8, head_is_full: bool) !void {
+    var storage: HeaderStorage = undefined;
+    try testing.expectError(expected, parseRequestHead(head, head_is_full, &storage));
+}
+
+fn expectResponseError(expected: HeadError, head: []const u8, request_method: Method) !void {
+    var storage: HeaderStorage = undefined;
+    try testing.expectError(
+        expected,
+        parseResponseHead(head, false, &storage, request_method),
+    );
+}
+
+test "http parser: plain GET parses with keep-alive and no body" {
+    const head = "GET /path?q=1 HTTP/1.1\r\nHost: origin.example\r\nAccept: */*\r\n\r\n";
+    var storage: HeaderStorage = undefined;
+    const request = try parseRequestHead(head, false, &storage);
+    try testing.expectEqual(Method.get, request.method);
+    try testing.expectEqualStrings("/path?q=1", request.target);
+    try testing.expectEqual(Version.http_1_1, request.version);
+    try testing.expectEqualStrings("origin.example", request.host.?);
+    try testing.expectEqual(BodyFraming.none, request.framing);
+    try testing.expect(request.keep_alive);
+    try testing.expectEqual(@as(u32, head.len), request.head_len);
+    try testing.expectEqual(@as(usize, 2), request.headers.len);
+    try testing.expectEqualStrings("Accept", request.headers[1].name);
+}
+
+test "http parser: POST with Content-Length frames the body and marks its start" {
+    const head = "POST /submit HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n";
+    const message = head ++ "hello";
+    var storage: HeaderStorage = undefined;
+    const request = try parseRequestHead(message, false, &storage);
+    try testing.expectEqual(BodyFraming{ .content_length = 5 }, request.framing);
+    try testing.expectEqual(@as(u32, head.len), request.head_len);
+    try testing.expectEqualStrings("hello", message[request.head_len..]);
+}
+
+test "http parser: chunked Transfer-Encoding frames the request body" {
+    const head = "POST /u HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n";
+    var storage: HeaderStorage = undefined;
+    const request = try parseRequestHead(head, false, &storage);
+    try testing.expectEqual(BodyFraming.chunked, request.framing);
+}
+
+test "http parser: smuggling shapes are malformed before any upstream byte" {
+    // TE + CL.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n",
+        false,
+    );
+    // Duplicate Content-Length, identical values included.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\n",
+        false,
+    );
+    // Garbage Content-Length: sign, suffix, list, empty.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: +5\r\n\r\n",
+        false,
+    );
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5x\r\n\r\n",
+        false,
+    );
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5, 5\r\n\r\n",
+        false,
+    );
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length:\r\n\r\n",
+        false,
+    );
+    // Transfer-Encoding that is not exactly "chunked".
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: gzip, chunked\r\n\r\n",
+        false,
+    );
+    // Duplicate Transfer-Encoding — the list form in disguise.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n",
+        false,
+    );
+    // Transfer-Encoding does not exist in HTTP/1.0.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.0\r\nTransfer-Encoding: chunked\r\n\r\n",
+        false,
+    );
+}
+
+test "http parser: Content-Length accepts leading zeros and the u64 maximum digits" {
+    var storage: HeaderStorage = undefined;
+    const zeros = try parseRequestHead(
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 0123\r\n\r\n",
+        false,
+        &storage,
+    );
+    try testing.expectEqual(BodyFraming{ .content_length = 123 }, zeros.framing);
+    // 20 digits can overflow u64; the parser caps at 19 outright.
+    try expectRequestError(
+        error.Malformed,
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 99999999999999999999\r\n\r\n",
+        false,
+    );
+}
+
+test "http parser: Host is mandatory and unique on HTTP/1.1" {
+    try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nAccept: */*\r\n\r\n", false);
+    try expectRequestError(
+        error.Malformed,
+        "GET / HTTP/1.1\r\nHost: a\r\nHost: b\r\n\r\n",
+        false,
+    );
+    try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost:\r\n\r\n", false);
+    // HTTP/1.0 may omit Host.
+    var storage: HeaderStorage = undefined;
+    const request = try parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
+    try testing.expectEqual(@as(?[]const u8, null), request.host);
+}
+
+test "http parser: keep-alive follows version defaults and Connection tokens" {
+    const Case = struct { head: []const u8, keep_alive: bool };
+    const cases = [_]Case{
+        .{ .head = "GET / HTTP/1.1\r\nHost: a\r\n\r\n", .keep_alive = true },
+        .{ .head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n", .keep_alive = false },
+        .{ .head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: Close\r\n\r\n", .keep_alive = false },
+        .{ .head = "GET / HTTP/1.0\r\n\r\n", .keep_alive = false },
+        .{ .head = "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n", .keep_alive = true },
+        // close wins over keep-alive when both tokens appear.
+        .{
+            .head = "GET / HTTP/1.0\r\nConnection: keep-alive, close\r\n\r\n",
+            .keep_alive = false,
+        },
+    };
+    for (cases) |case| {
+        var storage: HeaderStorage = undefined;
+        const request = try parseRequestHead(case.head, false, &storage);
+        try testing.expectEqual(case.keep_alive, request.keep_alive);
+    }
+}
+
+test "http parser: bare LF line terminators are malformed (fork-gate stopgap)" {
+    // The pinned hparse still accepts every one of these (§7 fork gate);
+    // the wrapper's CRLF-only scan must reject them.
+    try expectRequestError(error.Malformed, "GET / HTTP/1.1\nHost: a\r\n\r\n", false);
+    try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost: a\n\r\n", false);
+    try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost: a\r\n\n", false);
+    try expectResponseError(error.Malformed, "HTTP/1.1 200 OK\nContent-Length: 0\r\n\r\n", .get);
+}
+
+test "http parser: extension methods are malformed until the fork opens the enum" {
+    // §7 fork-gate item: hparse's method enum is closed, so PROPFIND-class
+    // tokens surface as 400 today. When the fork opens the enum this test
+    // flips to expecting a parsed extension method.
+    try expectRequestError(error.Malformed, "PROPFIND /dav HTTP/1.1\r\nHost: a\r\n\r\n", false);
+}
+
+test "http parser: request targets must be origin-form (or OPTIONS *)" {
+    // Absolute-form belongs to forward proxies.
+    try expectRequestError(
+        error.Malformed,
+        "GET http://other/ HTTP/1.1\r\nHost: a\r\n\r\n",
+        false,
+    );
+    try expectRequestError(error.Malformed, "GET * HTTP/1.1\r\nHost: a\r\n\r\n", false);
+    var storage: HeaderStorage = undefined;
+    const options = try parseRequestHead("OPTIONS * HTTP/1.1\r\nHost: a\r\n\r\n", false, &storage);
+    try testing.expectEqualStrings("*", options.target);
+    // CONNECT's authority-form parses so the proxy can answer 501 itself.
+    const connect = try parseRequestHead(
+        "CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n",
+        false,
+        &storage,
+    );
+    try testing.expectEqual(Method.connect, connect.method);
+}
+
+test "http parser: partial heads are Incomplete until the buffer fills" {
+    try expectRequestError(error.Incomplete, "GET / HTTP/1.1\r\nHost: a\r\n", false);
+    try expectRequestError(error.Incomplete, "GET /still-in-the-request-line", false);
+    // The same bytes in a full buffer become the oversize verdicts (§7):
+    // request line still open → 414, header section open → 431.
+    try expectRequestError(error.UriTooLong, "GET /still-in-the-request-line", true);
+    try expectRequestError(error.HeadTooLarge, "GET / HTTP/1.1\r\nHost: a\r\n", true);
+}
+
+test "http parser: header-array overflow is 431-class, not 400" {
+    const head = "GET / HTTP/1.1\r\nHost: a\r\n" ++ ("X-Filler: 1\r\n" ** constants.headers_max) ++ "\r\n";
+    try expectRequestError(error.HeadTooLarge, head, false);
+}
+
+test "http parser: response heads frame per RFC 9112 §6.3 precedence" {
+    var storage: HeaderStorage = undefined;
+    const sized = try parseResponseHead(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        false,
+        &storage,
+        .get,
+    );
+    try testing.expectEqual(@as(u16, 200), sized.status);
+    try testing.expectEqual(BodyFraming{ .content_length = 2 }, sized.framing);
+    try testing.expect(sized.keep_alive);
+
+    const chunked = try parseResponseHead(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+        false,
+        &storage,
+        .get,
+    );
+    try testing.expectEqual(BodyFraming.chunked, chunked.framing);
+
+    // No framing headers at all: the body runs to close, reuse is off.
+    const unframed = try parseResponseHead("HTTP/1.1 200 OK\r\n\r\n", false, &storage, .get);
+    try testing.expectEqual(BodyFraming.until_close, unframed.framing);
+    try testing.expect(!unframed.keep_alive);
+
+    // Chunked-not-final also runs to close (RFC 9112 §6.3 item 4).
+    const te_other = try parseResponseHead(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\n\r\n",
+        false,
+        &storage,
+        .get,
+    );
+    try testing.expectEqual(BodyFraming.until_close, te_other.framing);
+    try testing.expect(!te_other.keep_alive);
+}
+
+test "http parser: bodiless statuses and HEAD ignore framing headers" {
+    var storage: HeaderStorage = undefined;
+    const head_response = try parseResponseHead(
+        "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n",
+        false,
+        &storage,
+        .head,
+    );
+    try testing.expectEqual(BodyFraming.none, head_response.framing);
+    try testing.expect(head_response.keep_alive);
+
+    const no_content = try parseResponseHead("HTTP/1.1 204 No Content\r\n\r\n", false, &storage, .get);
+    try testing.expectEqual(BodyFraming.none, no_content.framing);
+    try testing.expect(no_content.keep_alive);
+
+    const informational = try parseResponseHead("HTTP/1.1 100 Continue\r\n\r\n", false, &storage, .post);
+    try testing.expectEqual(BodyFraming.none, informational.framing);
+}
+
+test "http parser: origin smuggling shapes and alien statuses tear down" {
+    try expectResponseError(
+        error.Malformed,
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 2\r\n\r\n",
+        .get,
+    );
+    try expectResponseError(
+        error.Malformed,
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 2\r\n\r\n",
+        .get,
+    );
+    try expectResponseError(error.Malformed, "HTTP/1.1 099 Weird\r\n\r\n", .get);
+    try expectResponseError(error.Malformed, "HTTP/1.1 600 Weird\r\n\r\n", .get);
+}
+
+test "http parser: header helpers are case-insensitive" {
+    const headers = [_]Header{
+        .{ .name = "Content-Type", .value = "text/plain" },
+        .{ .name = "Upgrade", .value = "h2c" },
+    };
+    try testing.expectEqualStrings("h2c", headerValue(&headers, "upgrade").?);
+    try testing.expectEqual(@as(?[]const u8, null), headerValue(&headers, "host"));
+    try testing.expect(tokenListHas(" Keep-Alive , Close", "close"));
+    try testing.expect(tokenListHas("close", "CLOSE"));
+    try testing.expect(!tokenListHas("closed", "close"));
+    try testing.expect(!tokenListHas("", "close"));
+}
+
+// Chunked-scanner tests drive `feed` through `chunkedOutcome`, the same
+// harness the fuzz oracle uses, so unit cases and fuzz share semantics.
+
+const ChunkedOutcome = struct {
+    consumed: u64,
+    done: bool,
+    failure: ?ChunkedScanner.Error,
+};
+
+/// Feeds `input` in pieces of at most `feed_bytes_max` and reports the
+/// aggregate outcome. Split-invariance of `ChunkedScanner` means the
+/// result must not depend on `feed_bytes_max`.
+fn chunkedOutcome(input: []const u8, feed_bytes_max: usize) ChunkedOutcome {
+    assert(feed_bytes_max >= 1);
+    var scanner = ChunkedScanner{};
+    var outcome = ChunkedOutcome{ .consumed = 0, .done = false, .failure = null };
+    var offset: usize = 0;
+    while (offset < input.len) {
+        const end = @min(input.len, offset + feed_bytes_max);
+        const progress = scanner.feed(input[offset..end]) catch |err| {
+            outcome.failure = err;
+            return outcome;
+        };
+        assert(progress.consumed >= 1);
+        outcome.consumed += progress.consumed;
+        offset += progress.consumed;
+        if (progress.done) {
+            outcome.done = true;
+            return outcome;
+        }
+        // feed() consumes its whole slice unless the message ended.
+        assert(offset == end);
+    }
+    return outcome;
+}
+
+test "chunked: a simple body scans to done at every split size" {
+    const body = "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+    for ([_]usize{ 1, 2, 3, 5, body.len }) |feed_bytes_max| {
+        const outcome = chunkedOutcome(body, feed_bytes_max);
+        try testing.expectEqual(@as(?ChunkedScanner.Error, null), outcome.failure);
+        try testing.expect(outcome.done);
+        try testing.expectEqual(@as(u64, body.len), outcome.consumed);
+    }
+}
+
+test "chunked: extensions and trailers are forwarded, bounded, and end cleanly" {
+    const body = "5;name=value\r\nhello\r\n0\r\nX-Trailer: yes\r\n\r\n";
+    for ([_]usize{ 1, body.len }) |feed_bytes_max| {
+        const outcome = chunkedOutcome(body, feed_bytes_max);
+        try testing.expectEqual(@as(?ChunkedScanner.Error, null), outcome.failure);
+        try testing.expect(outcome.done);
+        try testing.expectEqual(@as(u64, body.len), outcome.consumed);
+    }
+}
+
+test "chunked: pipelined bytes after the terminator are left unconsumed" {
+    const body = "1\r\na\r\n0\r\n\r\n";
+    const stream = body ++ "GET";
+    const outcome = chunkedOutcome(stream, stream.len);
+    try testing.expect(outcome.done);
+    try testing.expectEqual(@as(u64, body.len), outcome.consumed);
+}
+
+test "chunked: framing violations are malformed" {
+    const malformed_cases = [_][]const u8{
+        "\r\n", // no size digit at all
+        "g\r\n", // not a hex digit
+        ";ext\r\n", // extension before any digit
+        "5\nhello\r\n0\r\n\r\n", // bare LF after size
+        "5\r\nhelloX\r\n0\r\n\r\n", // chunk data not followed by CR
+        "5\r\nhello\rX0\r\n\r\n", // CR not followed by LF
+        "0\r\nX-T: v\n\r\n", // bare LF inside trailer
+        "0\r\n\rX", // final CR not followed by LF
+    };
+    for (malformed_cases) |case| {
+        const outcome = chunkedOutcome(case, case.len);
+        try testing.expectEqual(@as(?ChunkedScanner.Error, error.Malformed), outcome.failure);
+    }
+}
+
+test "chunked: size lines and trailers hit their static bounds" {
+    // A size line longer than the bound (extensions included).
+    const long_line = "1;" ++ ("e" ** constants.chunked_line_bytes_max) ++ "\r\na\r\n0\r\n\r\n";
+    try testing.expectEqual(
+        @as(?ChunkedScanner.Error, error.Oversize),
+        chunkedOutcome(long_line, long_line.len).failure,
+    );
+    // A chunk size that would overflow u64 (17 hex digits).
+    const huge_size = "11111111111111111\r\n";
+    try testing.expectEqual(
+        @as(?ChunkedScanner.Error, error.Oversize),
+        chunkedOutcome(huge_size, huge_size.len).failure,
+    );
+    // A trailer section past its bound.
+    const trailer_line = "X-Filler: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n";
+    const repeats = constants.chunked_trailer_bytes_max / trailer_line.len + 1;
+    const long_trailer = "0\r\n" ++ (trailer_line ** repeats) ++ "\r\n";
+    try testing.expectEqual(
+        @as(?ChunkedScanner.Error, error.Oversize),
+        chunkedOutcome(long_trailer, long_trailer.len).failure,
+    );
+}
+
+// Fuzzing (§9 gate 2): arbitrary bytes through the wrapper — parse or
+// reject with no third outcome, every returned slice inside the input,
+// and chunked scanning invariant under how the input is split.
+
+fn sliceWithin(outer: []const u8, inner: []const u8) bool {
+    const outer_start = @intFromPtr(outer.ptr);
+    const inner_start = @intFromPtr(inner.ptr);
+    return inner_start >= outer_start and
+        inner_start + inner.len <= outer_start + outer.len;
+}
+
+fn checkRequestParse(input: []const u8, head_is_full: bool) void {
+    var storage: HeaderStorage = undefined;
+    const request = parseRequestHead(input, head_is_full, &storage) catch return;
+    assert(request.head_len >= 1);
+    assert(request.head_len <= input.len);
+    assert(sliceWithin(input, request.target));
+    assert(request.target.len >= 1);
+    if (request.host) |host| {
+        assert(host.len >= 1);
+        assert(sliceWithin(input, host));
+    }
+    if (request.version == .http_1_1) {
+        assert(request.host != null);
+    }
+    for (request.headers) |header| {
+        assert(header.name.len >= 1);
+        assert(sliceWithin(input, header.name));
+        assert(sliceWithin(input, header.value));
+    }
+    assert(request.framing != .until_close);
+}
+
+fn checkResponseParse(input: []const u8, head_is_full: bool) void {
+    var storage: HeaderStorage = undefined;
+    const response = parseResponseHead(input, head_is_full, &storage, .get) catch return;
+    assert(response.head_len >= 1);
+    assert(response.head_len <= input.len);
+    assert(response.status >= 100);
+    assert(response.status <= 599);
+    for (response.headers) |header| {
+        assert(header.name.len >= 1);
+        assert(sliceWithin(input, header.name));
+        assert(sliceWithin(input, header.value));
+    }
+    if (response.framing == .until_close) {
+        assert(!response.keep_alive);
+    }
+}
+
+const fuzz_corpus_request = "POST /submit HTTP/1.1\r\nHost: origin\r\nContent-Length: 5\r\n\r\nhello";
+const fuzz_corpus_response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+const fuzz_corpus_chunked = "5\r\nhello\r\n0\r\nX-Trailer: v\r\n\r\n";
+
+test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
+    try std.testing.fuzz({}, fuzzParserInputs, .{
+        .corpus = &.{ fuzz_corpus_request, fuzz_corpus_response, fuzz_corpus_chunked },
+    });
+}
+
+fn fuzzParserInputs(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    const input_len = smith.slice(&input_buffer);
+    assert(input_len <= input_buffer.len);
+    const input = input_buffer[0..input_len];
+
+    checkRequestParse(input, false);
+    checkResponseParse(input, false);
+    if (input.len >= 1) {
+        checkRequestParse(input, true);
+        checkResponseParse(input, true);
+    }
+
+    // Split-invariance oracle: whole-buffer and byte-at-a-time feeding
+    // must agree — the relay feeds recv-sized pieces, the peer picks the
+    // split, and the verdict may depend on neither. Consumed counts are
+    // only comparable on success: a failing feed() call reports no
+    // partial progress (the connection is torn down regardless), so the
+    // pre-failure tally is inherently split-dependent.
+    const whole = chunkedOutcome(input, @max(input.len, 1));
+    const bytewise = chunkedOutcome(input, 1);
+    assert((whole.failure == null) == (bytewise.failure == null));
+    if (whole.failure) |failure| {
+        assert(failure == bytewise.failure.?);
+    } else {
+        assert(whole.consumed == bytewise.consumed);
+        assert(whole.done == bytewise.done);
+    }
+}

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -588,12 +588,7 @@ fn analyzeHeaders(
         }
         if (std.ascii.eqlIgnoreCase(raw_header.key, "connection")) {
             // Multiple Connection headers combine as one list (RFC 9110).
-            if (tokenListHas(raw_header.value, "close")) {
-                analysis.connection_close = true;
-            }
-            if (tokenListHas(raw_header.value, "keep-alive")) {
-                analysis.connection_keep_alive = true;
-            }
+            scanConnectionTokens(raw_header.value, &analysis);
             continue;
         }
     }
@@ -602,6 +597,24 @@ fn analyzeHeaders(
         assert(host.len >= 1);
     }
     return analysis;
+}
+
+/// Set the persistence flags from one Connection header value in a single
+/// token pass — scanning the list twice (once per token) was a measured
+/// hot spot (§9). Tokens are OWS-trimmed and matched case-insensitively.
+fn scanConnectionTokens(value: []const u8, analysis: *HeaderAnalysis) void {
+    var tokens = std.mem.splitScalar(u8, value, ',');
+    while (tokens.next()) |raw_token| {
+        const token = std.mem.trim(u8, raw_token, " \t");
+        if (token.len == 0) {
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(token, "close")) {
+            analysis.connection_close = true;
+        } else if (std.ascii.eqlIgnoreCase(token, "keep-alive")) {
+            analysis.connection_keep_alive = true;
+        }
+    }
 }
 
 /// Request-side framing (RFC 9112 §6.3): length-delimited or nothing.

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -109,6 +109,9 @@ pub const RequestHead = struct {
 /// as `RequestHead`.
 pub const ResponseHead = struct {
     status: u16,
+    /// The origin's reason phrase, forwarded verbatim by the renderer;
+    /// null when the origin sent none (bare `HTTP/1.1 200\r\n`).
+    status_message: ?[]const u8,
     version: Version,
     headers: []const Header,
     framing: BodyFraming,
@@ -248,6 +251,7 @@ pub fn parseResponseHead(
 
     return .{
         .status = raw_status,
+        .status_message = raw_status_message,
         .version = version,
         .headers = headers_storage[0..raw_header_count],
         .framing = framing,
@@ -1009,6 +1013,7 @@ test "http parser: response heads frame per RFC 9112 §6.3 precedence" {
         .get,
     );
     try testing.expectEqual(@as(u16, 200), sized.status);
+    try testing.expectEqualStrings("OK", sized.status_message.?);
     try testing.expectEqual(BodyFraming{ .content_length = 2 }, sized.framing);
     try testing.expect(sized.keep_alive);
 
@@ -1229,6 +1234,9 @@ fn checkResponseParse(input: []const u8, head_is_full: bool) void {
     assert(response.head_len <= input.len);
     assert(response.status >= 100);
     assert(response.status <= 599);
+    if (response.status_message) |message| {
+        assert(sliceWithin(input, message));
+    }
     for (response.headers) |header| {
         assert(header.name.len >= 1);
         assert(sliceWithin(input, header.name));

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -121,6 +121,47 @@ pub const ResponseHead = struct {
     head_len: u32,
 };
 
+/// The raw request-line and header outputs hparse fills. Kept in the
+/// caller's frame and written through by pointer so `parseRequestHead`
+/// copies no [headers_max]Header.
+const RawRequest = struct {
+    method: hparse.Method = .unknown,
+    method_token: ?[]const u8 = null,
+    target: ?[]const u8 = null,
+    version: hparse.Version = .@"1.0",
+    headers: [constants.headers_max]hparse.Header = undefined,
+    header_count: usize = 0,
+};
+
+/// Runs hparse over the request line and headers, mapping its verdicts
+/// to head errors (§7): a head that cannot complete inside a full buffer
+/// is oversize, not partial (request line still open → 414, else 431);
+/// Invalid is malformed; a full header array is load, not malice.
+fn parseRequestRaw(head: []const u8, head_is_full: bool, raw: *RawRequest) HeadError!u32 {
+    const head_len = hparse.parseRequest(
+        head,
+        &raw.method,
+        &raw.method_token,
+        &raw.target,
+        &raw.version,
+        &raw.headers,
+        &raw.header_count,
+    ) catch |err| switch (err) {
+        error.Incomplete => {
+            if (head_is_full) {
+                return oversizeRequestError(head);
+            }
+            return error.Incomplete;
+        },
+        error.Invalid => return error.Malformed,
+        error.TooManyHeaders => return error.HeadTooLarge,
+    };
+    assert(head_len >= 1);
+    assert(head_len <= head.len);
+    assert(raw.header_count <= constants.headers_max);
+    return @intCast(head_len);
+}
+
 /// Parses and validates one request head from `head`. `head_is_full` says
 /// the head buffer has no room left, turning a partial parse into the 414
 /// vs 431 oversize verdict instead of `error.Incomplete` (§7, §8).
@@ -134,45 +175,17 @@ pub fn parseRequestHead(
         assert(head.len >= 1);
     }
 
-    var raw_method: hparse.Method = .unknown;
-    var raw_method_token: ?[]const u8 = null;
-    var raw_target: ?[]const u8 = null;
-    var raw_version: hparse.Version = .@"1.0";
-    var raw_headers: [constants.headers_max]hparse.Header = undefined;
-    var raw_header_count: usize = 0;
-    const head_len = hparse.parseRequest(
-        head,
-        &raw_method,
-        &raw_method_token,
-        &raw_target,
-        &raw_version,
-        &raw_headers,
-        &raw_header_count,
-    ) catch |err| switch (err) {
-        // A head that cannot complete inside a full buffer is oversize,
-        // not partial (§7): request line still open → 414, else 431.
-        error.Incomplete => {
-            if (head_is_full) {
-                return oversizeRequestError(head);
-            }
-            return error.Incomplete;
-        },
-        error.Invalid => return error.Malformed,
-        // The bounded header array filling up is load, not malice (§7).
-        error.TooManyHeaders => return error.HeadTooLarge,
-    };
-    assert(head_len >= 1);
-    assert(head_len <= head.len);
-    assert(raw_header_count <= constants.headers_max);
+    var raw: RawRequest = .{};
+    const head_len = try parseRequestRaw(head, head_is_full, &raw);
 
-    const target = raw_target.?; // A successful parse always sets the target.
-    const method_token = raw_method_token.?; // Same contract as the target.
+    const target = raw.target.?; // A successful parse always sets the target.
+    const method_token = raw.method_token.?; // Same contract as the target.
     assert(method_token.len >= 1);
-    const method = methodFromRaw(raw_method);
+    const method = methodFromRaw(raw.method);
     try validateTarget(target, method);
-    const version = versionFromRaw(raw_version);
+    const version = versionFromRaw(raw.version);
 
-    const analysis = try analyzeHeaders(raw_headers[0..raw_header_count], headers_storage);
+    const analysis = try analyzeHeaders(raw.headers[0..raw.header_count], headers_storage);
     // An HTTP/1.1 request must carry exactly one Host (RFC 9112 §3.2);
     // duplicates were already rejected during analysis.
     if (version == .http_1_1) {
@@ -188,11 +201,11 @@ pub fn parseRequestHead(
         .method_token = method_token,
         .target = target,
         .version = version,
-        .headers = headers_storage[0..raw_header_count],
+        .headers = headers_storage[0..raw.header_count],
         .host = analysis.host,
         .framing = framing,
         .keep_alive = keepAliveDefault(version, &analysis),
-        .head_len = @intCast(head_len),
+        .head_len = head_len,
     };
 }
 

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -11,11 +11,10 @@
 //! caller re-parses from byte 0 once more bytes arrive, bounded by
 //! `constants.head_bytes_max`.
 //!
-//! Two §7 fork-gate items are still open against the current pin and are
-//! handled here until the pin moves: bare-LF line terminators are rejected
-//! by `rejectBareLineFeeds` (hparse still accepts them), and extension
-//! methods (PROPFIND, ...) surface as `error.Malformed` because hparse's
-//! method enum is still closed.
+//! The §7 fork hardening gate is fully cleared at the current pin: the
+//! fork rejects bare-LF line terminators itself (CRLF only) and parses
+//! extension methods (PROPFIND, ...) as tokens. The tests below keep both
+//! behaviors witnessed through this wrapper.
 
 const std = @import("std");
 const hparse = @import("hparse");
@@ -23,9 +22,10 @@ const constants = @import("../constants.zig");
 
 const assert = std.debug.assert;
 
-/// The nine methods the pinned hparse recognizes. Owned here (not
-/// re-exported) so opening the fork's method enum to extension tokens
-/// changes only this file's mapping, not every consumer.
+/// Request methods. The nine registered methods parse to their tags; any
+/// other RFC 9110 token (PROPFIND, MKCOL, ...) parses to `.extension`
+/// with the raw bytes in `RequestHead.method_token`. Owned here (not
+/// re-exported) so fork API changes stay confined to this file.
 pub const Method = enum(u8) {
     get,
     post,
@@ -36,6 +36,7 @@ pub const Method = enum(u8) {
     options,
     trace,
     patch,
+    extension,
 };
 
 /// HTTP/1.0 and HTTP/1.1 are served; anything else is malformed (§1
@@ -88,6 +89,9 @@ pub const HeadError = error{
 /// begins.
 pub const RequestHead = struct {
     method: Method,
+    /// The method's raw token bytes ("GET", "PROPFIND", ...) — what the
+    /// renderer writes into the upstream request line, whatever the tag.
+    method_token: []const u8,
     target: []const u8,
     version: Version,
     headers: []const Header,
@@ -128,6 +132,7 @@ pub fn parseRequestHead(
     }
 
     var raw_method: hparse.Method = .unknown;
+    var raw_method_token: ?[]const u8 = null;
     var raw_target: ?[]const u8 = null;
     var raw_version: hparse.Version = .@"1.0";
     var raw_headers: [constants.headers_max]hparse.Header = undefined;
@@ -135,6 +140,7 @@ pub fn parseRequestHead(
     const head_len = hparse.parseRequest(
         head,
         &raw_method,
+        &raw_method_token,
         &raw_target,
         &raw_version,
         &raw_headers,
@@ -156,8 +162,9 @@ pub fn parseRequestHead(
     assert(head_len <= head.len);
     assert(raw_header_count <= constants.headers_max);
 
-    try rejectBareLineFeeds(head[0..head_len]);
     const target = raw_target.?; // A successful parse always sets the target.
+    const method_token = raw_method_token.?; // Same contract as the target.
+    assert(method_token.len >= 1);
     const method = methodFromRaw(raw_method);
     try validateTarget(target, method);
     const version = versionFromRaw(raw_version);
@@ -175,6 +182,7 @@ pub fn parseRequestHead(
 
     return .{
         .method = method,
+        .method_token = method_token,
         .target = target,
         .version = version,
         .headers = headers_storage[0..raw_header_count],
@@ -226,7 +234,6 @@ pub fn parseResponseHead(
     assert(head_len <= head.len);
     assert(raw_header_count <= constants.headers_max);
 
-    try rejectBareLineFeeds(head[0..head_len]);
     // hparse only checks for three digits; the status class is ours.
     if (raw_status < 100) {
         return error.Malformed;
@@ -725,25 +732,6 @@ fn parseContentLength(value: []const u8) error{Malformed}!u64 {
     return total;
 }
 
-/// §7 fork-gate item still open: the pinned hparse accepts a bare LF as a
-/// line terminator — a smuggling ingredient when intermediaries disagree
-/// on where lines end. Enforce CRLF-only here until the fork rejects it
-/// at parse time; this scan then becomes a redundant second witness.
-fn rejectBareLineFeeds(head: []const u8) error{Malformed}!void {
-    assert(head.len >= 1);
-    for (head, 0..) |byte, index| {
-        if (byte != '\n') {
-            continue;
-        }
-        if (index == 0) {
-            return error.Malformed;
-        }
-        if (head[index - 1] != '\r') {
-            return error.Malformed;
-        }
-    }
-}
-
 /// The 414 vs 431 verdict for a request head that cannot complete inside
 /// a full head buffer (§7): no line terminator at all means the request
 /// line itself overflowed.
@@ -769,6 +757,7 @@ fn methodFromRaw(raw_method: hparse.Method) Method {
         .options => .options,
         .trace => .trace,
         .patch => .patch,
+        .extension => .extension,
     };
 }
 
@@ -816,6 +805,7 @@ test "http parser: plain GET parses with keep-alive and no body" {
     var storage: HeaderStorage = undefined;
     const request = try parseRequestHead(head, false, &storage);
     try testing.expectEqual(Method.get, request.method);
+    try testing.expectEqualStrings("GET", request.method_token);
     try testing.expectEqualStrings("/path?q=1", request.target);
     try testing.expectEqual(Version.http_1_1, request.version);
     try testing.expectEqualStrings("origin.example", request.host.?);
@@ -948,20 +938,32 @@ test "http parser: keep-alive follows version defaults and Connection tokens" {
     }
 }
 
-test "http parser: bare LF line terminators are malformed (fork-gate stopgap)" {
-    // The pinned hparse still accepts every one of these (§7 fork gate);
-    // the wrapper's CRLF-only scan must reject them.
+test "http parser: bare LF line terminators are malformed" {
+    // The hardened fork rejects bare LF at parse time (§7 fork gate,
+    // closed); these witness the contract through the wrapper's mapping.
     try expectRequestError(error.Malformed, "GET / HTTP/1.1\nHost: a\r\n\r\n", false);
     try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost: a\n\r\n", false);
     try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost: a\r\n\n", false);
     try expectResponseError(error.Malformed, "HTTP/1.1 200 OK\nContent-Length: 0\r\n\r\n", .get);
 }
 
-test "http parser: extension methods are malformed until the fork opens the enum" {
-    // §7 fork-gate item: hparse's method enum is closed, so PROPFIND-class
-    // tokens surface as 400 today. When the fork opens the enum this test
-    // flips to expecting a parsed extension method.
-    try expectRequestError(error.Malformed, "PROPFIND /dav HTTP/1.1\r\nHost: a\r\n\r\n", false);
+test "http parser: extension methods parse with their raw token" {
+    var storage: HeaderStorage = undefined;
+    const request = try parseRequestHead(
+        "PROPFIND /dav HTTP/1.1\r\nHost: a\r\nDepth: 1\r\n\r\n",
+        false,
+        &storage,
+    );
+    try testing.expectEqual(Method.extension, request.method);
+    try testing.expectEqualStrings("PROPFIND", request.method_token);
+    try testing.expectEqualStrings("/dav", request.target);
+    // Origin-form is still required: extension methods get no target
+    // leniency on a reverse proxy.
+    try expectRequestError(
+        error.Malformed,
+        "M-SEARCH * HTTP/1.1\r\nHost: a\r\n\r\n",
+        false,
+    );
 }
 
 test "http parser: request targets must be origin-form (or OPTIONS *)" {
@@ -1203,6 +1205,8 @@ fn checkRequestParse(input: []const u8, head_is_full: bool) void {
     assert(request.head_len <= input.len);
     assert(sliceWithin(input, request.target));
     assert(request.target.len >= 1);
+    assert(sliceWithin(input, request.method_token));
+    assert(request.method_token.len >= 1);
     if (request.host) |host| {
         assert(host.len >= 1);
         assert(sliceWithin(input, host));
@@ -1236,12 +1240,18 @@ fn checkResponseParse(input: []const u8, head_is_full: bool) void {
 }
 
 const fuzz_corpus_request = "POST /submit HTTP/1.1\r\nHost: origin\r\nContent-Length: 5\r\n\r\nhello";
+const fuzz_corpus_extension = "PROPFIND /dav HTTP/1.1\r\nHost: origin\r\nDepth: 1\r\n\r\n";
 const fuzz_corpus_response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
 const fuzz_corpus_chunked = "5\r\nhello\r\n0\r\nX-Trailer: v\r\n\r\n";
 
 test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
     try std.testing.fuzz({}, fuzzParserInputs, .{
-        .corpus = &.{ fuzz_corpus_request, fuzz_corpus_response, fuzz_corpus_chunked },
+        .corpus = &.{
+            fuzz_corpus_request,
+            fuzz_corpus_extension,
+            fuzz_corpus_response,
+            fuzz_corpus_chunked,
+        },
     });
 }
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -374,6 +374,11 @@ pub fn Proxy(comptime IoType: type) type {
             if (conn.l7.response_render_pending) {
                 conn.l7.response_render_pending = false;
                 beginResponseForward(server, conn);
+                // A deferred render that fails (oversize/malformed origin
+                // head) answers 502 (.l7_responding) or tears down — either
+                // way it leaves .l7_exchanging, and the request leg must not
+                // keep pumping into a connection that is already closing (§7).
+                if (conn.state != .l7_exchanging) return;
             }
             if (framingDone(&conn.l7.request_framing)) {
                 conn.l7.request_leg = .done;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -992,6 +992,19 @@ pub fn Proxy(comptime IoType: type) type {
                 server.releaseRelayBuffer(buffer);
                 conn.relay_buffer = null;
             }
+            // A still-attached upstream (a failed dial with no socket, an
+            // oversize-after-edit reject, a malformed body) closes and frees
+            // its slot now instead of riding the whole lingering drain (§5).
+            // Both data ops are free (asserted above), so nothing is armed on
+            // the upstream socket and the close is synchronous, like detach.
+            if (conn.upstream) |leased| {
+                if (conn.upstream_socket) |socket| {
+                    server.io.closeNow(socket);
+                }
+                server.upstreams.release(leased);
+                conn.upstream = null;
+                conn.upstream_socket = null;
+            }
             server.counters.increment(counter);
             conn.state = .l7_responding;
             conn.response_pending = shed.staticResponse(status, .close);

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -153,7 +153,10 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream_socket = parked.socket;
                 parked.head_len = 0;
                 conn.state = .l7_dialing;
-                renderAndStartLegs(server, conn);
+                // No await happened: this runs in the same callback as the
+                // parse whose result is still live, so the reuse path —
+                // the hot one — skips the re-parse the dial path needs.
+                renderRequestAndStartLegs(server, conn, request);
                 return;
             }
             conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
@@ -198,9 +201,10 @@ pub fn Proxy(comptime IoType: type) type {
             renderAndStartLegs(server, conn);
         }
 
-        /// Re-parse the request head — the bytes are unchanged, so this
-        /// cannot fail — and render it into the upstream slot's staging
-        /// buffer; then both legs begin.
+        /// The fresh-dial completion path: the head bytes are re-parsed —
+        /// only the bytes survive an await (§7), and they are unchanged,
+        /// so this cannot fail — then the legs begin. The checkout path
+        /// calls `renderRequestAndStartLegs` directly instead.
         fn renderAndStartLegs(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_dialing);
             var storage: parser.HeaderStorage = undefined;
@@ -213,12 +217,23 @@ pub fn Proxy(comptime IoType: type) type {
                 &storage,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
+            renderRequestAndStartLegs(server, conn, &request);
+        }
 
+        /// Render the request head into the upstream slot's staging
+        /// buffer and start both legs.
+        fn renderRequestAndStartLegs(
+            server: *ServerType,
+            conn: *ConnType,
+            request: *const parser.RequestHead,
+        ) void {
+            assert(conn.state == .l7_dialing);
+            assert(request.head_len == conn.l7.request_head_len);
             const upstream = conn.upstream.?;
             // No close announcement upstream: the connection is a parking
             // candidate (§5), and stripping the client's Connection header
             // already made persistence the wire default.
-            const rendered = render.renderRequestHead(&request, false, &upstream.head) catch {
+            const rendered = render.renderRequestHead(request, false, &upstream.head) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
@@ -594,8 +609,8 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.response_head_sent = 0;
             conn.l7.response_framing = framingFromParsed(response.framing);
 
-            // Feed the framing tracker over the excess now; the bytes are
-            // forwarded from upstream.head after the head is sent.
+            // Feed the framing tracker over the body excess that arrived
+            // coalesced with the head.
             const excess = upstream.head[response.head_len..upstream.head_len];
             const feed = feedFraming(&conn.l7.response_framing, excess);
             if (feed.malformed) {
@@ -603,8 +618,22 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             const direction = &conn.directions[1];
-            direction.transfer_len = feed.consumed;
             direction.sent_len = 0;
+            // The common small response arrives from the origin in one
+            // piece; forward it in one piece too. Appending the excess to
+            // the rendered head trades a bounded memcpy for a whole ring
+            // round trip per response. The fallback sends the same bytes
+            // as head, then excess from upstream.head.
+            if (rendered.len + feed.consumed <= conn.head.len) {
+                @memcpy(
+                    conn.head[rendered.len..][0..feed.consumed],
+                    excess[0..feed.consumed],
+                );
+                conn.l7.rendered_response_len = @intCast(rendered.len + feed.consumed);
+                direction.transfer_len = 0;
+            } else {
+                direction.transfer_len = feed.consumed;
+            }
 
             conn.l7.response_leg = .sending_head;
             armResponseHeadSend(server, conn);

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -13,10 +13,14 @@
 //! the framed body client → origin; the response leg arms as soon as the
 //! request head is on the wire — early responses are legal (§7) and
 //! waiting for the body to finish first can deadlock both windows — and
-//! mirrors head + framed body back. Every exchange currently ends in
-//! teardown with `Connection: close` announced both ways; keep-alive
-//! parking replaces that in the next slice, which also refines the
-//! deadline verdict into §8's 504 (today an expired exchange tears down).
+//! mirrors head + framed body back. A finished exchange settles both
+//! sides independently: the upstream connection parks on its endpoint's
+//! idle list when the origin allowed reuse (checked out again by any
+//! later request — §3's shared-pool win), and the downstream connection
+//! honors what its rendered response announced (§2), going idle at the
+//! cost of a slot + head buffer only (§5). Pipelining is unsupported
+//! (first response, then an announced close); the stale-checkout free
+//! replay and the §8 504 deadline verdict are Phase 2 (docs/PLANS.md).
 //!
 //! Buffer ownership rotates, never overlaps: conn.head holds the request
 //! head until it is rendered, then stages the rendered response head;
@@ -133,14 +137,28 @@ pub fn Proxy(comptime IoType: type) type {
             conn.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
             };
-            const pick = server.balancer.pick(conn.cluster_index);
-            conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
-                return respond(server, conn, 503, "l7_shed_upstream_slots");
-            };
-
             conn.l7.request_method = request.method;
             conn.l7.request_framing = framingFromParsed(request.framing);
             conn.l7.request_head_len = request.head_len;
+            conn.l7.client_keep_alive = request.keep_alive;
+
+            // The §3 reuse win: a parked connection to the picked endpoint
+            // beats a fresh dial. A close that slipped through while it
+            // was parked surfaces as a failure on first use — answered
+            // 502 until Phase 2's free replay (docs/PLANS.md).
+            const pick = server.balancer.pick(conn.cluster_index);
+            if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
+                server.counters.increment("upstream_reused");
+                conn.upstream = parked;
+                conn.upstream_socket = parked.socket;
+                parked.head_len = 0;
+                conn.state = .l7_dialing;
+                renderAndStartLegs(server, conn);
+                return;
+            }
+            conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
+                return respond(server, conn, 503, "l7_shed_upstream_slots");
+            };
             conn.state = .l7_dialing;
             server.storeDeadline(conn, server.config.connect_timeout_ms);
             conn.arm(&conn.op_connect, "connect");
@@ -197,10 +215,12 @@ pub fn Proxy(comptime IoType: type) type {
             assert(request.head_len == conn.l7.request_head_len);
 
             const upstream = conn.upstream.?;
-            const rendered = render.renderRequestHead(&request, true, &upstream.head) catch {
-                // Valid on arrival but no longer fits with the close
-                // announcement rendered in: the §7 oversize-after-edits
-                // verdict.
+            // No close announcement upstream: the connection is a parking
+            // candidate (§5), and stripping the client's Connection header
+            // already made persistence the wire default.
+            const rendered = render.renderRequestHead(&request, false, &upstream.head) catch {
+                // Valid on arrival but no longer fits after edits: the §7
+                // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
             };
             assert(rendered.len >= 1);
@@ -271,6 +291,9 @@ pub fn Proxy(comptime IoType: type) type {
                 // has been answered yet, so 400 is still legal.
                 respondOrTeardown(server, conn, 400, "l7_bad_request");
                 return;
+            }
+            if (feed.consumed < excess.len) {
+                conn.l7.client_pipelined = true;
             }
             const direction = &conn.directions[0];
             direction.transfer_len = feed.consumed;
@@ -382,8 +405,11 @@ pub fn Proxy(comptime IoType: type) type {
                 server.beginTeardown(conn);
                 return;
             }
-            // Bytes past the body belong to a pipelined next request;
-            // without keep-alive they are dropped with the connection.
+            if (feed.consumed < received) {
+                // Bytes past the body are a pipelined next request; the
+                // connection will close after this exchange (§2 note).
+                conn.l7.client_pipelined = true;
+            }
             const direction = &conn.directions[0];
             direction.transfer_len = feed.consumed;
             direction.sent_len = 0;
@@ -544,7 +570,22 @@ pub fn Proxy(comptime IoType: type) type {
             ) catch unreachable;
             assert(response.head_len == conn.l7.response_head_len_marker);
 
-            const rendered = render.renderResponseHead(&response, true, &conn.head) catch {
+            // The §8 persistence decision, made once and honored: honor
+            // the client's ask unless pipelining, pressure, or drain says
+            // otherwise — then announce whatever was decided (§2). An
+            // until-close body forces the close unconditionally: the FIN
+            // is the only thing delimiting the relayed body for the
+            // client, exactly as it delimited it for us.
+            const keep_downstream = conn.l7.client_keep_alive and
+                !conn.l7.client_pipelined and !server.draining and
+                !server.relay_pressure and response.framing != .until_close;
+            conn.l7.downstream_close_announced = !keep_downstream;
+            conn.l7.upstream_reusable = response.keep_alive;
+            const rendered = render.renderResponseHead(
+                &response,
+                !keep_downstream,
+                &conn.head,
+            ) catch {
                 upstreamFailed(server, conn);
                 return;
             };
@@ -773,16 +814,81 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
-        /// The response reached the client in full. Without keep-alive the
-        /// exchange ends the connection — the close was announced in both
-        /// rendered heads (§2) — and the request leg, done or not, ends
-        /// with it (an early response ends the exchange, §7).
+        /// The response reached the client in full: settle both sides.
+        /// The upstream connection parks for reuse when the origin allowed
+        /// it and the request went out completely (§5); the downstream
+        /// connection honors what its response announced (§2). An early
+        /// response with the request still in flight forfeits both — the
+        /// two byte streams are no longer alignable.
         fn finishExchange(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_started);
             conn.l7.response_leg = .done;
             server.counters.increment("l7_responses");
-            server.beginTeardown(conn);
+
+            const request_complete = conn.l7.request_leg == .done;
+            if (conn.l7.upstream_reusable and request_complete and !server.draining) {
+                parkUpstream(server, conn);
+            }
+            const keep_downstream = !conn.l7.downstream_close_announced and
+                request_complete and !server.draining;
+            if (keep_downstream) {
+                detachUpstream(server, conn);
+                resetForNextRequest(server, conn);
+            } else {
+                // A still-attached upstream closes with the teardown.
+                server.beginTeardown(conn);
+            }
+        }
+
+        /// Park the leased upstream on its endpoint's idle list (§5): the
+        /// socket stays open with no armed op, the stored deadline hands
+        /// reaping to the Server's sweep, and the conn detaches so its
+        /// teardown cannot close a connection it no longer owns.
+        fn parkUpstream(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            const upstream = conn.upstream.?;
+            assert(!upstream.parked);
+            server.upstreams.park(upstream);
+            upstream.deadline_ns = server.io.nowNs() +
+                @as(u64, server.idleTimeoutMs()) * std.time.ns_per_ms;
+            server.ensureUpstreamSweep();
+            conn.upstream = null;
+            conn.upstream_socket = null;
+        }
+
+        /// Close and release an upstream that did not park while the conn
+        /// itself lives on. The socket has no armed op at this point (both
+        /// data ops settled with the exchange), so the close is
+        /// synchronous, like the parked-reap path.
+        fn detachUpstream(server: *ServerType, conn: *ConnType) void {
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            if (conn.upstream) |leased| {
+                server.io.closeNow(conn.upstream_socket.?);
+                server.upstreams.release(leased);
+                conn.upstream = null;
+                conn.upstream_socket = null;
+            }
+            assert(conn.upstream_socket == null);
+        }
+
+        /// Keep-alive turnaround (§5): the relay buffer goes back to its
+        /// pool — an idle connection costs a slot and head buffer only —
+        /// the exchange state resets, and the next head read begins under
+        /// a fresh idle deadline.
+        fn resetForNextRequest(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.upstream == null);
+            assert(conn.armedCount() <= 1); // Only the deadline timer.
+            server.releaseRelayBuffer(conn.relay_buffer.?);
+            conn.relay_buffer = null;
+            conn.head_len = 0;
+            conn.l7 = .{};
+            conn.directions = .{ .{}, .{} };
+            conn.state = .l7_reading_head;
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            armHeadRecv(server, conn);
         }
 
         /// The upstream leg failed. Answer 502 only when the client has

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -284,29 +284,37 @@ pub fn Proxy(comptime IoType: type) type {
                 armRequestHeadSend(server, conn);
                 return;
             }
-            // Head on the wire: the response leg starts recving now —
-            // before the request body finishes — so an early response
-            // cannot wedge both TCP windows (§7). Its render into conn.head
-            // waits until the request head vacates that buffer.
+            // Head on the wire. Validate the request-body prefix that
+            // arrived coalesced with the head before the response leg
+            // commits its recv op: a body that already violates its own
+            // framing is answered 400 while both data ops are still free
+            // (§7). Once the response recv is armed that op is gone, and an
+            // op is never canceled (§5) — so a malformed body found later
+            // can only tear down. Checking here keeps the 400 reachable.
+            const excess = conn.head[conn.l7.request_head_len..conn.head_len];
+            const feed = feedFraming(&conn.l7.request_framing, excess);
+            if (feed.malformed) {
+                respond(server, conn, 400, "l7_bad_request");
+                return;
+            }
+            // The response leg starts recving now — before the request body
+            // finishes — so an early response cannot wedge both TCP windows
+            // (§7). Its render into conn.head waits until the request head
+            // vacates that buffer.
             startResponseLeg(server, conn);
-            drainRequestExcess(server, conn);
+            forwardRequestExcess(server, conn, feed);
         }
 
         /// Forward the body bytes that arrived coalesced with the head
         /// straight from conn.head (§7): a body larger than a relay buffer
         /// is never squeezed through one, and conn.head is freed for the
-        /// response head exactly when the last excess byte leaves it.
-        fn drainRequestExcess(server: *ServerType, conn: *ConnType) void {
+        /// response head exactly when the last excess byte leaves it. The
+        /// framing was already advanced and validated by the caller.
+        fn forwardRequestExcess(server: *ServerType, conn: *ConnType, feed: FeedResult) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_head);
+            assert(!feed.malformed);
             const excess = conn.head[conn.l7.request_head_len..conn.head_len];
-            const feed = feedFraming(&conn.l7.request_framing, excess);
-            if (feed.malformed) {
-                // The body prefix already violates its own framing; nothing
-                // has been answered yet, so 400 is still legal.
-                respondOrTeardown(server, conn, 400, "l7_bad_request");
-                return;
-            }
             if (feed.consumed < excess.len) {
                 conn.l7.client_pipelined = true;
             }
@@ -959,22 +967,6 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             respond(server, conn, 502, "l7_bad_gateway");
-        }
-
-        /// 400/503 with the request-body pump possibly armed: prefer the
-        /// response when the op is free, teardown otherwise.
-        fn respondOrTeardown(
-            server: *ServerType,
-            conn: *ConnType,
-            comptime status: u16,
-            comptime counter: []const u8,
-        ) void {
-            if (conn.armed.data_client_to_upstream or conn.armed.data_upstream_to_client) {
-                server.counters.increment(counter);
-                server.beginTeardown(conn);
-                return;
-            }
-            respond(server, conn, status, counter);
         }
 
         /// Answer a comptime static error response, then close (§8). Legal

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1,0 +1,226 @@
+//! The L7 HTTP/1.1 reverse-proxy state machine (DESIGN.md §7). Generic
+//! over the Io backend and driven by the Server's helpers (pools,
+//! counters, deadline, teardown), exactly as `net/relay.zig` drives the
+//! L4 path — L7 lives here, never inlined into the L4 relay.
+//!
+//! This slice covers head ingestion and the static-response rejects: an
+//! L7 connection reads its request head into the slot's head buffer,
+//! re-parsing from byte 0 on each recv (§7 detect-and-retry), and either
+//! answers a comptime static error response (§8) or — for a valid,
+//! supported request — reaches the point where the upstream leg begins.
+//! That leg (dial/checkout, forward, response relay, keep-alive) lands in
+//! the following slices; until then a valid request tears down after its
+//! head is parsed, so no request is mis-served in the interim.
+//!
+//! Parsed heads are never stored across a callback: parsing writes into a
+//! stack-local header array and only scalar verdicts survive, so the head
+//! bytes stay the single source of truth (§7) and the slot carries no
+//! 1 KiB of header storage.
+
+const std = @import("std");
+
+const constants = @import("../constants.zig");
+const conn_module = @import("../net/Conn.zig");
+const Io = @import("../io/io.zig");
+const parser = @import("parser.zig");
+const shed = @import("../shed.zig");
+
+const assert = std.debug.assert;
+
+pub fn Proxy(comptime IoType: type) type {
+    const ServerType = @import("../Server.zig").Server(IoType);
+    const ConnType = conn_module.Conn(IoType);
+
+    return struct {
+        /// Entry from admission: the slot is prepared in `.l7_reading_head`
+        /// with the head-read deadline armed; begin reading the request
+        /// head from the client.
+        pub fn start(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.head_len == 0);
+            armHeadRecv(server, conn);
+        }
+
+        fn armHeadRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            // Parsing turns a full buffer into an oversize verdict before
+            // we ever get here, so there is always room to read into.
+            assert(conn.head_len < constants.head_bytes_max);
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.recv(
+                conn.client_socket,
+                conn.head[conn.head_len..],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onHeadRecv,
+            );
+        }
+
+        fn onHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_reading_head);
+            const received = result catch |err| {
+                // A client that closes or resets before finishing its head
+                // simply leaves — there is nothing to answer. The §7
+                // head-read deadline handles the slowloris that stalls
+                // instead of closing.
+                if (err != error.EndOfStream) {
+                    server.witnessKernelPressure(err);
+                }
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(received >= 1);
+            conn.head_len += received;
+            assert(conn.head_len <= constants.head_bytes_max);
+            parseAndDispatch(server, conn);
+        }
+
+        /// Re-parse the accumulated head from byte 0 (§7). Incomplete and
+        /// room left → read more; oversize or malformed → the matching
+        /// static reject; a valid head → routing.
+        fn parseAndDispatch(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            const head = conn.head[0..conn.head_len];
+            const head_is_full = conn.head_len == constants.head_bytes_max;
+
+            var storage: parser.HeaderStorage = undefined;
+            const request = parser.parseRequestHead(head, head_is_full, &storage) catch |err| switch (err) {
+                error.Incomplete => {
+                    // A full buffer never yields Incomplete — the parser
+                    // converts it to the oversize verdicts below — so here
+                    // there is room to read more.
+                    assert(!head_is_full);
+                    armHeadRecv(server, conn);
+                    return;
+                },
+                error.Malformed => return reject(server, conn, 400, "l7_bad_request"),
+                error.UriTooLong => return reject(server, conn, 414, "l7_uri_too_long"),
+                error.HeadTooLarge => return reject(server, conn, 431, "l7_headers_too_large"),
+            };
+            routeRequest(server, conn, &request);
+        }
+
+        /// Policy gate before the upstream leg. Tunnels and protocol
+        /// upgrades are non-goals (§1, §7) — 501. Anything else is a
+        /// valid, routable request; the upstream leg takes over from here
+        /// in the next slice, so for now the exchange ends cleanly.
+        fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
+            assert(conn.state == .l7_reading_head);
+            if (request.method == .connect) {
+                return reject(server, conn, 501, "l7_not_implemented");
+            }
+            if (parser.headerValue(request.headers, "upgrade") != null) {
+                return reject(server, conn, 501, "l7_not_implemented");
+            }
+            server.beginTeardown(conn);
+        }
+
+        /// Answer a comptime static error response, then close (§8). Every
+        /// reject announces the close, so the connection does not survive.
+        fn reject(
+            server: *ServerType,
+            conn: *ConnType,
+            comptime status: u16,
+            comptime counter: []const u8,
+        ) void {
+            assert(conn.state == .l7_reading_head);
+            server.counters.increment(counter);
+            conn.state = .l7_responding;
+            conn.response_pending = shed.staticResponse(status, .close);
+            assert(conn.response_pending.len >= 1);
+            armResponseSend(server, conn);
+        }
+
+        fn armResponseSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_responding);
+            assert(conn.response_pending.len >= 1);
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.send(
+                conn.client_socket,
+                conn.response_pending,
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseSent,
+            );
+        }
+
+        fn onResponseSent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_responding);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(sent >= 1);
+            assert(sent <= conn.response_pending.len);
+            conn.response_pending = conn.response_pending[sent..];
+            if (conn.response_pending.len > 0) {
+                // Short send: resume from the new front of the slice (§6).
+                armResponseSend(server, conn);
+            } else {
+                // Response delivered; close it out without RST (§2).
+                beginLingeringClose(server, conn);
+            }
+        }
+
+        /// A client can still be sending its request — a body, or the rest
+        /// of an oversize head — when we answer an error. Closing then
+        /// would RST and discard the response we just sent (§2). Instead
+        /// half-close the write side (the client sees our response and
+        /// FIN) and drain the client's remaining input to EOF before the
+        /// teardown; the head-read deadline bounds a client that never
+        /// stops sending.
+        fn beginLingeringClose(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_responding);
+            conn.state = .l7_draining_request;
+            server.io.shutdown(conn.client_socket, .write);
+            armDrainRecv(server, conn);
+        }
+
+        fn armDrainRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_draining_request);
+            // The head buffer is scratch now — recv into it and discard.
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.recv(
+                conn.client_socket,
+                conn.head[0..],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onDrainRecv,
+            );
+        }
+
+        fn onDrainRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_draining_request);
+            _ = result catch {
+                // EOF or error: the client's inbound is drained, so the
+                // close is a clean FIN, not a data-discarding RST.
+                server.beginTeardown(conn);
+                return;
+            };
+            // More bytes to discard; keep draining under the deadline.
+            armDrainRecv(server, conn);
+        }
+    };
+}

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -984,6 +984,14 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
+            // The static response and its lingering drain read/write only
+            // conn.head, never a relay buffer; free any held one now so a
+            // reject or 503 storm cannot pin buffers — and the L4 admissions
+            // they gate — for the whole drain window (§5, §8).
+            if (conn.relay_buffer) |buffer| {
+                server.releaseRelayBuffer(buffer);
+                conn.relay_buffer = null;
+            }
             server.counters.increment(counter);
             conn.state = .l7_responding;
             conn.response_pending = shed.staticResponse(status, .close);

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -3,19 +3,26 @@
 //! counters, deadline, teardown), exactly as `net/relay.zig` drives the
 //! L4 path — L7 lives here, never inlined into the L4 relay.
 //!
-//! This slice covers head ingestion and the static-response rejects: an
-//! L7 connection reads its request head into the slot's head buffer,
-//! re-parsing from byte 0 on each recv (§7 detect-and-retry), and either
-//! answers a comptime static error response (§8) or — for a valid,
-//! supported request — reaches the point where the upstream leg begins.
-//! That leg (dial/checkout, forward, response relay, keep-alive) lands in
-//! the following slices; until then a valid request tears down after its
-//! head is parsed, so no request is mis-served in the interim.
+//! Lifecycle: `l7_reading_head` accumulates the request head and
+//! re-parses from byte 0 on each recv (§7 detect-and-retry); verdicts
+//! answer comptime static responses (§8) with a lingering close (§2). A
+//! valid request acquires its relay buffer and upstream slot (both §8
+//! rungs, 503), dials (`l7_dialing`), then `l7_exchanging` runs two
+//! semi-independent legs over the two data ops: the request leg sends
+//! the rendered head from the upstream slot's staging buffer and pumps
+//! the framed body client → origin; the response leg arms as soon as the
+//! request head is on the wire — early responses are legal (§7) and
+//! waiting for the body to finish first can deadlock both windows — and
+//! mirrors head + framed body back. Every exchange currently ends in
+//! teardown with `Connection: close` announced both ways; keep-alive
+//! parking replaces that in the next slice, which also refines the
+//! deadline verdict into §8's 504 (today an expired exchange tears down).
 //!
-//! Parsed heads are never stored across a callback: parsing writes into a
-//! stack-local header array and only scalar verdicts survive, so the head
-//! bytes stay the single source of truth (§7) and the slot carries no
-//! 1 KiB of header storage.
+//! Buffer ownership rotates, never overlaps: conn.head holds the request
+//! head until it is rendered, then stages the rendered response head;
+//! upstream.head stages the rendered request head, then accumulates the
+//! response head; the relay-buffer halves carry only framed body bytes
+//! (head-adjacent excess is copied across once at each pump start).
 
 const std = @import("std");
 
@@ -23,6 +30,7 @@ const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
 const Io = @import("../io/io.zig");
 const parser = @import("parser.zig");
+const render = @import("render.zig");
 const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
@@ -30,6 +38,7 @@ const assert = std.debug.assert;
 pub fn Proxy(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
+    const Framing = ConnType.Framing;
 
     return struct {
         /// Entry from admission: the slot is prepared in `.l7_reading_head`
@@ -100,37 +109,730 @@ pub fn Proxy(comptime IoType: type) type {
                     armHeadRecv(server, conn);
                     return;
                 },
-                error.Malformed => return reject(server, conn, 400, "l7_bad_request"),
-                error.UriTooLong => return reject(server, conn, 414, "l7_uri_too_long"),
-                error.HeadTooLarge => return reject(server, conn, 431, "l7_headers_too_large"),
+                error.Malformed => return respond(server, conn, 400, "l7_bad_request"),
+                error.UriTooLong => return respond(server, conn, 414, "l7_uri_too_long"),
+                error.HeadTooLarge => return respond(server, conn, 431, "l7_headers_too_large"),
             };
             routeRequest(server, conn, &request);
         }
 
-        /// Policy gate before the upstream leg. Tunnels and protocol
-        /// upgrades are non-goals (§1, §7) — 501. Anything else is a
-        /// valid, routable request; the upstream leg takes over from here
-        /// in the next slice, so for now the exchange ends cleanly.
+        /// Policy gate, then the exchange's admission: tunnels and
+        /// upgrades are non-goals (§1, §7) — 501; a routable request
+        /// claims its relay buffer and upstream slot (§8 rungs, 503) and
+        /// dials the balancer's pick for the listener's cluster.
         fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
+            assert(request.head_len <= conn.head_len);
             if (request.method == .connect) {
-                return reject(server, conn, 501, "l7_not_implemented");
+                return respond(server, conn, 501, "l7_not_implemented");
             }
             if (parser.headerValue(request.headers, "upgrade") != null) {
-                return reject(server, conn, 501, "l7_not_implemented");
+                return respond(server, conn, 501, "l7_not_implemented");
             }
+
+            conn.relay_buffer = server.acquireRelayBuffer() orelse {
+                return respond(server, conn, 503, "l7_shed_relay_buffers");
+            };
+            const pick = server.balancer.pick(conn.cluster_index);
+            conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
+                return respond(server, conn, 503, "l7_shed_upstream_slots");
+            };
+
+            conn.l7.request_method = request.method;
+            conn.l7.request_framing = framingFromParsed(request.framing);
+            conn.l7.request_head_len = request.head_len;
+            conn.state = .l7_dialing;
+            server.storeDeadline(conn, server.config.connect_timeout_ms);
+            conn.arm(&conn.op_connect, "connect");
+            server.io.connect(
+                pick.address,
+                &conn.op_connect.completion,
+                ConnType,
+                conn,
+                onUpstreamConnect,
+            );
+        }
+
+        fn onUpstreamConnect(conn: *ConnType, result: Io.ConnectError!IoType.Socket) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_connect, "connect");
+            if (conn.isTearingDown()) {
+                // The teardown raced the dial (§5): a socket that arrived
+                // anyway must still be shut down and closed.
+                if (result) |socket| {
+                    conn.upstream_socket = socket;
+                    server.io.shutdown(socket, .both);
+                } else |_| {}
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_dialing);
+            const socket = result catch {
+                server.counters.increment("upstream_connect_failed");
+                respond(server, conn, 502, "l7_bad_gateway");
+                return;
+            };
+            conn.upstream.?.socket = socket;
+            conn.upstream_socket = socket;
+            server.io.setNodelay(socket) catch {
+                server.counters.increment("kernel_pressure_errors");
+            };
+            renderAndStartLegs(server, conn);
+        }
+
+        /// Re-parse the request head — the bytes are unchanged, so this
+        /// cannot fail — and render it into the upstream slot's staging
+        /// buffer; then both legs begin.
+        fn renderAndStartLegs(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_dialing);
+            var storage: parser.HeaderStorage = undefined;
+            // The same bytes parsed successfully in routeRequest (§7:
+            // bytes are the single source of truth), so a failure here is
+            // an invariant violation, not an input condition.
+            const request = parser.parseRequestHead(
+                conn.head[0..conn.head_len],
+                false,
+                &storage,
+            ) catch unreachable;
+            assert(request.head_len == conn.l7.request_head_len);
+
+            const upstream = conn.upstream.?;
+            const rendered = render.renderRequestHead(&request, true, &upstream.head) catch {
+                // Valid on arrival but no longer fits with the close
+                // announcement rendered in: the §7 oversize-after-edits
+                // verdict.
+                return respond(server, conn, 431, "l7_headers_too_large");
+            };
+            assert(rendered.len >= 1);
+            conn.l7.rendered_request_len = @intCast(rendered.len);
+            conn.l7.request_head_sent = 0;
+            conn.state = .l7_exchanging;
+            conn.l7.request_leg = .sending_head;
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            armRequestHeadSend(server, conn);
+        }
+
+        fn armRequestHeadSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_head);
+            const l7 = &conn.l7;
+            assert(l7.request_head_sent < l7.rendered_request_len);
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.send(
+                conn.upstream_socket.?,
+                conn.upstream.?.head[l7.request_head_sent..l7.rendered_request_len],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onRequestHeadSent,
+            );
+        }
+
+        fn onRequestHeadSent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_head);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(sent >= 1);
+            conn.l7.request_head_sent += sent;
+            assert(conn.l7.request_head_sent <= conn.l7.rendered_request_len);
+            if (conn.l7.request_head_sent < conn.l7.rendered_request_len) {
+                armRequestHeadSend(server, conn);
+                return;
+            }
+            // Head on the wire: the response leg starts recving now —
+            // before the request body finishes — so an early response
+            // cannot wedge both TCP windows (§7). Its render into conn.head
+            // waits until the request head vacates that buffer.
+            startResponseLeg(server, conn);
+            drainRequestExcess(server, conn);
+        }
+
+        /// Forward the body bytes that arrived coalesced with the head
+        /// straight from conn.head (§7): a body larger than a relay buffer
+        /// is never squeezed through one, and conn.head is freed for the
+        /// response head exactly when the last excess byte leaves it.
+        fn drainRequestExcess(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_head);
+            const excess = conn.head[conn.l7.request_head_len..conn.head_len];
+            const feed = feedFraming(&conn.l7.request_framing, excess);
+            if (feed.malformed) {
+                // The body prefix already violates its own framing; nothing
+                // has been answered yet, so 400 is still legal.
+                respondOrTeardown(server, conn, 400, "l7_bad_request");
+                return;
+            }
+            const direction = &conn.directions[0];
+            direction.transfer_len = feed.consumed;
+            direction.sent_len = 0;
+            conn.l7.request_leg = .sending_body_excess;
+            if (feed.consumed >= 1) {
+                armRequestExcessSend(server, conn);
+            } else {
+                requestHeadVacated(server, conn);
+            }
+        }
+
+        fn armRequestExcessSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_body_excess);
+            const direction = &conn.directions[0];
+            assert(direction.sent_len < direction.transfer_len);
+            const base = conn.l7.request_head_len;
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.send(
+                conn.upstream_socket.?,
+                conn.head[base + direction.sent_len .. base + direction.transfer_len],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onRequestExcessSent,
+            );
+        }
+
+        fn onRequestExcessSent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_body_excess);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(sent >= 1);
+            const direction = &conn.directions[0];
+            direction.sent_len += sent;
+            assert(direction.sent_len <= direction.transfer_len);
+            if (direction.sent_len < direction.transfer_len) {
+                armRequestExcessSend(server, conn);
+                return;
+            }
+            requestHeadVacated(server, conn);
+        }
+
+        /// The request head has fully left conn.head: release any origin
+        /// response that was waiting to render there, then continue the
+        /// request body from the socket (or finish it if the excess
+        /// carried the whole body).
+        fn requestHeadVacated(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .sending_body_excess);
+            conn.l7.request_head_vacated = true;
+            if (conn.l7.response_render_pending) {
+                conn.l7.response_render_pending = false;
+                beginResponseForward(server, conn);
+            }
+            if (framingDone(&conn.l7.request_framing)) {
+                conn.l7.request_leg = .done;
+            } else {
+                conn.l7.request_leg = .pumping_body;
+                armRequestBodyRecv(server, conn);
+            }
+        }
+
+        fn armRequestBodyRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .pumping_body);
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.recv(
+                conn.client_socket,
+                &conn.relay_buffer.?.client_to_upstream,
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onRequestBodyRecv,
+            );
+        }
+
+        fn onRequestBodyRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .pumping_body);
+            const received = result catch |err| {
+                // EOF mid-body is a truncated request; any failure here
+                // dooms the exchange in the client's own direction.
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(received >= 1);
+            const chunk = conn.relay_buffer.?.client_to_upstream[0..received];
+            const feed = feedFraming(&conn.l7.request_framing, chunk);
+            if (feed.malformed) {
+                server.beginTeardown(conn);
+                return;
+            }
+            // Bytes past the body belong to a pipelined next request;
+            // without keep-alive they are dropped with the connection.
+            const direction = &conn.directions[0];
+            direction.transfer_len = feed.consumed;
+            direction.sent_len = 0;
+            if (feed.consumed >= 1) {
+                armRequestBodySend(server, conn);
+            } else {
+                assert(feed.done);
+                conn.l7.request_leg = .done;
+            }
+        }
+
+        fn armRequestBodySend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            const direction = &conn.directions[0];
+            assert(direction.sent_len < direction.transfer_len);
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.send(
+                conn.upstream_socket.?,
+                conn.relay_buffer.?.client_to_upstream[direction.sent_len..direction.transfer_len],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onRequestBodySent,
+            );
+        }
+
+        fn onRequestBodySent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.request_leg == .pumping_body);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(sent >= 1);
+            const direction = &conn.directions[0];
+            direction.sent_len += sent;
+            assert(direction.sent_len <= direction.transfer_len);
+            if (direction.sent_len < direction.transfer_len) {
+                armRequestBodySend(server, conn);
+                return;
+            }
+            // A full chunk moved: activity refreshes the deadline (§6).
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            if (framingDone(&conn.l7.request_framing)) {
+                conn.l7.request_leg = .done;
+            } else {
+                armRequestBodyRecv(server, conn);
+            }
+        }
+
+        fn startResponseLeg(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .idle);
+            assert(conn.upstream.?.head_len == 0);
+            conn.l7.response_leg = .awaiting_head;
+            armResponseHeadRecv(server, conn);
+        }
+
+        fn armResponseHeadRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            const upstream = conn.upstream.?;
+            assert(upstream.head_len < constants.head_bytes_max);
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.recv(
+                conn.upstream_socket.?,
+                upstream.head[upstream.head_len..],
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseHeadRecv,
+            );
+        }
+
+        fn onResponseHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            const received = result catch |err| {
+                server.witnessKernelPressure(err);
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(received >= 1);
+            const upstream = conn.upstream.?;
+            upstream.head_len += received;
+            assert(upstream.head_len <= constants.head_bytes_max);
+            parseResponseAndDispatch(server, conn);
+        }
+
+        /// Detect-and-retry over the origin's head, mirroring the request
+        /// side; any verdict other than "valid" or "more bytes" dooms the
+        /// upstream leg (an origin is configured, not adversarial, but §7
+        /// framing strictness applies to it all the same).
+        fn parseResponseAndDispatch(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            const upstream = conn.upstream.?;
+            const head = upstream.head[0..upstream.head_len];
+            const head_is_full = upstream.head_len == constants.head_bytes_max;
+
+            var storage: parser.HeaderStorage = undefined;
+            const response = parser.parseResponseHead(
+                head,
+                head_is_full,
+                &storage,
+                conn.l7.request_method,
+            ) catch |err| switch (err) {
+                error.Incomplete => {
+                    assert(!head_is_full);
+                    armResponseHeadRecv(server, conn);
+                    return;
+                },
+                error.Malformed, error.UriTooLong, error.HeadTooLarge => {
+                    upstreamFailed(server, conn);
+                    return;
+                },
+            };
+            // The render reuses conn.head, so it must wait until the
+            // request head has vacated that buffer (§7 buffer rotation);
+            // record the head boundary so the deferred render agrees.
+            conn.l7.response_head_len_marker = response.head_len;
+            if (conn.l7.request_head_vacated) {
+                beginResponseForward(server, conn);
+            } else {
+                conn.l7.response_render_pending = true;
+            }
+        }
+
+        /// Render the origin's head into conn.head (free once the request
+        /// head has vacated it) and forward the coalesced body excess
+        /// straight from upstream.head — never copied through a relay
+        /// buffer, so an oversized coalesced body is fine.
+        fn beginResponseForward(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            assert(conn.l7.request_head_vacated);
+            const upstream = conn.upstream.?;
+            // The same bytes parsed successfully already (§7 single source
+            // of truth), so this re-parse cannot fail.
+            var storage: parser.HeaderStorage = undefined;
+            const response = parser.parseResponseHead(
+                upstream.head[0..upstream.head_len],
+                false,
+                &storage,
+                conn.l7.request_method,
+            ) catch unreachable;
+            assert(response.head_len == conn.l7.response_head_len_marker);
+
+            const rendered = render.renderResponseHead(&response, true, &conn.head) catch {
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(rendered.len >= 1);
+            conn.l7.rendered_response_len = @intCast(rendered.len);
+            conn.l7.response_head_sent = 0;
+            conn.l7.response_framing = framingFromParsed(response.framing);
+
+            // Feed the framing tracker over the excess now; the bytes are
+            // forwarded from upstream.head after the head is sent.
+            const excess = upstream.head[response.head_len..upstream.head_len];
+            const feed = feedFraming(&conn.l7.response_framing, excess);
+            if (feed.malformed) {
+                upstreamFailed(server, conn);
+                return;
+            }
+            const direction = &conn.directions[1];
+            direction.transfer_len = feed.consumed;
+            direction.sent_len = 0;
+
+            conn.l7.response_leg = .sending_head;
+            armResponseHeadSend(server, conn);
+        }
+
+        fn armResponseHeadSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .sending_head);
+            const l7 = &conn.l7;
+            assert(l7.response_head_sent < l7.rendered_response_len);
+            l7.response_started = true;
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.send(
+                conn.client_socket,
+                conn.head[l7.response_head_sent..l7.rendered_response_len],
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseHeadSent,
+            );
+        }
+
+        fn onResponseHeadSent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .sending_head);
+            const sent = result catch |err| {
+                // The client is gone; nothing to answer anyone.
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(sent >= 1);
+            conn.l7.response_head_sent += sent;
+            assert(conn.l7.response_head_sent <= conn.l7.rendered_response_len);
+            if (conn.l7.response_head_sent < conn.l7.rendered_response_len) {
+                armResponseHeadSend(server, conn);
+                return;
+            }
+            // Head on the wire; forward the coalesced body excess straight
+            // from upstream.head, then pump the rest from the socket.
+            const direction = &conn.directions[1];
+            if (direction.transfer_len >= 1) {
+                conn.l7.response_leg = .sending_body_excess;
+                armResponseExcessSend(server, conn);
+            } else {
+                afterResponseExcess(server, conn);
+            }
+        }
+
+        fn armResponseExcessSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .sending_body_excess);
+            const direction = &conn.directions[1];
+            assert(direction.sent_len < direction.transfer_len);
+            const base = conn.l7.response_head_len_marker;
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.send(
+                conn.client_socket,
+                conn.upstream.?.head[base + direction.sent_len .. base + direction.transfer_len],
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseExcessSent,
+            );
+        }
+
+        fn onResponseExcessSent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .sending_body_excess);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(sent >= 1);
+            const direction = &conn.directions[1];
+            direction.sent_len += sent;
+            assert(direction.sent_len <= direction.transfer_len);
+            if (direction.sent_len < direction.transfer_len) {
+                armResponseExcessSend(server, conn);
+                return;
+            }
+            afterResponseExcess(server, conn);
+        }
+
+        /// The head and its coalesced excess are on the wire; finish if the
+        /// body ended there, else pump the remaining body from the origin.
+        fn afterResponseExcess(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            conn.l7.response_leg = .pumping_body;
+            if (framingDone(&conn.l7.response_framing)) {
+                finishExchange(server, conn);
+            } else {
+                armResponseBodyRecv(server, conn);
+            }
+        }
+
+        fn armResponseBodyRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .pumping_body);
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.recv(
+                conn.upstream_socket.?,
+                &conn.relay_buffer.?.upstream_to_client,
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseBodyRecv,
+            );
+        }
+
+        fn onResponseBodyRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .pumping_body);
+            const received = result catch |err| {
+                if (err == error.EndOfStream) {
+                    if (conn.l7.response_framing == .until_close) {
+                        // The origin's EOF is this framing's terminator.
+                        finishExchange(server, conn);
+                        return;
+                    }
+                    // Truncated inside a length-delimited body: the client
+                    // must see the truncation too, so tear down.
+                }
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(received >= 1);
+            const chunk = conn.relay_buffer.?.upstream_to_client[0..received];
+            const feed = feedFraming(&conn.l7.response_framing, chunk);
+            if (feed.malformed) {
+                server.beginTeardown(conn);
+                return;
+            }
+            const direction = &conn.directions[1];
+            direction.transfer_len = feed.consumed;
+            direction.sent_len = 0;
+            if (feed.consumed >= 1) {
+                armResponseBodySend(server, conn);
+            } else {
+                assert(feed.done);
+                finishExchange(server, conn);
+            }
+        }
+
+        fn armResponseBodySend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            const direction = &conn.directions[1];
+            assert(direction.sent_len < direction.transfer_len);
+            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            server.io.send(
+                conn.client_socket,
+                conn.relay_buffer.?.upstream_to_client[direction.sent_len..direction.transfer_len],
+                &conn.op_data_upstream_to_client.completion,
+                ConnType,
+                conn,
+                onResponseBodySent,
+            );
+        }
+
+        fn onResponseBodySent(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .pumping_body);
+            const sent = result catch |err| {
+                server.witnessKernelPressure(err);
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(sent >= 1);
+            const direction = &conn.directions[1];
+            direction.sent_len += sent;
+            assert(direction.sent_len <= direction.transfer_len);
+            if (direction.sent_len < direction.transfer_len) {
+                armResponseBodySend(server, conn);
+                return;
+            }
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            if (framingDone(&conn.l7.response_framing)) {
+                finishExchange(server, conn);
+            } else {
+                armResponseBodyRecv(server, conn);
+            }
+        }
+
+        /// The response reached the client in full. Without keep-alive the
+        /// exchange ends the connection — the close was announced in both
+        /// rendered heads (§2) — and the request leg, done or not, ends
+        /// with it (an early response ends the exchange, §7).
+        fn finishExchange(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_started);
+            conn.l7.response_leg = .done;
+            server.counters.increment("l7_responses");
             server.beginTeardown(conn);
         }
 
-        /// Answer a comptime static error response, then close (§8). Every
-        /// reject announces the close, so the connection does not survive.
-        fn reject(
+        /// The upstream leg failed. Answer 502 only when the client has
+        /// seen no response byte and both data ops are free — the static
+        /// response and its lingering drain need them, and ops are never
+        /// canceled (§5). Otherwise the only honest outcome is teardown: a
+        /// half-sent response cannot be repaired, and an armed op holds the
+        /// completion the answer would need.
+        fn upstreamFailed(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            if (conn.l7.response_started or conn.armed.data_client_to_upstream or
+                conn.armed.data_upstream_to_client)
+            {
+                server.beginTeardown(conn);
+                return;
+            }
+            respond(server, conn, 502, "l7_bad_gateway");
+        }
+
+        /// 400/503 with the request-body pump possibly armed: prefer the
+        /// response when the op is free, teardown otherwise.
+        fn respondOrTeardown(
             server: *ServerType,
             conn: *ConnType,
             comptime status: u16,
             comptime counter: []const u8,
         ) void {
-            assert(conn.state == .l7_reading_head);
+            if (conn.armed.data_client_to_upstream or conn.armed.data_upstream_to_client) {
+                server.counters.increment(counter);
+                server.beginTeardown(conn);
+                return;
+            }
+            respond(server, conn, status, counter);
+        }
+
+        /// Answer a comptime static error response, then close (§8). Legal
+        /// from head reading (rejects), dialing (502), and the exchange
+        /// (upstream failures) — every caller guarantees both data ops are
+        /// free, because the send and the lingering drain need them.
+        fn respond(
+            server: *ServerType,
+            conn: *ConnType,
+            comptime status: u16,
+            comptime counter: []const u8,
+        ) void {
+            assert(conn.state == .l7_reading_head or conn.state == .l7_dialing or
+                conn.state == .l7_exchanging);
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.l7.response_started);
             server.counters.increment(counter);
             conn.state = .l7_responding;
             conn.response_pending = shed.staticResponse(status, .close);
@@ -224,6 +926,68 @@ pub fn Proxy(comptime IoType: type) type {
             };
             // More bytes to discard; keep draining under the deadline.
             armDrainRecv(server, conn);
+        }
+
+        const FeedResult = struct {
+            consumed: u32,
+            done: bool,
+            malformed: bool,
+        };
+
+        /// Advance a framing tracker over `bytes`, reporting how many of
+        /// them belong to the message. Consumed < bytes.len means the
+        /// message ended mid-chunk; the rest is pipelined data, dropped
+        /// while every exchange closes its connection.
+        fn feedFraming(framing: *Framing, bytes: []const u8) FeedResult {
+            assert(bytes.len <= constants.head_bytes_max);
+            switch (framing.*) {
+                .none => return .{ .consumed = 0, .done = true, .malformed = false },
+                .content_length => |*remaining| {
+                    const consumed: u32 = @intCast(@min(remaining.*, bytes.len));
+                    remaining.* -= consumed;
+                    return .{
+                        .consumed = consumed,
+                        .done = remaining.* == 0,
+                        .malformed = false,
+                    };
+                },
+                .chunked => |*scanner| {
+                    if (bytes.len == 0) {
+                        return .{ .consumed = 0, .done = false, .malformed = false };
+                    }
+                    const progress = scanner.feed(bytes) catch {
+                        return .{ .consumed = 0, .done = false, .malformed = true };
+                    };
+                    return .{
+                        .consumed = progress.consumed,
+                        .done = progress.done,
+                        .malformed = false,
+                    };
+                },
+                .until_close => return .{
+                    .consumed = @intCast(bytes.len),
+                    .done = false,
+                    .malformed = false,
+                },
+            }
+        }
+
+        fn framingDone(framing: *const Framing) bool {
+            return switch (framing.*) {
+                .none => true,
+                .content_length => |remaining| remaining == 0,
+                .chunked => |scanner| scanner.state == .done,
+                .until_close => false,
+            };
+        }
+
+        fn framingFromParsed(parsed: parser.BodyFraming) Framing {
+            return switch (parsed) {
+                .none => .none,
+                .content_length => |length| .{ .content_length = length },
+                .chunked => .{ .chunked = .{} },
+                .until_close => .until_close,
+            };
         }
     };
 }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -69,10 +69,10 @@ pub fn Proxy(comptime IoType: type) type {
                 // A client that closes or resets before finishing its head
                 // simply leaves — there is nothing to answer. The §7
                 // head-read deadline handles the slowloris that stalls
-                // instead of closing.
-                if (err != error.EndOfStream) {
-                    server.witnessKernelPressure(err);
-                }
+                // instead of closing. The witness filters internally: only
+                // Unexpected (kernel pressure) is counted, so orderly
+                // EndOfStream/Reset pass through it uncounted.
+                server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -213,9 +213,12 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_draining_request);
-            _ = result catch {
+            _ = result catch |err| {
                 // EOF or error: the client's inbound is drained, so the
-                // close is a clean FIN, not a data-discarding RST.
+                // close is a clean FIN, not a data-discarding RST. Kernel
+                // pressure on the drain recv is still witnessed (§8) —
+                // this op fires most during a reject storm under load.
+                server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
                 return;
             };

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -559,23 +559,26 @@ pub fn Proxy(comptime IoType: type) type {
             // record the head boundary so the deferred render agrees.
             conn.l7.response_head_len_marker = response.head_len;
             if (conn.l7.request_head_vacated) {
-                beginResponseForward(server, conn);
+                // conn.head is already free, so render straight from the
+                // parse we just did — no second parse of the same bytes.
+                // This is the common path: the request head vacates long
+                // before the origin answers.
+                renderResponse(server, conn, &response);
             } else {
                 conn.l7.response_render_pending = true;
             }
         }
 
-        /// Render the origin's head into conn.head (free once the request
-        /// head has vacated it) and forward the coalesced body excess
-        /// straight from upstream.head — never copied through a relay
-        /// buffer, so an oversized coalesced body is fine.
+        /// Deferred render path: the origin answered before the request
+        /// head vacated conn.head, so the first parse's stack storage is
+        /// gone and the bytes must be re-parsed (unchanged, §7 single
+        /// source of truth, so it cannot fail). The common path renders
+        /// from the first parse via `renderResponse` and never gets here.
         fn beginResponseForward(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .awaiting_head);
             assert(conn.l7.request_head_vacated);
             const upstream = conn.upstream.?;
-            // The same bytes parsed successfully already (§7 single source
-            // of truth), so this re-parse cannot fail.
             var storage: parser.HeaderStorage = undefined;
             const response = parser.parseResponseHead(
                 upstream.head[0..upstream.head_len],
@@ -584,6 +587,22 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.l7.request_method,
             ) catch unreachable;
             assert(response.head_len == conn.l7.response_head_len_marker);
+            renderResponse(server, conn, &response);
+        }
+
+        /// Render the origin's head into conn.head (free once the request
+        /// head has vacated it) and forward the coalesced body excess
+        /// straight from upstream.head — never copied through a relay
+        /// buffer, so an oversized coalesced body is fine.
+        fn renderResponse(
+            server: *ServerType,
+            conn: *ConnType,
+            response: *const parser.ResponseHead,
+        ) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            assert(conn.l7.request_head_vacated);
+            const upstream = conn.upstream.?;
 
             // The §8 persistence decision, made once and honored: honor
             // the client's ask unless pipelining, pressure, or drain says
@@ -597,7 +616,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const rendered = render.renderResponseHead(
-                &response,
+                response,
                 !keep_downstream,
                 &conn.head,
             ) catch {

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -1,0 +1,349 @@
+//! Head rendering for the L7 proxy (DESIGN.md §7): parsed heads are
+//! *rendered* into a fixed staging buffer, never edited in place — the
+//! zero-copy slices of the source head stay valid throughout. Rendering
+//! strips hop-by-hop headers both ways (RFC 9110 §7.6.1) and injects
+//! `Connection: close` when the proxy will close (§2); Phase-2 header
+//! edits will be applied here too. A head that no longer fits after
+//! rendering is oversize — 431 downstream, teardown upstream (§7).
+
+const std = @import("std");
+const constants = @import("../constants.zig");
+const parser = @import("parser.zig");
+
+const assert = std.debug.assert;
+
+/// Header names never forwarded, beyond the Connection-nominated set
+/// (RFC 9110 §7.6.1). Transfer-Encoding and Trailer are deliberately
+/// absent: the body is relayed verbatim in its original framing, so its
+/// framing headers must travel with it.
+const hop_by_hop_names = [_][]const u8{
+    "connection",
+    "keep-alive",
+    "proxy-connection",
+    "te",
+    "upgrade",
+};
+
+/// Header names a Connection header may NOT nominate away. Stripping
+/// Content-Length or Transfer-Encoding would desynchronize the receiver
+/// from the framing this proxy already committed to — a smuggling vector
+/// — and stripping Host would unroute an HTTP/1.1 request.
+const protected_names = [_][]const u8{
+    "host",
+    "content-length",
+    "transfer-encoding",
+};
+
+/// Renders the upstream request line and end-to-end headers from a
+/// parsed head. The client's version is preserved — framing decisions on
+/// both hops key off the real versions — and `inject_close` announces
+/// that this upstream connection will not be reused (§2).
+pub fn renderRequestHead(
+    request: *const parser.RequestHead,
+    inject_close: bool,
+    buffer: []u8,
+) error{Oversize}![]const u8 {
+    // The proxy answers CONNECT with 501 itself, never forwards it (§7).
+    assert(request.method != .connect);
+    assert(request.method_token.len >= 1);
+    assert(request.target.len >= 1);
+    assert(buffer.len <= std.math.maxInt(u32));
+
+    var staging = Staging{ .buffer = buffer };
+    try staging.append(request.method_token);
+    try staging.append(" ");
+    try staging.append(request.target);
+    try staging.append(switch (request.version) {
+        .http_1_0 => " HTTP/1.0\r\n",
+        .http_1_1 => " HTTP/1.1\r\n",
+    });
+    try appendEndToEndHeaders(&staging, request.headers);
+    if (inject_close) {
+        try staging.append("Connection: close\r\n");
+    }
+    try staging.append("\r\n");
+    assert(staging.len >= 1);
+    return staging.buffer[0..staging.len];
+}
+
+/// Renders the downstream status line and end-to-end headers. The
+/// origin's version and reason phrase are preserved verbatim;
+/// `inject_close` announces that the proxy will close the downstream
+/// connection after this response (§2).
+pub fn renderResponseHead(
+    response: *const parser.ResponseHead,
+    inject_close: bool,
+    buffer: []u8,
+) error{Oversize}![]const u8 {
+    assert(response.status >= 100);
+    assert(response.status <= 599);
+    assert(buffer.len <= std.math.maxInt(u32));
+
+    var staging = Staging{ .buffer = buffer };
+    try staging.append(switch (response.version) {
+        .http_1_0 => "HTTP/1.0 ",
+        .http_1_1 => "HTTP/1.1 ",
+    });
+    try staging.append(&statusDigits(response.status));
+    if (response.status_message) |message| {
+        try staging.append(" ");
+        try staging.append(message);
+    }
+    try staging.append("\r\n");
+    try appendEndToEndHeaders(&staging, response.headers);
+    if (inject_close) {
+        try staging.append("Connection: close\r\n");
+    }
+    try staging.append("\r\n");
+    assert(staging.len >= 1);
+    return staging.buffer[0..staging.len];
+}
+
+/// Bounded append cursor over the caller's staging buffer; overflowing
+/// it is the `Oversize` verdict, never a wider write.
+const Staging = struct {
+    buffer: []u8,
+    len: u32 = 0,
+
+    fn append(staging: *Staging, bytes: []const u8) error{Oversize}!void {
+        assert(staging.len <= staging.buffer.len);
+        if (staging.buffer.len - staging.len < bytes.len) {
+            return error.Oversize;
+        }
+        @memcpy(staging.buffer[staging.len..][0..bytes.len], bytes);
+        staging.len += @intCast(bytes.len);
+        assert(staging.len <= staging.buffer.len);
+    }
+};
+
+/// Appends every end-to-end header as `Name: value\r\n`, preserving the
+/// sender's name casing and value bytes. Bounded by `headers_max`.
+fn appendEndToEndHeaders(
+    staging: *Staging,
+    headers: []const parser.Header,
+) error{Oversize}!void {
+    assert(headers.len <= constants.headers_max);
+    for (headers) |header| {
+        assert(header.name.len >= 1);
+        if (isHopByHop(header.name, headers)) {
+            continue;
+        }
+        try staging.append(header.name);
+        try staging.append(": ");
+        try staging.append(header.value);
+        try staging.append("\r\n");
+    }
+}
+
+/// True when the header must not be forwarded: in the static hop-by-hop
+/// set, or nominated by a Connection header (RFC 9110 §7.6.1) — unless
+/// it is protected (see `protected_names`).
+fn isHopByHop(name: []const u8, headers: []const parser.Header) bool {
+    assert(name.len >= 1);
+    for (hop_by_hop_names) |hop_name| {
+        if (std.ascii.eqlIgnoreCase(name, hop_name)) {
+            return true;
+        }
+    }
+    for (protected_names) |protected_name| {
+        if (std.ascii.eqlIgnoreCase(name, protected_name)) {
+            return false;
+        }
+    }
+    // Both loops are bounded: headers_max entries, head_bytes_max value
+    // bytes. In practice this is one Connection header with few tokens.
+    for (headers) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, "connection")) {
+            continue;
+        }
+        if (parser.tokenListHas(header.value, name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// The three ASCII digits of a 1xx–5xx status code.
+fn statusDigits(status: u16) [3]u8 {
+    assert(status >= 100);
+    assert(status <= 599);
+    return .{
+        '0' + @as(u8, @intCast(status / 100)),
+        '0' + @as(u8, @intCast(status / 10 % 10)),
+        '0' + @as(u8, @intCast(status % 10)),
+    };
+}
+
+// Tests. The load-bearing oracle is parse → render → reparse: whatever
+// zoxy accepts must render into a head zoxy itself accepts, with the
+// routing- and framing-relevant fields intact and hop-by-hop gone.
+
+const testing = std.testing;
+
+/// Fuzz/test staging: normalization can grow a head (a missing space
+/// after `:` is rendered back, one byte per header), so the oracle
+/// buffer carries slack; the production staging area is exactly
+/// `head_bytes_max` and overflowing it is the 431/teardown verdict.
+const oracle_buffer_bytes = constants.head_bytes_max + @as(u32, constants.headers_max) + 64;
+
+test "render: request strips hop-by-hop and nominated, keeps the rest" {
+    const head = "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-Nominated\r\n" ++
+        "Keep-Alive: timeout=5\r\nTE: trailers\r\nX-Nominated: v\r\nX-Keep: yes\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+
+    const rendered = try renderRequestHead(&request, false, &buffer);
+    try testing.expectEqualStrings(
+        "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
+        rendered,
+    );
+
+    const closed = try renderRequestHead(&request, true, &buffer);
+    try testing.expectEqualStrings(
+        "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
+        closed,
+    );
+}
+
+test "render: nominating a protected header does not strip it" {
+    // `Connection: content-length` must not remove the header the proxy
+    // framed the body by — stripping it would desynchronize the upstream.
+    const head = "POST /u HTTP/1.1\r\nHost: a\r\nConnection: Content-Length, Host\r\n" ++
+        "Content-Length: 5\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, false, &buffer);
+    try testing.expectEqualStrings(
+        "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
+        rendered,
+    );
+}
+
+test "render: framing headers travel with the body" {
+    const head = "POST /u HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, false, &buffer);
+
+    var reparse_storage: parser.HeaderStorage = undefined;
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    try testing.expectEqual(parser.BodyFraming.chunked, reparsed.framing);
+}
+
+test "render: client version is preserved" {
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, false, &buffer);
+    try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
+}
+
+test "render: response preserves status line and strips hop-by-hop" {
+    const head = "HTTP/1.1 418 I'm a teapot\r\nConnection: keep-alive\r\n" ++
+        "Content-Length: 0\r\nX-Origin: yes\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const response = try parser.parseResponseHead(head, false, &storage, .get);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+
+    const rendered = try renderResponseHead(&response, false, &buffer);
+    try testing.expectEqualStrings(
+        "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n\r\n",
+        rendered,
+    );
+
+    const closed = try renderResponseHead(&response, true, &buffer);
+    try testing.expectEqualStrings(
+        "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n" ++
+            "Connection: close\r\n\r\n",
+        closed,
+    );
+}
+
+test "render: bare status line without a reason phrase round-trips" {
+    var storage: parser.HeaderStorage = undefined;
+    const response = try parser.parseResponseHead("HTTP/1.0 204\r\n\r\n", false, &storage, .get);
+    try testing.expectEqual(@as(?[]const u8, null), response.status_message);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderResponseHead(&response, false, &buffer);
+    try testing.expectEqualStrings("HTTP/1.0 204\r\n\r\n", rendered);
+}
+
+test "render: a head that no longer fits is Oversize" {
+    const head = "GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var small: [16]u8 = undefined;
+    try testing.expectError(error.Oversize, renderRequestHead(&request, false, &small));
+}
+
+// Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
+// turn into a head the parser accepts again, with routing and framing
+// intact and hop-by-hop headers gone.
+
+fn checkRequestRender(input: []const u8) void {
+    var storage: parser.HeaderStorage = undefined;
+    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    if (request.method == .connect) {
+        return; // Never rendered: the proxy answers CONNECT itself.
+    }
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = renderRequestHead(&request, false, &buffer) catch unreachable;
+
+    var reparse_storage: parser.HeaderStorage = undefined;
+    // A rendered head failing our own parser would mean the proxy emits
+    // requests it would itself reject — the oracle's core claim.
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch unreachable;
+    assert(reparsed.method == request.method);
+    assert(std.mem.eql(u8, reparsed.method_token, request.method_token));
+    assert(std.mem.eql(u8, reparsed.target, request.target));
+    assert(reparsed.version == request.version);
+    assert(std.meta.eql(reparsed.framing, request.framing));
+    if (request.host) |host| {
+        assert(std.mem.eql(u8, reparsed.host.?, host));
+    }
+    for (reparsed.headers) |header| {
+        for (hop_by_hop_names) |hop_name| {
+            assert(!std.ascii.eqlIgnoreCase(header.name, hop_name));
+        }
+    }
+}
+
+fn checkResponseRender(input: []const u8) void {
+    var storage: parser.HeaderStorage = undefined;
+    const response = parser.parseResponseHead(input, false, &storage, .get) catch return;
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = renderResponseHead(&response, false, &buffer) catch unreachable;
+
+    var reparse_storage: parser.HeaderStorage = undefined;
+    const reparsed = parser.parseResponseHead(rendered, false, &reparse_storage, .get) catch unreachable;
+    assert(reparsed.status == response.status);
+    assert(reparsed.version == response.version);
+    assert(std.meta.eql(reparsed.framing, response.framing));
+    assert((reparsed.status_message == null) == (response.status_message == null));
+    if (response.status_message) |message| {
+        assert(std.mem.eql(u8, reparsed.status_message.?, message));
+    }
+}
+
+test "fuzz: parse-render-reparse keeps routing and framing intact" {
+    try std.testing.fuzz({}, fuzzRenderInputs, .{
+        .corpus = &.{
+            "POST /submit HTTP/1.1\r\nHost: origin\r\nContent-Length: 5\r\n\r\nhello",
+            "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-N\r\nX-N: v\r\nTE: t\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+        },
+    });
+}
+
+fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    const input_len = smith.slice(&input_buffer);
+    assert(input_len <= input_buffer.len);
+    const input = input_buffer[0..input_len];
+    checkRequestRender(input);
+    checkResponseRender(input);
+}

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -135,10 +135,18 @@ fn appendEndToEndHeaders(
         }
     }
     const nominations = connection_values[0..connection_count];
+    // `close` and `keep-alive` are connection options, not header names —
+    // `keep-alive` is already a hop-by-hop name and `close` names no
+    // forwardable header — so a Connection listing only those nominates
+    // nothing to strip. Detect a real nomination once here; the common
+    // case then skips the per-header token scan entirely, splitting the
+    // Connection value once rather than once per header (§9).
+    const active_nominations =
+        if (nominatesRealHeader(nominations)) nominations else nominations[0..0];
 
     for (headers) |header| {
         assert(header.name.len >= 1);
-        if (isHopByHop(header.name, nominations)) {
+        if (isHopByHop(header.name, active_nominations)) {
             continue;
         }
         try staging.append(header.name);
@@ -148,11 +156,37 @@ fn appendEndToEndHeaders(
     }
 }
 
+/// True when a Connection value names a header to strip beyond the
+/// standard `close`/`keep-alive` options. Splits each token list once so
+/// the per-header hop-by-hop test can skip the (usually empty) nomination
+/// scan in the common case.
+fn nominatesRealHeader(nominations: []const []const u8) bool {
+    assert(nominations.len <= constants.headers_max);
+    for (nominations) |value| {
+        var tokens = std.mem.splitScalar(u8, value, ',');
+        while (tokens.next()) |raw_token| {
+            const token = std.mem.trim(u8, raw_token, " \t");
+            if (token.len == 0) {
+                continue;
+            }
+            if (std.ascii.eqlIgnoreCase(token, "close")) {
+                continue;
+            }
+            if (std.ascii.eqlIgnoreCase(token, "keep-alive")) {
+                continue;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 /// True when the header must not be forwarded: in the static hop-by-hop
 /// set, or nominated by a Connection header (RFC 9110 §7.6.1) — unless
-/// it is protected (see `protected_names`). `nominations` is the
-/// pre-collected set of Connection header values, so this is O(1) in the
-/// common no-Connection-header case rather than a re-scan per header.
+/// it is protected (see `protected_names`). `nominations` is the set of
+/// Connection values that name a real header (empty in the common
+/// close/keep-alive-only case), so this is O(1) then rather than a token
+/// scan per header.
 fn isHopByHop(name: []const u8, nominations: []const []const u8) bool {
     assert(name.len >= 1);
     assert(nominations.len <= constants.headers_max);
@@ -228,6 +262,27 @@ test "render: nominating a protected header does not strip it" {
     const rendered = try renderRequestHead(&request, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
+        rendered,
+    );
+}
+
+test "render: standard Connection options do not nominate a same-named header" {
+    // `close`/`keep-alive` are persistence directives (RFC 9110 §7.6.1),
+    // not nominations — so the per-header token scan is skipped for them,
+    // and a (bogus) header literally named "Close" is forwarded, not
+    // stripped. A real nomination on the same Connection still strips
+    // (covered by the strips-hop-by-hop-and-nominated test above).
+    const head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: keep-alive, close\r\n" ++
+        "Close: x\r\nKeep-Alive: timeout=5\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, false, &buffer);
+    // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
+    // hop-by-hop name); the "Close" header survives — close nominates
+    // nothing.
+    try testing.expectEqualStrings(
+        "GET / HTTP/1.1\r\nHost: a\r\nClose: x\r\n\r\n",
         rendered,
     );
 }

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -123,9 +123,22 @@ fn appendEndToEndHeaders(
     headers: []const parser.Header,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
+    // Collect the Connection header value(s) once (usually zero or one).
+    // Re-finding them inside the per-header hop-by-hop test made the walk
+    // O(headers²) — the render's top user-CPU cost under load (§9).
+    var connection_values: [constants.headers_max][]const u8 = undefined;
+    var connection_count: u32 = 0;
+    for (headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "connection")) {
+            connection_values[connection_count] = header.value;
+            connection_count += 1;
+        }
+    }
+    const nominations = connection_values[0..connection_count];
+
     for (headers) |header| {
         assert(header.name.len >= 1);
-        if (isHopByHop(header.name, headers)) {
+        if (isHopByHop(header.name, nominations)) {
             continue;
         }
         try staging.append(header.name);
@@ -137,9 +150,12 @@ fn appendEndToEndHeaders(
 
 /// True when the header must not be forwarded: in the static hop-by-hop
 /// set, or nominated by a Connection header (RFC 9110 §7.6.1) — unless
-/// it is protected (see `protected_names`).
-fn isHopByHop(name: []const u8, headers: []const parser.Header) bool {
+/// it is protected (see `protected_names`). `nominations` is the
+/// pre-collected set of Connection header values, so this is O(1) in the
+/// common no-Connection-header case rather than a re-scan per header.
+fn isHopByHop(name: []const u8, nominations: []const []const u8) bool {
     assert(name.len >= 1);
+    assert(nominations.len <= constants.headers_max);
     for (hop_by_hop_names) |hop_name| {
         if (std.ascii.eqlIgnoreCase(name, hop_name)) {
             return true;
@@ -150,13 +166,8 @@ fn isHopByHop(name: []const u8, headers: []const parser.Header) bool {
             return false;
         }
     }
-    // Both loops are bounded: headers_max entries, head_bytes_max value
-    // bytes. In practice this is one Connection header with few tokens.
-    for (headers) |header| {
-        if (!std.ascii.eqlIgnoreCase(header.name, "connection")) {
-            continue;
-        }
-        if (parser.tokenListHas(header.value, name)) {
+    for (nominations) |value| {
+        if (parser.tokenListHas(value, name)) {
             return true;
         }
     }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -449,6 +449,31 @@ test "l7: a malformed request head is answered 400 and closed with FIN" {
     try bed.expectDrained();
 }
 
+test "l7: a malformed chunked body coalesced with the head is answered 400" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 7,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // The head is valid, so it is sent upstream and the response leg is
+    // about to arm — but the chunk-size line coalesced behind it opens with
+    // a non-hex byte, a framing violation the moment it is fed. The client
+    // still gets a 400, not the bare teardown a post-arm detection forces
+    // (§7): the body is validated before the response recv commits its op.
+    try bed.exchange("POST /x HTTP/1.1\r\nHost: o\r\nTransfer-Encoding: chunked\r\n\r\nZ");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
 test "l7: oversize request line is 414, oversize header section is 431" {
     {
         var bed: Http1Bed = undefined;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1,0 +1,348 @@
+//! Directed L7 scenarios over SimIo (§9), separate from the L4 harness
+//! in server_test.zig so neither over-generalizes the other. This slice
+//! covers head ingestion and the static-response rejects: a client sends
+//! a request head (split arbitrarily by the adversary) and observes
+//! either the exact static error response or, for a valid request, a
+//! clean close with no response — the upstream leg lands next. Every
+//! scenario ends with counters reconciled and all pools drained.
+
+const std = @import("std");
+
+const config_module = @import("config.zig");
+const Io = @import("io/io.zig");
+const Server = @import("Server.zig").Server;
+const SimIo = @import("io/SimIo.zig");
+
+const assert = std.debug.assert;
+
+const ServerSim = Server(SimIo);
+
+/// A scripted HTTP client: sends `request` (the adversary may split the
+/// send into 1-byte pieces), then reads until the peer closes,
+/// accumulating the response bytes for the assertions.
+const HttpClient = struct {
+    io: *SimIo = undefined,
+    /// Drained when this client's exchange ends, so the run reaches true
+    /// quiescence instead of deadlocking on the still-armed accept — the
+    /// L4 harness drains from client-end for the same reason.
+    server: *ServerSim = undefined,
+    connect_completion: SimIo.Completion = .{},
+    send_completion: SimIo.Completion = .{},
+    recv_completion: SimIo.Completion = .{},
+    socket: SimIo.Socket = undefined,
+    request: []const u8 = undefined,
+    sent_len: u32 = 0,
+    receive_buffer: [512]u8 = undefined,
+    received_len: u32 = 0,
+    /// Set once the server closes (FIN) or resets the connection.
+    closed: bool = false,
+
+    fn start(client: *HttpClient, io: *SimIo, server: *ServerSim, address: std.Io.net.IpAddress) void {
+        client.io = io;
+        client.server = server;
+        io.connect(address, &client.connect_completion, HttpClient, client, onConnect);
+    }
+
+    fn onConnect(client: *HttpClient, result: Io.ConnectError!SimIo.Socket) void {
+        client.socket = result catch unreachable;
+        client.armRecv();
+        client.armSend();
+    }
+
+    fn armSend(client: *HttpClient) void {
+        assert(client.sent_len < client.request.len);
+        client.io.send(
+            client.socket,
+            client.request[client.sent_len..],
+            &client.send_completion,
+            HttpClient,
+            client,
+            onSend,
+        );
+    }
+
+    fn onSend(client: *HttpClient, result: Io.SendError!u32) void {
+        // A reject may close the connection before the whole request is
+        // sent; a send failure then is expected, not an error.
+        const sent = result catch return;
+        client.sent_len += sent;
+        assert(client.sent_len <= client.request.len);
+        if (client.sent_len < client.request.len) {
+            client.armSend();
+        }
+    }
+
+    fn armRecv(client: *HttpClient) void {
+        client.io.recv(
+            client.socket,
+            client.receive_buffer[client.received_len..],
+            &client.recv_completion,
+            HttpClient,
+            client,
+            onRecv,
+        );
+    }
+
+    fn onRecv(client: *HttpClient, result: Io.RecvError!u32) void {
+        const received = result catch {
+            // FIN or RST: the exchange is over. Begin the drain so the
+            // run winds down instead of idling on the armed accept.
+            client.io.closeNow(client.socket);
+            client.closed = true;
+            client.server.beginDrain();
+            return;
+        };
+        assert(received >= 1);
+        client.received_len += received;
+        assert(client.received_len <= client.receive_buffer.len);
+        client.armRecv();
+    }
+
+    fn response(client: *const HttpClient) []const u8 {
+        return client.receive_buffer[0..client.received_len];
+    }
+};
+
+/// Single-listener L7 harness: one http listener, no origin (the
+/// upstream leg is not exercised in this slice), one client.
+const Http1Bed = struct {
+    arena_state: std.heap.ArenaAllocator,
+    sim_io: SimIo,
+    endpoints: [1]std.Io.net.IpAddress,
+    clusters: [1]config_module.Config.Cluster,
+    listeners: [1]config_module.Config.Listener,
+    config: config_module.Config,
+    server: ServerSim,
+    client: HttpClient,
+
+    const idle_timeout_ms: u32 = 1000;
+
+    fn bindAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8080") catch unreachable;
+    }
+
+    fn originAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
+    }
+
+    fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, seed: u64, partial_io: bool) !void {
+        bed.arena_state = std.heap.ArenaAllocator.init(gpa);
+        errdefer bed.arena_state.deinit();
+        const arena = bed.arena_state.allocator();
+
+        try bed.sim_io.init(arena, .{ .seed = seed, .adversary = .{ .partial_io = partial_io } });
+        bed.endpoints = .{originAddress()};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
+        bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .http }};
+        bed.config = .{
+            .listeners = &bed.listeners,
+            .clusters = &bed.clusters,
+            .connect_timeout_ms = 50,
+            .idle_timeout_ms = idle_timeout_ms,
+            .drain_deadline_ms = 1000,
+            .max_lifetime_ms = 0,
+        };
+        try bed.server.init(arena, &bed.sim_io, &bed.config, .{ .conn_slots = 4, .relay_buffers = 2 });
+        try bed.server.start();
+        bed.client = .{};
+    }
+
+    fn tearDown(bed: *Http1Bed) void {
+        bed.arena_state.deinit();
+    }
+
+    /// Send one request and run to quiescence. The client begins the
+    /// drain when it sees the connection close, so a single run winds the
+    /// whole scenario down; by the time it returns the client has its
+    /// outcome and the pools have drained.
+    fn exchange(bed: *Http1Bed, request: []const u8) !void {
+        bed.client.request = request;
+        bed.client.start(&bed.sim_io, &bed.server, bindAddress());
+        try bed.sim_io.run();
+    }
+
+    fn expectDrained(bed: *Http1Bed) !void {
+        try std.testing.expect(bed.server.isIdle());
+        try std.testing.expect(bed.server.reconcile());
+        try std.testing.expect(bed.sim_io.sockets.isFullyReleased());
+    }
+};
+
+test "l7: a malformed request head is answered 400 and closed" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, 1, false);
+    defer bed.tearDown();
+
+    // A bare LF terminator is a smuggling shape the parser rejects (§7).
+    try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+
+    try std.testing.expect(bed.client.closed);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "l7: oversize request line is 414, oversize header section is 431" {
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, 2, false);
+        defer bed.tearDown();
+
+        // A request line longer than head_bytes_max with no CRLF: 414.
+        const long_target = "/" ++ ("a" ** 9000);
+        try bed.exchange("GET " ++ long_target ++ " HTTP/1.1\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
+        try bed.expectDrained();
+    }
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, 3, false);
+        defer bed.tearDown();
+
+        // A valid request line, then a header section that overflows the
+        // buffer before the terminating CRLF: 431.
+        const filler = "X-Filler: " ++ ("v" ** 200) ++ "\r\n";
+        var request: [10000]u8 = undefined;
+        var len: usize = 0;
+        const prefix = "GET / HTTP/1.1\r\nHost: a\r\n";
+        @memcpy(request[0..prefix.len], prefix);
+        len += prefix.len;
+        while (len + filler.len <= request.len) {
+            @memcpy(request[len..][0..filler.len], filler);
+            len += filler.len;
+        }
+        try bed.exchange(request[0..len]);
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_headers_too_large"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: CONNECT and Upgrade are answered 501" {
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, 4, false);
+        defer bed.tearDown();
+        try bed.exchange("CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n");
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+        try bed.expectDrained();
+    }
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, 5, false);
+        defer bed.tearDown();
+        try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n");
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a valid request is closed without a response (upstream leg pending)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, 6, false);
+    defer bed.tearDown();
+
+    try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n");
+
+    // No response yet — the upstream leg lands next slice — but the
+    // connection is torn down cleanly and accounted for.
+    try std.testing.expect(bed.client.closed);
+    try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
+    try bed.expectDrained();
+}
+
+test "l7: rejects survive 1-byte adversarial delivery across seeds" {
+    // The head arrives one byte per recv: the parse-retry loop must reach
+    // the same verdict however the request is fragmented (§7).
+    var seed: u64 = 1;
+    while (seed <= 15) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, seed, true);
+        defer bed.tearDown();
+
+        try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: the head-read deadline reaps a slowloris that never completes" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, 7, false);
+    defer bed.tearDown();
+
+    // A partial head with no terminator: the client sends it and then
+    // goes silent, so only the head-read deadline can end the connection.
+    try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\n");
+
+    try std.testing.expect(bed.client.closed);
+    try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "l7: the head-ingestion path allocates nothing after init" {
+    // §9 zero-alloc gate for L7: run a reject exchange (head recv, parse,
+    // static response, lingering close, teardown) under a counting
+    // allocator, then again under one that *fails* past the init count.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var bed: Http1Bed = undefined;
+    try bed.setUp(failing.allocator(), 9, true);
+    defer bed.tearDown();
+    const allocations_after_init = failing.allocations;
+    try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+    try bed.expectDrained();
+    try std.testing.expectEqual(allocations_after_init, failing.allocations);
+
+    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = allocations_after_init,
+    });
+    var strict_bed: Http1Bed = undefined;
+    try strict_bed.setUp(strict.allocator(), 9, true);
+    defer strict_bed.tearDown();
+    try strict_bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+    try strict_bed.expectDrained();
+}
+
+test "l7: an http listener admits without a relay buffer" {
+    // The idle L7 connection holds a slot only (§5): even with the relay
+    // pool sized to zero-usable it still admits and rejects.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, 8, false);
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("shed_relay_buffers"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+    try bed.expectDrained();
+}

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1,15 +1,16 @@
 //! Directed L7 scenarios over SimIo (§9), separate from the L4 harness
-//! in server_test.zig so neither over-generalizes the other. This slice
-//! covers head ingestion and the static-response rejects: a client sends
-//! a request head (split arbitrarily by the adversary) and observes
-//! either the exact static error response or, for a valid request, a
-//! clean close with no response — the upstream leg lands next. Every
-//! scenario ends with counters reconciled and all pools drained.
+//! in server_test.zig so neither over-generalizes the other. Covers head
+//! ingestion and static-response rejects (before any dial), and the full
+//! upstream leg against a scripted HTTP origin: request head + framed
+//! body forwarded, response head + framed body relayed back, byte-exact
+//! under 1-byte adversarial delivery. Every scenario ends with counters
+//! reconciled and all pools drained.
 
 const std = @import("std");
 
 const config_module = @import("config.zig");
 const Io = @import("io/io.zig");
+const parser = @import("http/parser.zig");
 const Server = @import("Server.zig").Server;
 const SimIo = @import("io/SimIo.zig");
 
@@ -18,13 +19,11 @@ const assert = std.debug.assert;
 const ServerSim = Server(SimIo);
 
 /// A scripted HTTP client: sends `request` (the adversary may split the
-/// send into 1-byte pieces), then reads until the peer closes,
-/// accumulating the response bytes for the assertions.
+/// send), then reads until the peer closes, recording the response bytes
+/// and whether the close was an orderly FIN or an RST — the §2 property
+/// (a delivered response must end in FIN, never a data-discarding RST).
 const HttpClient = struct {
     io: *SimIo = undefined,
-    /// Drained when this client's exchange ends, so the run reaches true
-    /// quiescence instead of deadlocking on the still-armed accept — the
-    /// L4 harness drains from client-end for the same reason.
     server: *ServerSim = undefined,
     connect_completion: SimIo.Completion = .{},
     send_completion: SimIo.Completion = .{},
@@ -32,10 +31,11 @@ const HttpClient = struct {
     socket: SimIo.Socket = undefined,
     request: []const u8 = undefined,
     sent_len: u32 = 0,
-    receive_buffer: [512]u8 = undefined,
+    receive_buffer: [4096]u8 = undefined,
     received_len: u32 = 0,
-    /// Set once the server closes (FIN) or resets the connection.
-    closed: bool = false,
+    outcome: Outcome = .pending,
+
+    const Outcome = enum(u8) { pending, fin, reset };
 
     fn start(client: *HttpClient, io: *SimIo, server: *ServerSim, address: std.Io.net.IpAddress) void {
         client.io = io;
@@ -84,11 +84,11 @@ const HttpClient = struct {
     }
 
     fn onRecv(client: *HttpClient, result: Io.RecvError!u32) void {
-        const received = result catch {
-            // FIN or RST: the exchange is over. Begin the drain so the
-            // run winds down instead of idling on the armed accept.
+        const received = result catch |err| {
+            client.outcome = if (err == error.Reset) .reset else .fin;
             client.io.closeNow(client.socket);
-            client.closed = true;
+            // Begin the drain so the run winds down instead of idling on
+            // the armed accept — the L4 harness drains from client-end too.
             client.server.beginDrain();
             return;
         };
@@ -103,8 +103,146 @@ const HttpClient = struct {
     }
 };
 
-/// Single-listener L7 harness: one http listener, no origin (the
-/// upstream leg is not exercised in this slice), one client.
+/// A scripted HTTP origin: reads one request (head + framed body, tracked
+/// with zoxy's own parser so the test asserts on exactly what the proxy
+/// forwarded), sends a canned `response`, then lingering-closes. One
+/// connection per scenario is enough for the no-keep-alive exchanges.
+const HttpOrigin = struct {
+    io: *SimIo = undefined,
+    listener: SimIo.Listener = undefined,
+    accept_completion: SimIo.Completion = .{},
+    listening: bool = false,
+    response: []const u8 = "",
+    conn: OConn = .{},
+    accepted: bool = false,
+
+    const OConn = struct {
+        origin: *HttpOrigin = undefined,
+        socket: SimIo.Socket = undefined,
+        recv_completion: SimIo.Completion = .{},
+        send_completion: SimIo.Completion = .{},
+        request_buffer: [16384]u8 = undefined,
+        request_len: u32 = 0,
+        request_complete: bool = false,
+        /// Total request bytes expected (head + framed body), known once
+        /// the head parses. 0 means the head has not parsed yet.
+        request_expected: u32 = 0,
+        response_sent: u32 = 0,
+
+        fn armRecv(oconn: *OConn) void {
+            oconn.origin.io.recv(
+                oconn.socket,
+                oconn.request_buffer[oconn.request_len..],
+                &oconn.recv_completion,
+                OConn,
+                oconn,
+                onRecv,
+            );
+        }
+
+        fn onRecv(oconn: *OConn, result: Io.RecvError!u32) void {
+            const received = result catch {
+                oconn.origin.io.closeNow(oconn.socket);
+                return;
+            };
+            oconn.request_len += received;
+            oconn.tryAdvance();
+        }
+
+        /// Parse the head once to learn the total request size (head +
+        /// content-length body — the only body shape these tests send),
+        /// then read until the whole request has arrived and respond.
+        fn tryAdvance(oconn: *OConn) void {
+            if (oconn.request_expected == 0) {
+                var storage: parser.HeaderStorage = undefined;
+                const request = parser.parseRequestHead(
+                    oconn.request_buffer[0..oconn.request_len],
+                    false,
+                    &storage,
+                ) catch |err| {
+                    if (err == error.Incomplete) {
+                        oconn.armRecv();
+                        return;
+                    }
+                    oconn.origin.io.closeNow(oconn.socket);
+                    return;
+                };
+                const body_length: u32 = switch (request.framing) {
+                    .content_length => |length| @intCast(length),
+                    else => 0,
+                };
+                oconn.request_expected = request.head_len + body_length;
+            }
+            assert(oconn.request_len <= oconn.request_expected);
+            if (oconn.request_len < oconn.request_expected) {
+                oconn.armRecv();
+                return;
+            }
+            oconn.request_complete = true;
+            oconn.armSend();
+        }
+
+        fn armSend(oconn: *OConn) void {
+            assert(oconn.response_sent < oconn.origin.response.len);
+            oconn.origin.io.send(
+                oconn.socket,
+                oconn.origin.response[oconn.response_sent..],
+                &oconn.send_completion,
+                OConn,
+                oconn,
+                onSend,
+            );
+        }
+
+        fn onSend(oconn: *OConn, result: Io.SendError!u32) void {
+            const sent = result catch {
+                oconn.origin.io.closeNow(oconn.socket);
+                return;
+            };
+            oconn.response_sent += sent;
+            if (oconn.response_sent < oconn.origin.response.len) {
+                oconn.armSend();
+            } else {
+                // Response delivered; close (Connection: close both ways).
+                oconn.origin.io.closeNow(oconn.socket);
+            }
+        }
+    };
+
+    fn start(origin: *HttpOrigin, io: *SimIo, address: std.Io.net.IpAddress) !void {
+        origin.io = io;
+        origin.listener = try io.listen(address);
+        origin.listening = true;
+        origin.armAccept();
+    }
+
+    fn armAccept(origin: *HttpOrigin) void {
+        origin.io.accept(origin.listener, &origin.accept_completion, HttpOrigin, origin, onAccept);
+    }
+
+    fn onAccept(origin: *HttpOrigin, result: Io.AcceptError!SimIo.Socket) void {
+        const socket = result catch |err| {
+            assert(err == error.Canceled);
+            return;
+        };
+        assert(!origin.accepted);
+        origin.accepted = true;
+        origin.conn.origin = origin;
+        origin.conn.socket = socket;
+        origin.conn.armRecv();
+        origin.armAccept();
+    }
+
+    fn stopListening(origin: *HttpOrigin) void {
+        if (origin.listening) {
+            origin.io.listenClose(origin.listener);
+            origin.listening = false;
+        }
+    }
+};
+
+/// Single-listener L7 harness: one http listener, a scripted origin, one
+/// client.
 const Http1Bed = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
@@ -113,6 +251,7 @@ const Http1Bed = struct {
     listeners: [1]config_module.Config.Listener,
     config: config_module.Config,
     server: ServerSim,
+    origin: HttpOrigin,
     client: HttpClient,
 
     const idle_timeout_ms: u32 = 1000;
@@ -125,12 +264,22 @@ const Http1Bed = struct {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
     }
 
-    fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, seed: u64, partial_io: bool) !void {
+    const Options = struct {
+        seed: u64,
+        partial_io: bool = false,
+        origin_response: []const u8 = "",
+        origin_listens: bool = true,
+    };
+
+    fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
         bed.arena_state = std.heap.ArenaAllocator.init(gpa);
         errdefer bed.arena_state.deinit();
         const arena = bed.arena_state.allocator();
 
-        try bed.sim_io.init(arena, .{ .seed = seed, .adversary = .{ .partial_io = partial_io } });
+        try bed.sim_io.init(arena, .{
+            .seed = options.seed,
+            .adversary = .{ .partial_io = options.partial_io },
+        });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .http }};
@@ -142,8 +291,16 @@ const Http1Bed = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
         };
-        try bed.server.init(arena, &bed.sim_io, &bed.config, .{ .conn_slots = 4, .relay_buffers = 2 });
+        try bed.server.init(arena, &bed.sim_io, &bed.config, .{
+            .conn_slots = 4,
+            .relay_buffers = 2,
+            .upstream_slots = 2,
+        });
         try bed.server.start();
+        bed.origin = .{ .response = options.origin_response };
+        if (options.origin_listens) {
+            try bed.origin.start(&bed.sim_io, originAddress());
+        }
         bed.client = .{};
     }
 
@@ -159,6 +316,7 @@ const Http1Bed = struct {
         bed.client.request = request;
         bed.client.start(&bed.sim_io, &bed.server, bindAddress());
         try bed.sim_io.run();
+        bed.origin.stopListening();
     }
 
     fn expectDrained(bed: *Http1Bed) !void {
@@ -168,15 +326,15 @@ const Http1Bed = struct {
     }
 };
 
-test "l7: a malformed request head is answered 400 and closed" {
+test "l7: a malformed request head is answered 400 and closed with FIN" {
     var bed: Http1Bed = undefined;
-    try bed.setUp(std.testing.allocator, 1, false);
+    try bed.setUp(std.testing.allocator, .{ .seed = 1 });
     defer bed.tearDown();
 
     // A bare LF terminator is a smuggling shape the parser rejects (§7).
     try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
 
-    try std.testing.expect(bed.client.closed);
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
         "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
         bed.client.response(),
@@ -189,10 +347,9 @@ test "l7: a malformed request head is answered 400 and closed" {
 test "l7: oversize request line is 414, oversize header section is 431" {
     {
         var bed: Http1Bed = undefined;
-        try bed.setUp(std.testing.allocator, 2, false);
+        try bed.setUp(std.testing.allocator, .{ .seed = 2 });
         defer bed.tearDown();
 
-        // A request line longer than head_bytes_max with no CRLF: 414.
         const long_target = "/" ++ ("a" ** 9000);
         try bed.exchange("GET " ++ long_target ++ " HTTP/1.1\r\n");
 
@@ -205,11 +362,9 @@ test "l7: oversize request line is 414, oversize header section is 431" {
     }
     {
         var bed: Http1Bed = undefined;
-        try bed.setUp(std.testing.allocator, 3, false);
+        try bed.setUp(std.testing.allocator, .{ .seed = 3 });
         defer bed.tearDown();
 
-        // A valid request line, then a header section that overflows the
-        // buffer before the terminating CRLF: 431.
         const filler = "X-Filler: " ++ ("v" ** 200) ++ "\r\n";
         var request: [10000]u8 = undefined;
         var len: usize = 0;
@@ -234,7 +389,7 @@ test "l7: oversize request line is 414, oversize header section is 431" {
 test "l7: CONNECT and Upgrade are answered 501" {
     {
         var bed: Http1Bed = undefined;
-        try bed.setUp(std.testing.allocator, 4, false);
+        try bed.setUp(std.testing.allocator, .{ .seed = 4 });
         defer bed.tearDown();
         try bed.exchange("CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n");
         try std.testing.expectEqualStrings(
@@ -246,7 +401,7 @@ test "l7: CONNECT and Upgrade are answered 501" {
     }
     {
         var bed: Http1Bed = undefined;
-        try bed.setUp(std.testing.allocator, 5, false);
+        try bed.setUp(std.testing.allocator, .{ .seed = 5 });
         defer bed.tearDown();
         try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n");
         try std.testing.expectEqualStrings(
@@ -258,34 +413,160 @@ test "l7: CONNECT and Upgrade are answered 501" {
     }
 }
 
-test "l7: a valid request is closed without a response (upstream leg pending)" {
+test "l7: a GET is proxied and the origin's response relayed back" {
     var bed: Http1Bed = undefined;
-    try bed.setUp(std.testing.allocator, 6, false);
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 6,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello",
+    });
     defer bed.tearDown();
 
     try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n");
 
-    // No response yet — the upstream leg lands next slice — but the
-    // connection is torn down cleanly and accounted for.
-    try std.testing.expect(bed.client.closed);
-    try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
-    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+    // The client saw the origin's response, rewritten with Connection:
+    // close (the proxy announces the coming close), ending in a FIN.
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+        bed.client.response(),
+    );
+    // The origin received the request, rewritten with Connection: close.
+    try std.testing.expect(bed.origin.conn.request_complete);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        false,
+        &storage,
+    );
+    try std.testing.expectEqual(parser.Method.get, forwarded.method);
+    try std.testing.expectEqualStrings("/path", forwarded.target);
+    try std.testing.expect(!forwarded.keep_alive);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
-    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
+    try bed.expectDrained();
+}
+
+test "l7: a POST body is forwarded and a sized response returned, byte-exact under the adversary" {
+    var seed: u64 = 1;
+    while (seed <= 12) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("POST /submit HTTP/1.1\r\nHost: o\r\nContent-Length: 11\r\n\r\nhello world");
+
+        try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+            bed.client.response(),
+        );
+        // The origin received the whole 11-byte body after the head.
+        try std.testing.expect(bed.origin.conn.request_complete);
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try parser.parseRequestHead(
+            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            false,
+            &storage,
+        );
+        const body = bed.origin.conn.request_buffer[forwarded.head_len..bed.origin.conn.request_len];
+        try std.testing.expectEqualStrings("hello world", body);
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a body coalesced with the head, larger than a relay buffer, forwards intact" {
+    // The client sends head + a 6000-byte body in one shot: the excess
+    // (~6 KB) exceeds a 4 KiB relay buffer, so it must be forwarded
+    // straight from the 8 KiB head buffer, not copied through one.
+    const body_len = 6000;
+    var request: [7000]u8 = undefined;
+    const head = "POST /big HTTP/1.1\r\nHost: o\r\nContent-Length: 6000\r\n\r\n";
+    @memcpy(request[0..head.len], head);
+    for (request[head.len .. head.len + body_len], 0..) |*byte, index| {
+        byte.* = @intCast('A' + (index % 26));
+    }
+    const request_len = head.len + body_len;
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 40,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(request[0..request_len]);
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    // The origin received the whole 6000-byte body byte-for-byte.
+    try std.testing.expect(bed.origin.conn.request_complete);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        false,
+        &storage,
+    );
+    const forwarded_body = bed.origin.conn.request_buffer[forwarded.head_len..bed.origin.conn.request_len];
+    try std.testing.expectEqualStrings(request[head.len..request_len], forwarded_body);
+    try bed.expectDrained();
+}
+
+test "l7: a connection-close (until-close) response body relays to the client's EOF" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 20,
+        // No Content-Length and no Transfer-Encoding: the body runs to
+        // the origin's close (§6.3 until-close).
+        .origin_response = "HTTP/1.1 200 OK\r\n\r\nstreamed body bytes",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /stream HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nstreamed body bytes",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: an unreachable origin is answered 502" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 30, .origin_listens = false });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try bed.expectDrained();
 }
 
 test "l7: rejects survive 1-byte adversarial delivery across seeds" {
-    // The head arrives one byte per recv: the parse-retry loop must reach
-    // the same verdict however the request is fragmented (§7).
     var seed: u64 = 1;
     while (seed <= 15) : (seed += 1) {
         var bed: Http1Bed = undefined;
-        try bed.setUp(std.testing.allocator, seed, true);
+        try bed.setUp(std.testing.allocator, .{ .seed = seed, .partial_io = true });
         defer bed.tearDown();
 
         try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
 
+        try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
         try std.testing.expectEqualStrings(
             "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
             bed.client.response(),
@@ -297,14 +578,13 @@ test "l7: rejects survive 1-byte adversarial delivery across seeds" {
 
 test "l7: the head-read deadline reaps a slowloris that never completes" {
     var bed: Http1Bed = undefined;
-    try bed.setUp(std.testing.allocator, 7, false);
+    try bed.setUp(std.testing.allocator, .{ .seed = 7 });
     defer bed.tearDown();
 
     // A partial head with no terminator: the client sends it and then
     // goes silent, so only the head-read deadline can end the connection.
     try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\n");
 
-    try std.testing.expect(bed.client.closed);
     try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
@@ -312,15 +592,16 @@ test "l7: the head-read deadline reaps a slowloris that never completes" {
 }
 
 test "l7: the head-ingestion path allocates nothing after init" {
-    // §9 zero-alloc gate for L7: run a reject exchange (head recv, parse,
-    // static response, lingering close, teardown) under a counting
-    // allocator, then again under one that *fails* past the init count.
+    // §9 zero-alloc gate for L7: run a full proxied exchange under a
+    // counting allocator, then again under one that *fails* past the
+    // init count.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
     var bed: Http1Bed = undefined;
-    try bed.setUp(failing.allocator(), 9, true);
+    try bed.setUp(failing.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
     defer bed.tearDown();
     const allocations_after_init = failing.allocations;
-    try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+    try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nContent-Length: 3\r\n\r\nabc");
     try bed.expectDrained();
     try std.testing.expectEqual(allocations_after_init, failing.allocations);
 
@@ -328,21 +609,21 @@ test "l7: the head-ingestion path allocates nothing after init" {
         .fail_index = allocations_after_init,
     });
     var strict_bed: Http1Bed = undefined;
-    try strict_bed.setUp(strict.allocator(), 9, true);
+    try strict_bed.setUp(strict.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
     defer strict_bed.tearDown();
-    try strict_bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
+    try strict_bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nContent-Length: 3\r\n\r\nabc");
     try strict_bed.expectDrained();
 }
 
 test "l7: an http listener admits without a relay buffer" {
-    // The idle L7 connection holds a slot only (§5): even with the relay
-    // pool sized to zero-usable it still admits and rejects.
+    // The idle L7 connection holds a slot only (§5): a reject never
+    // touches the relay pool.
     var bed: Http1Bed = undefined;
-    try bed.setUp(std.testing.allocator, 8, false);
+    try bed.setUp(std.testing.allocator, .{ .seed = 8 });
     defer bed.tearDown();
 
     try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
-    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("shed_relay_buffers"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_relay_buffers"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
     try bed.expectDrained();
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -29,7 +29,17 @@ const HttpClient = struct {
     send_completion: SimIo.Completion = .{},
     recv_completion: SimIo.Completion = .{},
     socket: SimIo.Socket = undefined,
+    address: std.Io.net.IpAddress = undefined,
     request: []const u8 = undefined,
+    /// Sent on the same connection once the first response is complete —
+    /// sequential keep-alive, never pipelining.
+    second_request: ?[]const u8 = null,
+    /// A client to start when this one finishes (upstream-reuse tests
+    /// chain connections deterministically).
+    next: ?*HttpClient = null,
+    /// The last client begins the drain; a scenario that wants to watch
+    /// the idle sweep instead arms a drain timer and clears this.
+    drain_on_finish: bool = true,
     sent_len: u32 = 0,
     receive_buffer: [4096]u8 = undefined,
     received_len: u32 = 0,
@@ -40,6 +50,7 @@ const HttpClient = struct {
     fn start(client: *HttpClient, io: *SimIo, server: *ServerSim, address: std.Io.net.IpAddress) void {
         client.io = io;
         client.server = server;
+        client.address = address;
         io.connect(address, &client.connect_completion, HttpClient, client, onConnect);
     }
 
@@ -87,15 +98,48 @@ const HttpClient = struct {
         const received = result catch |err| {
             client.outcome = if (err == error.Reset) .reset else .fin;
             client.io.closeNow(client.socket);
-            // Begin the drain so the run winds down instead of idling on
-            // the armed accept — the L4 harness drains from client-end too.
-            client.server.beginDrain();
+            if (client.next) |successor| {
+                client.next = null;
+                successor.start(client.io, client.server, client.address);
+                return;
+            }
+            if (client.drain_on_finish) {
+                // Begin the drain so the run winds down instead of idling
+                // on the armed accept — the L4 harness does the same.
+                client.server.beginDrain();
+            }
             return;
         };
         assert(received >= 1);
         client.received_len += received;
         assert(client.received_len <= client.receive_buffer.len);
+        client.maybeSendSecond();
         client.armRecv();
+    }
+
+    /// Sequential keep-alive: once the first response is complete (its
+    /// content-length body fully received), send the queued second
+    /// request on the same connection.
+    fn maybeSendSecond(client: *HttpClient) void {
+        const queued = client.second_request orelse return;
+        var storage: parser.HeaderStorage = undefined;
+        const first = parser.parseResponseHead(
+            client.receive_buffer[0..client.received_len],
+            false,
+            &storage,
+            .get,
+        ) catch return; // Incomplete head: keep reading.
+        const body_len: u32 = switch (first.framing) {
+            .content_length => |length| @intCast(length),
+            else => 0,
+        };
+        if (client.received_len < first.head_len + body_len) {
+            return;
+        }
+        client.second_request = null;
+        client.request = queued;
+        client.sent_len = 0;
+        client.armSend();
     }
 
     fn response(client: *const HttpClient) []const u8 {
@@ -103,18 +147,24 @@ const HttpClient = struct {
     }
 };
 
-/// A scripted HTTP origin: reads one request (head + framed body, tracked
+/// A scripted HTTP origin: reads requests (head + framed body, tracked
 /// with zoxy's own parser so the test asserts on exactly what the proxy
-/// forwarded), sends a canned `response`, then lingering-closes. One
-/// connection per scenario is enough for the no-keep-alive exchanges.
+/// forwarded) and answers each with the canned `response`. It keeps its
+/// connection alive between requests — parked upstream connections come
+/// back to it — unless `close_after_response` scripts the origin-side
+/// close (until-close bodies, and the stale-parked scenario). One
+/// connection per scenario: a second accept trips an assert, which is
+/// itself the reuse witness.
 const HttpOrigin = struct {
     io: *SimIo = undefined,
     listener: SimIo.Listener = undefined,
     accept_completion: SimIo.Completion = .{},
     listening: bool = false,
     response: []const u8 = "",
+    close_after_response: bool = false,
     conn: OConn = .{},
     accepted: bool = false,
+    requests_served: u32 = 0,
 
     const OConn = struct {
         origin: *HttpOrigin = undefined,
@@ -123,9 +173,13 @@ const HttpOrigin = struct {
         send_completion: SimIo.Completion = .{},
         request_buffer: [16384]u8 = undefined,
         request_len: u32 = 0,
+        /// Start of the request currently being read; earlier requests
+        /// stay captured in the buffer for the tests' assertions.
+        request_offset: u32 = 0,
         request_complete: bool = false,
-        /// Total request bytes expected (head + framed body), known once
-        /// the head parses. 0 means the head has not parsed yet.
+        closed: bool = false,
+        /// Total bytes expected for the current request (head + framed
+        /// body), known once its head parses. 0 means not parsed yet.
         request_expected: u32 = 0,
         response_sent: u32 = 0,
 
@@ -143,6 +197,7 @@ const HttpOrigin = struct {
         fn onRecv(oconn: *OConn, result: Io.RecvError!u32) void {
             const received = result catch {
                 oconn.origin.io.closeNow(oconn.socket);
+                oconn.closed = true;
                 return;
             };
             oconn.request_len += received;
@@ -156,7 +211,7 @@ const HttpOrigin = struct {
             if (oconn.request_expected == 0) {
                 var storage: parser.HeaderStorage = undefined;
                 const request = parser.parseRequestHead(
-                    oconn.request_buffer[0..oconn.request_len],
+                    oconn.request_buffer[oconn.request_offset..oconn.request_len],
                     false,
                     &storage,
                 ) catch |err| {
@@ -165,6 +220,7 @@ const HttpOrigin = struct {
                         return;
                     }
                     oconn.origin.io.closeNow(oconn.socket);
+                    oconn.closed = true;
                     return;
                 };
                 const body_length: u32 = switch (request.framing) {
@@ -173,8 +229,9 @@ const HttpOrigin = struct {
                 };
                 oconn.request_expected = request.head_len + body_length;
             }
-            assert(oconn.request_len <= oconn.request_expected);
-            if (oconn.request_len < oconn.request_expected) {
+            const current_len = oconn.request_len - oconn.request_offset;
+            assert(current_len <= oconn.request_expected);
+            if (current_len < oconn.request_expected) {
                 oconn.armRecv();
                 return;
             }
@@ -197,15 +254,26 @@ const HttpOrigin = struct {
         fn onSend(oconn: *OConn, result: Io.SendError!u32) void {
             const sent = result catch {
                 oconn.origin.io.closeNow(oconn.socket);
+                oconn.closed = true;
                 return;
             };
             oconn.response_sent += sent;
             if (oconn.response_sent < oconn.origin.response.len) {
                 oconn.armSend();
-            } else {
-                // Response delivered; close (Connection: close both ways).
-                oconn.origin.io.closeNow(oconn.socket);
+                return;
             }
+            oconn.origin.requests_served += 1;
+            if (oconn.origin.close_after_response) {
+                oconn.origin.io.closeNow(oconn.socket);
+                oconn.closed = true;
+                return;
+            }
+            // Keep-alive: the next request appends after this one (the
+            // buffer keeps every request for the tests' assertions).
+            oconn.request_offset = oconn.request_len;
+            oconn.request_expected = 0;
+            oconn.response_sent = 0;
+            oconn.armRecv();
         }
     };
 
@@ -233,6 +301,16 @@ const HttpOrigin = struct {
         origin.armAccept();
     }
 
+    /// Close a still-open origin-side connection at scenario end so the
+    /// socket leak check is exact — its EOF delivery may race the loop
+    /// stop (the L4 harness does the same).
+    fn closeRemaining(origin: *HttpOrigin) void {
+        if (origin.accepted and !origin.conn.closed) {
+            origin.io.closeNow(origin.conn.socket);
+            origin.conn.closed = true;
+        }
+    }
+
     fn stopListening(origin: *HttpOrigin) void {
         if (origin.listening) {
             origin.io.listenClose(origin.listener);
@@ -253,6 +331,8 @@ const Http1Bed = struct {
     server: ServerSim,
     origin: HttpOrigin,
     client: HttpClient,
+    client2: HttpClient,
+    drain_timer_completion: SimIo.Completion,
 
     const idle_timeout_ms: u32 = 1000;
 
@@ -269,6 +349,7 @@ const Http1Bed = struct {
         partial_io: bool = false,
         origin_response: []const u8 = "",
         origin_listens: bool = true,
+        origin_closes: bool = false,
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -297,11 +378,34 @@ const Http1Bed = struct {
             .upstream_slots = 2,
         });
         try bed.server.start();
-        bed.origin = .{ .response = options.origin_response };
+        bed.origin = .{
+            .response = options.origin_response,
+            .close_after_response = options.origin_closes,
+        };
         if (options.origin_listens) {
             try bed.origin.start(&bed.sim_io, originAddress());
         }
         bed.client = .{};
+        bed.client2 = .{};
+        bed.drain_timer_completion = .{};
+    }
+
+    /// A sweep-observation scenario cannot let the client drive the drain
+    /// (the drain reaps parked upstreams instantly); this timer drains
+    /// after the idle sweep has had time to act.
+    fn armDrainTimer(bed: *Http1Bed, delay_ms: u32) void {
+        bed.sim_io.timerStart(
+            &bed.drain_timer_completion,
+            @as(u64, delay_ms) * std.time.ns_per_ms,
+            Http1Bed,
+            bed,
+            onDrainTimer,
+        );
+    }
+
+    fn onDrainTimer(bed: *Http1Bed, result: Io.TimerError!void) void {
+        result catch unreachable; // Nothing cancels the test drain timer.
+        bed.server.beginDrain();
     }
 
     fn tearDown(bed: *Http1Bed) void {
@@ -320,6 +424,7 @@ const Http1Bed = struct {
     }
 
     fn expectDrained(bed: *Http1Bed) !void {
+        bed.origin.closeRemaining();
         try std.testing.expect(bed.server.isIdle());
         try std.testing.expect(bed.server.reconcile());
         try std.testing.expect(bed.sim_io.sockets.isFullyReleased());
@@ -421,7 +526,7 @@ test "l7: a GET is proxied and the origin's response relayed back" {
     });
     defer bed.tearDown();
 
-    try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n");
+    try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\nConnection: close\r\n\r\n");
 
     // The client saw the origin's response, rewritten with Connection:
     // close (the proxy announces the coming close), ending in a FIN.
@@ -440,7 +545,10 @@ test "l7: a GET is proxied and the origin's response relayed back" {
     );
     try std.testing.expectEqual(parser.Method.get, forwarded.method);
     try std.testing.expectEqualStrings("/path", forwarded.target);
-    try std.testing.expect(!forwarded.keep_alive);
+    // The client asked to close, but that is hop-by-hop: the upstream
+    // connection stays reusable (§5) — the client's Connection header is
+    // stripped and no close is injected toward the origin.
+    try std.testing.expect(forwarded.keep_alive);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try bed.expectDrained();
@@ -457,7 +565,7 @@ test "l7: a POST body is forwarded and a sized response returned, byte-exact und
         });
         defer bed.tearDown();
 
-        try bed.exchange("POST /submit HTTP/1.1\r\nHost: o\r\nContent-Length: 11\r\n\r\nhello world");
+        try bed.exchange("POST /submit HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 11\r\n\r\nhello world");
 
         try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
         try std.testing.expectEqualStrings(
@@ -484,7 +592,7 @@ test "l7: a body coalesced with the head, larger than a relay buffer, forwards i
     // straight from the 8 KiB head buffer, not copied through one.
     const body_len = 6000;
     var request: [7000]u8 = undefined;
-    const head = "POST /big HTTP/1.1\r\nHost: o\r\nContent-Length: 6000\r\n\r\n";
+    const head = "POST /big HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 6000\r\n\r\n";
     @memcpy(request[0..head.len], head);
     for (request[head.len .. head.len + body_len], 0..) |*byte, index| {
         byte.* = @intCast('A' + (index % 26));
@@ -523,8 +631,9 @@ test "l7: a connection-close (until-close) response body relays to the client's 
     try bed.setUp(std.testing.allocator, .{
         .seed = 20,
         // No Content-Length and no Transfer-Encoding: the body runs to
-        // the origin's close (§6.3 until-close).
+        // the origin's close (§6.3 until-close), so the origin must close.
         .origin_response = "HTTP/1.1 200 OK\r\n\r\nstreamed body bytes",
+        .origin_closes = true,
     });
     defer bed.tearDown();
 
@@ -601,7 +710,7 @@ test "l7: the head-ingestion path allocates nothing after init" {
     try bed.setUp(failing.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
     defer bed.tearDown();
     const allocations_after_init = failing.allocations;
-    try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nContent-Length: 3\r\n\r\nabc");
+    try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
     try bed.expectDrained();
     try std.testing.expectEqual(allocations_after_init, failing.allocations);
 
@@ -611,7 +720,7 @@ test "l7: the head-ingestion path allocates nothing after init" {
     var strict_bed: Http1Bed = undefined;
     try strict_bed.setUp(strict.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
     defer strict_bed.tearDown();
-    try strict_bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nContent-Length: 3\r\n\r\nabc");
+    try strict_bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
     try strict_bed.expectDrained();
 }
 
@@ -625,5 +734,132 @@ test "l7: an http listener admits without a relay buffer" {
     try bed.exchange("GET / HTTP/1.1\nHost: a\r\n\r\n");
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_relay_buffers"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+    try bed.expectDrained();
+}
+
+test "l7: downstream keep-alive serves two requests on one connection" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 50,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // First request asks to keep the connection; the second announces the
+    // close, ending the scenario cleanly.
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    // One client connection, two responses: the first without a close
+    // announcement, the second with one, then FIN.
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_responses"));
+    // The idle turnaround also parked and reused the upstream connection.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a parked upstream connection is reused across client connections" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 51,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // Two separate client connections, each closing downstream — the
+    // upstream connection parks after the first and serves the second
+    // (the origin accepting only once is asserted in its harness).
+    bed.client.next = &bed.client2;
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client2.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("admitted"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("completed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: the idle sweep reaps a parked upstream past its deadline" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 52,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // The client must not drain (that reaps parked instantly); a timer
+    // drains well after the sweep has had time to act on the idle
+    // deadline.
+    bed.client.drain_on_finish = false;
+    bed.armDrainTimer(Http1Bed.idle_timeout_ms * 3);
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_idle_reaped"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_reused"));
+    try bed.expectDrained();
+}
+
+test "l7: a pipelining client gets its first response, then the close" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 53,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // Both requests in one write: the second is pipelined. Pipelining is
+    // unsupported — the first exchange completes and the connection
+    // closes; the client recovers by retrying per RFC.
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n" ++
+        "GET /two HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "l7: a stale parked connection is answered 502 until Phase 2's replay" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 54,
+        // The origin's response claims keep-alive, but it closes right
+        // after — the §5 stale-parked scenario, detected on first use.
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_closes = true,
+    });
+    defer bed.tearDown();
+
+    bed.client.next = &bed.client2;
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client2.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
     try bed.expectDrained();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,9 +76,11 @@ fn ensureFdBudget() !void {
 
 fn printBudgets(io: std.Io, config: *const zoxy.config.Config) !void {
     const constants = zoxy.constants;
+    const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
     const memory_total = constants.memoryBytesTotal(
         @sizeOf(ServerXev.ConnType),
         @sizeOf(zoxy.RelayBuffer),
+        @sizeOf(UpstreamType),
     );
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
@@ -86,6 +88,7 @@ fn printBudgets(io: std.Io, config: *const zoxy.config.Config) !void {
     try writer.print(
         \\zoxy budgets (closed-form, DESIGN.md §5/§8):
         \\  memory  pools {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
+        \\          + upstream slots {d} x {d} B
         \\  fds     {d} worst case (asserted against RLIMIT_NOFILE)
         \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
         \\  config  {d} listener(s), {d} cluster(s)
@@ -96,6 +99,8 @@ fn printBudgets(io: std.Io, config: *const zoxy.config.Config) !void {
         @sizeOf(ServerXev.ConnType),
         constants.relay_buffers_max,
         @sizeOf(zoxy.RelayBuffer),
+        constants.upstream_slots_max,
+        @sizeOf(UpstreamType),
         constants.fds_max,
         constants.ring_entries,
         constants.completion_queue_entries,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -174,6 +174,22 @@ pub fn Conn(comptime IoType: type) type {
             /// True once any response byte reached the client — the §8
             /// verdict split between answering 502 and plain teardown.
             response_started: bool = false,
+            /// The client's persistence ask (RFC 9112 §9), captured at
+            /// routing; the render-time decision may still announce close
+            /// (pressure, drain, §8).
+            client_keep_alive: bool = false,
+            /// What the rendered response told the client. The connection
+            /// honors its own announcement: a keep-alive answer keeps
+            /// serving, an announced close closes (§2).
+            downstream_close_announced: bool = true,
+            /// The origin's persistence verdict from its response head;
+            /// parking requires it (§5).
+            upstream_reusable: bool = false,
+            /// The client sent bytes past the request's framing — a
+            /// pipelined next request. Pipelining is unsupported: the
+            /// exchange completes and the connection closes, dropping the
+            /// early bytes (§2 note; clients recover per RFC).
+            client_pipelined: bool = false,
 
             pub const Leg = enum(u8) {
                 idle,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -9,12 +9,15 @@
 const std = @import("std");
 
 const constants = @import("../constants.zig");
+const parser = @import("../http/parser.zig");
 const relay = @import("relay.zig");
+const upstream_module = @import("upstream.zig");
 
 const assert = std.debug.assert;
 
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
+    const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
 
     return struct {
         pool_next: u32,
@@ -57,6 +60,15 @@ pub fn Conn(comptime IoType: type) type {
         /// memory, shrunk from the front as bytes are sent. Empty
         /// otherwise; idle on the L4 path.
         response_pending: []const u8,
+        /// The listener's cluster; the L7 path routes and dials after the
+        /// head parses, long after admission (§7).
+        cluster_index: u16,
+        /// The leased upstream slot during an L7 exchange; released at
+        /// teardown alongside the conn slot (§5). Null outside exchanges
+        /// and on the whole L4 path.
+        upstream: ?*UpstreamType,
+        /// L7 exchange bookkeeping (§7); reset per exchange.
+        l7: L7State,
 
         op_data_client_to_upstream: Op,
         op_data_upstream_to_client: Op,
@@ -73,14 +85,17 @@ pub fn Conn(comptime IoType: type) type {
             // L4 relay states.
             connecting,
             relaying,
-            // L7 states (§7). More join as the request path fills in;
-            // `l7_reading_head` accumulates and re-parses the request head
-            // (§7 detect-and-retry), `l7_responding` writes a static
-            // error response (§8), and `l7_draining_request` half-closes
-            // the write side after a response and drains the client's
-            // remaining input so the close does not RST away that response
-            // (§2 lingering close).
+            // L7 states (§7): `l7_reading_head` accumulates and re-parses
+            // the request head (detect-and-retry); `l7_dialing` awaits the
+            // upstream connect; `l7_exchanging` runs the two legs (request
+            // out, response back — each with its own sub-state in `l7`);
+            // `l7_responding` writes a static error response (§8); and
+            // `l7_draining_request` half-closes the write side after a
+            // response and drains the client's remaining input so the
+            // close does not RST away that response (§2 lingering close).
             l7_reading_head,
+            l7_dialing,
+            l7_exchanging,
             l7_responding,
             l7_draining_request,
             /// Teardown begun: sockets shut down, pending ops draining,
@@ -100,10 +115,78 @@ pub fn Conn(comptime IoType: type) type {
         /// True in any pre-teardown serving state — the states from which
         /// `beginTeardown` is a legal transition.
         pub fn isLive(conn: *const Self) bool {
-            return conn.state == .connecting or conn.state == .relaying or
-                conn.state == .l7_reading_head or conn.state == .l7_responding or
-                conn.state == .l7_draining_request;
+            return switch (conn.state) {
+                .connecting,
+                .relaying,
+                .l7_reading_head,
+                .l7_dialing,
+                .l7_exchanging,
+                .l7_responding,
+                .l7_draining_request,
+                => true,
+                .tearing_down, .closing => false,
+            };
         }
+
+        /// How a message body is delimited and how much of it remains —
+        /// the §7 framing verdicts turned into countdown state the pumps
+        /// consume chunk by chunk.
+        pub const Framing = union(enum) {
+            none,
+            /// Body bytes still to relay.
+            content_length: u64,
+            /// The scanner owns the end-of-message detection.
+            chunked: parser.ChunkedScanner,
+            /// Responses only: the body runs to the origin's EOF.
+            until_close,
+        };
+
+        /// Per-leg progress of an L7 exchange (§7). The request leg sends
+        /// the rendered head, then pumps the framed body client → origin;
+        /// the response leg starts as soon as the request head is on the
+        /// wire (early responses are legal, §7) and mirrors it back.
+        pub const L7State = struct {
+            request_leg: Leg = .idle,
+            response_leg: Leg = .idle,
+            request_method: parser.Method = .get,
+            request_framing: Framing = .none,
+            response_framing: Framing = .none,
+            /// Bytes of `head` consumed by the request head; body excess
+            /// received with it sits at [request_head_len..head_len].
+            request_head_len: u32 = 0,
+            /// Bytes of `upstream.head` consumed by the response head;
+            /// body excess received with it sits at [marker..head_len].
+            response_head_len_marker: u32 = 0,
+            /// Length of the rendered head being sent (request leg: into
+            /// upstream.head; response leg: into conn.head).
+            rendered_request_len: u32 = 0,
+            rendered_response_len: u32 = 0,
+            /// Send cursors over the rendered heads (short sends resume).
+            request_head_sent: u32 = 0,
+            response_head_sent: u32 = 0,
+            /// True once the request head has been forwarded off conn.head
+            /// (head sent and any coalesced body excess drained), so the
+            /// response head may render into conn.head (§7 buffer rotation).
+            request_head_vacated: bool = false,
+            /// The origin's head parsed while conn.head was still occupied;
+            /// render it once `request_head_vacated`.
+            response_render_pending: bool = false,
+            /// True once any response byte reached the client — the §8
+            /// verdict split between answering 502 and plain teardown.
+            response_started: bool = false,
+
+            pub const Leg = enum(u8) {
+                idle,
+                sending_head,
+                awaiting_head,
+                /// Forwarding body bytes that arrived coalesced with the
+                /// head, sent straight from the head buffer (§7) so a body
+                /// larger than a relay buffer is never copied through one.
+                sending_body_excess,
+                pumping_body,
+                done,
+            };
+        };
 
         pub const Direction = enum(u1) {
             client_to_upstream,
@@ -151,6 +234,7 @@ pub fn Conn(comptime IoType: type) type {
             client_socket: IoType.Socket,
             buffer: ?*relay.RelayBuffer,
             state: State,
+            cluster_index: u16,
         ) void {
             assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;
@@ -164,6 +248,9 @@ pub fn Conn(comptime IoType: type) type {
             conn.directions = .{ .{}, .{} };
             conn.head_len = 0;
             conn.response_pending = &.{};
+            conn.cluster_index = cluster_index;
+            conn.upstream = null;
+            conn.l7 = .{};
             conn.op_data_client_to_upstream = .{};
             conn.op_data_upstream_to_client = .{};
             conn.op_connect = .{};
@@ -176,6 +263,8 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.armedCount() == 0);
             assert(conn.head_len == 0);
             assert(conn.response_pending.len == 0);
+            assert(conn.upstream == null);
+            assert(conn.l7.request_leg == .idle);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -8,6 +8,7 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
 const relay = @import("relay.zig");
 
 const assert = std.debug.assert;
@@ -35,6 +36,18 @@ pub fn Conn(comptime IoType: type) type {
         birth_ns: u64,
         armed: Armed,
         directions: [2]DirectionState,
+        /// L7 request/response head bytes accumulate here across recv
+        /// retries (§5, §7); idle on L4 connections, which relay through
+        /// the relay buffer only. Parsing is detect-and-retry from byte 0
+        /// (§7), so these bytes stay the single source of truth: nothing
+        /// parsed is stored across callbacks, and a re-parse after an
+        /// await costs one bounded scan instead of 2 KiB of per-slot
+        /// header storage. Deliberately not zeroed at admission — bytes
+        /// past `head_len` are never read.
+        head: [constants.head_bytes_max]u8,
+        /// Bytes of `head` filled so far; the head's end is found by
+        /// parsing, the body (or a pipelined next head) follows it.
+        head_len: u32,
 
         op_data_client_to_upstream: Op,
         op_data_upstream_to_client: Op,
@@ -116,6 +129,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.birth_ns = server.io.nowNs();
             conn.armed = .{};
             conn.directions = .{ .{}, .{} };
+            conn.head_len = 0;
             conn.op_data_client_to_upstream = .{};
             conn.op_data_upstream_to_client = .{};
             conn.op_connect = .{};
@@ -126,6 +140,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.op_deadline_cancel = .{};
             assert(conn.state == .connecting);
             assert(conn.armedCount() == 0);
+            assert(conn.head_len == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -26,7 +26,11 @@ pub fn Conn(comptime IoType: type) type {
         /// its presence one field means an unset upstream can never be
         /// read as a live fd handle.
         upstream_socket: ?IoType.Socket,
-        relay_buffer: *relay.RelayBuffer,
+        /// Held for the L4 connection's life; on the L7 path it is null
+        /// until a body relay starts and again once the connection goes
+        /// idle on keep-alive — an idle L7 connection costs a slot and
+        /// head buffer only (§5).
+        relay_buffer: ?*relay.RelayBuffer,
         /// Absolute deadline; state transitions only store a new value —
         /// the armed timer op is never touched (§4).
         deadline_ns: u64,
@@ -48,6 +52,11 @@ pub fn Conn(comptime IoType: type) type {
         /// Bytes of `head` filled so far; the head's end is found by
         /// parsing, the body (or a pipelined next head) follows it.
         head_len: u32,
+        /// The static error response still to be written to the client
+        /// while in `.l7_responding` (§8): a slice into comptime static
+        /// memory, shrunk from the front as bytes are sent. Empty
+        /// otherwise; idle on the L4 path.
+        response_pending: []const u8,
 
         op_data_client_to_upstream: Op,
         op_data_upstream_to_client: Op,
@@ -61,8 +70,19 @@ pub fn Conn(comptime IoType: type) type {
         const Self = @This();
 
         pub const State = enum(u8) {
+            // L4 relay states.
             connecting,
             relaying,
+            // L7 states (§7). More join as the request path fills in;
+            // `l7_reading_head` accumulates and re-parses the request head
+            // (§7 detect-and-retry), `l7_responding` writes a static
+            // error response (§8), and `l7_draining_request` half-closes
+            // the write side after a response and drains the client's
+            // remaining input so the close does not RST away that response
+            // (§2 lingering close).
+            l7_reading_head,
+            l7_responding,
+            l7_draining_request,
             /// Teardown begun: sockets shut down, pending ops draining,
             /// closes not yet submitted.
             tearing_down,
@@ -75,6 +95,14 @@ pub fn Conn(comptime IoType: type) type {
         /// True once teardown has begun, in either teardown phase.
         pub fn isTearingDown(conn: *const Self) bool {
             return conn.state == .tearing_down or conn.state == .closing;
+        }
+
+        /// True in any pre-teardown serving state — the states from which
+        /// `beginTeardown` is a legal transition.
+        pub fn isLive(conn: *const Self) bool {
+            return conn.state == .connecting or conn.state == .relaying or
+                conn.state == .l7_reading_head or conn.state == .l7_responding or
+                conn.state == .l7_draining_request;
         }
 
         pub const Direction = enum(u1) {
@@ -113,15 +141,20 @@ pub fn Conn(comptime IoType: type) type {
         };
 
         /// Admission-time reset. `pool_next` and `generation` are owned
-        /// by the pool and deliberately untouched.
+        /// by the pool and deliberately untouched. `buffer` is the L4
+        /// relay buffer, or null on the L7 path (§5); `state` is the
+        /// protocol's entry state (`.connecting` for L4, `.l7_reading_head`
+        /// for L7).
         pub fn prepare(
             conn: *Self,
             server: *ServerType,
             client_socket: IoType.Socket,
-            buffer: *relay.RelayBuffer,
+            buffer: ?*relay.RelayBuffer,
+            state: State,
         ) void {
+            assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;
-            conn.state = .connecting;
+            conn.state = state;
             conn.client_socket = client_socket;
             conn.upstream_socket = null;
             conn.relay_buffer = buffer;
@@ -130,6 +163,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.armed = .{};
             conn.directions = .{ .{}, .{} };
             conn.head_len = 0;
+            conn.response_pending = &.{};
             conn.op_data_client_to_upstream = .{};
             conn.op_data_upstream_to_client = .{};
             conn.op_connect = .{};
@@ -138,9 +172,10 @@ pub fn Conn(comptime IoType: type) type {
             conn.op_close_upstream = .{};
             conn.op_deadline = .{};
             conn.op_deadline_cancel = .{};
-            assert(conn.state == .connecting);
+            assert(conn.state == state);
             assert(conn.armedCount() == 0);
             assert(conn.head_len == 0);
+            assert(conn.response_pending.len == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -106,7 +106,7 @@ pub fn Relay(comptime IoType: type) type {
                     maybeFinish(server, conn);
                     return;
                 }
-                witnessKernelPressure(server, err);
+                server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -132,7 +132,7 @@ pub fn Relay(comptime IoType: type) type {
             const state = directionState(conn, direction);
             assert(state.phase == .sending);
             const sent = result catch |err| {
-                witnessKernelPressure(server, err);
+                server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -146,20 +146,6 @@ pub fn Relay(comptime IoType: type) type {
                 // deadline out (§6); the armed timer op is not touched.
                 server.storeDeadline(conn, server.idleTimeoutMs());
                 armRecv(server, conn, direction);
-            }
-        }
-
-        /// §8 kernel-pressure rung on the data path. On an established
-        /// relay socket the orderly failures are EndOfStream (peeled off by
-        /// the caller) and Reset — a normal RST. Anything else is a
-        /// non-orderly op failure, which on a live socket is resource
-        /// exhaustion (ENOBUFS/ENOMEM), so witness it before the teardown,
-        /// matching how the accept/connect/setNodelay sites count kernel
-        /// pressure. The teardown itself is unchanged. (`Canceled` never
-        /// reaches the relay: data ops are never canceled, §5.)
-        fn witnessKernelPressure(server: *ServerType, err: anyerror) void {
-            if (err == error.Unexpected) {
-                server.counters.increment("kernel_pressure_errors");
             }
         }
 
@@ -193,7 +179,9 @@ pub fn Relay(comptime IoType: type) type {
         }
 
         fn buffer(conn: *ConnType, comptime direction: Direction) []u8 {
-            return &@field(conn.relay_buffer, @tagName(direction));
+            // The L4 relay always holds its buffer for the connection's
+            // life (§6); it is only ever null on an idle L7 connection.
+            return &@field(conn.relay_buffer.?, @tagName(direction));
         }
 
         fn opposite(comptime direction: Direction) Direction {

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -1,0 +1,323 @@
+//! The shared upstream connection pool with per-endpoint idle lists
+//! (DESIGN.md §3, §5): one pool for the whole process, owned and touched
+//! only by the loop thread — every request sees every parked connection
+//! (the Pingora reuse win) with zero synchronization. A slot is
+//! pool-acquired for its whole connected life: leased while serving a
+//! request, parked on an idle list between requests (it still holds an
+//! fd), released only at teardown. A parked upstream holds no armed data
+//! op (§5); its deadline timer — embedded when the L7 state machine
+//! lands — is the idle timeout, and an origin close that slips through
+//! is detected at checkout. Exhaustion is a shed signal (§8), never
+//! growth. Idle lists are doubly linked so a deadline-fired teardown
+//! unparks from the middle of a list in O(1).
+
+const std = @import("std");
+
+const constants = @import("../constants.zig");
+const Pool = @import("../mem/Pool.zig").Pool;
+
+const assert = std.debug.assert;
+
+/// `idle_next`/`idle_prev`/`idle_heads` value marking "no slot".
+const idle_none: u32 = std.math.maxInt(u32);
+
+/// Idle lists are indexed by the flattened endpoint key, so the head
+/// array covers the worst-case config shape.
+const endpoint_keys_max: u32 =
+    @as(u32, constants.clusters_max) * constants.endpoints_per_cluster_max;
+
+pub fn UpstreamPool(comptime IoType: type) type {
+    return struct {
+        slot_pool: Pool(Upstream),
+        idle_heads: [endpoint_keys_max]u32,
+        /// Parked slots across all endpoints; leased = acquired − idle.
+        idle_count: u32,
+
+        const Self = @This();
+
+        /// One upstream connection slot (§5 pool 3): identity, socket,
+        /// idle links, and the head buffer response heads are parsed
+        /// into and rendered upstream heads are staged in. Embedded
+        /// completions and the deadline timer join with the L7 state
+        /// machine, one field per proven race (the Conn precedent).
+        pub const Upstream = struct {
+            pool_next: u32,
+            generation: u32,
+            /// Undefined until the owner dials; a slot is only parked
+            /// after its connection is established.
+            socket: IoType.Socket,
+            cluster_index: u16,
+            endpoint_index: u16,
+            parked: bool,
+            idle_next: u32,
+            idle_prev: u32,
+            head: [constants.head_bytes_max]u8,
+        };
+
+        /// In-place init via out-pointer for pointer stability. `arena`
+        /// is the config arena — the pool's only allocation, ever (§5).
+        pub fn init(
+            pool: *Self,
+            arena: std.mem.Allocator,
+            count: u32,
+        ) error{OutOfMemory}!void {
+            assert(count >= 1);
+            try pool.slot_pool.init(arena, count);
+            @memset(&pool.idle_heads, idle_none);
+            pool.idle_count = 0;
+            assert(pool.slot_pool.slots.len == count);
+            assert(pool.leasedCount() == 0);
+        }
+
+        /// A fresh slot for a new dial to the endpoint, or null when the
+        /// pool is exhausted — the caller sheds (§8: 503). The socket is
+        /// left undefined for the dialer to fill in.
+        pub fn acquire(pool: *Self, cluster_index: u16, endpoint_index: u16) ?*Upstream {
+            assert(cluster_index < constants.clusters_max);
+            assert(endpoint_index < constants.endpoints_per_cluster_max);
+            const upstream = pool.slot_pool.acquire() orelse return null;
+            upstream.cluster_index = cluster_index;
+            upstream.endpoint_index = endpoint_index;
+            upstream.parked = false;
+            upstream.idle_next = idle_none;
+            upstream.idle_prev = idle_none;
+            assert(pool.idle_count < pool.slot_pool.acquired_count);
+            return upstream;
+        }
+
+        /// Parks a leased connection on its endpoint's idle list for
+        /// reuse (LIFO: the most recently used connection is the most
+        /// likely to still be open and cache-warm).
+        pub fn park(pool: *Self, upstream: *Upstream) void {
+            assert(!upstream.parked);
+            assert(upstream.idle_next == idle_none);
+            assert(upstream.idle_prev == idle_none);
+            const index = pool.slot_pool.indexOf(upstream);
+            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+
+            upstream.idle_next = pool.idle_heads[key];
+            if (upstream.idle_next != idle_none) {
+                pool.slot_pool.slots[upstream.idle_next].idle_prev = index;
+            }
+            pool.idle_heads[key] = index;
+            upstream.parked = true;
+            pool.idle_count += 1;
+            assert(pool.idle_count <= pool.slot_pool.acquired_count);
+        }
+
+        /// The most recently parked connection for the endpoint, leased
+        /// again — or null, and the caller dials fresh via `acquire`.
+        pub fn checkout(pool: *Self, cluster_index: u16, endpoint_index: u16) ?*Upstream {
+            assert(cluster_index < constants.clusters_max);
+            assert(endpoint_index < constants.endpoints_per_cluster_max);
+            const key = endpointKey(cluster_index, endpoint_index);
+            const head = pool.idle_heads[key];
+            if (head == idle_none) {
+                return null;
+            }
+
+            const upstream = &pool.slot_pool.slots[head];
+            assert(upstream.cluster_index == cluster_index);
+            assert(upstream.endpoint_index == endpoint_index);
+            pool.unpark(upstream);
+            return upstream;
+        }
+
+        /// Removes a parked connection from anywhere in its idle list —
+        /// the head via `checkout`, the middle when its idle deadline
+        /// fires and the connection is torn down.
+        pub fn unpark(pool: *Self, upstream: *Upstream) void {
+            assert(upstream.parked);
+            assert(pool.idle_count >= 1);
+            const index = pool.slot_pool.indexOf(upstream);
+            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+
+            if (upstream.idle_prev == idle_none) {
+                assert(pool.idle_heads[key] == index);
+                pool.idle_heads[key] = upstream.idle_next;
+            } else {
+                pool.slot_pool.slots[upstream.idle_prev].idle_next = upstream.idle_next;
+            }
+            if (upstream.idle_next != idle_none) {
+                pool.slot_pool.slots[upstream.idle_next].idle_prev = upstream.idle_prev;
+            }
+            upstream.idle_next = idle_none;
+            upstream.idle_prev = idle_none;
+            upstream.parked = false;
+            pool.idle_count -= 1;
+        }
+
+        /// Returns a leased slot to the free list at connection
+        /// teardown. A parked slot must be unparked first — releasing it
+        /// directly would leave a dangling idle-list entry.
+        pub fn release(pool: *Self, upstream: *Upstream) void {
+            assert(!upstream.parked);
+            assert(upstream.idle_next == idle_none);
+            assert(upstream.idle_prev == idle_none);
+            pool.slot_pool.release(upstream);
+            assert(pool.idle_count <= pool.slot_pool.acquired_count);
+        }
+
+        /// Slots currently serving a request (acquired but not parked).
+        pub fn leasedCount(pool: *const Self) u32 {
+            assert(pool.idle_count <= pool.slot_pool.acquired_count);
+            return pool.slot_pool.acquired_count - pool.idle_count;
+        }
+
+        /// The simulator's leak invariant (§9): every scenario drains
+        /// every pool to zero.
+        pub fn isFullyReleased(pool: *const Self) bool {
+            assert(pool.idle_count <= pool.slot_pool.acquired_count);
+            return pool.slot_pool.isFullyReleased();
+        }
+    };
+}
+
+fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
+    assert(cluster_index < constants.clusters_max);
+    assert(endpoint_index < constants.endpoints_per_cluster_max);
+    return @as(u32, cluster_index) * constants.endpoints_per_cluster_max + endpoint_index;
+}
+
+// Tests drive the pool through a socket-free fake Io: the pool never
+// touches the socket, it only stores it for the owner.
+
+const TestIo = struct {
+    pub const Socket = u32;
+};
+
+const TestPool = UpstreamPool(TestIo);
+
+test "upstream: dial-park-checkout-release keeps the same connection" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 4);
+
+    const dialed = pool.acquire(0, 0).?;
+    dialed.socket = 77;
+    try std.testing.expectEqual(@as(u32, 1), pool.leasedCount());
+
+    pool.park(dialed);
+    try std.testing.expectEqual(@as(u32, 1), pool.idle_count);
+    try std.testing.expectEqual(@as(u32, 0), pool.leasedCount());
+
+    // Checkout returns the same live connection — same slot, same
+    // socket, same generation (only release recycles a slot).
+    const generation_at_park = dialed.generation;
+    const reused = pool.checkout(0, 0).?;
+    try std.testing.expectEqual(dialed, reused);
+    try std.testing.expectEqual(@as(TestIo.Socket, 77), reused.socket);
+    try std.testing.expectEqual(generation_at_park, reused.generation);
+
+    pool.release(reused);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: checkout is LIFO per endpoint" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 4);
+
+    const first = pool.acquire(0, 0).?;
+    const second = pool.acquire(0, 0).?;
+    pool.park(first);
+    pool.park(second);
+
+    try std.testing.expectEqual(second, pool.checkout(0, 0).?);
+    try std.testing.expectEqual(first, pool.checkout(0, 0).?);
+    try std.testing.expectEqual(@as(?*TestPool.Upstream, null), pool.checkout(0, 0));
+
+    pool.release(first);
+    pool.release(second);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: endpoints do not share idle connections" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 4);
+
+    const parked = pool.acquire(1, 2).?;
+    pool.park(parked);
+
+    // Neither a sibling endpoint nor another cluster may steal it.
+    try std.testing.expectEqual(@as(?*TestPool.Upstream, null), pool.checkout(1, 3));
+    try std.testing.expectEqual(@as(?*TestPool.Upstream, null), pool.checkout(2, 2));
+    try std.testing.expectEqual(parked, pool.checkout(1, 2).?);
+
+    pool.release(parked);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: unpark removes from the middle of an idle list" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 4);
+
+    const first = pool.acquire(0, 0).?;
+    const second = pool.acquire(0, 0).?;
+    const third = pool.acquire(0, 0).?;
+    pool.park(first);
+    pool.park(second);
+    pool.park(third);
+
+    // An idle deadline fires on the middle entry: it leaves its list and
+    // the LIFO order of the rest is undisturbed.
+    pool.unpark(second);
+    pool.release(second);
+    try std.testing.expectEqual(@as(u32, 2), pool.idle_count);
+
+    try std.testing.expectEqual(third, pool.checkout(0, 0).?);
+    try std.testing.expectEqual(first, pool.checkout(0, 0).?);
+    try std.testing.expectEqual(@as(?*TestPool.Upstream, null), pool.checkout(0, 0));
+
+    pool.release(first);
+    pool.release(third);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: exhaustion is a shed signal, parked slots stay counted" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 2);
+
+    const first = pool.acquire(0, 0).?;
+    const second = pool.acquire(0, 1).?;
+    // A parked connection still owns its slot: the pool is exhausted
+    // even though nothing is leased for it.
+    pool.park(first);
+    pool.park(second);
+    try std.testing.expectEqual(@as(?*TestPool.Upstream, null), pool.acquire(0, 2));
+    try std.testing.expectEqual(@as(u32, 0), pool.leasedCount());
+
+    pool.unpark(first);
+    pool.release(first);
+    try std.testing.expectEqual(second, pool.checkout(0, 1).?);
+    pool.release(second);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: zero allocations after init" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var arena_state = std.heap.ArenaAllocator.init(failing.allocator());
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 8);
+    const allocations_after_init = failing.allocations;
+
+    var cycle: u32 = 0;
+    while (cycle < 100_000) : (cycle += 1) {
+        const upstream = pool.acquire(3, 7) orelse unreachable;
+        pool.park(upstream);
+        const reused = pool.checkout(3, 7) orelse unreachable;
+        assert(reused == upstream);
+        pool.release(reused);
+    }
+    try std.testing.expectEqual(allocations_after_init, failing.allocations);
+    try std.testing.expect(pool.isFullyReleased());
+}

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -56,6 +56,11 @@ pub fn UpstreamPool(comptime IoType: type) type {
             /// head; the rendered upstream request head tracks its own
             /// length in the owning connection instead.
             head_len: u32,
+            /// Absolute idle deadline while parked (§5): a parked
+            /// connection holds no armed op, so the Server's single sweep
+            /// timer compares this against the clock and reaps overdue
+            /// connections with a synchronous close.
+            deadline_ns: u64,
         };
 
         /// In-place init via out-pointer for pointer stability. `arena`
@@ -86,6 +91,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.idle_next = idle_none;
             upstream.idle_prev = idle_none;
             upstream.head_len = 0;
+            upstream.deadline_ns = 0;
             assert(pool.idle_count < pool.slot_pool.acquired_count);
             return upstream;
         }

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -52,6 +52,10 @@ pub fn UpstreamPool(comptime IoType: type) type {
             idle_next: u32,
             idle_prev: u32,
             head: [constants.head_bytes_max]u8,
+            /// Valid prefix of `head` while it accumulates a response
+            /// head; the rendered upstream request head tracks its own
+            /// length in the owning connection instead.
+            head_len: u32,
         };
 
         /// In-place init via out-pointer for pointer stability. `arena`
@@ -81,6 +85,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.parked = false;
             upstream.idle_next = idle_none;
             upstream.idle_prev = idle_none;
+            upstream.head_len = 0;
             assert(pool.idle_count < pool.slot_pool.acquired_count);
             return upstream;
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -19,6 +19,7 @@ pub const http = struct {
 pub const Io = @import("io/io.zig");
 pub const Pool = @import("mem/Pool.zig").Pool;
 pub const RelayBuffer = @import("net/relay.zig").RelayBuffer;
+pub const UpstreamPool = @import("net/upstream.zig").UpstreamPool;
 pub const Server = @import("Server.zig").Server;
 pub const shed = @import("shed.zig");
 /// Shared test-support harness pieces (used by server_test and the sim).

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,11 +9,12 @@ pub const config = @import("config.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
 /// L7 HTTP/1.1 modules (§7). `parser` wraps the vendored hparse behind
-/// the trust boundary, `render` writes upstream/downstream heads; the
-/// proxy state machine joins them in a later slice.
+/// the trust boundary, `render` writes upstream/downstream heads, and
+/// `proxy` is the request-lifecycle state machine over both.
 pub const http = struct {
     pub const parser = @import("http/parser.zig");
     pub const render = @import("http/render.zig");
+    pub const proxy = @import("http/proxy.zig");
 };
 pub const Io = @import("io/io.zig");
 pub const Pool = @import("mem/Pool.zig").Pool;
@@ -33,6 +34,7 @@ test {
     _ = counters;
     _ = http.parser;
     _ = http.render;
+    _ = http.proxy;
     _ = Io;
     _ = Server;
     _ = shed;
@@ -45,5 +47,6 @@ test {
     _ = @import("io/sim_io_test.zig");
     _ = @import("io/xev_smoke_test.zig");
     _ = @import("server_test.zig");
+    _ = @import("http_proxy_test.zig");
     _ = @import("zero_alloc_test.zig");
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -39,6 +39,7 @@ test {
     _ = @import("mem/Pool.zig");
     _ = @import("net/Conn.zig");
     _ = @import("net/relay.zig");
+    _ = @import("net/upstream.zig");
     _ = @import("testing/origin.zig");
     _ = @import("io/contract_test.zig");
     _ = @import("io/sim_io_test.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -8,6 +8,11 @@ pub const balancer = @import("balancer.zig");
 pub const config = @import("config.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
+/// L7 HTTP/1.1 modules (§7). `parser` wraps the vendored hparse behind
+/// the trust boundary; the proxy state machine joins it in a later slice.
+pub const http = struct {
+    pub const parser = @import("http/parser.zig");
+};
 pub const Io = @import("io/io.zig");
 pub const Pool = @import("mem/Pool.zig").Pool;
 pub const RelayBuffer = @import("net/relay.zig").RelayBuffer;
@@ -24,6 +29,7 @@ test {
     _ = config;
     _ = constants;
     _ = counters;
+    _ = http.parser;
     _ = Io;
     _ = Server;
     _ = shed;

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,9 +9,11 @@ pub const config = @import("config.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
 /// L7 HTTP/1.1 modules (§7). `parser` wraps the vendored hparse behind
-/// the trust boundary; the proxy state machine joins it in a later slice.
+/// the trust boundary, `render` writes upstream/downstream heads; the
+/// proxy state machine joins them in a later slice.
 pub const http = struct {
     pub const parser = @import("http/parser.zig");
+    pub const render = @import("http/render.zig");
 };
 pub const Io = @import("io/io.zig");
 pub const Pool = @import("mem/Pool.zig").Pool;
@@ -30,6 +32,7 @@ test {
     _ = constants;
     _ = counters;
     _ = http.parser;
+    _ = http.render;
     _ = Io;
     _ = Server;
     _ = shed;

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -218,7 +218,7 @@ pub const TestBed = struct {
         try bed.sim_io.init(arena, options.sim);
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
-        bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0 }};
+        bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 }};
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -1,11 +1,59 @@
-//! The exhaustion ladder's shed actions (DESIGN.md §8). Un-admitted
-//! sheds are synchronous: the socket has no slot, so there is no
-//! completion to embed and no ring op to spend — shedding costs at most
-//! two direct syscalls and the accept stays armed.
+//! The exhaustion ladder's shed actions and static responses (DESIGN.md
+//! §8). Un-admitted sheds are synchronous: the socket has no slot, so
+//! there is no completion to embed and no ring op to spend — shedding
+//! costs at most two direct syscalls and the accept stays armed. Admitted
+//! L7 sheds answer with a comptime-rendered response from static memory.
 
 const std = @import("std");
 
 const assert = std.debug.assert;
+
+/// Whether the downstream connection survives a static response. `close`
+/// announces it in the response (§2: clients that pipeline into an
+/// unannounced close read errors); `keep` leaves the connection serving.
+pub const Persistence = enum {
+    keep,
+    close,
+};
+
+/// A comptime-rendered static error response (§8): sent directly from
+/// static memory, never staged through the connection's head buffer —
+/// whose bytes the parsed head's zero-copy slices may still reference.
+/// Shedding costs one send, no allocation, no copy. The status set is
+/// closed in `reasonPhrase`: an unlisted status is a compile error.
+pub fn staticResponse(comptime status: u16, comptime persistence: Persistence) []const u8 {
+    comptime assert(status >= 400);
+    comptime assert(status <= 599);
+    const bytes = comptime std.fmt.comptimePrint(
+        "HTTP/1.1 {d} {s}\r\nContent-Length: 0\r\n{s}\r\n",
+        .{
+            status,
+            reasonPhrase(status),
+            switch (persistence) {
+                .keep => "",
+                .close => "Connection: close\r\n",
+            },
+        },
+    );
+    return bytes;
+}
+
+/// Reason phrases for the closed set of statuses the ladder (§8) and the
+/// L7 state machine (§7) send.
+fn reasonPhrase(comptime status: u16) []const u8 {
+    comptime assert(status >= 400);
+    comptime assert(status <= 599);
+    return switch (status) {
+        400 => "Bad Request",
+        414 => "URI Too Long",
+        431 => "Request Header Fields Too Large",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        else => @compileError("unlisted static-response status"),
+    };
+}
 
 /// Conn-slots-exhausted rung: close immediately with SO_LINGER-0 so the
 /// client gets an RST — an immediate signal instead of a timeout, and
@@ -20,4 +68,36 @@ pub fn closeWithRst(comptime IoType: type, io: *IoType, socket: IoType.Socket) v
 /// Relay-buffers-exhausted rung: plain immediate close (§8 table).
 pub fn closeQuietly(comptime IoType: type, io: *IoType, socket: IoType.Socket) void {
     io.closeNow(socket);
+}
+
+test "shed: static responses are exact bytes with close announced" {
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        staticResponse(503, .close),
+    );
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        staticResponse(503, .keep),
+    );
+}
+
+test "shed: every static response parses as a valid bodiless head" {
+    // Round-trip through zoxy's own parser: each response must be a
+    // complete, correctly framed head whose persistence matches the
+    // requested one — the same verdict a strict client would reach.
+    const parser = @import("http/parser.zig");
+    inline for ([_]u16{ 400, 414, 431, 501, 502, 503, 504 }) |status| {
+        inline for ([_]Persistence{ .keep, .close }) |persistence| {
+            const bytes = staticResponse(status, persistence);
+            var storage: parser.HeaderStorage = undefined;
+            const head = try parser.parseResponseHead(bytes, false, &storage, .get);
+            try std.testing.expectEqual(status, head.status);
+            try std.testing.expectEqual(
+                parser.BodyFraming{ .content_length = 0 },
+                head.framing,
+            );
+            try std.testing.expectEqual(persistence == .keep, head.keep_alive);
+            try std.testing.expectEqual(@as(u32, @intCast(bytes.len)), head.head_len);
+        }
+    }
 }


### PR DESCRIPTION
Phase 1 (L7 HTTP/1.1 — [PLANS.md](docs/PLANS.md)): the reverse-proxy path end to end, a profile-directed perf pass, a correctness-hardening pass from an adversarial review, and the simulation gate that now covers it. zoxy serves HTTP/1.1 reverse-proxy traffic with keep-alive both sides, alongside the untouched L4 relay.

## 1. The L7 reverse proxy (feature commits, in order)

1. hparse integration + the §7 trust boundary (`src/http/parser.zig`, the only file allowed to import hparse).
2. Pin bump past the hardening gate (bare-LF rejection + extension-method tokens).
3. Kernel-pressure witness fix on the lingering-drain recv.
4. Static error responses (§8) — comptime byte arrays, round-tripped through our own parser.
5. Head renderer (§7) — hop-by-hop strip + close injection, fuzzed parse→render→reparse oracle.
6. Shared upstream pool (§3, §5) — per-endpoint idle lists, LIFO checkout.
7. Per-listener `protocol` config + Conn head buffer.
8. L7 head ingestion + rejects (§7, §8) — admission fork, parse-retry, 400/414/431/501 with lingering close.
9. Phase-1 budget re-derivation (§8) — `conn_slots_max` CQ-derived (1020), comptime-asserted.
10. The upstream leg (§7) — dial/502, two concurrent legs over two data ops, framed body pumps both ways, byte-exact under the adversary.
11. Keep-alive both sides (§2, §3, §5) — upstream parking/checkout, sweep-based idle reaping, downstream persistence honored.

## 2. Performance investigation (Tier-0 → live profile → the answer)

- Tier-0 micro ruled out head-parse CPU (~105ns/req vs the apparent ~180µs gap).
- A live `cycles:u` profile (new profiler `--protocol http`) found the render's O(headers²) Connection-nomination re-scan; fixed to O(N), then a follow-up made the parser's Connection scan single-pass too.
- Response coalescing + a reuse-path reparse skip (later a first-parse render skip) trimmed real syscalls.
- The bench now **always pins** the proxy under test to a dedicated P-core (`bench/affinity.zig`, matching §3 deployment).
- **The answer:** updating the load generator (zrk 0.1.0 → 0.3.6) revealed the old numbers were a measurement artifact — the generator, not the proxy. Under the fixed generator, all four paths sit at **the same ~+20µs hop** across banded runs — **zoxy L7 is at parity with haproxy http**, p99 at or below. The L7 code does +22% more `io_uring_enter`s than L4 (the request→response turnaround), but that costs ~zero latency at load.

## 3. Correctness hardening (adversarial review pass)

A recall-biased code review of the branch surfaced ten candidates. Seven were real and are fixed here; two were verified **non-bugs** and deliberately left alone.

**Fixed:**
- **Crash** — `requestHeadVacated` fell through to `armRequestBodyRecv` after a deferred origin-response render failed and left `.l7_exchanging` (502/teardown), tripping its state assertion. Now re-checks state (§7).
- **Wrong behavior** — a malformed chunked request-body prefix coalesced with the head was silently torn down instead of answered 400, because the response recv armed before the body was validated. Reordered so the 400 is reachable; removed the now-dead `respondOrTeardown` (§7).
- **Resource starvation ×2** — the relay buffer and the leased upstream were pinned through the whole lingering-reject drain; both are released in `respond()` now, the one point every reject funnels through (§5, §8).
- **TigerStyle** — `parseRequestHead` split under the 70-line limit (no `[headers_max]Header` copy); `scanConnectionTokens` gained its assertions; a dead `flags` param dropped from the profiler.

**Verified non-bugs (not changed):**
- `keep_downstream` "ignoring" the origin's `Connection: close` — correct: `Connection` is hop-by-hop (RFC 9110 §7.6.1); the proxy makes its own downstream persistence decision and `finishExchange` already handles it. "Fixing" it would defeat connection reuse.
- `oversizeRequestError` returning 414 for binary garbage — refuted: hparse rejects non-token method bytes as `Invalid` → 400, so a TLS/port-scan payload never reaches the 414 path.

## 4. The L7 simulation gate (§9)

The deterministic sim was L4-only — the L7 state machine, the riskiest code in the tree, had **zero** schedule-fuzz coverage, which is how the two bugs above shipped. This adds the L7 harness (`sim/l7.zig`):

- An HTTP scripted **origin** (sized / chunked / until-close / truncated / reset / mute / two *instant* origins that answer before the request finishes) and a script-driven **client** (10 scripts: the valid shapes, the §7 reject shapes, and the keep-alive/pipelined/silent patterns), mixed with the L4 population in one scenario so both serving paths share one server, one schedule, and the same pools.
- **Two oracle tiers.** Adversarial seeds check prefix-legality — every received byte must be a prefix of a legal transcript, and no malformed byte (§7) may ever reach an origin. A clean quarter of seeds hardens to each script's **exact golden outcome** (count, status, and byte coverage pinned), so a silently torn-down exchange that should have been answered fails the seed instead of passing as a cut.

**Retro-validated against the two bugs it existed to have caught** — with each fix reverted in a scratch worktree:

| Shipped bug | Fix reverted | Sim verdict |
|---|---|---|
| deferred-render crash | `21d3260` | seed 474 panics at the exact shipped assertion |
| silent teardown vs 400 | `9fb553e` | seed 47 fails `GoldenOutcomeMissed` |

Both seeds pass on fixed code; a 3000-seed sweep is green (each seed run twice under the determinism gate).

## Verification

`zig build ci` (unit + fuzz oracles, boundary lint, sim — now mixed L4/L7) and `zig fmt --check` green on every commit; each slice passed an adversarial code review before commit. The pinned Tier-1 bench is clean (flat RSS, clean drain, zero socket errors, 99.9% upstream reuse), with zoxy at parity with haproxy on both L4 and L7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
