### PR TITLE
test(l7): gate the keep-alive reuse turnaround for zero allocation (§9)

### DIFF
--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -725,10 +725,11 @@ test "l7: the head-read deadline reaps a slowloris that never completes" {
     try bed.expectDrained();
 }
 
-test "l7: the head-ingestion path allocates nothing after init" {
-    // §9 zero-alloc gate for L7: run a full proxied exchange under a
-    // counting allocator, then again under one that *fails* past the
-    // init count.
+test "l7: a single close-terminated exchange allocates nothing after init" {
+    // §9 zero-alloc gate for the L7 upstream leg: a full proxied
+    // exchange — dial, request head + body, response, forward, close —
+    // under a counting allocator, then again under one that *fails* past
+    // the init count.
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
     var bed: Http1Bed = undefined;
@@ -746,6 +747,40 @@ test "l7: the head-ingestion path allocates nothing after init" {
     try strict_bed.setUp(strict.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
     defer strict_bed.tearDown();
     try strict_bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
+    try strict_bed.expectDrained();
+}
+
+test "l7: the keep-alive reuse turnaround allocates nothing after init" {
+    // §9 zero-alloc gate for the §5 park/checkout/reset path: two
+    // requests on one client connection reuse the parked upstream — the
+    // most allocation-prone L7 lifecycle code, and the one a single
+    // close-terminated exchange never touches. Counting run, then a
+    // failing run pinned to the init count.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    const second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    const first_request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var bed: Http1Bed = undefined;
+    try bed.setUp(failing.allocator(), .{ .seed = 50, .origin_response = response });
+    defer bed.tearDown();
+    const allocations_after_init = failing.allocations;
+    bed.client.second_request = second_request;
+    try bed.exchange(first_request);
+    try bed.expectDrained();
+    // The turnaround must actually have parked and reused the upstream,
+    // or this gates nothing.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(allocations_after_init, failing.allocations);
+
+    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = allocations_after_init,
+    });
+    var strict_bed: Http1Bed = undefined;
+    try strict_bed.setUp(strict.allocator(), .{ .seed = 50, .origin_response = response });
+    defer strict_bed.tearDown();
+    strict_bed.client.second_request = second_request;
+    try strict_bed.exchange(first_request);
     try strict_bed.expectDrained();
 }
 


### PR DESCRIPTION
Closes a §9 zero-alloc gate gap found while auditing whether the four DESIGN.md §9 gates fully cover the L7 path (the same audit that surfaced the missing L7 simulation).

## The gap

The §9 zero-alloc gate ran the L4 relay (`zero_alloc_test.zig`) and a single close-terminated L7 exchange under a `FailingAllocator`, but never the **§5 keep-alive turnaround** — `parkUpstream` / `checkout` / `resetForNextRequest`, which run on every reused request and are the most allocation-prone L7 lifecycle code. That path sat under only the plain testing allocator, so a stray `alloc` there would have passed CI — the same shape of hole that hid the L7 simulation gap.

## The change (test-only)

- Add `l7: the keep-alive reuse turnaround allocates nothing after init` — drives two requests on one client connection (parked-upstream reuse) under a counting allocator, then again under a failing allocator pinned to the init count. It asserts `upstream_reused == 1` so the gate can't pass green without actually exercising the reuse path.
- Rename `l7: the head-ingestion path allocates nothing after init` → `l7: a single close-terminated exchange allocates nothing after init`: the test always ran a full proxied exchange (dial + request head/body + response + forward), not just head ingestion — the name was misleading.

## Gate scorecard after this

- **Simulation** — mixed L4/L7 (landed in #47).
- **Fuzz** — config + render + parser (incl. a chunked corpus and a whole-vs-bytewise split-invariance oracle). Complete.
- **Zero-alloc** — L4 + single L7 exchange + **the keep-alive reuse turnaround** (this PR). Complete.
- **Bench Tier-1** — L7 keep-alive is benched; the `Connection: close` variant (§9 lists it) is still open, deferred to the path-routing work.

`zig build ci` and `zig fmt --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
