### PR TITLE
Path routing: canonical-path longest-prefix tables (§7)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -459,6 +459,28 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   duplicate/garbage Content-Length) → 400 before any byte reaches an
   upstream. `Upgrade` → 501 (non-goal). Hop-by-hop headers stripped both
   ways; `Connection: close` injected when the proxy will close (§2).
+- **Path routing on the canonical path only** (settled 2026-07-19). An
+  `http` listener maps the request path to a cluster through a
+  per-listener longest-prefix route table (`"routes": [{ "prefix":
+  "/api", "cluster": "api" }, …]`; the existing `"cluster"` field stays
+  as sugar for a single catch-all route). The table is resolved at
+  config load into an immutable arena table sorted longest-prefix-first
+  — matching is a bounded linear scan, never an allocation — and
+  `routes_max` caps it. No route matches → static `404` (§8). Matching
+  consults only the **canonical path**, computed once in the trust
+  boundary: the query splits off untouched (opaque to the proxy,
+  forwarded verbatim); unreserved percent-escapes (RFC 3986 §2.3) are
+  decoded and surviving escapes' hex uppercased; then dot-segments are
+  collapsed. Structure-changing escapes are rejected as 400 — encoded
+  slash (`%2F`), NUL (`%00`), truncated or non-hex escapes — and so is
+  a path that climbs above the root. Duplicate slashes are preserved:
+  `//a` names a different resource than `/a`, and consistency, not
+  merging, is what makes it safe. The rendered upstream request line
+  carries that same canonical path, so the router and the origin cannot
+  disagree about which resource a request names — the `/api/../admin`
+  confusion class dies structurally, not by backend convention.
+  Host-based rules are deferred: the parser already extracts `Host`,
+  and host rules extend the same table compatibly when needed.
 - **Early responses are legal.** An origin may answer before the request
   body finishes (RFC 9110 — e.g. 413 mid-upload): the response head is
   forwarded when it arrives, and the remaining request body is drained or
@@ -466,9 +488,13 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   from the start instead of assuming strict request-then-response.
 - **Phases, Pingora-style but compile-time.** The request lifecycle
   exposes fixed extension points — `admit`, `route`, `upstream_pick`,
-  `settle` — as plain function calls into one module (`src/phases.zig`),
-  not a runtime filter chain. Programmability can be added later by
-  swapping that module; the proxy core stays generic and small.
+  `settle` — as plain function calls, one module per concern: admission
+  in `Server.zig`, path → cluster in `http/router.zig`, endpoint pick
+  in `balancer.zig`, settlement in `http/proxy.zig`. (Phase 0 sketched
+  these as a single `phases.zig`; they materialized as separate seams,
+  which is the same design with better boundaries.) Not a runtime
+  filter chain: programmability is added by extending the owning module
+  at compile time; the proxy core stays generic and small.
 - **Configurable filters/rules: filters are data, not code.**
   Zero-alloc extensibility means no plugins,
   no closures, no dynamic dispatch chains — instead, a rule is *compiled
@@ -487,8 +513,8 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   everything else. This is nginx/HAProxy's config-rule model, not Envoy's
   runtime filter chain — WASM/scripting is explicitly out (an interpreter
   with unbounded fuel or an embedded allocator cannot satisfy the gate);
-  anything beyond the closed action enum is a Zig function added to
-  `phases.zig` at compile time.
+  anything beyond the closed action enum is a Zig function added to the
+  owning phase module at compile time.
 - **Resilience is minimal by design:** per-request and per-try deadlines
   (head-read gets its own deadline, so a slowloris meets the clock or
   `head_bytes_max`, whichever comes first); one free replay of a request
@@ -519,8 +545,9 @@ the loop thread.
 | request deadline | timer completion | `504` if no response byte sent, else teardown |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
-- **Static error responses.** `503`/`504`/`431`/`414`/`400` are comptime
-  byte arrays sent directly from static memory — never staged through
+- **Static error responses.** `400`/`404`/`414`/`431`/`501`/`503`/`504`
+  are comptime byte arrays sent directly from static memory — never
+  staged through
   the connection's head buffer, whose bytes the parsed head's zero-copy
   slices may still reference (§7). Shedding costs one send, no
   allocation, no copy.
@@ -679,8 +706,9 @@ src/
   http/
     parser.zig        // hparse wrapper: strictness + framing + chunked decoder
     render.zig        // §7 head rendering: hop-by-hop strip + close injection
+    router.zig        // §7 path routing: canonical-path longest-prefix table
     proxy.zig         // L7 state machine over phases
-  phases.zig          // admit / route / upstream_pick / settle
+  balancer.zig        // upstream endpoint pick: round-robin → P2C (§7)
   shed.zig            // exhaustion ladder: decisions + static responses
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
   worker.zig          // SPMC job queue + SPSC completion rings (Phase 3)

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -14,13 +14,25 @@ behind all four gates of §9.
   ladder rungs that exist so far, all four test gates, static-memory and
   fd-budget printout. Spec-complete 2026-07-13: the kernel-pressure
   witness on the relay data path (0a4c0bb) closed the last §8 audit gap.
-- **Phase 1 — L7 HTTP/1.1. Next.** Head parser + framing, routing,
-  upstream pool + keep-alive both sides, relay-buffer decoupling (idle
-  costs no relay memory), static error responses, remaining ladder
-  rungs. Entry gate: the hparse fork must clear the hardening list
-  recorded in §7 before this phase lands — **cleared 2026-07-18**
-  (zoxy-io/hparse PR #3: CRLF-only line terminators + extension-method
-  tokens; pin at 65521ed).
+- **Phase 1 — L7 HTTP/1.1. Shipped.** Head parser + framing, upstream
+  pool + keep-alive both sides, relay-buffer decoupling (idle costs no
+  relay memory), static error responses, remaining ladder rungs. Entry
+  gate: the hparse fork must clear the hardening list recorded in §7
+  before this phase lands — **cleared 2026-07-18** (zoxy-io/hparse
+  PR #3: CRLF-only line terminators + extension-method tokens; pin at
+  65521ed). Spec-complete 2026-07-19 (PR #47) with all four §9 gates
+  covering L7: the mixed-protocol simulation (golden + prefix oracles,
+  retro-validated against two shipped bugs), the keep-alive-reuse
+  zero-alloc gate, and the `Connection: close` Tier-1 bands.
+- **Phase 1.5 — path routing. In progress.** Longest-prefix
+  path → cluster tables per listener, matched on the §7 canonical path
+  (decode unreserved escapes, collapse dot-segments; structure-changing
+  escapes → 400) with the canonical path forwarded upstream, so the
+  router and the origin cannot diverge — the settled §7 decision
+  (2026-07-19). No match → the 404 static verdict. The sim gains a
+  routing-correctness oracle: distinct canonical bodies per cluster
+  plus path-confusion scripts (`/a/../b`, `%2e%2e`, encoded slash).
+  Host rules deferred as a compatible extension of the same table.
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
   stale-replay (a checkout that fails on first use answers 502 today),
   per-try deadline and the §8 request-deadline 504 verdict (an expired

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -20,6 +20,7 @@ const zoxy = @import("zoxy");
 
 const Io = zoxy.Io;
 const parser = zoxy.http.parser;
+const constants = zoxy.constants;
 
 const assert = std.debug.assert;
 
@@ -206,6 +207,32 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 conn.beginRespond();
             }
 
+            /// True when `target` is already in §7 canonical form:
+            /// re-canonicalizing leaves the path unchanged and the query
+            /// verbatim, so path + query reproduces the target exactly.
+            /// OPTIONS asterisk-form has no path and is trivially canonical.
+            fn targetIsCanonical(conn: *Conn, target: []const u8) bool {
+                _ = conn;
+                assert(target.len >= 1);
+                if (target[0] != '/') {
+                    return true;
+                }
+                var canon_buf: [constants.head_bytes_max]u8 = undefined;
+                const canonical = parser.canonicalTarget(target, &canon_buf) catch {
+                    return false;
+                };
+                assert(canonical.path.len >= 1);
+                assert(canonical.path[0] == '/');
+                if (canonical.path.len + canonical.query.len != target.len) {
+                    return false;
+                }
+                assert(canonical.path.len <= target.len);
+                if (!std.mem.startsWith(u8, target, canonical.path)) {
+                    return false;
+                }
+                return std.mem.eql(u8, target[canonical.path.len..], canonical.query);
+            }
+
             /// Returns true when the head is parsed and the phase moved
             /// on; false when it armed a recv or closed on a violation.
             fn parseHead(conn: *Conn) bool {
@@ -228,6 +255,16 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     conn.close();
                     return false;
                 };
+                // §7 canonical forwarding: the proxy sends the canonical
+                // path the router matched on, so what the origin receives
+                // must already be canonical — re-canonicalizing is a no-op.
+                // A raw dot-segment or decodable escape here would mean the
+                // router and the origin could disagree about the resource.
+                if (!conn.targetIsCanonical(request.target)) {
+                    conn.origin.violations += 1;
+                    conn.close();
+                    return false;
+                }
                 switch (request.framing) {
                     .none => conn.framing_tag = .none,
                     .content_length => |length| {
@@ -478,6 +515,12 @@ pub const Script = enum(u8) {
     /// Connects and sends nothing: the head-read deadline reaps it;
     /// any response byte is a violation.
     silent,
+    /// A GET whose path only reaches the routable resource after
+    /// canonicalization — an encoded `..` that collapses a segment away
+    /// (`/deep/%2e%2e/sim` → `/sim`). It must route and forward exactly as
+    /// `/sim` would; the origin's canonical oracle catches a raw-path
+    /// forward, and a router matching raw bytes would route it elsewhere.
+    confusion,
 };
 
 /// A verify-time verdict over everything the client received.
@@ -581,6 +624,9 @@ pub fn Client(comptime IoType: type) type {
                 .keepalive_pair => get_request,
                 .pipelined => get_request ++ get_request,
                 .silent => "",
+                // Canonicalizes to /sim (the `/deep` segment is popped by
+                // the decoded `..`), so it routes and forwards as /sim.
+                .confusion => "GET /deep/%2e%2e/sim HTTP/1.1\r\nHost: sim\r\n\r\n",
             };
         }
 
@@ -966,7 +1012,7 @@ pub fn Client(comptime IoType: type) type {
 
         fn expectedResponses(script: Script) u8 {
             return switch (script) {
-                .get, .post_sized, .post_big, .post_chunked => 1,
+                .get, .post_sized, .post_big, .post_chunked, .confusion => 1,
                 .post_chunked_malformed, .malformed_head => 1,
                 .oversize_uri, .connect_method, .pipelined => 1,
                 .keepalive_pair => 2,
@@ -993,7 +1039,7 @@ pub fn Client(comptime IoType: type) type {
         /// value unread.
         fn goldenStatus(script: Script) u16 {
             return switch (script) {
-                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined => 200,
+                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined, .confusion => 200,
                 .post_chunked_malformed, .malformed_head => 400,
                 .oversize_uri => 414,
                 .connect_method => 501,
@@ -1008,7 +1054,7 @@ pub fn Client(comptime IoType: type) type {
         fn methodOf(script: Script) parser.Method {
             return switch (script) {
                 .post_sized, .post_big, .post_chunked, .post_chunked_malformed => .post,
-                .get, .malformed_head, .oversize_uri => .get,
+                .get, .malformed_head, .oversize_uri, .confusion => .get,
                 .connect_method, .keepalive_pair, .pipelined, .silent => .get,
             };
         }
@@ -1020,7 +1066,7 @@ pub fn Client(comptime IoType: type) type {
         /// client may see nothing at all.
         fn statusAllowed(script: Script, status: u16) bool {
             return switch (script) {
-                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined => //
+                .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined, .confusion => //
                 status == 200 or status == 502 or status == 503,
                 // The head routes before its body is validated, so the §8
                 // rungs and a killed dial can still precede the 400.

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -118,6 +118,8 @@ const Harness = struct {
     endpoints_l4: [1]std.Io.net.IpAddress,
     endpoints_http: [1]std.Io.net.IpAddress,
     clusters: [2]zoxy.config.Config.Cluster,
+    routes_l4: [1]zoxy.http.router.Route,
+    routes_http: [1]zoxy.http.router.Route,
     listener_configs: [2]zoxy.config.Config.Listener,
     config: zoxy.config.Config,
     origin: Origin,
@@ -199,9 +201,11 @@ const Harness = struct {
             .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4 },
             .{ .name = "origin-http", .endpoints = &harness.endpoints_http },
         };
+        harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
+        harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
         harness.listener_configs = .{
-            .{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 },
-            .{ .bind_address = httpBindAddress(), .cluster_index = 1, .protocol = .http },
+            .{ .bind_address = bindAddress(), .routes = &harness.routes_l4, .protocol = .l4 },
+            .{ .bind_address = httpBindAddress(), .routes = &harness.routes_http, .protocol = .http },
         };
         harness.config = .{
             .listeners = &harness.listener_configs,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -125,7 +125,10 @@ pub fn Server(comptime IoType: type) type {
                     .listener = try server.io.listen(listener_config.bind_address),
                     .accept_completion = .{},
                     .retry_completion = .{},
-                    .cluster_index = listener_config.cluster_index,
+                    // L4 has one route (the whole listener → one cluster);
+                    // L7 admits under the first route and refines to the
+                    // path's route once the head parses (§7).
+                    .cluster_index = listener_config.routes[0].cluster_index,
                     .protocol = listener_config.protocol,
                     .accepting = false,
                 };

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -20,6 +20,7 @@ const conn_module = @import("net/Conn.zig");
 const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
 const proxy = @import("http/proxy.zig");
+const router = @import("http/router.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
 const upstream_module = @import("net/upstream.zig");
@@ -82,6 +83,9 @@ pub fn Server(comptime IoType: type) type {
             /// ring budget stays one op (§8).
             retry_completion: IoType.Completion,
             cluster_index: u16,
+            /// The listener's §7 route table, handed to each admitted L7
+            /// connection so `routeRequest` can pick a cluster by path.
+            routes: []const router.Route,
             /// Copied from config so admission forks without reaching back
             /// through the listener index (§6, §7).
             protocol: config_module.Config.Listener.Protocol,
@@ -129,6 +133,7 @@ pub fn Server(comptime IoType: type) type {
                     // L7 admits under the first route and refines to the
                     // path's route once the head parses (§7).
                     .cluster_index = listener_config.routes[0].cluster_index,
+                    .routes = listener_config.routes,
                     .protocol = listener_config.protocol,
                     .accepting = false,
                 };
@@ -406,6 +411,10 @@ pub fn Server(comptime IoType: type) type {
                 server.idleTimeoutMs(),
                 state.cluster_index,
             );
+            // The L7 path routes by canonical path once the head parses;
+            // hand it the listener's table (§7).
+            conn.routes = state.routes;
+            assert(conn.routes.len >= 1);
             Proxy.start(server, conn);
         }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -11,6 +11,8 @@
 const std = @import("std");
 
 const constants = @import("constants.zig");
+const router = @import("http/router.zig");
+const parser = @import("http/parser.zig");
 
 const assert = std.debug.assert;
 
@@ -30,7 +32,12 @@ pub const Config = struct {
 
     pub const Listener = struct {
         bind_address: std.Io.net.IpAddress,
-        cluster_index: u16,
+        /// The §7 path-routing table, sorted longest-prefix-first and
+        /// never empty. A listener configured with a single `"cluster"`
+        /// resolves to one catch-all route (`prefix = "/"`); `l4`
+        /// listeners always have exactly that one route (no path to
+        /// match). Matched by `http/router.zig`.
+        routes: []const router.Route,
         protocol: Protocol,
 
         /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
@@ -60,6 +67,12 @@ pub const ValidationError = error{
     ClustersEmpty,
     ClustersOverLimit,
     ClusterNameDuplicate,
+    ListenerClusterOrRoutes,
+    ListenerL4Routes,
+    RoutesEmpty,
+    RoutesOverLimit,
+    RoutePrefixNotCanonical,
+    RoutePrefixDuplicate,
     EndpointsEmpty,
     EndpointsOverLimit,
     EndpointInvalid,
@@ -104,9 +117,17 @@ const ConfigJson = struct {
 
 const ListenerJson = struct {
     bind: []const u8,
-    cluster: []const u8,
+    /// Exactly one of `cluster` (sugar for a single catch-all route) or
+    /// `routes` (an explicit §7 path table) must be present.
+    cluster: ?[]const u8 = null,
+    routes: ?[]const RouteJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
+};
+
+const RouteJson = struct {
+    prefix: []const u8,
+    cluster: []const u8,
 };
 
 const ClusterJson = struct {
@@ -250,14 +271,99 @@ fn resolveListeners(
                 return error.ListenerBindDuplicate;
             }
         }
+        const protocol = try protocolOf(listener_json.protocol);
         listeners[index] = .{
             .bind_address = bind_address,
-            .cluster_index = try clusterIndexOf(clusters, listener_json.cluster),
-            .protocol = try protocolOf(listener_json.protocol),
+            .routes = try resolveRoutes(arena, &listener_json, clusters, protocol),
+            .protocol = protocol,
         };
     }
     assert(listeners.len == listeners_json.len);
     return listeners;
+}
+
+/// Resolve a listener's route table (§7). `"cluster": "x"` is sugar for a
+/// single catch-all route; `"routes": [...]` is the explicit table.
+/// Exactly one form is required. Prefixes must already be canonical (so
+/// they compare directly against the canonical request path) and unique;
+/// the table is sorted longest-prefix-first for the request-time scan.
+/// `l4` listeners have no path, so they take only the `cluster` form.
+fn resolveRoutes(
+    arena: std.mem.Allocator,
+    listener_json: *const ListenerJson,
+    clusters: []const Config.Cluster,
+    protocol: Config.Listener.Protocol,
+) ParseError![]const router.Route {
+    const has_cluster = listener_json.cluster != null;
+    const has_routes = listener_json.routes != null;
+    if (has_cluster == has_routes) {
+        return error.ListenerClusterOrRoutes; // Neither, or both.
+    }
+    if (has_cluster) {
+        const routes = try arena.alloc(router.Route, 1);
+        routes[0] = .{
+            .prefix = "/",
+            .cluster_index = try clusterIndexOf(clusters, listener_json.cluster.?),
+        };
+        assert(routes.len == 1); // The sugar is always one catch-all route.
+        return routes;
+    }
+    if (protocol == .l4) {
+        return error.ListenerL4Routes; // L4 relays bytes; there is no path.
+    }
+    const routes_json = listener_json.routes.?;
+    if (routes_json.len == 0) {
+        return error.RoutesEmpty;
+    }
+    if (routes_json.len > constants.routes_max) {
+        return error.RoutesOverLimit;
+    }
+    const routes = try arena.alloc(router.Route, routes_json.len);
+    for (routes_json, 0..) |route_json, index| {
+        try validateRoutePrefix(route_json.prefix);
+        for (routes_json[0..index]) |previous| {
+            if (std.mem.eql(u8, previous.prefix, route_json.prefix)) {
+                return error.RoutePrefixDuplicate;
+            }
+        }
+        routes[index] = .{
+            .prefix = route_json.prefix,
+            .cluster_index = try clusterIndexOf(clusters, route_json.cluster),
+        };
+    }
+    // Longest-prefix-first, so the router's linear scan finds the most
+    // specific match first (§7). Descending by length; ties are already
+    // rejected as duplicates above, so order among equal lengths is moot.
+    std.mem.sort(router.Route, routes, {}, routeLongerFirst);
+    assert(routes.len >= 1);
+    assert(routes.len <= constants.routes_max);
+    return routes;
+}
+
+fn routeLongerFirst(_: void, left: router.Route, right: router.Route) bool {
+    return left.prefix.len > right.prefix.len;
+}
+
+/// A route prefix must be an origin-form path already in canonical form,
+/// so it compares byte-for-byte against the canonicalized request path
+/// (§7) — no per-request normalization, no router/backend divergence. A
+/// prefix that canonicalization would change (dot-segments, decodable or
+/// structure-changing escapes, a missing leading slash, a query) is
+/// rejected at load, not silently mismatched at request time.
+fn validateRoutePrefix(prefix: []const u8) ParseError!void {
+    if (prefix.len == 0 or prefix[0] != '/') {
+        return error.RoutePrefixNotCanonical;
+    }
+    if (prefix.len > constants.head_bytes_max) {
+        return error.RoutePrefixNotCanonical;
+    }
+    var out: [constants.head_bytes_max]u8 = undefined;
+    const canonical = parser.canonicalTarget(prefix, &out) catch {
+        return error.RoutePrefixNotCanonical;
+    };
+    if (canonical.query.len != 0 or !std.mem.eql(u8, canonical.path, prefix)) {
+        return error.RoutePrefixNotCanonical;
+    }
 }
 
 /// The closed protocol vocabulary; anything else is its own error so a
@@ -314,7 +420,10 @@ test "config: the shipped example parses and resolves" {
     const parsed = try parse(arena_state.allocator(), example_json);
     try std.testing.expectEqual(@as(usize, 1), parsed.listeners.len);
     try std.testing.expectEqual(@as(usize, 1), parsed.clusters.len);
-    try std.testing.expectEqual(@as(u16, 0), parsed.listeners[0].cluster_index);
+    // The `"cluster"` sugar resolves to one catch-all route.
+    try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].routes.len);
+    try std.testing.expectEqualStrings("/", parsed.listeners[0].routes[0].prefix);
+    try std.testing.expectEqual(@as(u16, 0), parsed.listeners[0].routes[0].cluster_index);
     try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
@@ -385,6 +494,67 @@ test "config: listener protocol defaults to l4 and accepts http" {
         );
         try std.testing.expectEqual(Config.Listener.Protocol.http, parsed.listeners[0].protocol);
     }
+}
+
+test "config: explicit routes resolve, sorted longest-prefix-first" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","routes":[
+        \\   {"prefix":"/","cluster":"root"},
+        \\   {"prefix":"/api/v2","cluster":"v2"},
+        \\   {"prefix":"/api","cluster":"api"}]}],
+        \\ "clusters":{"root":{"endpoints":["127.0.0.1:2"]},
+        \\   "api":{"endpoints":["127.0.0.1:3"]},
+        \\   "v2":{"endpoints":["127.0.0.1:4"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    const routes = parsed.listeners[0].routes;
+    try std.testing.expectEqual(@as(usize, 3), routes.len);
+    // Descending by prefix length, whatever the config order.
+    try std.testing.expectEqualStrings("/api/v2", routes[0].prefix);
+    try std.testing.expectEqualStrings("/api", routes[1].prefix);
+    try std.testing.expectEqualStrings("/", routes[2].prefix);
+    // The cluster the router will hand back for the longest match.
+    try std.testing.expectEqual(
+        @as(?u16, routes[0].cluster_index),
+        router.route(routes, "/api/v2/x"),
+    );
+    try std.testing.expectEqual(
+        @as(?u16, routes[2].cluster_index),
+        router.route(routes, "/elsewhere"),
+    );
+}
+
+test "config: routing schema rejects malformed tables" {
+    const base_clusters =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    ;
+    // Neither cluster nor routes.
+    try expectParseError(error.ListenerClusterOrRoutes, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\"}]," ++ base_clusters);
+    // Both cluster and routes.
+    try expectParseError(error.ListenerClusterOrRoutes, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"," ++
+        "\"routes\":[{\"prefix\":\"/\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // Routes on an l4 listener: there is no path to match.
+    try expectParseError(error.ListenerL4Routes, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\"," ++
+        "\"routes\":[{\"prefix\":\"/\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // Empty routes table.
+    try expectParseError(error.RoutesEmpty, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[]}]," ++ base_clusters);
+    // A non-canonical prefix (dot-segment) — would mismatch at request time.
+    try expectParseError(error.RoutePrefixNotCanonical, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"prefix\":\"/a/../b\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // A prefix without a leading slash.
+    try expectParseError(error.RoutePrefixNotCanonical, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"prefix\":\"api\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // Duplicate prefixes.
+    try expectParseError(error.RoutePrefixDuplicate, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"prefix\":\"/x\",\"cluster\":\"a\"}," ++
+        "{\"prefix\":\"/x\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // An unknown cluster named by a route.
+    try expectParseError(error.ClusterUnknown, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"prefix\":\"/\",\"cluster\":\"ghost\"}]}]," ++ base_clusters);
 }
 
 test "config: unknown listener protocol fails loudly" {
@@ -538,7 +708,13 @@ fn fuzzParse(context: void, smith: *std.testing.Smith) !void {
         assert(parsed.listeners.len >= 1);
         assert(parsed.clusters.len >= 1);
         for (parsed.listeners) |listener| {
-            assert(listener.cluster_index < parsed.clusters.len);
+            assert(listener.routes.len >= 1);
+            assert(listener.routes.len <= constants.routes_max);
+            for (listener.routes) |route| {
+                assert(route.cluster_index < parsed.clusters.len);
+                assert(route.prefix.len >= 1);
+                assert(route.prefix[0] == '/');
+            }
         }
     } else |_| {}
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -128,6 +128,11 @@ pub const clusters_max: u16 = 16;
 /// Upper bound on endpoints in one cluster.
 pub const endpoints_per_cluster_max: u16 = 64;
 
+/// Upper bound on routes in one listener's path-routing table (§7). Config
+/// data, not a runtime pool: routes are immutable arena slices, and the
+/// request-time match is a bounded linear scan over at most this many.
+pub const routes_max: u16 = 32;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -166,6 +171,7 @@ comptime {
     assert(relay_buffer_bytes >= 512);
     assert(clusters_max >= 1);
     assert(endpoints_per_cluster_max >= 1);
+    assert(routes_max >= 1);
     assert(loop_completions_per_tick_max >= 1);
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -36,6 +36,9 @@ pub const Counters = struct {
     l7_uri_too_long: Value = Value.init(0),
     l7_headers_too_large: Value = Value.init(0),
     l7_not_implemented: Value = Value.init(0),
+    /// No route matched the request's canonical path (§7), answered 404.
+    /// Like the other reject counters the connection completes normally.
+    l7_no_route: Value = Value.init(0),
     /// §8 rungs at the L7 request level, answered 503: relay buffers or
     /// upstream slots exhausted when a valid request needed them. Like
     /// the reject counters these connections complete normally, so they

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -720,6 +720,172 @@ fn keepAliveDefault(version: Version, analysis: *const HeaderAnalysis) bool {
     };
 }
 
+/// A canonical origin-form target, split once in the trust boundary
+/// (§7 path routing). `path` lives in the caller's `out` buffer; `query`
+/// is the verbatim suffix of the original target — including its
+/// leading `?` when present — and is opaque to the proxy.
+pub const CanonicalTarget = struct {
+    path: []const u8,
+    query: []const u8,
+};
+
+/// The §7 canonical form: the query splits off untouched, unreserved
+/// percent-escapes (RFC 3986 §2.3) are decoded and surviving escapes'
+/// hex uppercased, then dot-segments are collapsed. Structure-changing
+/// escapes — encoded slash, NUL, truncated or non-hex — are Malformed,
+/// and so is a path that climbs above the root. Routing matches this
+/// form and the renderer forwards it, so the router and the origin can
+/// never disagree about which resource a request names.
+pub fn canonicalTarget(
+    target: []const u8,
+    out: *[constants.head_bytes_max]u8,
+) error{Malformed}!CanonicalTarget {
+    // validateTarget admitted only origin-form here; asterisk-form and
+    // CONNECT never route by path and stay with the caller.
+    assert(target.len >= 1);
+    assert(target[0] == '/');
+    assert(target.len <= out.len);
+    const question = std.mem.indexOfScalar(u8, target, '?');
+    const raw_path = target[0 .. question orelse target.len];
+    const query = target[question orelse target.len ..];
+    const decoded_len = try decodeTargetPath(raw_path, out);
+    const path_len = try collapseDotSegments(out[0..decoded_len]);
+    // Canonicalization only ever shrinks; both stages keep the leading
+    // slash, so the result is itself a valid origin-form path.
+    assert(path_len >= 1);
+    assert(path_len <= raw_path.len);
+    assert(out[0] == '/');
+    return .{ .path = out[0..path_len], .query = query };
+}
+
+/// Stage one of §7 canonicalization: percent-escapes are decoded when
+/// unreserved (decoding them can never change what the path names),
+/// kept with uppercased hex otherwise, and rejected when they would
+/// change the path's structure — an encoded slash or NUL — or are not
+/// two hex digits. Raw bytes pass through verbatim: hparse already
+/// excludes controls, space, and DEL from the target charset.
+fn decodeTargetPath(path: []const u8, out: []u8) error{Malformed}!u32 {
+    assert(path.len >= 1);
+    assert(path[0] == '/');
+    assert(path.len <= out.len);
+    var read: u32 = 0;
+    var write: u32 = 0;
+    while (read < path.len) {
+        assert(write <= read);
+        const byte = path[read];
+        if (byte != '%') {
+            out[write] = byte;
+            write += 1;
+            read += 1;
+            continue;
+        }
+        if (path.len - read < 3) {
+            return error.Malformed; // A truncated escape.
+        }
+        const high = hexNibble(path[read + 1]) orelse return error.Malformed;
+        const low = hexNibble(path[read + 2]) orelse return error.Malformed;
+        const value: u8 = high * 16 + low;
+        if (value == 0) {
+            return error.Malformed; // Encoded NUL.
+        }
+        if (value == '/') {
+            return error.Malformed; // An encoded slash changes structure.
+        }
+        if (isUnreservedByte(value)) {
+            out[write] = value;
+            write += 1;
+        } else {
+            out[write] = '%';
+            out[write + 1] = upperHexDigit(path[read + 1]);
+            out[write + 2] = upperHexDigit(path[read + 2]);
+            write += 3;
+        }
+        read += 3;
+    }
+    assert(write >= 1);
+    assert(write <= path.len);
+    assert(out[0] == '/');
+    return write;
+}
+
+/// Stage two of §7 canonicalization, after escapes are decoded (the
+/// order is the security property: `%2E%2E` must collapse exactly like
+/// `..`). In-place RFC 3986 remove_dot_segments over a decoded path,
+/// except stricter at the root: `..` with nothing left to pop names the
+/// root's parent, which no legitimate client asks for — Malformed, not
+/// the RFC's silent clamp.
+fn collapseDotSegments(bytes: []u8) error{Malformed}!u32 {
+    assert(bytes.len >= 1);
+    assert(bytes[0] == '/');
+    assert(bytes.len <= constants.head_bytes_max);
+    var read: u32 = 0;
+    var write: u32 = 0;
+    while (read < bytes.len) {
+        assert(bytes[read] == '/');
+        assert(write <= read);
+        var segment_end: u32 = read + 1;
+        while (segment_end < bytes.len and bytes[segment_end] != '/') {
+            segment_end += 1;
+        }
+        const segment = bytes[read + 1 .. segment_end];
+        const at_end = segment_end == bytes.len;
+        if (std.mem.eql(u8, segment, ".")) {
+            // "/a/." is "/a/" (RFC 3986 §5.2.4): a trailing dot keeps
+            // its slash; a middle one vanishes with it.
+            if (at_end) {
+                bytes[write] = '/';
+                write += 1;
+            }
+        } else if (std.mem.eql(u8, segment, "..")) {
+            if (write == 0) {
+                return error.Malformed; // Climbs above the root.
+            }
+            // write > 0 implies bytes[0] == '/', so a previous slash
+            // always exists.
+            const previous = std.mem.lastIndexOfScalar(u8, bytes[0..write], '/').?;
+            write = @intCast(previous);
+            if (at_end) {
+                bytes[write] = '/';
+                write += 1;
+            }
+        } else {
+            // An ordinary segment — empty included: `//a` names a
+            // different resource than `/a` and is preserved (§7).
+            bytes[write] = '/';
+            std.mem.copyForwards(u8, bytes[write + 1 .. write + 1 + segment.len], segment);
+            write += 1 + @as(u32, @intCast(segment.len));
+        }
+        read = segment_end;
+    }
+    assert(write >= 1);
+    assert(bytes[0] == '/');
+    return write;
+}
+
+fn hexNibble(byte: u8) ?u8 {
+    return switch (byte) {
+        '0'...'9' => byte - '0',
+        'a'...'f' => byte - 'a' + 10,
+        'A'...'F' => byte - 'A' + 10,
+        else => null,
+    };
+}
+
+fn upperHexDigit(byte: u8) u8 {
+    assert(hexNibble(byte) != null);
+    if (byte >= 'a' and byte <= 'f') {
+        return byte - ('a' - 'A');
+    }
+    return byte;
+}
+
+/// RFC 3986 §2.3 unreserved: decoding these can never change what the
+/// path names, so the canonical form always holds them raw.
+fn isUnreservedByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '.' or
+        byte == '_' or byte == '~';
+}
+
 /// A reverse proxy routes origin-form targets (§7 routes host/path);
 /// asterisk-form is legal for OPTIONS. CONNECT's authority-form passes
 /// through so the proxy can answer it with 501 rather than 400.
@@ -1322,4 +1488,116 @@ fn fuzzParserInputs(context: void, smith: *std.testing.Smith) !void {
         assert(whole.consumed == bytewise.consumed);
         assert(whole.done == bytewise.done);
     }
+}
+
+test "canonicalTarget: table of canonical forms and rejects" {
+    const Case = struct {
+        target: []const u8,
+        path: ?[]const u8, // null means Malformed
+        query: []const u8 = "",
+    };
+    const cases = [_]Case{
+        // Identity and query splitting; the query is verbatim, always.
+        .{ .target = "/", .path = "/" },
+        .{ .target = "/a/b", .path = "/a/b" },
+        .{ .target = "/a?x=1", .path = "/a", .query = "?x=1" },
+        .{ .target = "/a?", .path = "/a", .query = "?" },
+        .{ .target = "/?a", .path = "/", .query = "?a" },
+        .{ .target = "/a?%2F%zz/../", .path = "/a", .query = "?%2F%zz/../" },
+        // Unreserved escapes decode; others keep uppercased hex.
+        .{ .target = "/%61%2D%5F%7E", .path = "/a-_~" },
+        .{ .target = "/caf%c3%a9", .path = "/caf%C3%A9" },
+        // A space is not unreserved: %41 decodes, %20 stays encoded —
+        // no raw space can ever reach a request line.
+        .{ .target = "/%41%20x", .path = "/A%20x" },
+        // Dot segments collapse after decoding (the §7 order).
+        .{ .target = "/a/./b", .path = "/a/b" },
+        .{ .target = "/a/../b", .path = "/b" },
+        .{ .target = "/a/b/..", .path = "/a/" },
+        .{ .target = "/a/.", .path = "/a/" },
+        .{ .target = "/./a", .path = "/a" },
+        .{ .target = "/a/%2e%2e/b", .path = "/b" },
+        .{ .target = "/a/%2E", .path = "/a/" },
+        // Duplicate slashes are preserved; ".." still pops them.
+        .{ .target = "//a", .path = "//a" },
+        .{ .target = "/a//b", .path = "/a//b" },
+        .{ .target = "/a/", .path = "/a/" },
+        .{ .target = "/a//../b", .path = "/a/b" },
+        // A leading empty segment is a real segment ".." can pop, so
+        // "//.." is not a root climb — it is consistent, and consistency
+        // (both router and origin see the canonical form) is the property
+        // that matters, not rejection.
+        .{ .target = "//../a", .path = "/a" },
+        .{ .target = "//..", .path = "/" },
+        // Rejects: structure-changing or malformed escapes, root climbs.
+        .{ .target = "/%2F", .path = null },
+        .{ .target = "/%2f", .path = null },
+        .{ .target = "/%00", .path = null },
+        .{ .target = "/%", .path = null },
+        .{ .target = "/%A", .path = null },
+        .{ .target = "/%GG", .path = null },
+        .{ .target = "/..", .path = null },
+        .{ .target = "/../a", .path = null },
+        .{ .target = "/a/../..", .path = null },
+        .{ .target = "/%2e%2e/a", .path = null },
+        .{ .target = "/./..", .path = null },
+    };
+    for (cases) |case| {
+        var out: [constants.head_bytes_max]u8 = undefined;
+        const result = canonicalTarget(case.target, &out);
+        if (case.path) |expected_path| {
+            const canonical = try result;
+            try std.testing.expectEqualStrings(expected_path, canonical.path);
+            try std.testing.expectEqualStrings(case.query, canonical.query);
+        } else {
+            try std.testing.expectError(error.Malformed, result);
+        }
+    }
+}
+
+test "canonicalTarget: canonicalization is idempotent" {
+    const targets = [_][]const u8{ "/a/../b", "/caf%c3%a9", "//a/./b%7e", "/a/b/.." };
+    for (targets) |target| {
+        var out: [constants.head_bytes_max]u8 = undefined;
+        const first = try canonicalTarget(target, &out);
+        var out_again: [constants.head_bytes_max]u8 = undefined;
+        const second = try canonicalTarget(first.path, &out_again);
+        try std.testing.expectEqualStrings(first.path, second.path);
+        try std.testing.expectEqual(@as(usize, 0), second.query.len);
+    }
+}
+
+test "fuzz: canonicalTarget rejects or emits the canonical form" {
+    try std.testing.fuzz({}, fuzzCanonicalTarget, .{ .corpus = &.{
+        "/a/../b%2e?q",
+        "/%2e%2e/x",
+        "/a%2Fb",
+        "/a//b/./c/%7e%ZZ",
+    } });
+}
+
+fn fuzzCanonicalTarget(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    input_buffer[0] = '/';
+    const tail_len = smith.slice(input_buffer[1..]);
+    const input = input_buffer[0 .. 1 + tail_len];
+
+    var out: [constants.head_bytes_max]u8 = undefined;
+    // Reject-or-canonical, no third outcome: a reject ends the case.
+    const canonical = canonicalTarget(input, &out) catch return;
+    // Rooted, never grown, and the split covers the input.
+    assert(canonical.path.len >= 1);
+    assert(canonical.path[0] == '/');
+    assert(canonical.path.len + canonical.query.len <= input.len);
+    // No dot-segment survives in canonical form.
+    assert(std.mem.indexOf(u8, canonical.path, "/../") == null);
+    assert(std.mem.indexOf(u8, canonical.path, "/./") == null);
+    assert(!std.mem.endsWith(u8, canonical.path, "/.."));
+    assert(!std.mem.endsWith(u8, canonical.path, "/."));
+    // The canonical form is its own canonical form.
+    var out_again: [constants.head_bytes_max]u8 = undefined;
+    const again = try canonicalTarget(canonical.path, &out_again);
+    assert(std.mem.eql(u8, again.path, canonical.path));
+    assert(again.query.len == 0);
 }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -35,6 +35,7 @@ const conn_module = @import("../net/Conn.zig");
 const Io = @import("../io/io.zig");
 const parser = @import("parser.zig");
 const render = @import("render.zig");
+const router = @import("router.zig");
 const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
@@ -120,10 +121,49 @@ pub fn Proxy(comptime IoType: type) type {
             routeRequest(server, conn, &request);
         }
 
+        /// The cluster for `request`'s canonical path (§7). Origin-form is
+        /// canonicalized and matched by longest prefix; OPTIONS
+        /// asterisk-form has no path and routes to the catch-all. A target
+        /// that will not canonicalize is BadPath (400); an unmatched path
+        /// is NoRoute (404).
+        fn resolveCluster(
+            conn: *ConnType,
+            request: *const parser.RequestHead,
+            scratch: *[constants.head_bytes_max]u8,
+        ) error{ BadPath, NoRoute }!u16 {
+            assert(request.target.len >= 1);
+            assert(conn.routes.len >= 1);
+            if (request.target[0] != '/') {
+                // validateTarget admitted only asterisk-form here.
+                assert(request.method == .options);
+                return router.catchAll(conn.routes) orelse error.NoRoute;
+            }
+            const canonical = parser.canonicalTarget(request.target, scratch) catch {
+                return error.BadPath;
+            };
+            return router.route(conn.routes, canonical.path) orelse error.NoRoute;
+        }
+
+        /// The canonical bytes to forward for `request` (§7): origin-form
+        /// canonicalizes, OPTIONS asterisk-form passes through. routeRequest
+        /// already proved canonicalization succeeds, so this cannot fail —
+        /// the same bytes are the single source of truth.
+        fn effectiveTarget(
+            request: *const parser.RequestHead,
+            scratch: *[constants.head_bytes_max]u8,
+        ) parser.CanonicalTarget {
+            assert(request.target.len >= 1);
+            if (request.target[0] != '/') {
+                return .{ .path = request.target, .query = "" };
+            }
+            return parser.canonicalTarget(request.target, scratch) catch unreachable;
+        }
+
         /// Policy gate, then the exchange's admission: tunnels and
-        /// upgrades are non-goals (§1, §7) — 501; a routable request
-        /// claims its relay buffer and upstream slot (§8 rungs, 503) and
-        /// dials the balancer's pick for the listener's cluster.
+        /// upgrades are non-goals (§1, §7) — 501; the canonical path
+        /// selects a cluster (400 if it will not canonicalize, 404 if no
+        /// route matches, §7/§8); a routable request then claims its
+        /// relay buffer and upstream slot (§8 rungs, 503) and dials.
         fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len <= conn.head_len);
@@ -133,6 +173,15 @@ pub fn Proxy(comptime IoType: type) type {
             if (parser.headerValue(request.headers, "upgrade") != null) {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
+
+            // §7 path routing: canonicalize the target and match it to a
+            // cluster before acquiring any resource, so a bad path or an
+            // unrouted one is rejected cheaply.
+            var scratch: [constants.head_bytes_max]u8 = undefined;
+            conn.cluster_index = resolveCluster(conn, request, &scratch) catch |err| switch (err) {
+                error.BadPath => return respond(server, conn, 400, "l7_bad_request"),
+                error.NoRoute => return respond(server, conn, 404, "l7_no_route"),
+            };
 
             conn.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
@@ -230,10 +279,14 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_dialing);
             assert(request.head_len == conn.l7.request_head_len);
             const upstream = conn.upstream.?;
+            // Forward the §7 canonical target the router matched on, so the
+            // origin and the router never disagree about the resource.
+            var scratch: [constants.head_bytes_max]u8 = undefined;
+            const target = effectiveTarget(request, &scratch);
             // No close announcement upstream: the connection is a parking
             // candidate (§5), and stripping the client's Connection header
             // already made persistence the wire default.
-            const rendered = render.renderRequestHead(request, false, &upstream.head) catch {
+            const rendered = render.renderRequestHead(request, target, false, &upstream.head) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -40,19 +40,23 @@ const protected_names = [_][]const u8{
 /// that this upstream connection will not be reused (§2).
 pub fn renderRequestHead(
     request: *const parser.RequestHead,
+    target: parser.CanonicalTarget,
     inject_close: bool,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     // The proxy answers CONNECT with 501 itself, never forwards it (§7).
     assert(request.method != .connect);
     assert(request.method_token.len >= 1);
-    assert(request.target.len >= 1);
+    // The forwarded target is the §7 canonical form the router matched on
+    // (or `*` for OPTIONS), so the origin sees exactly the path we routed.
+    assert(target.path.len >= 1);
     assert(buffer.len <= std.math.maxInt(u32));
 
     var staging = Staging{ .buffer = buffer };
     try staging.append(request.method_token);
     try staging.append(" ");
-    try staging.append(request.target);
+    try staging.append(target.path);
+    try staging.append(target.query);
     try staging.append(switch (request.version) {
         .http_1_0 => " HTTP/1.0\r\n",
         .http_1_1 => " HTTP/1.1\r\n",
@@ -238,13 +242,13 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, true, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, true, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
@@ -259,7 +263,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -277,7 +281,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, false, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -292,7 +296,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, false, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -303,7 +307,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, false, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -341,8 +345,9 @@ test "render: a head that no longer fits is Oversize" {
     const head = "GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
+    const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, false, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, false, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -355,8 +360,17 @@ fn checkRequestRender(input: []const u8) void {
     if (request.method == .connect) {
         return; // Never rendered: the proxy answers CONNECT itself.
     }
+    // Mirror the routeRequest gate (§7): an origin-form target that will
+    // not canonicalize is a 400 and never reaches the renderer; OPTIONS
+    // asterisk-form has no path and forwards verbatim.
+    var scratch: [constants.head_bytes_max]u8 = undefined;
+    const target: parser.CanonicalTarget = if (request.target[0] == '/')
+        (parser.canonicalTarget(request.target, &scratch) catch return)
+    else
+        .{ .path = request.target, .query = "" };
+
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, false, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, false, &buffer) catch unreachable;
 
     var reparse_storage: parser.HeaderStorage = undefined;
     // A rendered head failing our own parser would mean the proxy emits
@@ -364,7 +378,11 @@ fn checkRequestRender(input: []const u8) void {
     const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch unreachable;
     assert(reparsed.method == request.method);
     assert(std.mem.eql(u8, reparsed.method_token, request.method_token));
-    assert(std.mem.eql(u8, reparsed.target, request.target));
+    // §7 canonical forwarding: the origin sees the canonical path plus the
+    // verbatim query — exactly what the router matched on.
+    assert(reparsed.target.len == target.path.len + target.query.len);
+    assert(std.mem.startsWith(u8, reparsed.target, target.path));
+    assert(std.mem.eql(u8, reparsed.target[target.path.len..], target.query));
     assert(reparsed.version == request.version);
     assert(std.meta.eql(reparsed.framing, request.framing));
     if (request.host) |host| {

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -1,0 +1,97 @@
+//! §7 path routing: map a canonical request path to a cluster through a
+//! per-listener longest-prefix table. Pure — the table is built,
+//! validated, and sorted longest-prefix-first at config load
+//! (`config.zig`), so a request-time match is a bounded linear scan over
+//! immutable arena data, never an allocation on the loop. No match is a
+//! real outcome: the caller answers 404 (§8).
+
+const std = @import("std");
+
+const assert = std.debug.assert;
+
+/// One routing rule: a canonical path prefix and the cluster it selects.
+/// Prefixes are validated canonical at config load (§7), so they compare
+/// directly against the canonical request path with no per-request
+/// normalization.
+pub const Route = struct {
+    prefix: []const u8,
+    cluster_index: u16,
+};
+
+/// The cluster for `path`, or null when no route matches (the caller's
+/// 404, §8). `routes` is sorted longest-prefix-first, so the first prefix
+/// that matches at a segment boundary is the most specific — the scan
+/// stops there. `path` is the canonical request path (§7).
+pub fn route(routes: []const Route, path: []const u8) ?u16 {
+    assert(routes.len >= 1);
+    assert(path.len >= 1);
+    assert(path[0] == '/');
+    for (routes) |candidate| {
+        if (matches(candidate.prefix, path)) {
+            return candidate.cluster_index;
+        }
+    }
+    return null;
+}
+
+/// A prefix matches only when it covers whole path segments: the path
+/// equals the prefix, the prefix is slash-terminated, or the byte right
+/// after the prefix is `/`. So `/api` matches `/api` and `/api/v1` but
+/// never `/apihost` — a string prefix that splits a segment is not a
+/// route. `/` is slash-terminated, so the root prefix is the catch-all.
+fn matches(prefix: []const u8, path: []const u8) bool {
+    assert(prefix.len >= 1);
+    assert(prefix[0] == '/');
+    assert(path.len >= 1);
+    assert(path[0] == '/');
+    if (!std.mem.startsWith(u8, path, prefix)) {
+        return false;
+    }
+    if (path.len == prefix.len) {
+        return true;
+    }
+    assert(path.len > prefix.len);
+    if (prefix[prefix.len - 1] == '/') {
+        return true;
+    }
+    return path[prefix.len] == '/';
+}
+
+test "router: longest-prefix wins at segment boundaries" {
+    // As config.zig will store them: sorted longest-prefix-first.
+    const routes = [_]Route{
+        .{ .prefix = "/api/v2", .cluster_index = 3 },
+        .{ .prefix = "/api", .cluster_index = 2 },
+        .{ .prefix = "/", .cluster_index = 0 },
+    };
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "/api/v2"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "/api/v2/x"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "/api"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "/api/v1"));
+    // A segment-splitting string prefix is not a match: "/api" must not
+    // capture "/apihost", so it falls through to the catch-all.
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/apihost"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/other"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/"));
+}
+
+test "router: no catch-all means no match is null (404)" {
+    const routes = [_]Route{
+        .{ .prefix = "/api", .cluster_index = 1 },
+    };
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "/api"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "/api/deep/path"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/apix"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/elsewhere"));
+}
+
+test "router: a slash-terminated prefix matches its whole subtree" {
+    const routes = [_]Route{
+        .{ .prefix = "/assets/", .cluster_index = 5 },
+        .{ .prefix = "/", .cluster_index = 0 },
+    };
+    try std.testing.expectEqual(@as(?u16, 5), route(&routes, "/assets/img.png"));
+    // "/assets" (no trailing slash) is not under "/assets/"; catch-all.
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/assets"));
+}

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -34,6 +34,20 @@ pub fn route(routes: []const Route, path: []const u8) ?u16 {
     return null;
 }
 
+/// The cluster of the catch-all route (`prefix == "/"`), or null if the
+/// table has none. Used for a target with no path — OPTIONS asterisk-form
+/// (§7) — which cannot match a path prefix but still names the whole
+/// server.
+pub fn catchAll(routes: []const Route) ?u16 {
+    assert(routes.len >= 1);
+    for (routes) |candidate| {
+        if (candidate.prefix.len == 1 and candidate.prefix[0] == '/') {
+            return candidate.cluster_index;
+        }
+    }
+    return null;
+}
+
 /// A prefix matches only when it covers whole path segments: the path
 /// equals the prefix, the prefix is slash-terminated, or the byte right
 /// after the prefix is `/`. So `/api` matches `/api` and `/api/v1` but
@@ -94,4 +108,16 @@ test "router: a slash-terminated prefix matches its whole subtree" {
     try std.testing.expectEqual(@as(?u16, 5), route(&routes, "/assets/img.png"));
     // "/assets" (no trailing slash) is not under "/assets/"; catch-all.
     try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/assets"));
+}
+
+test "router: catchAll finds the root route for pathless targets" {
+    const with_root = [_]Route{
+        .{ .prefix = "/api", .cluster_index = 1 },
+        .{ .prefix = "/", .cluster_index = 7 },
+    };
+    try std.testing.expectEqual(@as(?u16, 7), catchAll(&with_root));
+    const without_root = [_]Route{
+        .{ .prefix = "/api", .cluster_index = 1 },
+    };
+    try std.testing.expectEqual(@as(?u16, null), catchAll(&without_root));
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const router = @import("http/router.zig");
 const Io = @import("io/io.zig");
 const parser = @import("http/parser.zig");
 const Server = @import("Server.zig").Server;
@@ -326,6 +327,7 @@ const Http1Bed = struct {
     sim_io: SimIo,
     endpoints: [1]std.Io.net.IpAddress,
     clusters: [1]config_module.Config.Cluster,
+    routes: [1]router.Route,
     listeners: [1]config_module.Config.Listener,
     config: config_module.Config,
     server: ServerSim,
@@ -363,7 +365,8 @@ const Http1Bed = struct {
         });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
-        bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .http }};
+        bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .http }};
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -352,6 +352,9 @@ const Http1Bed = struct {
         origin_response: []const u8 = "",
         origin_listens: bool = true,
         origin_closes: bool = false,
+        /// The single route's prefix; "/" is the catch-all. A narrower
+        /// prefix lets a test drive the no-route 404 path (§7).
+        route_prefix: []const u8 = "/",
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -365,7 +368,7 @@ const Http1Bed = struct {
         });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
-        bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        bed.routes = .{.{ .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .http }};
         bed.config = .{
             .listeners = &bed.listeners,
@@ -579,6 +582,68 @@ test "l7: a GET is proxied and the origin's response relayed back" {
     try std.testing.expect(forwarded.keep_alive);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "l7: the origin sees the canonical path, query verbatim (§7)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 12,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // Dot-segments collapse, %2E decodes then collapses; the query is
+    // opaque and forwarded byte-for-byte, %2F and all.
+    try bed.exchange("GET /a/%2e%2e/b/./c?x=1%2F2 HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        false,
+        &storage,
+    );
+    // Router and origin agree on the same canonical resource: /a/.. pops
+    // to /, then /b/./c collapses to /b/c; the query rides along untouched.
+    try std.testing.expectEqualStrings("/b/c?x=1%2F2", forwarded.target);
+    try bed.expectDrained();
+}
+
+test "l7: an unroutable path is answered 404" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 13, .route_prefix = "/api" });
+    defer bed.tearDown();
+
+    // The only route is /api; /elsewhere matches nothing, so the origin is
+    // never dialed and the client gets a 404 (§7, §8).
+    try bed.exchange("GET /elsewhere HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
+    try std.testing.expectEqual(@as(u64, 0), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a structure-changing escape in the path is answered 400" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 14 });
+    defer bed.tearDown();
+
+    // %2F is an encoded slash: it would change the path's structure, so
+    // the canonicalizer rejects it before routing (§7).
+    try bed.exchange("GET /a%2Fb HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
     try bed.expectDrained();
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 
 const constants = @import("../constants.zig");
 const parser = @import("../http/parser.zig");
+const router = @import("../http/router.zig");
 const relay = @import("relay.zig");
 const upstream_module = @import("upstream.zig");
 
@@ -60,9 +61,14 @@ pub fn Conn(comptime IoType: type) type {
         /// memory, shrunk from the front as bytes are sent. Empty
         /// otherwise; idle on the L4 path.
         response_pending: []const u8,
-        /// The listener's cluster; the L7 path routes and dials after the
-        /// head parses, long after admission (§7).
+        /// The cluster to dial. Seeded from the listener at admission; on
+        /// the L7 path `routeRequest` overwrites it with the request
+        /// path's cluster once the head parses (§7).
         cluster_index: u16,
+        /// The listener's §7 route table (empty on the L4 path, which has
+        /// no path to match). Set once at admission and constant for the
+        /// connection's life, so it survives keep-alive turnarounds.
+        routes: []const router.Route,
         /// The leased upstream slot during an L7 exchange; released at
         /// teardown alongside the conn slot (§5). Null outside exchanges
         /// and on the whole L4 path.
@@ -265,6 +271,8 @@ pub fn Conn(comptime IoType: type) type {
             conn.head_len = 0;
             conn.response_pending = &.{};
             conn.cluster_index = cluster_index;
+            // L4 never routes by path; admitHttp installs the real table.
+            conn.routes = &.{};
             conn.upstream = null;
             conn.l7 = .{};
             conn.op_data_client_to_upstream = .{};

--- a/src/root.zig
+++ b/src/root.zig
@@ -14,6 +14,7 @@ pub const counters = @import("counters.zig");
 pub const http = struct {
     pub const parser = @import("http/parser.zig");
     pub const render = @import("http/render.zig");
+    pub const router = @import("http/router.zig");
     pub const proxy = @import("http/proxy.zig");
 };
 pub const Io = @import("io/io.zig");
@@ -35,6 +36,7 @@ test {
     _ = counters;
     _ = http.parser;
     _ = http.render;
+    _ = http.router;
     _ = http.proxy;
     _ = Io;
     _ = Server;

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const router = @import("http/router.zig");
 const Io = @import("io/io.zig");
 const Server = @import("Server.zig").Server;
 const SimIo = @import("io/SimIo.zig");
@@ -189,6 +190,7 @@ pub const TestBed = struct {
     sim_io: SimIo,
     endpoints: [1]std.Io.net.IpAddress,
     clusters: [1]config_module.Config.Cluster,
+    routes: [1]router.Route,
     listeners: [1]config_module.Config.Listener,
     config: config_module.Config,
     server: ServerSim,
@@ -218,7 +220,8 @@ pub const TestBed = struct {
         try bed.sim_io.init(arena, options.sim);
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
-        bed.listeners = .{.{ .bind_address = bindAddress(), .cluster_index = 0, .protocol = .l4 }};
+        bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .l4 }};
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -45,6 +45,7 @@ fn reasonPhrase(comptime status: u16) []const u8 {
     comptime assert(status <= 599);
     return switch (status) {
         400 => "Bad Request",
+        404 => "Not Found",
         414 => "URI Too Long",
         431 => "Request Header Fields Too Large",
         501 => "Not Implemented",
@@ -86,7 +87,7 @@ test "shed: every static response parses as a valid bodiless head" {
     // complete, correctly framed head whose persistence matches the
     // requested one — the same verdict a strict client would reach.
     const parser = @import("http/parser.zig");
-    inline for ([_]u16{ 400, 414, 431, 501, 502, 503, 504 }) |status| {
+    inline for ([_]u16{ 400, 404, 414, 431, 501, 502, 503, 504 }) |status| {
         inline for ([_]Persistence{ .keep, .close }) |persistence| {
             const bytes = staticResponse(status, persistence);
             var storage: parser.HeaderStorage = undefined;


### PR DESCRIPTION
Phase 1.5 — path routing. An `http` listener maps the request path to a cluster through a per-listener longest-prefix table, matched on the **canonical** path — and the canonical path is what gets forwarded upstream, so the router and the origin can never disagree about which resource a request names. The path-confusion class (`/api/../admin`) dies structurally, not by backend convention.

Two product decisions were settled up front: **canonical forwarding** (not verbatim) and **path-only** (Host routing deferred as a compatible extension of the same table — the parser already extracts Host).

## The slices (each reviewed adversarially before commit)

1. **Docs (§7).** Settle the design before code: canonical-only matching, canonical forwarding, longest-prefix tables, 404 on no-route. Reconcile the §10 module map — the phase seams materialized as `Server.zig` / `http/router.zig` / `balancer.zig` / `http/proxy.zig`, not one `phases.zig`.
2. **Canonical path in the trust boundary.** `parser.canonicalTarget`: split the query off verbatim, decode unreserved percent-escapes (uppercasing any that survive), then collapse dot-segments — in that order, so `%2e%2e` collapses exactly like `..`. Structure-changing escapes (`%2F`, `%00`), malformed escapes, and root climbs are 400s; duplicate slashes are preserved (consistency, not merging, is the safe property).
3. **`router.zig` + config schema.** A pure longest-prefix matcher (segment-boundary: `/api` matches `/api` and `/api/v1`, never `/apihost`; `/` is the catch-all). `Config.Listener` gains a route table; JSON `"routes": [{prefix,cluster}]`, with `"cluster": "x"` kept as sugar for one catch-all route so every pre-routing config stays valid. Prefixes are validated canonical at load, so they compare byte-for-byte against the canonical request path.
4. **Wiring.** `routeRequest` canonicalizes the target, routes it to a cluster (400 if it won't canonicalize, 404 if nothing matches — both before any resource is acquired), and the renderer forwards that same canonical path. OPTIONS asterisk-form routes to the catch-all. New `l7_no_route` counter and 404 static response.
5. **Sim fuzzing.** The HTTP origin gains a §7 oracle — every forwarded target must already be canonical — and a `/deep/%2e%2e/sim` confusion script exercises decode-then-collapse and canonical forwarding under 1-byte fragmentation across every seed.

## Verification

- **Directed tests** (http_proxy_test.zig): the origin sees the canonical path with the query byte-for-byte (`/a/%2e%2e/b/./c?x=1%2F2` → `/b/c?x=1%2F2`), an unroutable path is 404 with the origin never dialed, a `%2F` in the path is 400; router matching (boundary, longest-prefix, catch-all, 404); the full config reject matrix.
- **Fuzz oracles** (§9 gate 2): `canonicalTarget` (rooted, never grows, no surviving dot-segment, self-canonical) and the render oracle (the forwarded target is canonical path + verbatim query). Slice 1 was reviewed with 8M fuzz iterations plus a 50M-input differential cross-check against an independent RFC 3986 §5.2.4 reference — zero divergences.
- **Simulation** (§9 gate 1): the origin canonical oracle is **retro-validated** — forwarding the raw target instead of the canonical one fails the sim at seed 10 (`OriginSawMalformedBytes`). 3000-seed sweep green.
- `zig build ci` and `zig fmt --check` green on every commit; every function within the 70-line limit.

Host-based rules extend the same table when needed; the routing-decision-to-distinct-backends fuzzing (a second sim cluster) was left out as disproportionate — the directed tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
