### PR TITLE
Host routing: the route table's outer dimension (§7)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -479,8 +479,28 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   carries that same canonical path, so the router and the origin cannot
   disagree about which resource a request names — the `/api/../admin`
   confusion class dies structurally, not by backend convention.
-  Host-based rules are deferred: the parser already extracts `Host`,
-  and host rules extend the same table compatibly when needed.
+- **Host is the route table's outer dimension** (settled 2026-07-20).
+  A route gains an optional `host` (`{ "host": "api.example.com",
+  "prefix": "/v2", "cluster": "v2" }`); a route with no `host` matches
+  any host, exactly as today. Matching filters to the routes whose host
+  equals the request's — falling back to the any-host routes when none
+  does — then takes the longest prefix within that set, so a
+  host-specific route always beats an any-host route and `host + path`
+  composes without a second routing pass. This is the nginx `server` /
+  Envoy `virtual_host` nesting (host contains routes), *not* a parallel
+  host-picks-cluster path: **cluster selection is the route table's
+  alone**, so there is one precedence rule to reason about. Host is
+  matched on its **canonical form** — lowercased and port-stripped (RFC
+  9110 §4.2.3 makes `Host` case-insensitive, and the authority's port is
+  not part of the routing name) — computed once in the trust boundary
+  like the path. Unlike the path, the `Host` header is **forwarded
+  verbatim**: an origin virtual-host may legitimately be case- or
+  port-sensitive, and the proxy has no per-origin knowledge to justify
+  rewriting it — the canonical form is a routing *key*, not a
+  replacement. A request with no `Host` (legal in HTTP/1.0) or an empty
+  one matches only the any-host routes; config hosts must themselves be
+  canonical (rejected at load otherwise), so a request host compares
+  byte-for-byte against them.
 - **Early responses are legal.** An origin may answer before the request
   body finishes (RFC 9110 — e.g. 413 mid-upload): the response head is
   forwarded when it arrives, and the remaining request body is drained or
@@ -501,8 +521,12 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   at config time* into bounded, immutable tables in the config arena
   (match programs over method/host/path/header slices; action lists drawn
   from a closed enum: reject-with-status, add/remove/set header, rewrite
-  path prefix, pick cluster), each with a static limit
+  path prefix), each with a static limit
   (`rules_per_route_max`, `actions_per_rule_max`, `header_edits_max`).
+  Cluster selection is deliberately *not* a filter action: the route
+  table (host + path) is the single mechanism that decides which backend
+  serves a request, so there is one precedence rule, not two engines
+  competing.
   At request time the phase points *interpret* those tables against the
   parsed head — bounded loops over arena data, zero-copy matches on head-
   buffer slices. Mutations never edit the head buffer in place: the

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -24,15 +24,21 @@ behind all four gates of §9.
   covering L7: the mixed-protocol simulation (golden + prefix oracles,
   retro-validated against two shipped bugs), the keep-alive-reuse
   zero-alloc gate, and the `Connection: close` Tier-1 bands.
-- **Phase 1.5 — path routing. In progress.** Longest-prefix
-  path → cluster tables per listener, matched on the §7 canonical path
-  (decode unreserved escapes, collapse dot-segments; structure-changing
-  escapes → 400) with the canonical path forwarded upstream, so the
-  router and the origin cannot diverge — the settled §7 decision
-  (2026-07-19). No match → the 404 static verdict. The sim gains a
-  routing-correctness oracle: distinct canonical bodies per cluster
-  plus path-confusion scripts (`/a/../b`, `%2e%2e`, encoded slash).
-  Host rules deferred as a compatible extension of the same table.
+- **Phase 1.5 — path routing. Shipped 2026-07-20 (PR #50).** Longest-
+  prefix path → cluster tables per listener, matched on the §7 canonical
+  path (decode unreserved escapes, collapse dot-segments; structure-
+  changing escapes → 400) with the canonical path forwarded upstream, so
+  the router and the origin cannot diverge. No match → the 404 static
+  verdict. The sim fuzzes canonical forwarding (an origin oracle
+  rejecting a non-canonical forward) and a path-confusion script.
+- **Phase 1.6 — host routing. In progress.** Host becomes the route
+  table's outer dimension (§7, settled 2026-07-20): an optional per-route
+  `host`, matched host-specific-first then longest-prefix, so `host +
+  path` composes in one table with one precedence rule. Host is matched
+  on its canonical form (lowercased, port-stripped) computed in the trust
+  boundary but forwarded verbatim. No-Host requests match only any-host
+  routes. Cluster selection stays the route table's alone — `pick
+  cluster` is not a filter action.
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
   stale-replay (a checkout that fails on first use answers 502 today),
   per-try deadline and the §8 request-deadline 504 verdict (an expired

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,7 +72,8 @@ pub const ValidationError = error{
     RoutesEmpty,
     RoutesOverLimit,
     RoutePrefixNotCanonical,
-    RoutePrefixDuplicate,
+    RouteHostNotCanonical,
+    RouteDuplicate,
     EndpointsEmpty,
     EndpointsOverLimit,
     EndpointInvalid,
@@ -126,6 +127,8 @@ const ListenerJson = struct {
 };
 
 const RouteJson = struct {
+    /// Optional §7 host scope; absent means the route matches any host.
+    host: ?[]const u8 = null,
     prefix: []const u8,
     cluster: []const u8,
 };
@@ -321,27 +324,63 @@ fn resolveRoutes(
     const routes = try arena.alloc(router.Route, routes_json.len);
     for (routes_json, 0..) |route_json, index| {
         try validateRoutePrefix(route_json.prefix);
+        const host = if (route_json.host) |raw| try validateRouteHost(raw) else null;
         for (routes_json[0..index]) |previous| {
-            if (std.mem.eql(u8, previous.prefix, route_json.prefix)) {
-                return error.RoutePrefixDuplicate;
+            // Earlier routes already passed validateRouteHost, so their raw
+            // host equals its canonical form — a byte compare is sound.
+            if (optionalHostEql(previous.host, host) and
+                std.mem.eql(u8, previous.prefix, route_json.prefix))
+            {
+                return error.RouteDuplicate;
             }
         }
         routes[index] = .{
+            .host = host,
             .prefix = route_json.prefix,
             .cluster_index = try clusterIndexOf(clusters, route_json.cluster),
         };
     }
-    // Longest-prefix-first, so the router's linear scan finds the most
-    // specific match first (§7). Descending by length; ties are already
-    // rejected as duplicates above, so order among equal lengths is moot.
-    std.mem.sort(router.Route, routes, {}, routeLongerFirst);
+    // Host-specific first, then longest-prefix-first (§7): the router's
+    // linear scan then finds the most specific match first — any route
+    // scoped to the request's host before any any-host route, and within a
+    // group the longest prefix. Ties are rejected as duplicates above.
+    std.mem.sort(router.Route, routes, {}, routeMoreSpecific);
     assert(routes.len >= 1);
     assert(routes.len <= constants.routes_max);
     return routes;
 }
 
-fn routeLongerFirst(_: void, left: router.Route, right: router.Route) bool {
+fn routeMoreSpecific(_: void, left: router.Route, right: router.Route) bool {
+    const left_scoped = left.host != null;
+    const right_scoped = right.host != null;
+    if (left_scoped != right_scoped) {
+        return left_scoped; // A host-scoped route sorts before an any-host one.
+    }
     return left.prefix.len > right.prefix.len;
+}
+
+fn optionalHostEql(left: ?[]const u8, right: ?[]const u8) bool {
+    const left_host = left orelse return right == null;
+    const right_host = right orelse return false;
+    return std.mem.eql(u8, left_host, right_host);
+}
+
+/// A route host must already be in §7 canonical form (lowercased,
+/// port-stripped), so a request's canonical host compares byte-for-byte
+/// against it. A host canonicalization would change — mixed case, a port,
+/// oversize — is rejected at load, not silently mismatched at request time.
+fn validateRouteHost(host: []const u8) ParseError![]const u8 {
+    if (host.len == 0 or host.len > constants.host_bytes_max) {
+        return error.RouteHostNotCanonical;
+    }
+    var out: [constants.host_bytes_max]u8 = undefined;
+    const canonical = parser.canonicalHost(host, &out) orelse {
+        return error.RouteHostNotCanonical;
+    };
+    if (!std.mem.eql(u8, canonical, host)) {
+        return error.RouteHostNotCanonical;
+    }
+    return host; // The config slice, already canonical.
 }
 
 /// A route prefix must be an origin-form path already in canonical form,
@@ -518,11 +557,11 @@ test "config: explicit routes resolve, sorted longest-prefix-first" {
     // The cluster the router will hand back for the longest match.
     try std.testing.expectEqual(
         @as(?u16, routes[0].cluster_index),
-        router.route(routes, "/api/v2/x"),
+        router.route(routes, null, "/api/v2/x"),
     );
     try std.testing.expectEqual(
         @as(?u16, routes[2].cluster_index),
-        router.route(routes, "/elsewhere"),
+        router.route(routes, null, "/elsewhere"),
     );
 }
 
@@ -548,13 +587,51 @@ test "config: routing schema rejects malformed tables" {
     // A prefix without a leading slash.
     try expectParseError(error.RoutePrefixNotCanonical, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"routes\":[{\"prefix\":\"api\",\"cluster\":\"a\"}]}]," ++ base_clusters);
-    // Duplicate prefixes.
-    try expectParseError(error.RoutePrefixDuplicate, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+    // Duplicate (host, prefix) — same any-host prefix twice.
+    try expectParseError(error.RouteDuplicate, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"routes\":[{\"prefix\":\"/x\",\"cluster\":\"a\"}," ++
         "{\"prefix\":\"/x\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // A non-canonical host (uppercase) — would mismatch at request time.
+    try expectParseError(error.RouteHostNotCanonical, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"host\":\"API.Example.com\",\"prefix\":\"/\",\"cluster\":\"a\"}]}]," ++ base_clusters);
+    // A host carrying a port — the port is not part of the routing name.
+    try expectParseError(error.RouteHostNotCanonical, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"routes\":[{\"host\":\"api.example.com:8080\",\"prefix\":\"/\",\"cluster\":\"a\"}]}]," ++ base_clusters);
     // An unknown cluster named by a route.
     try expectParseError(error.ClusterUnknown, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"routes\":[{\"prefix\":\"/\",\"cluster\":\"ghost\"}]}]," ++ base_clusters);
+}
+
+test "config: host routes resolve, host-specific sorted before any-host" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","routes":[
+        \\   {"prefix":"/","cluster":"root"},
+        \\   {"host":"api.example.com","prefix":"/","cluster":"api"},
+        \\   {"host":"api.example.com","prefix":"/v2","cluster":"v2"}]}],
+        \\ "clusters":{"root":{"endpoints":["127.0.0.1:2"]},
+        \\   "api":{"endpoints":["127.0.0.1:3"]},
+        \\   "v2":{"endpoints":["127.0.0.1:4"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    const routes = parsed.listeners[0].routes;
+    try std.testing.expectEqual(@as(usize, 3), routes.len);
+    // Host-specific first (longest-prefix within), then any-host.
+    try std.testing.expectEqualStrings("api.example.com", routes[0].host.?);
+    try std.testing.expectEqualStrings("/v2", routes[0].prefix);
+    try std.testing.expectEqualStrings("api.example.com", routes[1].host.?);
+    try std.testing.expectEqualStrings("/", routes[1].prefix);
+    try std.testing.expectEqual(@as(?[]const u8, null), routes[2].host);
+    // The router hands host-specificity precedence over prefix length.
+    try std.testing.expectEqual(
+        @as(?u16, routes[1].cluster_index),
+        router.route(routes, "api.example.com", "/other"),
+    );
+    try std.testing.expectEqual(
+        @as(?u16, routes[2].cluster_index),
+        router.route(routes, "other.example.com", "/v2"),
+    );
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -72,6 +72,12 @@ pub const head_bytes_max: u32 = 8 * 1024;
 /// maps to 431, distinguishable from malformed input's 400 (§7).
 pub const headers_max: u16 = 64;
 
+/// Upper bound on a canonical routing host (§7). A DNS name is ≤ 253
+/// bytes (RFC 1035) and an `[IPv6]` authority fits well under this; a
+/// Host longer than this canonicalizes to "unmatchable", so it only
+/// meets the any-host routes — never malformed, just unroutable by host.
+pub const host_bytes_max: u16 = 256;
+
 /// Upper bound on one chunk-size line (hex size, extensions, CRLF) in a
 /// chunked body (§7). Bounded so a hostile peer cannot stream an endless
 /// size line through the relay; kept under one relay buffer so a legal
@@ -179,6 +185,7 @@ comptime {
     assert(relay_pressure_idle_divisor >= 2);
     assert(head_bytes_max >= 1024);
     assert(headers_max >= 8);
+    assert(host_bytes_max >= 1);
     assert(upstream_slots_max >= 1);
     assert(chunked_line_bytes_max >= 32);
     assert(chunked_line_bytes_max <= relay_buffer_bytes);

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -886,6 +886,42 @@ fn isUnreservedByte(byte: u8) bool {
         byte == '_' or byte == '~';
 }
 
+/// The §7 canonical routing form of a `Host` header value: lowercased
+/// (RFC 9110 §4.2.3 host equality is case-insensitive) with the
+/// authority's port stripped (a port is not part of the routing name).
+/// `out` receives the lowercased bytes; the returned slice points into
+/// it. Null means "unmatchable" — an empty or oversize host — which
+/// meets only the any-host routes, never a match error: a Host is a
+/// routing key, and a key that fits no config host simply does not match.
+/// The header itself is forwarded verbatim (§7); this is the key alone.
+/// Only case and port are folded; anything else (a trailing-dot FQDN,
+/// say) yields a distinct key, so it can only under-match to any-host —
+/// never over-match a vhost it should not reach.
+pub fn canonicalHost(host: []const u8, out: *[constants.host_bytes_max]u8) ?[]const u8 {
+    if (host.len == 0) {
+        return null;
+    }
+    if (host.len > out.len) {
+        return null; // Oversize: unmatchable, not malformed.
+    }
+    // An IPv6 literal wears brackets and its own colons, so the port (if
+    // any) starts only after the ']'; a plain host has no colon before
+    // its port.
+    const authority_end = if (host[0] == '[')
+        (std.mem.indexOfScalar(u8, host, ']') orelse return null) + 1
+    else
+        std.mem.indexOfScalar(u8, host, ':') orelse host.len;
+    assert(authority_end <= host.len);
+    if (authority_end == 0) {
+        return null; // A host that is only a port (":8080") matches nothing.
+    }
+    for (host[0..authority_end], 0..) |byte, index| {
+        out[index] = std.ascii.toLower(byte);
+    }
+    assert(authority_end >= 1);
+    return out[0..authority_end];
+}
+
 /// A reverse proxy routes origin-form targets (§7 routes host/path);
 /// asterisk-form is legal for OPTIONS. CONNECT's authority-form passes
 /// through so the proxy can answer it with 501 rather than 400.
@@ -1600,4 +1636,67 @@ fn fuzzCanonicalTarget(context: void, smith: *std.testing.Smith) !void {
     const again = try canonicalTarget(canonical.path, &out_again);
     assert(std.mem.eql(u8, again.path, canonical.path));
     assert(again.query.len == 0);
+}
+
+test "canonicalHost: lowercase, strip port, bracket-aware" {
+    const Case = struct { host: []const u8, want: ?[]const u8 };
+    const cases = [_]Case{
+        .{ .host = "api.example.com", .want = "api.example.com" },
+        .{ .host = "API.Example.COM", .want = "api.example.com" },
+        .{ .host = "api.example.com:8080", .want = "api.example.com" },
+        .{ .host = "API.EXAMPLE.COM:443", .want = "api.example.com" },
+        .{ .host = "localhost", .want = "localhost" },
+        // IPv6 literals keep their brackets and inner colons; only a port
+        // past the ']' is stripped, and the hex lowercases.
+        .{ .host = "[::1]", .want = "[::1]" },
+        .{ .host = "[::1]:8080", .want = "[::1]" },
+        .{ .host = "[2001:DB8::1]:443", .want = "[2001:db8::1]" },
+        // Unmatchable (null): empty, port-only, or an unterminated bracket.
+        .{ .host = "", .want = null },
+        .{ .host = ":8080", .want = null },
+        .{ .host = "[::1", .want = null },
+    };
+    for (cases) |case| {
+        var out: [constants.host_bytes_max]u8 = undefined;
+        const got = canonicalHost(case.host, &out);
+        if (case.want) |want| {
+            try std.testing.expectEqualStrings(want, got.?);
+        } else {
+            try std.testing.expectEqual(@as(?[]const u8, null), got);
+        }
+    }
+    // Oversize is unmatchable, not a crash.
+    var big: [constants.host_bytes_max + 1]u8 = undefined;
+    @memset(&big, 'a');
+    var out: [constants.host_bytes_max]u8 = undefined;
+    try std.testing.expectEqual(@as(?[]const u8, null), canonicalHost(&big, &out));
+}
+
+test "fuzz: canonicalHost is idempotent and never uppercases" {
+    try std.testing.fuzz({}, fuzzCanonicalHost, .{ .corpus = &.{
+        "API.Example.com:8080",
+        "[2001:DB8::1]:443",
+        ":onlyport",
+        "a",
+    } });
+}
+
+fn fuzzCanonicalHost(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    var input_buffer: [constants.host_bytes_max]u8 = undefined;
+    const input_len = smith.slice(&input_buffer);
+    const input = input_buffer[0..input_len];
+
+    var out: [constants.host_bytes_max]u8 = undefined;
+    const canonical = canonicalHost(input, &out) orelse return; // null is legal.
+    // Never grows, and never yields an uppercase letter.
+    assert(canonical.len >= 1);
+    assert(canonical.len <= input.len);
+    for (canonical) |byte| {
+        assert(!std.ascii.isUpper(byte));
+    }
+    // Idempotent: the canonical form is its own canonical form.
+    var out_again: [constants.host_bytes_max]u8 = undefined;
+    const again = canonicalHost(canonical, &out_again).?;
+    assert(std.mem.eql(u8, again, canonical));
 }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -121,27 +121,33 @@ pub fn Proxy(comptime IoType: type) type {
             routeRequest(server, conn, &request);
         }
 
-        /// The cluster for `request`'s canonical path (§7). Origin-form is
-        /// canonicalized and matched by longest prefix; OPTIONS
-        /// asterisk-form has no path and routes to the catch-all. A target
-        /// that will not canonicalize is BadPath (400); an unmatched path
-        /// is NoRoute (404).
+        /// The cluster for `request`'s canonical host and path (§7). The
+        /// host is canonicalized (null when absent/unmatchable → any-host
+        /// routes only); origin-form paths are canonicalized and matched
+        /// by longest prefix; OPTIONS asterisk-form names the whole server,
+        /// so it routes as path "/". A target that will not canonicalize
+        /// is BadPath (400); an unmatched host/path is NoRoute (404).
         fn resolveCluster(
             conn: *ConnType,
             request: *const parser.RequestHead,
             scratch: *[constants.head_bytes_max]u8,
+            host_scratch: *[constants.host_bytes_max]u8,
         ) error{ BadPath, NoRoute }!u16 {
             assert(request.target.len >= 1);
             assert(conn.routes.len >= 1);
+            const host: ?[]const u8 = if (request.host) |raw|
+                parser.canonicalHost(raw, host_scratch)
+            else
+                null;
             if (request.target[0] != '/') {
                 // validateTarget admitted only asterisk-form here.
                 assert(request.method == .options);
-                return router.catchAll(conn.routes) orelse error.NoRoute;
+                return router.route(conn.routes, host, "/") orelse error.NoRoute;
             }
             const canonical = parser.canonicalTarget(request.target, scratch) catch {
                 return error.BadPath;
             };
-            return router.route(conn.routes, canonical.path) orelse error.NoRoute;
+            return router.route(conn.routes, host, canonical.path) orelse error.NoRoute;
         }
 
         /// The canonical bytes to forward for `request` (§7): origin-form
@@ -174,11 +180,12 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
 
-            // §7 path routing: canonicalize the target and match it to a
-            // cluster before acquiring any resource, so a bad path or an
-            // unrouted one is rejected cheaply.
+            // §7 routing: canonicalize the host and path and match them to
+            // a cluster before acquiring any resource, so a bad path or an
+            // unrouted host/path is rejected cheaply.
             var scratch: [constants.head_bytes_max]u8 = undefined;
-            conn.cluster_index = resolveCluster(conn, request, &scratch) catch |err| switch (err) {
+            var host_scratch: [constants.host_bytes_max]u8 = undefined;
+            conn.cluster_index = resolveCluster(conn, request, &scratch, &host_scratch) catch |err| switch (err) {
                 error.BadPath => return respond(server, conn, 400, "l7_bad_request"),
                 error.NoRoute => return respond(server, conn, 404, "l7_no_route"),
             };

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -1,51 +1,53 @@
-//! §7 path routing: map a canonical request path to a cluster through a
-//! per-listener longest-prefix table. Pure — the table is built,
-//! validated, and sorted longest-prefix-first at config load
-//! (`config.zig`), so a request-time match is a bounded linear scan over
-//! immutable arena data, never an allocation on the loop. No match is a
-//! real outcome: the caller answers 404 (§8).
+//! §7 routing: map a request's canonical host and path to a cluster
+//! through a per-listener table. Host is the outer dimension — a
+//! host-specific route beats an any-host one — and path is longest-prefix
+//! within that. Pure: the table is built, validated, and sorted at config
+//! load (`config.zig`) so a host-specific match precedes any any-host
+//! match and each group is longest-prefix-first, making a request-time
+//! match a bounded linear scan over immutable arena data, never an
+//! allocation on the loop. No match is a real outcome: the caller
+//! answers 404 (§8).
 
 const std = @import("std");
 
 const assert = std.debug.assert;
 
-/// One routing rule: a canonical path prefix and the cluster it selects.
-/// Prefixes are validated canonical at config load (§7), so they compare
-/// directly against the canonical request path with no per-request
-/// normalization.
+/// One routing rule: a canonical path prefix and the cluster it selects,
+/// optionally scoped to a canonical host (`null` = any host). Both keys
+/// are validated canonical at config load (§7), so they compare directly
+/// against the request's canonical host/path with no per-request work.
 pub const Route = struct {
+    host: ?[]const u8 = null,
     prefix: []const u8,
     cluster_index: u16,
 };
 
-/// The cluster for `path`, or null when no route matches (the caller's
-/// 404, §8). `routes` is sorted longest-prefix-first, so the first prefix
-/// that matches at a segment boundary is the most specific — the scan
-/// stops there. `path` is the canonical request path (§7).
-pub fn route(routes: []const Route, path: []const u8) ?u16 {
+/// The cluster for a request's canonical `host` (null when the request
+/// carried no usable Host) and canonical `path`, or null when nothing
+/// matches (the caller's 404, §8). `routes` is sorted host-specific-first
+/// then longest-prefix-first, so the first matching route is the most
+/// specific: any route scoped to the request's host beats every any-host
+/// route, and within a group the longest prefix wins.
+pub fn route(routes: []const Route, host: ?[]const u8, path: []const u8) ?u16 {
     assert(routes.len >= 1);
     assert(path.len >= 1);
     assert(path[0] == '/');
     for (routes) |candidate| {
-        if (matches(candidate.prefix, path)) {
+        if (hostMatches(candidate.host, host) and matches(candidate.prefix, path)) {
             return candidate.cluster_index;
         }
     }
     return null;
 }
 
-/// The cluster of the catch-all route (`prefix == "/"`), or null if the
-/// table has none. Used for a target with no path — OPTIONS asterisk-form
-/// (§7) — which cannot match a path prefix but still names the whole
-/// server.
-pub fn catchAll(routes: []const Route) ?u16 {
-    assert(routes.len >= 1);
-    for (routes) |candidate| {
-        if (candidate.prefix.len == 1 and candidate.prefix[0] == '/') {
-            return candidate.cluster_index;
-        }
-    }
-    return null;
+/// An any-host route (`route_host == null`) matches every request. A
+/// host-scoped route matches only when the request carried a host and it
+/// equals the route's — so a request with no usable Host (`req_host ==
+/// null`) meets only the any-host routes (§7).
+fn hostMatches(route_host: ?[]const u8, req_host: ?[]const u8) bool {
+    const scoped = route_host orelse return true;
+    const requested = req_host orelse return false;
+    return std.mem.eql(u8, scoped, requested);
 }
 
 /// A prefix matches only when it covers whole path segments: the path
@@ -78,26 +80,26 @@ test "router: longest-prefix wins at segment boundaries" {
         .{ .prefix = "/api", .cluster_index = 2 },
         .{ .prefix = "/", .cluster_index = 0 },
     };
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "/api/v2"));
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "/api/v2/x"));
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "/api"));
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "/api/v1"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2/x"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api/v1"));
     // A segment-splitting string prefix is not a match: "/api" must not
     // capture "/apihost", so it falls through to the catch-all.
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/apihost"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/other"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/apihost"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/other"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/"));
 }
 
 test "router: no catch-all means no match is null (404)" {
     const routes = [_]Route{
         .{ .prefix = "/api", .cluster_index = 1 },
     };
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "/api"));
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "/api/deep/path"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/apix"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, "/elsewhere"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api/deep/path"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/apix"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/elsewhere"));
 }
 
 test "router: a slash-terminated prefix matches its whole subtree" {
@@ -105,19 +107,40 @@ test "router: a slash-terminated prefix matches its whole subtree" {
         .{ .prefix = "/assets/", .cluster_index = 5 },
         .{ .prefix = "/", .cluster_index = 0 },
     };
-    try std.testing.expectEqual(@as(?u16, 5), route(&routes, "/assets/img.png"));
+    try std.testing.expectEqual(@as(?u16, 5), route(&routes, null, "/assets/img.png"));
     // "/assets" (no trailing slash) is not under "/assets/"; catch-all.
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "/assets"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/assets"));
 }
 
-test "router: catchAll finds the root route for pathless targets" {
-    const with_root = [_]Route{
-        .{ .prefix = "/api", .cluster_index = 1 },
-        .{ .prefix = "/", .cluster_index = 7 },
+test "router: a host-specific route beats an any-host one, whatever the prefix" {
+    // As config.zig sorts them: host-specific first, then longest-prefix.
+    const routes = [_]Route{
+        .{ .host = "a.example", .prefix = "/api", .cluster_index = 1 },
+        .{ .host = "a.example", .prefix = "/", .cluster_index = 2 },
+        .{ .prefix = "/deep", .cluster_index = 3 },
+        .{ .prefix = "/", .cluster_index = 0 },
     };
-    try std.testing.expectEqual(@as(?u16, 7), catchAll(&with_root));
-    const without_root = [_]Route{
-        .{ .prefix = "/api", .cluster_index = 1 },
+    // Host a.example: its own routes win, longest-prefix among them.
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "a.example", "/api/x"));
+    // Host a.example, /deep/x: no host route matches except its own
+    // catch-all "/", which STILL beats the longer any-host "/deep" —
+    // host-specificity dominates prefix length.
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/deep/x"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/other"));
+    // A different host falls entirely to the any-host routes.
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "b.example", "/deep/x"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "b.example", "/api"));
+    // No usable Host matches only any-host routes.
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/deep"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/whatever"));
+}
+
+test "router: a host-scoped table 404s a request whose host is absent" {
+    const routes = [_]Route{
+        .{ .host = "only.example", .prefix = "/", .cluster_index = 1 },
     };
-    try std.testing.expectEqual(@as(?u16, null), catchAll(&without_root));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "only.example", "/x"));
+    // Wrong host, or no host at all: nothing any-host to fall back to.
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, "other.example", "/x"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/x"));
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -355,6 +355,9 @@ const Http1Bed = struct {
         /// The single route's prefix; "/" is the catch-all. A narrower
         /// prefix lets a test drive the no-route 404 path (§7).
         route_prefix: []const u8 = "/",
+        /// The single route's host scope; null is any-host. A canonical
+        /// host lets a test drive host routing and its 404 (§7).
+        route_host: ?[]const u8 = null,
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -368,7 +371,7 @@ const Http1Bed = struct {
         });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
-        bed.routes = .{.{ .prefix = options.route_prefix, .cluster_index = 0 }};
+        bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .http }};
         bed.config = .{
             .listeners = &bed.listeners,
@@ -645,6 +648,87 @@ test "l7: a structure-changing escape in the path is answered 400" {
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
     try bed.expectDrained();
+}
+
+test "l7: the Host header selects a host-scoped route, case- and port-insensitively" {
+    // The route is scoped to a canonical host; a request whose canonical
+    // Host equals it routes there, whatever the wire case or port (§7).
+    const wire_hosts = [_][]const u8{ "api.example", "API.Example", "Api.Example:8080" };
+    for (wire_hosts, 0..) |host, index| {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 20 + index,
+            .route_host = "api.example",
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        var request_buffer: [128]u8 = undefined;
+        const request = try std.fmt.bufPrint(
+            &request_buffer,
+            "GET /x HTTP/1.1\r\nHost: {s}\r\nConnection: close\r\n\r\n",
+            .{host},
+        );
+        try bed.exchange(request);
+
+        try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+            bed.client.response(),
+        );
+        // The origin got the request verbatim-Host'd (host is a routing
+        // key, forwarded as sent — here the wire Host rides along).
+        try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a request to a host with no route is answered 404" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 24, .route_host = "api.example" });
+    defer bed.tearDown();
+
+    // The only route is scoped to api.example; another host has no
+    // any-host route to fall back to, so it is 404 and never dialed (§7).
+    try bed.exchange("GET /x HTTP/1.1\r\nHost: other.example\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {
+    // Any-host route (the default): a Host-less HTTP/1.0 request still
+    // routes.
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 25,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+        try bed.exchange("GET /x HTTP/1.0\r\nConnection: close\r\n\r\n");
+        try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+        try bed.expectDrained();
+    }
+    // Host-scoped route: a Host-less request cannot match it, so 404.
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{ .seed = 26, .route_host = "api.example" });
+        defer bed.tearDown();
+        try bed.exchange("GET /x HTTP/1.0\r\n\r\n");
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
+        try bed.expectDrained();
+    }
 }
 
 test "l7: a POST body is forwarded and a sized response returned, byte-exact under the adversary" {


### PR DESCRIPTION
Phase 1.6 — host routing. Host becomes the route table's **outer dimension**: a route may name an optional `host`, matched host-specific-first then longest-prefix, so `host + path` composes in one table with one precedence rule. This is nginx `server` / Envoy `virtual_host` nesting (host contains routes), not a parallel host-picks-cluster engine — cluster selection stays the route table's alone.

## The slices (mechanism slices reviewed adversarially)

1. **Docs (§7).** Settle the semantics before code: host is the outer dimension (host-specific beats any-host, then longest prefix); the host is matched on its canonical form but the `Host` header is forwarded **verbatim** (an origin vhost may legitimately be case- or port-sensitive, and the canonical form is a routing key, not a rewrite); no-Host requests match only any-host routes; config hosts must be canonical. Also tightened the filters bullet — `pick cluster` leaves the closed action enum, so routing is one mechanism, not two engines competing.
2. **`parser.canonicalHost`.** The trust-boundary routing key: lowercased (RFC 9110 §4.2.3 case-insensitivity), port-stripped (the port is not part of the routing name), bracket-aware for IPv6 literals. Returns null — "unmatchable" — for an empty/oversize/malformed host rather than an error: a Host is a routing key, so one that fits no config host meets only the any-host routes, never a 400. Only case and port are folded, so any other shape can only under-match, never over-match a vhost.
3. **Router host dimension + config.** `Route` gains an optional `host` (null = any host); `route(routes, host, path)` returns the first route where host and prefix both match, over a table sorted host-specific-first then longest-prefix — so a single scan gives host-specificity precedence over prefix length. `catchAll` is gone: OPTIONS asterisk-form routes as path `/`, now host-aware. Config validates each route host already-canonical (`canonicalHost(h) == h`), dedups on `(host, prefix)`, and the `"cluster"` sugar is an any-host catch-all.
4. **End-to-end.** Case/port-insensitive host match (`api.example`, `API.Example`, `Api.Example:8080` all route there), a wrong-host 404 with the origin never dialed, and an HTTP/1.0 no-Host request matching only any-host routes.

## Config shape

```json
{
  "listeners": [
    { "bind": "127.0.0.1:8080", "protocol": "http", "routes": [
        { "host": "api.example.com", "prefix": "/v2", "cluster": "v2" },
        { "host": "api.example.com", "prefix": "/",   "cluster": "api" },
        { "prefix": "/", "cluster": "web" }
    ]},
    { "bind": "127.0.0.1:8443", "protocol": "l4", "cluster": "raw" }
  ],
  "clusters": {
    "v2":  { "endpoints": ["127.0.0.1:9002"] },
    "api": { "endpoints": ["127.0.0.1:9001"] },
    "web": { "endpoints": ["127.0.0.1:9000"] },
    "raw": { "endpoints": ["127.0.0.1:7000"] }
  },
  "timeouts": { "connect_ms": 5000, "idle_ms": 60000, "drain_deadline_ms": 10000 }
}
```

A listener names either `"cluster"` (sugar for one any-host catch-all route) or `"routes"` (the explicit table); an `l4` listener may use only `"cluster"`. Backward compatible: the `"cluster"` form and every pre-host config still parse unchanged.

## Verification

- Router unit tests (host-specificity beats prefix length; a host-scoped table 404s an absent/wrong host) and the config resolve/reject matrix (host sorting, non-canonical/ported host, `(host,prefix)` dup).
- `canonicalHost` fuzz oracle (idempotent, never grows, no uppercase, null-or-valid).
- E2E over the SimIo bed under the adversary.
- `zig build ci` + `zig fmt --check` green on every commit; every function within the 70-line limit; 2000-seed sim sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
