### PR TITLE
feat(filter): §7 programmable filters

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -533,7 +533,14 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   upstream head is *rendered* (already required for hop-by-hop stripping
   and `Connection` injection), so header edits are applied during
   rendering into the same fixed staging area, and a head that no longer
-  fits after edits → 431. Evaluation cost is bounded and load-shed like
+  fits after edits → 431. A path rewrite changes *only what is forwarded*:
+  routing already chose the cluster from the original canonical path, so a
+  rewrite never re-routes and never chains (first-applicable rule wins, like
+  the reject verdict — a later rule matches the original path, not the
+  rewritten one). Both prefixes are validated canonical at load and the
+  replacement is a *segment-correct* join (stripping a prefix to root gives
+  `/x`, not the distinct resource `//x`), so the forwarded path is canonical
+  by construction. Evaluation cost is bounded and load-shed like
   everything else. This is nginx/HAProxy's config-rule model, not Envoy's
   runtime filter chain — WASM/scripting is explicitly out (an interpreter
   with unbounded fuel or an embedded allocator cannot satisfy the gate);

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -31,14 +31,53 @@ behind all four gates of §9.
   the router and the origin cannot diverge. No match → the 404 static
   verdict. The sim fuzzes canonical forwarding (an origin oracle
   rejecting a non-canonical forward) and a path-confusion script.
-- **Phase 1.6 — host routing. In progress.** Host becomes the route
-  table's outer dimension (§7, settled 2026-07-20): an optional per-route
-  `host`, matched host-specific-first then longest-prefix, so `host +
-  path` composes in one table with one precedence rule. Host is matched
-  on its canonical form (lowercased, port-stripped) computed in the trust
+- **Phase 1.6 — host routing. Shipped 2026-07-20 (PR #51).** Host is the
+  route table's outer dimension (§7): an optional per-route `host`,
+  matched host-specific-first then longest-prefix, so `host + path`
+  composes in one table with one precedence rule. Host is matched on its
+  canonical form (lowercased, port-stripped) computed in the trust
   boundary but forwarded verbatim. No-Host requests match only any-host
   routes. Cluster selection stays the route table's alone — `pick
   cluster` is not a filter action.
+- **Phase 1.7 — programmable filters. Planned.** The "filters are data,
+  not code" model of §7, and the piece that finally gives the `route`
+  phase seam (`http/router.zig`) and the renderer real programmable
+  content — cluster selection already being the route table's alone, so
+  filters never compete with routing for the backend decision. A *rule*
+  is `{ match, actions }`, compiled at config load into bounded immutable
+  arena tables and *interpreted* per request — never scripted, never
+  allocating.
+  - **Match** — a conjunction of predicates over the parsed head:
+    method ∈ set, canonical host/path prefix or exact (reusing the §7
+    canonical forms so a filter and the router agree byte-for-byte), and
+    header present / equals / contains. Zero-copy against head-buffer
+    slices; `match_predicates_max` bounds the conjunction.
+  - **Actions** — a closed enum, ordered list per rule: `reject` (a
+    static status from the §8 set, e.g. 403/404/429), `set`/`add`/`remove`
+    header, `rewrite` a path prefix. No `pick cluster` (routing owns the
+    backend), no WASM/scripting (an interpreter with unbounded fuel or an
+    embedded allocator cannot satisfy §9). Anything past the enum is a
+    Zig function in the owning phase module.
+  - **Where it runs** — reject before the relay buffer/upstream are
+    acquired (like the §8 rejects); header/path mutations applied during
+    the existing head *render* (already required for hop-by-hop stripping
+    and `Connection` injection), so nothing edits the head buffer in
+    place and a head that no longer fits after edits is the existing
+    oversize-after-edits 431. A path rewrite re-canonicalizes and must
+    re-satisfy routing, or it is a config error caught at load.
+  - **Limits** — `rules_per_listener_max`, `actions_per_rule_max`,
+    `header_edits_max`, `match_predicates_max`, all closed-form in the
+    budget; evaluation is bounded loops, load-shed like everything else.
+  - **Gates** — config resolve/reject tests for the rule tables; a fuzz
+    oracle that a rendered head after edits still re-parses (the
+    render-oracle already proves this shape for hop-by-hop edits); sim
+    scripts asserting a reject fires before any dial and a header/path
+    edit reaches the origin exactly once.
+  - **Slices (sketch)** — (1) rule/action config schema + validation +
+    constants; (2) the match interpreter (pure, over a parsed head) +
+    the `reject` action at the route phase; (3) header-edit actions woven
+    into the renderer + the 431-after-edits path; (4) the `rewrite`
+    action with re-canonicalize-and-reroute; (5) sim oracles.
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
   stale-replay (a checkout that fails on first use answers 502 today),
   per-try deadline and the §8 request-deadline 504 verdict (an expired

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -39,7 +39,8 @@ behind all four gates of §9.
   boundary but forwarded verbatim. No-Host requests match only any-host
   routes. Cluster selection stays the route table's alone — `pick
   cluster` is not a filter action.
-- **Phase 1.7 — programmable filters. Planned.** The "filters are data,
+- **Phase 1.7 — programmable filters. Implemented 2026-07-20 (branch
+  `feat/filters`).** The "filters are data,
   not code" model of §7, and the piece that finally gives the `route`
   phase seam (`http/router.zig`) and the renderer real programmable
   content — cluster selection already being the route table's alone, so
@@ -63,21 +64,30 @@ behind all four gates of §9.
     the existing head *render* (already required for hop-by-hop stripping
     and `Connection` injection), so nothing edits the head buffer in
     place and a head that no longer fits after edits is the existing
-    oversize-after-edits 431. A path rewrite re-canonicalizes and must
-    re-satisfy routing, or it is a config error caught at load.
-  - **Limits** — `rules_per_listener_max`, `actions_per_rule_max`,
-    `header_edits_max`, `match_predicates_max`, all closed-form in the
-    budget; evaluation is bounded loops, load-shed like everything else.
+    oversize-after-edits 431. A path rewrite changes *only the forwarded
+    path* — routing already chose the cluster from the original canonical
+    path, so a rewrite never re-routes and never chains (first-applicable
+    rule wins). Its `from`/`to` prefixes are validated canonical at load
+    and the replacement is a segment-correct join, so the forwarded path
+    is canonical by construction (see DESIGN.md §7).
+  - **Limits** (as shipped in `constants.zig`) —
+    `filters_per_listener_max`, `actions_per_filter_max`,
+    `header_matches_per_filter_max`, and `header_edits_max` (the
+    listener's total header edits, bounding the renderer's materialized
+    edit buffer); evaluation is bounded loops, load-shed like everything
+    else.
   - **Gates** — config resolve/reject tests for the rule tables; a fuzz
     oracle that a rendered head after edits still re-parses (the
     render-oracle already proves this shape for hop-by-hop edits); sim
     scripts asserting a reject fires before any dial and a header/path
     edit reaches the origin exactly once.
-  - **Slices (sketch)** — (1) rule/action config schema + validation +
+  - **Slices (as shipped)** — (1) rule/action config schema + validation +
     constants; (2) the match interpreter (pure, over a parsed head) +
     the `reject` action at the route phase; (3) header-edit actions woven
-    into the renderer + the 431-after-edits path; (4) the `rewrite`
-    action with re-canonicalize-and-reroute; (5) sim oracles.
+    into the renderer + the 431-after-edits path + a reserved-name guard
+    against editing proxy-managed headers; (4) the `rewrite` action
+    (forwarded path only, segment-correct join, no re-route); (5) sim +
+    adversarial-cross-seed oracles.
 - **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
   stale-replay (a checkout that fails on first use answers 502 today),
   per-try deadline and the §8 request-deadline 504 verdict (an expired

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -521,6 +521,18 @@ pub const Script = enum(u8) {
     /// `/sim` would; the origin's canonical oracle catches a raw-path
     /// forward, and a router matching raw bytes would route it elsewhere.
     confusion,
+    /// A GET under `/reject`: a §7 filter rejects it with 403 before any
+    /// resource is acquired or origin dialed. The golden outcome is exactly
+    /// that 403, and the origin must never see the request.
+    filter_reject,
+    /// A GET under `/edit`: a §7 filter adds a header to the forwarded
+    /// request. It routes and succeeds (200); the origin's §7 oracle proves
+    /// the edited head still forwards canonical.
+    filter_edit,
+    /// A GET under `/rewrite`: a §7 filter rewrites the forwarded path to
+    /// `/sim`. It routes on the original path and succeeds (200); the
+    /// origin sees a canonical rewritten path, never `//`-merged.
+    filter_rewrite,
 };
 
 /// A verify-time verdict over everything the client received.
@@ -627,6 +639,11 @@ pub fn Client(comptime IoType: type) type {
                 // Canonicalizes to /sim (the `/deep` segment is popped by
                 // the decoded `..`), so it routes and forwards as /sim.
                 .confusion => "GET /deep/%2e%2e/sim HTTP/1.1\r\nHost: sim\r\n\r\n",
+                // §7 filter scripts: a distinct path per action so the
+                // listener's rules fire only for these, never the others.
+                .filter_reject => "GET /reject HTTP/1.1\r\nHost: sim\r\n\r\n",
+                .filter_edit => "GET /edit HTTP/1.1\r\nHost: sim\r\n\r\n",
+                .filter_rewrite => "GET /rewrite HTTP/1.1\r\nHost: sim\r\n\r\n",
             };
         }
 
@@ -1015,6 +1032,7 @@ pub fn Client(comptime IoType: type) type {
                 .get, .post_sized, .post_big, .post_chunked, .confusion => 1,
                 .post_chunked_malformed, .malformed_head => 1,
                 .oversize_uri, .connect_method, .pipelined => 1,
+                .filter_reject, .filter_edit, .filter_rewrite => 1,
                 .keepalive_pair => 2,
                 .silent => 0,
             };
@@ -1040,6 +1058,10 @@ pub fn Client(comptime IoType: type) type {
         fn goldenStatus(script: Script) u16 {
             return switch (script) {
                 .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined, .confusion => 200,
+                // The edit and rewrite scripts route and succeed; only the
+                // reject script's golden verdict is its 403.
+                .filter_edit, .filter_rewrite => 200,
+                .filter_reject => 403,
                 .post_chunked_malformed, .malformed_head => 400,
                 .oversize_uri => 414,
                 .connect_method => 501,
@@ -1056,6 +1078,7 @@ pub fn Client(comptime IoType: type) type {
                 .post_sized, .post_big, .post_chunked, .post_chunked_malformed => .post,
                 .get, .malformed_head, .oversize_uri, .confusion => .get,
                 .connect_method, .keepalive_pair, .pipelined, .silent => .get,
+                .filter_reject, .filter_edit, .filter_rewrite => .get,
             };
         }
 
@@ -1068,9 +1091,23 @@ pub fn Client(comptime IoType: type) type {
             return switch (script) {
                 .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined, .confusion => //
                 status == 200 or status == 502 or status == 503,
-                // The head routes before its body is validated, so the §8
-                // rungs and a killed dial can still precede the 400.
-                .post_chunked_malformed => status == 400 or status == 502 or status == 503,
+                // Edit and rewrite route and forward like a plain GET, so
+                // the §8 rungs and a killed dial can precede the 200.
+                .filter_edit, .filter_rewrite => status == 200 or status == 502 or status == 503,
+                // A reject is answered before any resource is acquired or
+                // origin dialed, so no §8 rung or dial failure can precede
+                // it — the only complete verdict is the 403.
+                .filter_reject => status == 403,
+                // The head routes and forwards before its body is
+                // validated, so several outcomes can precede the 400: the §8
+                // rungs, a killed dial, and — the subtlety — an early origin
+                // response. An instant origin answers 200 before the proxy
+                // ever pumps the malformed body (which it then contains,
+                // never forwarding it: the origin's §7 oracle still holds).
+                // Clean seeds pin the origin to `sized`, so they never race
+                // it and `goldenStatus` still demands the exact 400 there.
+                .post_chunked_malformed => //
+                status == 400 or status == 200 or status == 502 or status == 503,
                 .malformed_head => status == 400,
                 .oversize_uri => status == 414,
                 .connect_method => status == 501,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -120,6 +120,7 @@ const Harness = struct {
     clusters: [2]zoxy.config.Config.Cluster,
     routes_l4: [1]zoxy.http.router.Route,
     routes_http: [1]zoxy.http.router.Route,
+    filters_http: [3]zoxy.http.filter.Rule,
     listener_configs: [2]zoxy.config.Config.Listener,
     config: zoxy.config.Config,
     origin: Origin,
@@ -203,9 +204,32 @@ const Harness = struct {
         };
         harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
+        // §7 filters on the HTTP listener, one action each, scoped to a
+        // distinct path so they fire only for the filter_* scripts and
+        // leave every other script's golden outcome untouched: reject
+        // `/reject`, add a header under `/edit`, rewrite `/rewrite` → `/sim`.
+        harness.filters_http = .{
+            .{
+                .match = .{ .path_prefix = "/reject" },
+                .actions = &.{.{ .reject = 403 }},
+            },
+            .{
+                .match = .{ .path_prefix = "/edit" },
+                .actions = &.{.{ .header_set = .{ .name = "X-Sim-Filter", .value = "on" } }},
+            },
+            .{
+                .match = .{ .path_prefix = "/rewrite" },
+                .actions = &.{.{ .rewrite_prefix = .{ .from = "/rewrite", .to = "/sim" } }},
+            },
+        };
         harness.listener_configs = .{
             .{ .bind_address = bindAddress(), .routes = &harness.routes_l4, .protocol = .l4 },
-            .{ .bind_address = httpBindAddress(), .routes = &harness.routes_http, .protocol = .http },
+            .{
+                .bind_address = httpBindAddress(),
+                .routes = &harness.routes_http,
+                .filters = &harness.filters_http,
+                .protocol = .http,
+            },
         };
         harness.config = .{
             .listeners = &harness.listener_configs,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -21,6 +21,7 @@ const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
 const proxy = @import("http/proxy.zig");
 const router = @import("http/router.zig");
+const filter = @import("http/filter.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
 const upstream_module = @import("net/upstream.zig");
@@ -86,6 +87,9 @@ pub fn Server(comptime IoType: type) type {
             /// The listener's §7 route table, handed to each admitted L7
             /// connection so `routeRequest` can pick a cluster by path.
             routes: []const router.Route,
+            /// The listener's §7 filter rules, handed to each admitted L7
+            /// connection so `routeRequest` can evaluate policy.
+            filters: []const filter.Rule,
             /// Copied from config so admission forks without reaching back
             /// through the listener index (§6, §7).
             protocol: config_module.Config.Listener.Protocol,
@@ -134,6 +138,7 @@ pub fn Server(comptime IoType: type) type {
                     // path's route once the head parses (§7).
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
+                    .filters = listener_config.filters,
                     .protocol = listener_config.protocol,
                     .accepting = false,
                 };
@@ -411,9 +416,10 @@ pub fn Server(comptime IoType: type) type {
                 server.idleTimeoutMs(),
                 state.cluster_index,
             );
-            // The L7 path routes by canonical path once the head parses;
-            // hand it the listener's table (§7).
+            // The L7 path routes and filters once the head parses; hand it
+            // the listener's tables (§7).
             conn.routes = state.routes;
+            conn.filters = state.filters;
             assert(conn.routes.len >= 1);
             Proxy.start(server, conn);
         }

--- a/src/config.zig
+++ b/src/config.zig
@@ -86,6 +86,7 @@ pub const ValidationError = error{
     FilterMethodUnknown,
     FilterHeaderMatchesOverLimit,
     FilterHeaderMatchKind,
+    FilterHeaderContainsEmpty,
     FilterHeaderNameInvalid,
     FilterHeaderNameReserved,
     FilterHeaderValueInvalid,
@@ -361,11 +362,14 @@ fn resolveFilters(
     protocol: Config.Listener.Protocol,
 ) ParseError![]const filter.Rule {
     const filters_json = listener_json.filters orelse return &.{};
+    // Any `filters` key on an l4 listener is a mistake — l4 relays bytes,
+    // there is no head to match on — so reject it whether the array is
+    // populated or (vacuously) empty, before the empty-array shortcut.
+    if (protocol == .l4) {
+        return error.ListenerL4Filters;
+    }
     if (filters_json.len == 0) {
         return &.{};
-    }
-    if (protocol == .l4) {
-        return error.ListenerL4Filters; // No head to match on.
     }
     if (filters_json.len > constants.filters_per_listener_max) {
         return error.FiltersOverLimit;
@@ -458,11 +462,20 @@ fn resolveHeaderMatches(
             }
             match.* = .{ .name = header_json.name, .kind = .present, .value = "" };
         } else if (header_json.equals) |value| {
+            // An `equals: ""` predicate is meaningful — a header present
+            // with an empty value — so the empty value is legal here.
             try validateHeaderValue(value);
             match.* = .{ .name = header_json.name, .kind = .equals, .value = value };
         } else {
-            try validateHeaderValue(header_json.contains.?);
-            match.* = .{ .name = header_json.name, .kind = .contains, .value = header_json.contains.? };
+            const needle = header_json.contains.?;
+            // A `contains: ""` needle would match every present header
+            // (`indexOf(x, "")` is always 0) — a degenerate `present` in
+            // disguise. Reject it so `contains` is always a real substring.
+            if (needle.len == 0) {
+                return error.FilterHeaderContainsEmpty;
+            }
+            try validateHeaderValue(needle);
+            match.* = .{ .name = header_json.name, .kind = .contains, .value = needle };
         }
     }
     assert(matches.len == headers_json.len);
@@ -506,14 +519,10 @@ fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
         return .{ .reject = status };
     }
     if (action_json.header_set) |edit| {
-        try validateEditableHeaderName(edit.name);
-        try validateHeaderValue(edit.value);
-        return .{ .header_set = .{ .name = edit.name, .value = edit.value } };
+        return .{ .header_set = try resolveHeaderEdit(&edit) };
     }
     if (action_json.header_add) |edit| {
-        try validateEditableHeaderName(edit.name);
-        try validateHeaderValue(edit.value);
-        return .{ .header_add = .{ .name = edit.name, .value = edit.value } };
+        return .{ .header_add = try resolveHeaderEdit(&edit) };
     }
     if (action_json.header_remove) |name| {
         try validateEditableHeaderName(name);
@@ -525,12 +534,22 @@ fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
     return .{ .rewrite_prefix = .{ .from = rewrite.from, .to = rewrite.to } };
 }
 
+/// Validate a name/value header edit shared by `header_set` and
+/// `header_add`: an editable (non-proxy-managed) RFC 9110 token name and an
+/// injection-safe field-value. Both actions carry the identical contract.
+fn resolveHeaderEdit(edit: *const HeaderEditJson) ParseError!filter.HeaderEdit {
+    try validateEditableHeaderName(edit.name);
+    try validateHeaderValue(edit.value);
+    return .{ .name = edit.name, .value = edit.value };
+}
+
 /// A header name must be a non-empty RFC 9110 token (no separators or
 /// controls), so an edit or match names a real, unambiguous header.
 fn validateHeaderName(name: []const u8) ParseError!void {
     if (name.len == 0) {
         return error.FilterHeaderNameInvalid;
     }
+    assert(name.len >= 1); // Past the empty guard: the token scan is non-empty.
     for (name) |byte| {
         if (!isTokenByte(byte)) {
             return error.FilterHeaderNameInvalid;
@@ -568,11 +587,11 @@ fn validateEditableHeaderName(name: []const u8) ParseError!void {
 /// (slice 3), so the compiled edit is proven injection-safe at load —
 /// the same "already safe" guarantee the canonical host/path keys carry.
 /// An empty value is legal. Applied to emitted values and, for symmetry,
-/// to the compared match values.
+/// to the compared match values. The per-byte test is the parser's own
+/// `isForwardableByte`, so a filter and the parser share one definition.
 fn validateHeaderValue(value: []const u8) ParseError!void {
     for (value) |byte| {
-        const legal = byte == '\t' or (byte >= ' ' and byte != 0x7f);
-        if (!legal) {
+        if (!parser.isForwardableByte(byte)) {
             return error.FilterHeaderValueInvalid;
         }
     }
@@ -982,6 +1001,10 @@ test "config: filter schema rejects malformed rules" {
     // L4 listener may not carry filters.
     try expectParseError(error.ListenerL4Filters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
         "\"filters\":[{\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // Even a vacuously empty filters array on l4 is a mistake — the key is
+    // meaningless there, and an empty array must not slip past the guard.
+    try expectParseError(error.ListenerL4Filters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"filters\":[]}]," ++ tail);
     // A rule with no actions.
     try expectParseError(error.FilterActionsEmpty, head ++ "{\"actions\":[]}]}]," ++ tail);
     // An action object with no kind set.
@@ -994,6 +1017,9 @@ test "config: filter schema rejects malformed rules" {
     try expectParseError(error.FilterMethodUnknown, head ++ "{\"match\":{\"method\":[\"get\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
     // A header match with no predicate kind.
     try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"X\"}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A `contains` predicate with an empty needle: it would match every
+    // present header (a degenerate `present`), so it is rejected.
+    try expectParseError(error.FilterHeaderContainsEmpty, head ++ "{\"match\":{\"headers\":[{\"name\":\"X\",\"contains\":\"\"}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
     // A non-canonical match path prefix.
     try expectParseError(error.RoutePrefixNotCanonical, head ++ "{\"match\":{\"path_prefix\":\"/a/../b\"},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
     // A header edit with an invalid header name.

--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,7 @@ const constants = @import("constants.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
 const parser = @import("http/parser.zig");
+const render = @import("http/render.zig");
 
 const assert = std.debug.assert;
 
@@ -86,11 +87,13 @@ pub const ValidationError = error{
     FilterHeaderMatchesOverLimit,
     FilterHeaderMatchKind,
     FilterHeaderNameInvalid,
+    FilterHeaderNameReserved,
     FilterHeaderValueInvalid,
     FilterActionsEmpty,
     FilterActionsOverLimit,
     FilterActionKind,
     FilterRejectStatus,
+    FilterHeaderEditsOverLimit,
     EndpointsEmpty,
     EndpointsOverLimit,
     EndpointInvalid,
@@ -368,15 +371,38 @@ fn resolveFilters(
         return error.FiltersOverLimit;
     }
     const rules = try arena.alloc(filter.Rule, filters_json.len);
+    var header_edits: u32 = 0;
     for (filters_json, rules) |rule_json, *rule| {
         rule.* = .{
             .match = try resolveMatch(arena, &rule_json.match),
             .actions = try resolveActions(arena, rule_json.actions),
         };
+        header_edits += countHeaderEdits(rule.actions);
+    }
+    // A request applies the edits of every rule it matches, so the whole
+    // table's edits bound one render's materialized set (§7). Cap the
+    // total so the renderer's fixed buffer can never overflow.
+    if (header_edits > constants.header_edits_max) {
+        return error.FilterHeaderEditsOverLimit;
     }
     assert(rules.len == filters_json.len);
     assert(rules.len <= constants.filters_per_listener_max);
     return rules;
+}
+
+/// The number of header-edit actions (set/add/remove) in a rule — the
+/// reject and rewrite actions contribute no render-time header edit.
+fn countHeaderEdits(actions: []const filter.Action) u32 {
+    assert(actions.len <= constants.actions_per_filter_max);
+    var count: u32 = 0;
+    for (actions) |action| {
+        switch (action) {
+            .header_set, .header_add, .header_remove => count += 1,
+            .reject, .rewrite_prefix => {},
+        }
+    }
+    assert(count <= actions.len); // Edits are a subset of the actions.
+    return count;
 }
 
 fn resolveMatch(
@@ -480,17 +506,17 @@ fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
         return .{ .reject = status };
     }
     if (action_json.header_set) |edit| {
-        try validateHeaderName(edit.name);
+        try validateEditableHeaderName(edit.name);
         try validateHeaderValue(edit.value);
         return .{ .header_set = .{ .name = edit.name, .value = edit.value } };
     }
     if (action_json.header_add) |edit| {
-        try validateHeaderName(edit.name);
+        try validateEditableHeaderName(edit.name);
         try validateHeaderValue(edit.value);
         return .{ .header_add = .{ .name = edit.name, .value = edit.value } };
     }
     if (action_json.header_remove) |name| {
-        try validateHeaderName(name);
+        try validateEditableHeaderName(name);
         return .{ .header_remove = name };
     }
     const rewrite = action_json.rewrite_prefix.?;
@@ -508,6 +534,30 @@ fn validateHeaderName(name: []const u8) ParseError!void {
     for (name) |byte| {
         if (!isTokenByte(byte)) {
             return error.FilterHeaderNameInvalid;
+        }
+    }
+}
+
+/// An *edit* target must additionally not be a proxy-managed header: the
+/// renderer owns hop-by-hop stripping, `Connection` injection, `Host`
+/// routing, and the framing headers it committed to (§7). Letting a filter
+/// set/add/remove one of those would smuggle a framing or persistence
+/// change past the render's own decisions, so the compiled edit is proven
+/// harmless at load. Match predicates carry no such restriction — reading
+/// any header is safe.
+fn validateEditableHeaderName(name: []const u8) ParseError!void {
+    try validateHeaderName(name);
+    assert(name.len >= 1); // A valid token; the managed lists are non-empty.
+    for (render.hop_by_hop_names) |managed| {
+        assert(managed.len >= 1);
+        if (std.ascii.eqlIgnoreCase(name, managed)) {
+            return error.FilterHeaderNameReserved;
+        }
+    }
+    for (render.protected_names) |managed| {
+        assert(managed.len >= 1);
+        if (std.ascii.eqlIgnoreCase(name, managed)) {
+            return error.FilterHeaderNameReserved;
         }
     }
 }
@@ -954,6 +1004,34 @@ test "config: filter schema rejects malformed rules" {
     try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"X\",\"present\":false}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
     // A rewrite whose target is not canonical.
     try expectParseError(error.RoutePrefixNotCanonical, head ++ "{\"actions\":[{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b/../c\"}}]}]}]," ++ tail);
+    // A header edit may not name a proxy-managed header — case-insensitively.
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"Host\",\"value\":\"evil\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_remove\":\"content-length\"}]}]}]," ++ tail);
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_add\":{\"name\":\"Connection\",\"value\":\"close\"}}]}]}]," ++ tail);
+    // A matched header predicate may still name a managed header (read-only).
+    try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"Host\"}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+}
+
+test "config: a filter set over the header-edit budget is rejected" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    ;
+    // One header_edits_max+1 header edits spread one-per-rule (each rule
+    // stays under actions_per_filter_max): the whole-table total is what
+    // the renderer's fixed buffer must hold, so it is the total that caps.
+    const rules = comptime blk: {
+        var s: []const u8 = "";
+        var edit: u16 = 0;
+        while (edit < constants.header_edits_max + 1) : (edit += 1) {
+            if (edit != 0) s = s ++ ",";
+            s = s ++ "{\"actions\":[{\"header_remove\":\"X-Drop\"}]}";
+        }
+        break :blk s;
+    };
+    const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"cluster\":\"a\",\"filters\":[" ++ rules ++ "]}]," ++ tail;
+    try expectParseError(error.FilterHeaderEditsOverLimit, json);
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 
 const constants = @import("constants.zig");
 const router = @import("http/router.zig");
+const filter = @import("http/filter.zig");
 const parser = @import("http/parser.zig");
 
 const assert = std.debug.assert;
@@ -38,6 +39,10 @@ pub const Config = struct {
         /// listeners always have exactly that one route (no path to
         /// match). Matched by `http/router.zig`.
         routes: []const router.Route,
+        /// The §7 filter rules, in config order (evaluated top-down).
+        /// Empty on the L4 path and whenever no `"filters"` were given.
+        /// Compiled and interpreted by `http/filter.zig`.
+        filters: []const filter.Rule = &.{},
         protocol: Protocol,
 
         /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
@@ -74,6 +79,18 @@ pub const ValidationError = error{
     RoutePrefixNotCanonical,
     RouteHostNotCanonical,
     RouteDuplicate,
+    ListenerL4Filters,
+    FiltersOverLimit,
+    FilterMethodEmpty,
+    FilterMethodUnknown,
+    FilterHeaderMatchesOverLimit,
+    FilterHeaderMatchKind,
+    FilterHeaderNameInvalid,
+    FilterHeaderValueInvalid,
+    FilterActionsEmpty,
+    FilterActionsOverLimit,
+    FilterActionKind,
+    FilterRejectStatus,
     EndpointsEmpty,
     EndpointsOverLimit,
     EndpointInvalid,
@@ -122,8 +139,52 @@ const ListenerJson = struct {
     /// `routes` (an explicit §7 path table) must be present.
     cluster: ?[]const u8 = null,
     routes: ?[]const RouteJson = null,
+    /// Optional §7 filter rules; absent means none. HTTP-only.
+    filters: ?[]const FilterJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
+};
+
+const FilterJson = struct {
+    match: MatchJson = .{},
+    actions: []const ActionJson,
+};
+
+const MatchJson = struct {
+    /// Registered method tokens (uppercase); absent = any method.
+    method: ?[]const []const u8 = null,
+    host: ?[]const u8 = null,
+    path_prefix: ?[]const u8 = null,
+    headers: ?[]const HeaderMatchJson = null,
+};
+
+const HeaderMatchJson = struct {
+    name: []const u8,
+    /// Exactly one of these selects the predicate kind.
+    present: ?bool = null,
+    equals: ?[]const u8 = null,
+    contains: ?[]const u8 = null,
+};
+
+/// One action object carries exactly one field (the action's kind), the
+/// same "struct of optionals, validate exactly-one" shape the listener's
+/// cluster/routes fork uses — no JSON union parsing.
+const ActionJson = struct {
+    reject: ?u16 = null,
+    header_set: ?HeaderEditJson = null,
+    header_add: ?HeaderEditJson = null,
+    header_remove: ?[]const u8 = null,
+    rewrite_prefix: ?RewriteJson = null,
+};
+
+const HeaderEditJson = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+const RewriteJson = struct {
+    from: []const u8,
+    to: []const u8,
 };
 
 const RouteJson = struct {
@@ -278,11 +339,201 @@ fn resolveListeners(
         listeners[index] = .{
             .bind_address = bind_address,
             .routes = try resolveRoutes(arena, &listener_json, clusters, protocol),
+            .filters = try resolveFilters(arena, &listener_json, protocol),
             .protocol = protocol,
         };
     }
     assert(listeners.len == listeners_json.len);
     return listeners;
+}
+
+/// Compile a listener's §7 filter rules into immutable arena tables.
+/// HTTP-only (an l4 listener has no head to match); absent = none. Match
+/// keys are validated canonical so a filter and the router agree
+/// byte-for-byte, and each action is validated at load, so the request-
+/// time interpreter is bounded loops over trusted data.
+fn resolveFilters(
+    arena: std.mem.Allocator,
+    listener_json: *const ListenerJson,
+    protocol: Config.Listener.Protocol,
+) ParseError![]const filter.Rule {
+    const filters_json = listener_json.filters orelse return &.{};
+    if (filters_json.len == 0) {
+        return &.{};
+    }
+    if (protocol == .l4) {
+        return error.ListenerL4Filters; // No head to match on.
+    }
+    if (filters_json.len > constants.filters_per_listener_max) {
+        return error.FiltersOverLimit;
+    }
+    const rules = try arena.alloc(filter.Rule, filters_json.len);
+    for (filters_json, rules) |rule_json, *rule| {
+        rule.* = .{
+            .match = try resolveMatch(arena, &rule_json.match),
+            .actions = try resolveActions(arena, rule_json.actions),
+        };
+    }
+    assert(rules.len == filters_json.len);
+    assert(rules.len <= constants.filters_per_listener_max);
+    return rules;
+}
+
+fn resolveMatch(
+    arena: std.mem.Allocator,
+    match_json: *const MatchJson,
+) ParseError!filter.Match {
+    var match: filter.Match = .{};
+    if (match_json.host) |host| {
+        match.host = try validateRouteHost(host);
+    }
+    if (match_json.path_prefix) |prefix| {
+        try validateRoutePrefix(prefix);
+        match.path_prefix = prefix;
+    }
+    if (match_json.method) |tokens| {
+        if (tokens.len == 0) {
+            return error.FilterMethodEmpty;
+        }
+        var methods = std.EnumSet(parser.Method){};
+        for (tokens) |token| {
+            const method = parser.methodFromToken(token) orelse return error.FilterMethodUnknown;
+            methods.insert(method);
+        }
+        match.methods = methods;
+    }
+    if (match_json.headers) |headers_json| {
+        match.headers = try resolveHeaderMatches(arena, headers_json);
+    }
+    return match;
+}
+
+fn resolveHeaderMatches(
+    arena: std.mem.Allocator,
+    headers_json: []const HeaderMatchJson,
+) ParseError![]const filter.HeaderMatch {
+    if (headers_json.len > constants.header_matches_per_filter_max) {
+        return error.FilterHeaderMatchesOverLimit;
+    }
+    const matches = try arena.alloc(filter.HeaderMatch, headers_json.len);
+    for (headers_json, matches) |header_json, *match| {
+        try validateHeaderName(header_json.name);
+        // Exactly one predicate kind per header match.
+        const set: u8 = @as(u8, @intFromBool(header_json.present != null)) +
+            @intFromBool(header_json.equals != null) +
+            @intFromBool(header_json.contains != null);
+        assert(set <= 3); // The header match has three kind fields.
+        if (set != 1) {
+            return error.FilterHeaderMatchKind;
+        }
+        if (header_json.present) |present| {
+            if (!present) {
+                return error.FilterHeaderMatchKind; // "present: false" is not a predicate.
+            }
+            match.* = .{ .name = header_json.name, .kind = .present, .value = "" };
+        } else if (header_json.equals) |value| {
+            try validateHeaderValue(value);
+            match.* = .{ .name = header_json.name, .kind = .equals, .value = value };
+        } else {
+            try validateHeaderValue(header_json.contains.?);
+            match.* = .{ .name = header_json.name, .kind = .contains, .value = header_json.contains.? };
+        }
+    }
+    assert(matches.len == headers_json.len);
+    return matches;
+}
+
+fn resolveActions(
+    arena: std.mem.Allocator,
+    actions_json: []const ActionJson,
+) ParseError![]const filter.Action {
+    if (actions_json.len == 0) {
+        return error.FilterActionsEmpty;
+    }
+    if (actions_json.len > constants.actions_per_filter_max) {
+        return error.FilterActionsOverLimit;
+    }
+    const actions = try arena.alloc(filter.Action, actions_json.len);
+    for (actions_json, actions) |action_json, *action| {
+        action.* = try resolveAction(&action_json);
+    }
+    assert(actions.len == actions_json.len);
+    assert(actions.len <= constants.actions_per_filter_max);
+    return actions;
+}
+
+fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
+    // Exactly one action field carries the kind.
+    const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
+        @intFromBool(action_json.header_set != null) +
+        @intFromBool(action_json.header_add != null) +
+        @intFromBool(action_json.header_remove != null) +
+        @intFromBool(action_json.rewrite_prefix != null);
+    assert(set <= 5); // The action object has five kind fields.
+    if (set != 1) {
+        return error.FilterActionKind;
+    }
+    if (action_json.reject) |status| {
+        if (!filter.isRejectStatus(status)) {
+            return error.FilterRejectStatus;
+        }
+        return .{ .reject = status };
+    }
+    if (action_json.header_set) |edit| {
+        try validateHeaderName(edit.name);
+        try validateHeaderValue(edit.value);
+        return .{ .header_set = .{ .name = edit.name, .value = edit.value } };
+    }
+    if (action_json.header_add) |edit| {
+        try validateHeaderName(edit.name);
+        try validateHeaderValue(edit.value);
+        return .{ .header_add = .{ .name = edit.name, .value = edit.value } };
+    }
+    if (action_json.header_remove) |name| {
+        try validateHeaderName(name);
+        return .{ .header_remove = name };
+    }
+    const rewrite = action_json.rewrite_prefix.?;
+    try validateRoutePrefix(rewrite.from);
+    try validateRoutePrefix(rewrite.to);
+    return .{ .rewrite_prefix = .{ .from = rewrite.from, .to = rewrite.to } };
+}
+
+/// A header name must be a non-empty RFC 9110 token (no separators or
+/// controls), so an edit or match names a real, unambiguous header.
+fn validateHeaderName(name: []const u8) ParseError!void {
+    if (name.len == 0) {
+        return error.FilterHeaderNameInvalid;
+    }
+    for (name) |byte| {
+        if (!isTokenByte(byte)) {
+            return error.FilterHeaderNameInvalid;
+        }
+    }
+}
+
+/// A header value must be an RFC 9110 field-value: VCHAR / SP / HTAB /
+/// obs-text, and never CR, LF, NUL, or another control. A value carrying
+/// CRLF would inject a header when the renderer writes it upstream
+/// (slice 3), so the compiled edit is proven injection-safe at load —
+/// the same "already safe" guarantee the canonical host/path keys carry.
+/// An empty value is legal. Applied to emitted values and, for symmetry,
+/// to the compared match values.
+fn validateHeaderValue(value: []const u8) ParseError!void {
+    for (value) |byte| {
+        const legal = byte == '\t' or (byte >= ' ' and byte != 0x7f);
+        if (!legal) {
+            return error.FilterHeaderValueInvalid;
+        }
+    }
+}
+
+fn isTokenByte(byte: u8) bool {
+    return switch (byte) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        '0'...'9', 'a'...'z', 'A'...'Z' => true,
+        else => false,
+    };
 }
 
 /// Resolve a listener's route table (§7). `"cluster": "x"` is sugar for a
@@ -632,6 +883,77 @@ test "config: host routes resolve, host-specific sorted before any-host" {
         @as(?u16, routes[2].cluster_index),
         router.route(routes, "other.example.com", "/v2"),
     );
+}
+
+test "config: filters compile into rules with matches and actions" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","filters":[
+        \\   {"match":{"method":["GET","POST"],"path_prefix":"/admin",
+        \\             "headers":[{"name":"X-Env","equals":"prod"}]},
+        \\    "actions":[{"reject":403}]},
+        \\   {"match":{"host":"api.example"},
+        \\    "actions":[{"header_set":{"name":"X-Via","value":"zoxy"}},
+        \\               {"rewrite_prefix":{"from":"/old","to":"/new"}}]}]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    const filters = parsed.listeners[0].filters;
+    try std.testing.expectEqual(@as(usize, 2), filters.len);
+
+    // Rule 0: method set + path prefix + one header-equals match, reject 403.
+    const rule0 = filters[0];
+    try std.testing.expect(rule0.match.methods.?.contains(.get));
+    try std.testing.expect(rule0.match.methods.?.contains(.post));
+    try std.testing.expect(!rule0.match.methods.?.contains(.delete));
+    try std.testing.expectEqualStrings("/admin", rule0.match.path_prefix.?);
+    try std.testing.expectEqual(@as(usize, 1), rule0.match.headers.len);
+    try std.testing.expectEqualStrings("X-Env", rule0.match.headers[0].name);
+    try std.testing.expectEqual(filter.HeaderMatch.Kind.equals, rule0.match.headers[0].kind);
+    try std.testing.expectEqual(@as(usize, 1), rule0.actions.len);
+    try std.testing.expectEqual(@as(u16, 403), rule0.actions[0].reject);
+
+    // Rule 1: host match, header_set then rewrite_prefix.
+    const rule1 = filters[1];
+    try std.testing.expectEqualStrings("api.example", rule1.match.host.?);
+    try std.testing.expectEqual(@as(?std.EnumSet(parser.Method), null), rule1.match.methods);
+    try std.testing.expectEqual(@as(usize, 2), rule1.actions.len);
+    try std.testing.expectEqualStrings("X-Via", rule1.actions[0].header_set.name);
+    try std.testing.expectEqualStrings("/new", rule1.actions[1].rewrite_prefix.to);
+}
+
+test "config: filter schema rejects malformed rules" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"filters\":[";
+    // L4 listener may not carry filters.
+    try expectParseError(error.ListenerL4Filters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"filters\":[{\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A rule with no actions.
+    try expectParseError(error.FilterActionsEmpty, head ++ "{\"actions\":[]}]}]," ++ tail);
+    // An action object with no kind set.
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{}]}]}]," ++ tail);
+    // An action object with two kinds set.
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"reject\":403,\"header_remove\":\"X\"}]}]}]," ++ tail);
+    // A reject status outside the policy set.
+    try expectParseError(error.FilterRejectStatus, head ++ "{\"actions\":[{\"reject\":503}]}]}]," ++ tail);
+    // An unknown / lowercase method token.
+    try expectParseError(error.FilterMethodUnknown, head ++ "{\"match\":{\"method\":[\"get\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A header match with no predicate kind.
+    try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"X\"}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A non-canonical match path prefix.
+    try expectParseError(error.RoutePrefixNotCanonical, head ++ "{\"match\":{\"path_prefix\":\"/a/../b\"},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A header edit with an invalid header name.
+    try expectParseError(error.FilterHeaderNameInvalid, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"Bad Name\",\"value\":\"v\"}}]}]}]," ++ tail);
+    // A header value carrying CRLF — a smuggling vector when rendered.
+    try expectParseError(error.FilterHeaderValueInvalid, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"X\",\"value\":\"a\\r\\nInjected: 1\"}}]}]}]," ++ tail);
+    // "present: false" is not a predicate.
+    try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"X\",\"present\":false}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A rewrite whose target is not canonical.
+    try expectParseError(error.RoutePrefixNotCanonical, head ++ "{\"actions\":[{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b/../c\"}}]}]}]," ++ tail);
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -147,6 +147,14 @@ pub const filters_per_listener_max: u16 = 32;
 pub const actions_per_filter_max: u16 = 8;
 pub const header_matches_per_filter_max: u16 = 8;
 
+/// Upper bound on a listener's *total* header-edit actions (set/add/remove
+/// summed across every rule). A request applies the edits of all rules it
+/// matches, so the worst case — every rule matching — is the whole set;
+/// this bounds the fixed buffer the renderer materializes those edits into
+/// (§7). Config counts the edits across the rule table and rejects a set
+/// over this, so the render buffer can never overflow.
+pub const header_edits_max: u16 = 16;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -189,6 +197,7 @@ comptime {
     assert(filters_per_listener_max >= 1);
     assert(actions_per_filter_max >= 1);
     assert(header_matches_per_filter_max >= 1);
+    assert(header_edits_max >= 1);
     assert(loop_completions_per_tick_max >= 1);
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -139,6 +139,14 @@ pub const endpoints_per_cluster_max: u16 = 64;
 /// request-time match is a bounded linear scan over at most this many.
 pub const routes_max: u16 = 32;
 
+/// §7 "filters are data" bounds — one listener's rule table and each
+/// rule's shape. Config data, not pools: rules are immutable arena
+/// slices and evaluation is bounded loops over at most these many, so a
+/// filter set cannot make request handling unbounded.
+pub const filters_per_listener_max: u16 = 32;
+pub const actions_per_filter_max: u16 = 8;
+pub const header_matches_per_filter_max: u16 = 8;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -178,6 +186,9 @@ comptime {
     assert(clusters_max >= 1);
     assert(endpoints_per_cluster_max >= 1);
     assert(routes_max >= 1);
+    assert(filters_per_listener_max >= 1);
+    assert(actions_per_filter_max >= 1);
+    assert(header_matches_per_filter_max >= 1);
     assert(loop_completions_per_tick_max >= 1);
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -39,6 +39,9 @@ pub const Counters = struct {
     /// No route matched the request's canonical path (§7), answered 404.
     /// Like the other reject counters the connection completes normally.
     l7_no_route: Value = Value.init(0),
+    /// A §7 filter rule rejected the request with its policy status
+    /// (403/404/429/400). A reject, not a shed — the connection completes.
+    l7_filtered: Value = Value.init(0),
     /// §8 rungs at the L7 request level, answered 503: relay buffers or
     /// upstream slots exhausted when a valid request needed them. Like
     /// the reject counters these connections complete normally, so they

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -90,13 +90,19 @@ pub const AppliedHeaderEdit = struct {
 };
 
 /// The statuses a `reject` action may name — a subset of the §8 static
-/// responses that make sense as a policy verdict. Config rejects any
-/// other value at load, and `shed.staticResponse` must support each.
+/// responses that make sense as a policy verdict. This array is the single
+/// source of truth: config rejects any other value at load, the proxy's
+/// filter-reject dispatch matches on exactly this set, and
+/// `shed.staticResponse` must support each. Extend it in one place.
+pub const reject_statuses = [_]u16{ 400, 403, 404, 429 };
+
 pub fn isRejectStatus(status: u16) bool {
-    return switch (status) {
-        400, 403, 404, 429 => true,
-        else => false,
-    };
+    for (reject_statuses) |candidate| {
+        if (candidate == status) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /// The parsed head a rule matches against, in the §7 canonical forms:
@@ -138,69 +144,73 @@ pub fn firstReject(rules: []const Rule, view: RequestView) ?u16 {
     return null;
 }
 
-/// The header edits of every rule that matches `view`, in rule-then-action
-/// order, written into `out` and returned as its filled prefix (§7).
-/// `reject`/`rewrite_prefix` actions are skipped — this collects only the
-/// header edits the renderer applies. The caller sizes `out` at
-/// `header_edits_max`, which config caps a listener's total header edits
-/// at, so a matching subset always fits: the write is asserted in bounds.
-/// Bounded loops over immutable arena data; no allocation. Called at render
-/// (a matched reject would already have stopped the request at routing, so
-/// here every matched rule forwards and its edits apply).
-pub fn collectHeaderEdits(
+/// What the render phase applies to a forwarded request: the first
+/// applicable path rewrite and the header edits of every matched rule.
+pub const Forward = struct {
+    /// First-applicable rewrite (see `collectForward`), or null.
+    rewrite: ?Rewrite,
+    /// Matched rules' header edits, in rule-then-action order.
+    edits: []const AppliedHeaderEdit,
+};
+
+/// One pass over the rules a request matches, producing everything the
+/// render phase needs (§7): the first applicable path rewrite and every
+/// matched rule's header edits. A single scan — reject is evaluated earlier
+/// at routing, before any resource is acquired, so the two render-phase
+/// concerns share one walk rather than two, and `matches` is evaluated once
+/// per rule.
+///
+/// The rewrite is first-applicable-wins: the first matching rule whose
+/// `rewrite_prefix.from` is a segment-prefix of the path, and it never
+/// chains — a later rule matched the original path, not the rewritten one,
+/// so chaining has no coherent meaning. Header edits, by contrast, gather
+/// from *every* matched rule. The caller sizes `out` at `header_edits_max`,
+/// which config caps a listener's total header edits at, so a matching
+/// subset always fits: the write is asserted in bounds. Bounded loops over
+/// immutable arena data; no allocation. Called at render (a matched reject
+/// would already have stopped the request at routing, so here every matched
+/// rule forwards).
+pub fn collectForward(
     rules: []const Rule,
     view: RequestView,
     out: []AppliedHeaderEdit,
-) []const AppliedHeaderEdit {
+) Forward {
     assert(view.path.len >= 1);
+    assert(view.path[0] == '/');
     assert(out.len <= constants.header_edits_max);
+    var rewrite: ?Rewrite = null;
     var count: usize = 0;
     for (rules) |rule| {
         if (!matches(rule.match, view)) {
             continue;
         }
-        for (rule.actions) |action| {
-            const edit: ?AppliedHeaderEdit = switch (action) {
-                .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
-                .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
-                .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
-                .reject, .rewrite_prefix => null,
-            };
-            if (edit) |value| {
-                assert(count < out.len);
-                out[count] = value;
-                count += 1;
-            }
-        }
-    }
-    assert(count <= out.len);
-    return out[0..count];
-}
-
-/// The rewrite of the first matching rule whose `rewrite_prefix.from` is a
-/// segment-prefix of the forwarded path, or null (§7). First-applicable
-/// wins — like `firstReject`, and unlike the collected header edits — so a
-/// rewrite is predictable and never chains: a later rule matches on the
-/// original path, not the rewritten one, so chaining has no coherent
-/// meaning. Routing already chose the cluster from this same path; the
-/// rewrite changes only what is forwarded, never the route.
-pub fn firstRewrite(rules: []const Rule, view: RequestView) ?Rewrite {
-    assert(view.path.len >= 1);
-    assert(view.path[0] == '/');
-    for (rules) |rule| {
-        if (!matches(rule.match, view)) {
-            continue;
-        }
         for (rule.actions) |action| switch (action) {
-            .rewrite_prefix => |rewrite| {
-                if (router.prefixMatches(rewrite.from, view.path)) {
-                    return rewrite;
+            .header_set, .header_add, .header_remove => {
+                assert(count < out.len);
+                out[count] = appliedEdit(action);
+                count += 1;
+            },
+            .rewrite_prefix => |candidate| {
+                if (rewrite == null and router.prefixMatches(candidate.from, view.path)) {
+                    rewrite = candidate;
                 }
             },
-            .reject, .header_set, .header_add, .header_remove => {},
+            .reject => {},
         };
     }
-    return null;
+    assert(count <= out.len);
+    return .{ .rewrite = rewrite, .edits = out[0..count] };
+}
+
+/// Flatten a header-edit action into the renderer's `AppliedHeaderEdit`.
+/// The caller has already narrowed `action` to the three header kinds.
+fn appliedEdit(action: Action) AppliedHeaderEdit {
+    return switch (action) {
+        .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
+        .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
+        .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
+        .reject, .rewrite_prefix => unreachable,
+    };
 }
 
 /// The forwarded path with `rewrite.from` replaced by `rewrite.to`, written
@@ -216,7 +226,7 @@ pub fn firstRewrite(rules: []const Rule, view: RequestView) ?Rewrite {
 /// is canonical by construction (canonical form preserves empty segments, so
 /// a second pass would not repair a `//` the join must never create).
 /// `Oversize` when a longer `to` overruns `out` — the §7 oversize verdict.
-/// `firstRewrite` already proved the prefix matches.
+/// `collectForward` already proved the prefix matches.
 pub fn rewritePath(rewrite: Rewrite, path: []const u8, out: []u8) error{Oversize}![]const u8 {
     assert(path.len >= 1);
     assert(path[0] == '/');
@@ -261,6 +271,8 @@ pub fn rewritePath(rewrite: Rewrite, path: []const u8, out: []u8) error{Oversize
 /// canonical forms (the path via the router's segment-boundary match, so
 /// filters and routing agree byte-for-byte).
 fn matches(match: Match, view: RequestView) bool {
+    assert(view.path.len >= 1);
+    assert(view.path[0] == '/'); // Canonical path — callers guarantee it.
     if (match.methods) |set| {
         if (!set.contains(view.method)) {
             return false;
@@ -290,6 +302,8 @@ fn matches(match: Match, view: RequestView) bool {
 /// byte-exact / by substring. Multiple headers of the same name each get
 /// a chance — the predicate holds if any does.
 fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool {
+    assert(header_match.name.len >= 1); // A validated RFC 9110 token.
+    assert(headers.len <= constants.headers_max);
     for (headers) |header| {
         if (!std.ascii.eqlIgnoreCase(header.name, header_match.name)) {
             continue;
@@ -297,17 +311,28 @@ fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool
         switch (header_match.kind) {
             .present => return true,
             .equals => if (std.mem.eql(u8, header.value, header_match.value)) return true,
-            .contains => if (std.mem.indexOf(u8, header.value, header_match.value) != null) return true,
+            // Config rejects an empty `contains` needle, so this is a real
+            // substring test — never the always-true `indexOf(x, "")`.
+            .contains => {
+                assert(header_match.value.len >= 1);
+                if (std.mem.indexOf(u8, header.value, header_match.value) != null) return true;
+            },
         }
     }
     return false;
 }
 
-test "filter: isRejectStatus admits the policy set only" {
-    try std.testing.expect(isRejectStatus(403));
-    try std.testing.expect(isRejectStatus(429));
+test "filter: isRejectStatus admits exactly the reject_statuses set" {
+    // Every member of the single-source-of-truth set is admitted.
+    for (reject_statuses) |status| {
+        try std.testing.expect(isRejectStatus(status));
+    }
     try std.testing.expect(!isRejectStatus(200));
+    try std.testing.expect(!isRejectStatus(500));
     try std.testing.expect(!isRejectStatus(503));
+    // Pin the documented set so a drift (and the proxy's matching dispatch)
+    // is caught here rather than at runtime.
+    try std.testing.expectEqualSlices(u16, &.{ 400, 403, 404, 429 }, &reject_statuses);
 }
 
 test "filter: firstReject matches on method, host, path, header" {
@@ -396,7 +421,7 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
     }));
 }
 
-test "filter: collectHeaderEdits gathers matching rules' edits in order" {
+test "filter: collectForward gathers matching rules' edits in order" {
     const rules = [_]Rule{
         // Applies to every request: stamp a via header, drop cookies.
         .{ .match = .{}, .actions = &.{
@@ -404,7 +429,7 @@ test "filter: collectHeaderEdits gathers matching rules' edits in order" {
             .{ .header_remove = "Cookie" },
         } },
         // Applies only under /api: add a second via, and a reject that
-        // collectHeaderEdits must skip (it is not a header edit).
+        // collectForward must skip (it is not a header edit).
         .{ .match = .{ .path_prefix = "/api" }, .actions = &.{
             .{ .header_add = .{ .name = "X-Api", .value = "1" } },
             .{ .reject = 429 },
@@ -413,36 +438,38 @@ test "filter: collectHeaderEdits gathers matching rules' edits in order" {
     const empty: []const parser.Header = &.{};
     var buffer: [constants.header_edits_max]AppliedHeaderEdit = undefined;
 
-    // A /public request matches only the first rule: two edits.
-    const public = collectHeaderEdits(&rules, .{
+    // A /public request matches only the first rule: two edits, no rewrite.
+    const public = collectForward(&rules, .{
         .method = .get,
         .host = null,
         .path = "/public",
         .headers = empty,
     }, &buffer);
-    try std.testing.expectEqual(@as(usize, 2), public.len);
-    try std.testing.expectEqual(AppliedHeaderEdit.Kind.set, public[0].kind);
-    try std.testing.expectEqualStrings("X-Via", public[0].name);
-    try std.testing.expectEqual(AppliedHeaderEdit.Kind.remove, public[1].kind);
-    try std.testing.expectEqualStrings("Cookie", public[1].name);
+    try std.testing.expectEqual(@as(?Rewrite, null), public.rewrite);
+    try std.testing.expectEqual(@as(usize, 2), public.edits.len);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.set, public.edits[0].kind);
+    try std.testing.expectEqualStrings("X-Via", public.edits[0].name);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.remove, public.edits[1].kind);
+    try std.testing.expectEqualStrings("Cookie", public.edits[1].name);
 
     // A /api request matches both rules; the reject action is skipped, so
     // three header edits survive in rule-then-action order.
-    const api = collectHeaderEdits(&rules, .{
+    const api = collectForward(&rules, .{
         .method = .get,
         .host = null,
         .path = "/api/v1",
         .headers = empty,
     }, &buffer);
-    try std.testing.expectEqual(@as(usize, 3), api.len);
-    try std.testing.expectEqualStrings("X-Via", api[0].name);
-    try std.testing.expectEqualStrings("Cookie", api[1].name);
-    try std.testing.expectEqual(AppliedHeaderEdit.Kind.add, api[2].kind);
-    try std.testing.expectEqualStrings("X-Api", api[2].name);
+    try std.testing.expectEqual(@as(usize, 3), api.edits.len);
+    try std.testing.expectEqualStrings("X-Via", api.edits[0].name);
+    try std.testing.expectEqualStrings("Cookie", api.edits[1].name);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.add, api.edits[2].kind);
+    try std.testing.expectEqualStrings("X-Api", api.edits[2].name);
 }
 
-test "filter: firstRewrite picks the first applicable rewrite only" {
+test "filter: collectForward picks the first applicable rewrite only" {
     const empty: []const parser.Header = &.{};
+    var buffer: [constants.header_edits_max]AppliedHeaderEdit = undefined;
     const rules = [_]Rule{
         // Matches, but its rewrite's `from` is not a prefix of the path —
         // skipped, so the scan continues to the next rule.
@@ -458,23 +485,25 @@ test "filter: firstRewrite picks the first applicable rewrite only" {
             .{ .rewrite_prefix = .{ .from = "/api", .to = "/v3" } },
         } },
     };
-    const hit = firstRewrite(&rules, .{
+    const hit = collectForward(&rules, .{
         .method = .get,
         .host = null,
         .path = "/api/users",
         .headers = empty,
-    });
-    try std.testing.expect(hit != null);
-    try std.testing.expectEqualStrings("/api", hit.?.from);
-    try std.testing.expectEqualStrings("/v2", hit.?.to);
+    }, &buffer);
+    try std.testing.expect(hit.rewrite != null);
+    try std.testing.expectEqualStrings("/api", hit.rewrite.?.from);
+    try std.testing.expectEqualStrings("/v2", hit.rewrite.?.to);
+    try std.testing.expectEqual(@as(usize, 0), hit.edits.len); // rewrite-only rules
 
     // No rewrite's `from` prefixes a /public path → null.
-    try std.testing.expectEqual(@as(?Rewrite, null), firstRewrite(&rules, .{
+    const miss = collectForward(&rules, .{
         .method = .get,
         .host = null,
         .path = "/public",
         .headers = empty,
-    }));
+    }, &buffer);
+    try std.testing.expectEqual(@as(?Rewrite, null), miss.rewrite);
 }
 
 test "filter: rewritePath is a segment-correct prefix replacement" {

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -177,6 +177,85 @@ pub fn collectHeaderEdits(
     return out[0..count];
 }
 
+/// The rewrite of the first matching rule whose `rewrite_prefix.from` is a
+/// segment-prefix of the forwarded path, or null (§7). First-applicable
+/// wins — like `firstReject`, and unlike the collected header edits — so a
+/// rewrite is predictable and never chains: a later rule matches on the
+/// original path, not the rewritten one, so chaining has no coherent
+/// meaning. Routing already chose the cluster from this same path; the
+/// rewrite changes only what is forwarded, never the route.
+pub fn firstRewrite(rules: []const Rule, view: RequestView) ?Rewrite {
+    assert(view.path.len >= 1);
+    assert(view.path[0] == '/');
+    for (rules) |rule| {
+        if (!matches(rule.match, view)) {
+            continue;
+        }
+        for (rule.actions) |action| switch (action) {
+            .rewrite_prefix => |rewrite| {
+                if (router.prefixMatches(rewrite.from, view.path)) {
+                    return rewrite;
+                }
+            },
+            .reject, .header_set, .header_add, .header_remove => {},
+        };
+    }
+    return null;
+}
+
+/// The forwarded path with `rewrite.from` replaced by `rewrite.to`, written
+/// into `out` (§7). A segment-correct join: the segments surviving past
+/// `from` are rejoined to `to` with exactly one slash, so the result never
+/// gains a `//` or merges two segments — whether or not `from`/`to` are
+/// slash-terminated. This matters because a slash-terminated prefix (the
+/// root `/` is one, so it matches every path) leaves a suffix that does NOT
+/// begin with a slash: `from="/"`, `to="/x"`, `/foo` must yield `/x/foo`,
+/// never `/xfoo`; and stripping to root (`to="/"`) yields `/foo`, never the
+/// distinct resource `//foo`. `from` and `to` are validated canonical at
+/// load and the surviving segments are a canonical path's tail, so the join
+/// is canonical by construction (canonical form preserves empty segments, so
+/// a second pass would not repair a `//` the join must never create).
+/// `Oversize` when a longer `to` overruns `out` — the §7 oversize verdict.
+/// `firstRewrite` already proved the prefix matches.
+pub fn rewritePath(rewrite: Rewrite, path: []const u8, out: []u8) error{Oversize}![]const u8 {
+    assert(path.len >= 1);
+    assert(path[0] == '/');
+    assert(router.prefixMatches(rewrite.from, path));
+    assert(rewrite.to.len >= 1);
+    assert(rewrite.to[0] == '/');
+    // An exact match forwards `to` verbatim — its own trailing slash and all.
+    var rest = path[rewrite.from.len..];
+    if (rest.len == 0) {
+        if (rewrite.to.len > out.len) {
+            return error.Oversize;
+        }
+        @memcpy(out[0..rewrite.to.len], rewrite.to);
+        assert(out[0] == '/');
+        return out[0..rewrite.to.len];
+    }
+    // Rejoin with exactly one boundary slash: drop the suffix's leading
+    // slash when it has one (a non-slash-terminated `from` leaves it) and
+    // `to`'s trailing slash when it has one (root `to="/"` collapses to the
+    // empty base, so the single separator we write is the whole prefix).
+    if (rest[0] == '/') {
+        rest = rest[1..];
+    }
+    const to_base = if (rewrite.to[rewrite.to.len - 1] == '/')
+        rewrite.to[0 .. rewrite.to.len - 1]
+    else
+        rewrite.to;
+    const total = to_base.len + 1 + rest.len;
+    if (total > out.len) {
+        return error.Oversize;
+    }
+    @memcpy(out[0..to_base.len], to_base);
+    out[to_base.len] = '/';
+    @memcpy(out[to_base.len + 1 .. total], rest);
+    assert(out[0] == '/'); // `to_base` is empty (to=="/") or starts with '/'.
+    assert(total >= 1);
+    return out[0..total];
+}
+
 /// Whether a rule's match — a conjunction — holds for the request. A
 /// null/empty field is "any"; host and path prefix compare in the §7
 /// canonical forms (the path via the router's segment-boundary match, so
@@ -360,4 +439,91 @@ test "filter: collectHeaderEdits gathers matching rules' edits in order" {
     try std.testing.expectEqualStrings("Cookie", api[1].name);
     try std.testing.expectEqual(AppliedHeaderEdit.Kind.add, api[2].kind);
     try std.testing.expectEqualStrings("X-Api", api[2].name);
+}
+
+test "filter: firstRewrite picks the first applicable rewrite only" {
+    const empty: []const parser.Header = &.{};
+    const rules = [_]Rule{
+        // Matches, but its rewrite's `from` is not a prefix of the path —
+        // skipped, so the scan continues to the next rule.
+        .{ .match = .{}, .actions = &.{
+            .{ .rewrite_prefix = .{ .from = "/other", .to = "/x" } },
+        } },
+        // First applicable rewrite: matches and `/api` prefixes the path.
+        .{ .match = .{}, .actions = &.{
+            .{ .rewrite_prefix = .{ .from = "/api", .to = "/v2" } },
+        } },
+        // A later applicable rewrite that must never win (first wins).
+        .{ .match = .{}, .actions = &.{
+            .{ .rewrite_prefix = .{ .from = "/api", .to = "/v3" } },
+        } },
+    };
+    const hit = firstRewrite(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/api/users",
+        .headers = empty,
+    });
+    try std.testing.expect(hit != null);
+    try std.testing.expectEqualStrings("/api", hit.?.from);
+    try std.testing.expectEqualStrings("/v2", hit.?.to);
+
+    // No rewrite's `from` prefixes a /public path → null.
+    try std.testing.expectEqual(@as(?Rewrite, null), firstRewrite(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/public",
+        .headers = empty,
+    }));
+}
+
+test "filter: rewritePath is a segment-correct prefix replacement" {
+    var out: [64]u8 = undefined;
+    const cases = [_]struct { from: []const u8, to: []const u8, path: []const u8, want: []const u8 }{
+        // Ordinary replacement, suffix carries its own slash.
+        .{ .from = "/api", .to = "/v2", .path = "/api/users", .want = "/v2/users" },
+        // Exact match, empty suffix → just `to`.
+        .{ .from = "/api", .to = "/v2", .path = "/api", .want = "/v2" },
+        // Strip a prefix to root: `to == "/"` must not double the slash.
+        .{ .from = "/api", .to = "/", .path = "/api/users", .want = "/users" },
+        // `to` exactly root, exact match → root.
+        .{ .from = "/api", .to = "/", .path = "/api", .want = "/" },
+        // A `to` that itself ends in a slash also dedups the boundary.
+        .{ .from = "/api", .to = "/v2/", .path = "/api/users", .want = "/v2/users" },
+        // Multi-segment from and to.
+        .{ .from = "/a/b", .to = "/c/d", .path = "/a/b/e/f", .want = "/c/d/e/f" },
+        // Slash-terminated `from` — the root prefix matches every path and
+        // leaves a suffix that does NOT start with a slash; the join must
+        // still put exactly one slash between `to` and the survivors.
+        .{ .from = "/", .to = "/x", .path = "/foo", .want = "/x/foo" },
+        .{ .from = "/", .to = "/x", .path = "/", .want = "/x" },
+        // `to == "/"` with the root `from`: prepend nothing, keep the path.
+        .{ .from = "/", .to = "/", .path = "/foo/bar", .want = "/foo/bar" },
+        // An explicitly slash-terminated `from` prefix.
+        .{ .from = "/api/", .to = "/v2", .path = "/api/foo", .want = "/v2/foo" },
+        // Trailing slash preserved when the whole path is the prefix.
+        .{ .from = "/api", .to = "/v2", .path = "/api/", .want = "/v2/" },
+    };
+    for (cases) |case| {
+        const got = try rewritePath(
+            .{ .from = case.from, .to = case.to },
+            case.path,
+            &out,
+        );
+        try std.testing.expectEqualStrings(case.want, got);
+        // The result must be what canonicalization would produce — the join
+        // yields canonical output directly, no second pass.
+        var canon: [constants.head_bytes_max]u8 = undefined;
+        const recanon = try parser.canonicalTarget(got, &canon);
+        try std.testing.expectEqualStrings(got, recanon.path);
+    }
+}
+
+test "filter: rewritePath reports Oversize when the result would not fit" {
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectError(error.Oversize, rewritePath(
+        .{ .from = "/a", .to = "/longer" },
+        "/a/x",
+        &tiny,
+    ));
 }

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
 const parser = @import("parser.zig");
 const router = @import("router.zig");
 
@@ -74,6 +75,20 @@ pub const Rule = struct {
     actions: []const Action,
 };
 
+/// A header edit flattened for the renderer: the three header actions
+/// collapsed to one op plus the (config-validated) name and value. The
+/// renderer suppresses source copies of a `set`/`remove` name and appends
+/// a line for each `set`/`add`; `value` is unused for a `remove`. This is
+/// the render's input contract — `collectHeaderEdits` produces it from the
+/// rules a request matched.
+pub const AppliedHeaderEdit = struct {
+    kind: Kind,
+    name: []const u8,
+    value: []const u8,
+
+    pub const Kind = enum(u8) { set, add, remove };
+};
+
 /// The statuses a `reject` action may name — a subset of the §8 static
 /// responses that make sense as a policy verdict. Config rejects any
 /// other value at load, and `shed.staticResponse` must support each.
@@ -121,6 +136,45 @@ pub fn firstReject(rules: []const Rule, view: RequestView) ?u16 {
         }
     }
     return null;
+}
+
+/// The header edits of every rule that matches `view`, in rule-then-action
+/// order, written into `out` and returned as its filled prefix (§7).
+/// `reject`/`rewrite_prefix` actions are skipped — this collects only the
+/// header edits the renderer applies. The caller sizes `out` at
+/// `header_edits_max`, which config caps a listener's total header edits
+/// at, so a matching subset always fits: the write is asserted in bounds.
+/// Bounded loops over immutable arena data; no allocation. Called at render
+/// (a matched reject would already have stopped the request at routing, so
+/// here every matched rule forwards and its edits apply).
+pub fn collectHeaderEdits(
+    rules: []const Rule,
+    view: RequestView,
+    out: []AppliedHeaderEdit,
+) []const AppliedHeaderEdit {
+    assert(view.path.len >= 1);
+    assert(out.len <= constants.header_edits_max);
+    var count: usize = 0;
+    for (rules) |rule| {
+        if (!matches(rule.match, view)) {
+            continue;
+        }
+        for (rule.actions) |action| {
+            const edit: ?AppliedHeaderEdit = switch (action) {
+                .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
+                .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
+                .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
+                .reject, .rewrite_prefix => null,
+            };
+            if (edit) |value| {
+                assert(count < out.len);
+                out[count] = value;
+                count += 1;
+            }
+        }
+    }
+    assert(count <= out.len);
+    return out[0..count];
 }
 
 /// Whether a rule's match — a conjunction — holds for the request. A
@@ -261,4 +315,49 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
         .path = "/blocked/x",
         .headers = empty,
     }));
+}
+
+test "filter: collectHeaderEdits gathers matching rules' edits in order" {
+    const rules = [_]Rule{
+        // Applies to every request: stamp a via header, drop cookies.
+        .{ .match = .{}, .actions = &.{
+            .{ .header_set = .{ .name = "X-Via", .value = "zoxy" } },
+            .{ .header_remove = "Cookie" },
+        } },
+        // Applies only under /api: add a second via, and a reject that
+        // collectHeaderEdits must skip (it is not a header edit).
+        .{ .match = .{ .path_prefix = "/api" }, .actions = &.{
+            .{ .header_add = .{ .name = "X-Api", .value = "1" } },
+            .{ .reject = 429 },
+        } },
+    };
+    const empty: []const parser.Header = &.{};
+    var buffer: [constants.header_edits_max]AppliedHeaderEdit = undefined;
+
+    // A /public request matches only the first rule: two edits.
+    const public = collectHeaderEdits(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/public",
+        .headers = empty,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 2), public.len);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.set, public[0].kind);
+    try std.testing.expectEqualStrings("X-Via", public[0].name);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.remove, public[1].kind);
+    try std.testing.expectEqualStrings("Cookie", public[1].name);
+
+    // A /api request matches both rules; the reject action is skipped, so
+    // three header edits survive in rule-then-action order.
+    const api = collectHeaderEdits(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/api/v1",
+        .headers = empty,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 3), api.len);
+    try std.testing.expectEqualStrings("X-Via", api[0].name);
+    try std.testing.expectEqualStrings("Cookie", api[1].name);
+    try std.testing.expectEqual(AppliedHeaderEdit.Kind.add, api[2].kind);
+    try std.testing.expectEqualStrings("X-Api", api[2].name);
 }

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -1,0 +1,89 @@
+//! §7 "filters are data, not code": per-listener request-processing rules,
+//! compiled at config load (`config.zig`) into immutable arena tables and
+//! interpreted per request — never scripted, never allocating. A rule is a
+//! match (a conjunction of predicates over the parsed head, in the §7
+//! canonical forms so a filter and the router never disagree) and an
+//! ordered action list drawn from a closed enum. Cluster selection is NOT
+//! an action: the route table owns the backend decision (§7), so filters
+//! never compete with routing. This module holds the compiled shapes; the
+//! interpreter and the config-load compiler live in slices to come.
+
+const std = @import("std");
+
+const parser = @import("parser.zig");
+
+/// A single header predicate: the named header must be present, or equal,
+/// or contain the given value (case-insensitive name, per RFC 9110).
+pub const HeaderMatch = struct {
+    name: []const u8,
+    kind: Kind,
+    /// Unused for `.present`; the compared value otherwise.
+    value: []const u8,
+
+    pub const Kind = enum(u8) { present, equals, contains };
+};
+
+/// A rule's match: every present predicate must hold (a conjunction). A
+/// null/empty field is "any", so an all-null match is an unconditional
+/// rule. Host and path prefix are already canonical (§7), compared
+/// byte-for-byte against the request's canonical host/path.
+pub const Match = struct {
+    /// Registered methods the rule applies to; null = any method.
+    methods: ?std.EnumSet(parser.Method) = null,
+    host: ?[]const u8 = null,
+    path_prefix: ?[]const u8 = null,
+    headers: []const HeaderMatch = &.{},
+};
+
+/// One header edit's name and value (value unused for a remove).
+pub const HeaderEdit = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// A canonical path-prefix rewrite of the *forwarded* request only
+/// (routing already chose the cluster, §7): the matched `from` prefix is
+/// replaced by `to`, and the result re-canonicalized before it goes
+/// upstream. Both are validated canonical at config load.
+pub const Rewrite = struct {
+    from: []const u8,
+    to: []const u8,
+};
+
+/// The closed action enum (§7): no `pick cluster` (routing owns the
+/// backend), no scripting. Anything past this is a Zig function in the
+/// owning phase module, added at compile time.
+pub const Action = union(enum) {
+    /// Answer a static status and stop (§8 static-response machinery).
+    reject: u16,
+    /// Set (replacing any existing), add (append), or remove a header on
+    /// the forwarded request, applied during the head render.
+    header_set: HeaderEdit,
+    header_add: HeaderEdit,
+    header_remove: []const u8,
+    /// Rewrite the forwarded canonical path's prefix.
+    rewrite_prefix: Rewrite,
+};
+
+/// One compiled rule: match, then its ordered actions.
+pub const Rule = struct {
+    match: Match,
+    actions: []const Action,
+};
+
+/// The statuses a `reject` action may name — a subset of the §8 static
+/// responses that make sense as a policy verdict. Config rejects any
+/// other value at load, and `shed.staticResponse` must support each.
+pub fn isRejectStatus(status: u16) bool {
+    return switch (status) {
+        400, 403, 404, 429 => true,
+        else => false,
+    };
+}
+
+test "filter: isRejectStatus admits the policy set only" {
+    try std.testing.expect(isRejectStatus(403));
+    try std.testing.expect(isRejectStatus(429));
+    try std.testing.expect(!isRejectStatus(200));
+    try std.testing.expect(!isRejectStatus(503));
+}

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -11,6 +11,9 @@
 const std = @import("std");
 
 const parser = @import("parser.zig");
+const router = @import("router.zig");
+
+const assert = std.debug.assert;
 
 /// A single header predicate: the named header must be present, or equal,
 /// or contain the given value (case-insensitive name, per RFC 9110).
@@ -81,9 +84,181 @@ pub fn isRejectStatus(status: u16) bool {
     };
 }
 
+/// The parsed head a rule matches against, in the §7 canonical forms:
+/// `host` is the canonical routing host (null when absent/unmatchable),
+/// `path` the canonical request path (or "/" for asterisk-form), and
+/// `headers` the parsed head's headers (zero-copy slices).
+pub const RequestView = struct {
+    method: parser.Method,
+    host: ?[]const u8,
+    path: []const u8,
+    headers: []const parser.Header,
+};
+
+/// The reject status of the first matching rule that carries a `reject`
+/// action, or null to proceed (§7). Rules are evaluated top-down and
+/// actions in order, so the first reject reached wins — and because a
+/// matched rule's reject stops the request, any header/rewrite edits are
+/// then moot (they apply only to a request that forwards, handled at the
+/// render). Bounded loops over immutable arena data; no allocation.
+pub fn firstReject(rules: []const Rule, view: RequestView) ?u16 {
+    assert(view.path.len >= 1);
+    assert(view.path[0] == '/');
+    for (rules) |rule| {
+        if (!matches(rule.match, view)) {
+            continue;
+        }
+        for (rule.actions) |action| {
+            switch (action) {
+                .reject => |status| {
+                    assert(isRejectStatus(status));
+                    return status;
+                },
+                // Edits apply at the render, only when the request
+                // forwards; a reject anywhere in a matched rule stops it.
+                .header_set, .header_add, .header_remove, .rewrite_prefix => {},
+            }
+        }
+    }
+    return null;
+}
+
+/// Whether a rule's match — a conjunction — holds for the request. A
+/// null/empty field is "any"; host and path prefix compare in the §7
+/// canonical forms (the path via the router's segment-boundary match, so
+/// filters and routing agree byte-for-byte).
+fn matches(match: Match, view: RequestView) bool {
+    if (match.methods) |set| {
+        if (!set.contains(view.method)) {
+            return false;
+        }
+    }
+    if (match.host) |host| {
+        const request_host = view.host orelse return false;
+        if (!std.mem.eql(u8, host, request_host)) {
+            return false;
+        }
+    }
+    if (match.path_prefix) |prefix| {
+        if (!router.prefixMatches(prefix, view.path)) {
+            return false;
+        }
+    }
+    for (match.headers) |header_match| {
+        if (!headerMatches(header_match, view.headers)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// Whether some header satisfies the predicate. Name comparison is
+/// case-insensitive (RFC 9110); `equals`/`contains` compare the value
+/// byte-exact / by substring. Multiple headers of the same name each get
+/// a chance — the predicate holds if any does.
+fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool {
+    for (headers) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, header_match.name)) {
+            continue;
+        }
+        switch (header_match.kind) {
+            .present => return true,
+            .equals => if (std.mem.eql(u8, header.value, header_match.value)) return true,
+            .contains => if (std.mem.indexOf(u8, header.value, header_match.value) != null) return true,
+        }
+    }
+    return false;
+}
+
 test "filter: isRejectStatus admits the policy set only" {
     try std.testing.expect(isRejectStatus(403));
     try std.testing.expect(isRejectStatus(429));
     try std.testing.expect(!isRejectStatus(200));
     try std.testing.expect(!isRejectStatus(503));
+}
+
+test "filter: firstReject matches on method, host, path, header" {
+    const H = parser.Header;
+    const rules = [_]Rule{
+        // Reject a POST to /admin from a specific host with a header set.
+        .{
+            .match = .{
+                .methods = blk: {
+                    var set = std.EnumSet(parser.Method){};
+                    set.insert(.post);
+                    break :blk set;
+                },
+                .host = "api.example",
+                .path_prefix = "/admin",
+                .headers = &.{.{ .name = "X-Env", .kind = .equals, .value = "prod" }},
+            },
+            .actions = &.{.{ .reject = 403 }},
+        },
+    };
+    const prod = [_]H{.{ .name = "x-env", .value = "prod" }};
+    const dev = [_]H{.{ .name = "X-Env", .value = "dev" }};
+
+    // Full match → 403.
+    try std.testing.expectEqual(@as(?u16, 403), firstReject(&rules, .{
+        .method = .post,
+        .host = "api.example",
+        .path = "/admin/users",
+        .headers = &prod,
+    }));
+    // Wrong method, host, path, or header value → no reject.
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .get, // not POST
+        .host = "api.example",
+        .path = "/admin",
+        .headers = &prod,
+    }));
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .post,
+        .host = "other.example", // wrong host
+        .path = "/admin",
+        .headers = &prod,
+    }));
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .post,
+        .host = "api.example",
+        .path = "/public", // not under /admin
+        .headers = &prod,
+    }));
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .post,
+        .host = "api.example",
+        .path = "/admin",
+        .headers = &dev, // header value mismatch
+    }));
+    // A segment-splitting path must not match the /admin prefix.
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .post,
+        .host = "api.example",
+        .path = "/administrator",
+        .headers = &prod,
+    }));
+}
+
+test "filter: an all-any match is unconditional; edit-only rules never reject" {
+    const rules = [_]Rule{
+        .{ .match = .{}, .actions = &.{
+            .{ .header_set = .{ .name = "X-Via", .value = "zoxy" } },
+        } },
+        .{ .match = .{ .path_prefix = "/blocked" }, .actions = &.{.{ .reject = 404 }} },
+    };
+    const empty: []const parser.Header = &.{};
+    // The edit-only rule matches everything but does not reject.
+    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/anything",
+        .headers = empty,
+    }));
+    // The second rule rejects its prefix.
+    try std.testing.expectEqual(@as(?u16, 404), firstReject(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/blocked/x",
+        .headers = empty,
+    }));
 }

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -1025,7 +1025,11 @@ fn versionFromRaw(raw_version: hparse.Version) Version {
     };
 }
 
-fn isForwardableByte(byte: u8) bool {
+/// True for a byte legal in a forwarded field-value (RFC 9110): VCHAR, SP,
+/// HTAB, or obs-text — never CR, LF, NUL, or another control. Public so the
+/// filter config compiler validates edit values against the exact set the
+/// parser enforces, one definition for both.
+pub fn isForwardableByte(byte: u8) bool {
     return byte == '\t' or (byte >= ' ' and byte != 0x7f);
 }
 

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -979,6 +979,27 @@ fn oversizeRequestError(head: []const u8) HeadError {
     return error.HeadTooLarge;
 }
 
+/// The registered method for an uppercase token, or null for anything
+/// unregistered. HTTP methods are case-sensitive (RFC 9110 §9.1), so only
+/// the canonical uppercase spelling matches — filters name registered
+/// methods this way; an extension method (`.extension`) is not selectable
+/// by token here (§7).
+pub fn methodFromToken(token: []const u8) ?Method {
+    const table = .{
+        .{ "GET", Method.get },         .{ "POST", Method.post },
+        .{ "HEAD", Method.head },       .{ "PUT", Method.put },
+        .{ "DELETE", Method.delete },   .{ "CONNECT", Method.connect },
+        .{ "OPTIONS", Method.options }, .{ "TRACE", Method.trace },
+        .{ "PATCH", Method.patch },
+    };
+    inline for (table) |entry| {
+        if (std.mem.eql(u8, token, entry[0])) {
+            return entry[1];
+        }
+    }
+    return null;
+}
+
 fn methodFromRaw(raw_method: hparse.Method) Method {
     assert(raw_method != .unknown);
     return switch (raw_method) {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -179,6 +179,38 @@ pub fn Proxy(comptime IoType: type) type {
             return parser.canonicalTarget(request.target, scratch) catch unreachable;
         }
 
+        /// The §7 filter header edits matching `request`, materialized into
+        /// `out`. Empty when the listener has no filters — the common path
+        /// pays nothing (no host canonicalization, no scan). The match view
+        /// mirrors `requestKeys`: canonical host, and the canonical path
+        /// (origin-form, aliasing `target.path`) or "/" (OPTIONS
+        /// asterisk-form) — so the rules matched here are exactly those the
+        /// reject phase saw.
+        fn collectRequestEdits(
+            conn: *const ConnType,
+            request: *const parser.RequestHead,
+            target: parser.CanonicalTarget,
+            host_scratch: *[constants.host_bytes_max]u8,
+            out: *[constants.header_edits_max]filter.AppliedHeaderEdit,
+        ) []const filter.AppliedHeaderEdit {
+            if (conn.filters.len == 0) {
+                return &.{};
+            }
+            const host: ?[]const u8 = if (request.host) |raw|
+                parser.canonicalHost(raw, host_scratch)
+            else
+                null;
+            const match_path: []const u8 = if (request.target[0] == '/') target.path else "/";
+            assert(match_path.len >= 1);
+            assert(match_path[0] == '/');
+            return filter.collectHeaderEdits(conn.filters, .{
+                .method = request.method,
+                .host = host,
+                .path = match_path,
+                .headers = request.headers,
+            }, out);
+        }
+
         /// Policy gate, then the exchange's admission: tunnels and
         /// upgrades are non-goals (§1, §7) — 501; the canonical path
         /// selects a cluster (400 if it will not canonicalize, 404 if no
@@ -317,10 +349,16 @@ pub fn Proxy(comptime IoType: type) type {
             // origin and the router never disagree about the resource.
             var scratch: [constants.head_bytes_max]u8 = undefined;
             const target = effectiveTarget(request, &scratch);
+            // The §7 filter header edits this request matched (empty when
+            // the listener has no filters). Collected against the same
+            // canonical view the reject/route phase used.
+            var host_scratch: [constants.host_bytes_max]u8 = undefined;
+            var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
+            const edits = collectRequestEdits(conn, request, target, &host_scratch, &edit_buffer);
             // No close announcement upstream: the connection is a parking
             // candidate (§5), and stripping the client's Connection header
             // already made persistence the wire default.
-            const rendered = render.renderRequestHead(request, target, false, &upstream.head) catch {
+            const rendered = render.renderRequestHead(request, target, edits, false, &upstream.head) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -179,36 +179,55 @@ pub fn Proxy(comptime IoType: type) type {
             return parser.canonicalTarget(request.target, scratch) catch unreachable;
         }
 
-        /// The §7 filter header edits matching `request`, materialized into
-        /// `out`. Empty when the listener has no filters — the common path
-        /// pays nothing (no host canonicalization, no scan). The match view
-        /// mirrors `requestKeys`: canonical host, and the canonical path
-        /// (origin-form, aliasing `target.path`) or "/" (OPTIONS
-        /// asterisk-form) — so the rules matched here are exactly those the
-        /// reject phase saw.
-        fn collectRequestEdits(
+        /// The forwarded target and header edits after applying the
+        /// listener's §7 filters to `request` — `base` unchanged and no
+        /// edits when the listener has no filters (the common path pays
+        /// nothing). Routing already chose the cluster from `base.path`; a
+        /// rewrite changes only the forwarded path here, never the route,
+        /// and first-applicable wins. The match view mirrors `requestKeys`:
+        /// canonical host, and the canonical path (origin-form, aliasing
+        /// `base.path`) or "/" (OPTIONS asterisk-form) — so the rules that
+        /// fire are exactly those the reject phase saw. `Oversize` when a
+        /// rewrite's longer `to` overruns the path scratch (§7, 431).
+        const Forwarded = struct {
+            target: parser.CanonicalTarget,
+            edits: []const filter.AppliedHeaderEdit,
+        };
+        fn planForward(
             conn: *const ConnType,
             request: *const parser.RequestHead,
-            target: parser.CanonicalTarget,
+            base: parser.CanonicalTarget,
             host_scratch: *[constants.host_bytes_max]u8,
-            out: *[constants.header_edits_max]filter.AppliedHeaderEdit,
-        ) []const filter.AppliedHeaderEdit {
+            rewrite_scratch: *[constants.head_bytes_max]u8,
+            edit_buffer: *[constants.header_edits_max]filter.AppliedHeaderEdit,
+        ) error{Oversize}!Forwarded {
+            assert(base.path.len >= 1);
             if (conn.filters.len == 0) {
-                return &.{};
+                return .{ .target = base, .edits = &.{} };
             }
             const host: ?[]const u8 = if (request.host) |raw|
                 parser.canonicalHost(raw, host_scratch)
             else
                 null;
-            const match_path: []const u8 = if (request.target[0] == '/') target.path else "/";
+            const origin_form = request.target[0] == '/';
+            const match_path: []const u8 = if (origin_form) base.path else "/";
             assert(match_path.len >= 1);
             assert(match_path[0] == '/');
-            return filter.collectHeaderEdits(conn.filters, .{
+            const view = filter.RequestView{
                 .method = request.method,
                 .host = host,
                 .path = match_path,
                 .headers = request.headers,
-            }, out);
+            };
+            // Rewrite only origin-form targets; asterisk-form names no path.
+            var target = base;
+            if (origin_form) {
+                if (filter.firstRewrite(conn.filters, view)) |rewrite| {
+                    target.path = try filter.rewritePath(rewrite, base.path, rewrite_scratch);
+                }
+            }
+            const edits = filter.collectHeaderEdits(conn.filters, view, edit_buffer);
+            return .{ .target = target, .edits = edits };
         }
 
         /// Policy gate, then the exchange's admission: tunnels and
@@ -345,20 +364,32 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_dialing);
             assert(request.head_len == conn.l7.request_head_len);
             const upstream = conn.upstream.?;
-            // Forward the §7 canonical target the router matched on, so the
-            // origin and the router never disagree about the resource.
+            // The §7 canonical target the router matched on is the base the
+            // origin sees, unless a filter rewrites the forwarded path.
             var scratch: [constants.head_bytes_max]u8 = undefined;
-            const target = effectiveTarget(request, &scratch);
-            // The §7 filter header edits this request matched (empty when
-            // the listener has no filters). Collected against the same
+            const base = effectiveTarget(request, &scratch);
+            // Apply the listener's filters (empty when none): a rewrite of
+            // the forwarded path and any header edits, against the same
             // canonical view the reject/route phase used.
             var host_scratch: [constants.host_bytes_max]u8 = undefined;
+            var rewrite_scratch: [constants.head_bytes_max]u8 = undefined;
             var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
-            const edits = collectRequestEdits(conn, request, target, &host_scratch, &edit_buffer);
+            const plan = planForward(
+                conn,
+                request,
+                base,
+                &host_scratch,
+                &rewrite_scratch,
+                &edit_buffer,
+            ) catch {
+                // A rewritten path too long to forward: the §7 oversize
+                // verdict, answered like an oversize head.
+                return respond(server, conn, 431, "l7_headers_too_large");
+            };
             // No close announcement upstream: the connection is a parking
             // candidate (§5), and stripping the client's Connection header
             // already made persistence the wire default.
-            const rendered = render.renderRequestHead(request, target, edits, false, &upstream.head) catch {
+            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, &upstream.head) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -155,13 +155,16 @@ pub fn Proxy(comptime IoType: type) type {
         /// a closed-set static response, all counted as one filter reject.
         fn respondFilter(server: *ServerType, conn: *ConnType, status: u16) void {
             assert(filter.isRejectStatus(status));
-            switch (status) {
-                400 => respond(server, conn, 400, "l7_filtered"),
-                403 => respond(server, conn, 403, "l7_filtered"),
-                404 => respond(server, conn, 404, "l7_filtered"),
-                429 => respond(server, conn, 429, "l7_filtered"),
-                else => unreachable,
+            // `respond` needs a comptime status to select its static
+            // response, so bridge the runtime status by matching it against
+            // the same closed set `filter.isRejectStatus` guards — one
+            // source of truth, no hand-kept switch to drift out of sync.
+            inline for (filter.reject_statuses) |candidate| {
+                if (status == candidate) {
+                    return respond(server, conn, candidate, "l7_filtered");
+                }
             }
+            unreachable;
         }
 
         /// The canonical bytes to forward for `request` (§7): origin-form
@@ -205,6 +208,12 @@ pub fn Proxy(comptime IoType: type) type {
             if (conn.filters.len == 0) {
                 return .{ .target = base, .edits = &.{} };
             }
+            // The canonical host is recomputed here, not reused from the
+            // route phase: on the dial path the route-phase view does not
+            // survive the connect await (its scratch is freed), and the
+            // render form differs from the routing keys anyway (the
+            // forwarded target keeps its query and asterisk-form). One
+            // canonicalization per phase — deliberately not shared.
             const host: ?[]const u8 = if (request.host) |raw|
                 parser.canonicalHost(raw, host_scratch)
             else
@@ -219,15 +228,16 @@ pub fn Proxy(comptime IoType: type) type {
                 .path = match_path,
                 .headers = request.headers,
             };
+            // One scan yields both the rewrite and the header edits (§7).
+            const forward = filter.collectForward(conn.filters, view, edit_buffer);
             // Rewrite only origin-form targets; asterisk-form names no path.
             var target = base;
             if (origin_form) {
-                if (filter.firstRewrite(conn.filters, view)) |rewrite| {
+                if (forward.rewrite) |rewrite| {
                     target.path = try filter.rewritePath(rewrite, base.path, rewrite_scratch);
                 }
             }
-            const edits = filter.collectHeaderEdits(conn.filters, view, edit_buffer);
-            return .{ .target = target, .edits = edits };
+            return .{ .target = target, .edits = forward.edits };
         }
 
         /// Policy gate, then the exchange's admission: tunnels and

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -36,6 +36,7 @@ const Io = @import("../io/io.zig");
 const parser = @import("parser.zig");
 const render = @import("render.zig");
 const router = @import("router.zig");
+const filter = @import("filter.zig");
 const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
@@ -121,20 +122,20 @@ pub fn Proxy(comptime IoType: type) type {
             routeRequest(server, conn, &request);
         }
 
-        /// The cluster for `request`'s canonical host and path (§7). The
-        /// host is canonicalized (null when absent/unmatchable → any-host
-        /// routes only); origin-form paths are canonicalized and matched
-        /// by longest prefix; OPTIONS asterisk-form names the whole server,
-        /// so it routes as path "/". A target that will not canonicalize
-        /// is BadPath (400); an unmatched host/path is NoRoute (404).
-        fn resolveCluster(
-            conn: *ConnType,
+        /// The §7 canonical routing keys for `request`: the canonical host
+        /// (null when absent/unmatchable → any-host routes only) and the
+        /// canonical path — or "/" for OPTIONS asterisk-form, which names
+        /// the whole server. A target that will not canonicalize is
+        /// BadPath (400). One canonical view, shared by both filter
+        /// matching and routing, so they never disagree.
+        const RequestKeys = struct { host: ?[]const u8, path: []const u8 };
+
+        fn requestKeys(
             request: *const parser.RequestHead,
             scratch: *[constants.head_bytes_max]u8,
             host_scratch: *[constants.host_bytes_max]u8,
-        ) error{ BadPath, NoRoute }!u16 {
+        ) error{BadPath}!RequestKeys {
             assert(request.target.len >= 1);
-            assert(conn.routes.len >= 1);
             const host: ?[]const u8 = if (request.host) |raw|
                 parser.canonicalHost(raw, host_scratch)
             else
@@ -142,12 +143,25 @@ pub fn Proxy(comptime IoType: type) type {
             if (request.target[0] != '/') {
                 // validateTarget admitted only asterisk-form here.
                 assert(request.method == .options);
-                return router.route(conn.routes, host, "/") orelse error.NoRoute;
+                return .{ .host = host, .path = "/" };
             }
             const canonical = parser.canonicalTarget(request.target, scratch) catch {
                 return error.BadPath;
             };
-            return router.route(conn.routes, host, canonical.path) orelse error.NoRoute;
+            return .{ .host = host, .path = canonical.path };
+        }
+
+        /// Answer a §7 filter reject with its runtime policy status — each
+        /// a closed-set static response, all counted as one filter reject.
+        fn respondFilter(server: *ServerType, conn: *ConnType, status: u16) void {
+            assert(filter.isRejectStatus(status));
+            switch (status) {
+                400 => respond(server, conn, 400, "l7_filtered"),
+                403 => respond(server, conn, 403, "l7_filtered"),
+                404 => respond(server, conn, 404, "l7_filtered"),
+                429 => respond(server, conn, 429, "l7_filtered"),
+                else => unreachable,
+            }
         }
 
         /// The canonical bytes to forward for `request` (§7): origin-form
@@ -180,14 +194,27 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
 
-            // §7 routing: canonicalize the host and path and match them to
-            // a cluster before acquiring any resource, so a bad path or an
-            // unrouted host/path is rejected cheaply.
+            // §7: canonicalize the host and path once, then apply filters
+            // and routing to that one view before acquiring any resource,
+            // so a bad path, a policy reject, or an unrouted host/path is
+            // answered cheaply.
             var scratch: [constants.head_bytes_max]u8 = undefined;
             var host_scratch: [constants.host_bytes_max]u8 = undefined;
-            conn.cluster_index = resolveCluster(conn, request, &scratch, &host_scratch) catch |err| switch (err) {
-                error.BadPath => return respond(server, conn, 400, "l7_bad_request"),
-                error.NoRoute => return respond(server, conn, 404, "l7_no_route"),
+            const keys = requestKeys(request, &scratch, &host_scratch) catch {
+                return respond(server, conn, 400, "l7_bad_request");
+            };
+            // §7 filters run before routing: a policy reject stops the
+            // request whether or not it would have routed.
+            if (filter.firstReject(conn.filters, .{
+                .method = request.method,
+                .host = keys.host,
+                .path = keys.path,
+                .headers = request.headers,
+            })) |status| {
+                return respondFilter(server, conn, status);
+            }
+            conn.cluster_index = router.route(conn.routes, keys.host, keys.path) orelse {
+                return respond(server, conn, 404, "l7_no_route");
             };
 
             conn.relay_buffer = server.acquireRelayBuffer() orelse {

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -1,22 +1,26 @@
 //! Head rendering for the L7 proxy (DESIGN.md §7): parsed heads are
 //! *rendered* into a fixed staging buffer, never edited in place — the
 //! zero-copy slices of the source head stay valid throughout. Rendering
-//! strips hop-by-hop headers both ways (RFC 9110 §7.6.1) and injects
-//! `Connection: close` when the proxy will close (§2); Phase-2 header
-//! edits will be applied here too. A head that no longer fits after
-//! rendering is oversize — 431 downstream, teardown upstream (§7).
+//! strips hop-by-hop headers both ways (RFC 9110 §7.6.1), injects
+//! `Connection: close` when the proxy will close (§2), and applies the §7
+//! filter header edits that matched the request. A head that no longer
+//! fits after rendering is oversize — 431 downstream, teardown upstream
+//! (§7) — which now includes a head that outgrows the buffer only once the
+//! edits are applied (the oversize-after-edits verdict).
 
 const std = @import("std");
 const constants = @import("../constants.zig");
 const parser = @import("parser.zig");
+const filter = @import("filter.zig");
 
 const assert = std.debug.assert;
 
 /// Header names never forwarded, beyond the Connection-nominated set
 /// (RFC 9110 §7.6.1). Transfer-Encoding and Trailer are deliberately
 /// absent: the body is relayed verbatim in its original framing, so its
-/// framing headers must travel with it.
-const hop_by_hop_names = [_][]const u8{
+/// framing headers must travel with it. Public so the filter compiler can
+/// forbid an edit from naming a proxy-managed header (§7).
+pub const hop_by_hop_names = [_][]const u8{
     "connection",
     "keep-alive",
     "proxy-connection",
@@ -27,8 +31,9 @@ const hop_by_hop_names = [_][]const u8{
 /// Header names a Connection header may NOT nominate away. Stripping
 /// Content-Length or Transfer-Encoding would desynchronize the receiver
 /// from the framing this proxy already committed to — a smuggling vector
-/// — and stripping Host would unroute an HTTP/1.1 request.
-const protected_names = [_][]const u8{
+/// — and stripping Host would unroute an HTTP/1.1 request. Public for the
+/// same filter-edit guard as `hop_by_hop_names`.
+pub const protected_names = [_][]const u8{
     "host",
     "content-length",
     "transfer-encoding",
@@ -37,10 +42,15 @@ const protected_names = [_][]const u8{
 /// Renders the upstream request line and end-to-end headers from a
 /// parsed head. The client's version is preserved — framing decisions on
 /// both hops key off the real versions — and `inject_close` announces
-/// that this upstream connection will not be reused (§2).
+/// that this upstream connection will not be reused (§2). `edits` are the
+/// §7 filter header mutations that matched this request: a set/remove
+/// suppresses the source copies of its name, a set/add appends its
+/// (config-validated, injection-safe) line — proxy-managed names can never
+/// appear here, the filter compiler forbids them.
 pub fn renderRequestHead(
     request: *const parser.RequestHead,
     target: parser.CanonicalTarget,
+    edits: []const filter.AppliedHeaderEdit,
     inject_close: bool,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
@@ -50,6 +60,7 @@ pub fn renderRequestHead(
     // The forwarded target is the §7 canonical form the router matched on
     // (or `*` for OPTIONS), so the origin sees exactly the path we routed.
     assert(target.path.len >= 1);
+    assert(edits.len <= constants.header_edits_max);
     assert(buffer.len <= std.math.maxInt(u32));
 
     var staging = Staging{ .buffer = buffer };
@@ -61,7 +72,7 @@ pub fn renderRequestHead(
         .http_1_0 => " HTTP/1.0\r\n",
         .http_1_1 => " HTTP/1.1\r\n",
     });
-    try appendEndToEndHeaders(&staging, request.headers);
+    try appendEndToEndHeaders(&staging, request.headers, edits);
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -94,7 +105,8 @@ pub fn renderResponseHead(
         try staging.append(message);
     }
     try staging.append("\r\n");
-    try appendEndToEndHeaders(&staging, response.headers);
+    // Filters are request-side only (§7); the response carries no edits.
+    try appendEndToEndHeaders(&staging, response.headers, &.{});
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -121,12 +133,17 @@ const Staging = struct {
 };
 
 /// Appends every end-to-end header as `Name: value\r\n`, preserving the
-/// sender's name casing and value bytes. Bounded by `headers_max`.
+/// sender's name casing and value bytes. A §7 filter `set`/`remove` edit
+/// suppresses the source copies of its name; each `set`/`add` edit then
+/// appends its own line after the surviving source headers. Bounded by
+/// `headers_max` and `header_edits_max`.
 fn appendEndToEndHeaders(
     staging: *Staging,
     headers: []const parser.Header,
+    edits: []const filter.AppliedHeaderEdit,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
+    assert(edits.len <= constants.header_edits_max);
     // Collect the Connection header value(s) once (usually zero or one).
     // Re-finding them inside the per-header hop-by-hop test made the walk
     // O(headers²) — the render's top user-CPU cost under load (§9).
@@ -153,11 +170,41 @@ fn appendEndToEndHeaders(
         if (isHopByHop(header.name, active_nominations)) {
             continue;
         }
+        if (suppressedByEdit(header.name, edits)) {
+            continue;
+        }
         try staging.append(header.name);
         try staging.append(": ");
         try staging.append(header.value);
         try staging.append("\r\n");
     }
+    // Injected edits follow the surviving source headers; a `remove`
+    // contributes no line (its whole effect is the suppression above).
+    for (edits) |edit| {
+        switch (edit.kind) {
+            .set, .add => {
+                try staging.append(edit.name);
+                try staging.append(": ");
+                try staging.append(edit.value);
+                try staging.append("\r\n");
+            },
+            .remove => {},
+        }
+    }
+}
+
+/// True when a `set` or `remove` edit names this header, so its source
+/// copies must not be forwarded (`add` never suppresses — it appends).
+fn suppressedByEdit(name: []const u8, edits: []const filter.AppliedHeaderEdit) bool {
+    assert(name.len >= 1);
+    assert(edits.len <= constants.header_edits_max);
+    for (edits) |edit| {
+        switch (edit.kind) {
+            .set, .remove => if (std.ascii.eqlIgnoreCase(name, edit.name)) return true,
+            .add => {},
+        }
+    }
+    return false;
 }
 
 /// True when a Connection value names a header to strip beyond the
@@ -242,17 +289,100 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, true, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
     );
+}
+
+test "render: filter edits set, add, and remove headers" {
+    // set X-Env: source copy suppressed then the edit value appended; add
+    // X-Trace: source copy kept and a second appended; remove Cookie:
+    // source copy suppressed, nothing appended.
+    const head = "GET /p HTTP/1.1\r\nHost: a\r\nX-Env: dev\r\nX-Trace: t0\r\n" ++
+        "Cookie: sid=1\r\nX-Keep: yes\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    const edits = [_]filter.AppliedHeaderEdit{
+        .{ .kind = .set, .name = "X-Env", .value = "prod" },
+        .{ .kind = .add, .name = "X-Trace", .value = "t1" },
+        .{ .kind = .remove, .name = "cookie", .value = "" },
+    };
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, &buffer);
+    // Surviving source headers first (Host, kept X-Trace, X-Keep), then the
+    // injected set/add lines; the source X-Env and Cookie are gone.
+    try testing.expectEqualStrings(
+        "GET /p HTTP/1.1\r\nHost: a\r\nX-Trace: t0\r\nX-Keep: yes\r\n" ++
+            "X-Env: prod\r\nX-Trace: t1\r\n\r\n",
+        rendered,
+    );
+
+    // The edited head must re-parse as a valid request with the edits live.
+    var reparse_storage: parser.HeaderStorage = undefined;
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    try testing.expectEqualStrings("prod", parser.headerValue(reparsed.headers, "x-env").?);
+    try testing.expectEqual(@as(?[]const u8, null), parser.headerValue(reparsed.headers, "cookie"));
+}
+
+test "render: an edit that overflows the buffer is Oversize" {
+    // A head that fits on arrival but whose injected edit no longer does is
+    // the §7 oversize-after-edits verdict — the same 431 as an oversize
+    // source head.
+    const head = "GET /p HTTP/1.1\r\nHost: a\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    const edits = [_]filter.AppliedHeaderEdit{
+        .{ .kind = .add, .name = "X-Big", .value = "0123456789" },
+    };
+    // Room for the request line + Host, but not the appended X-Big line.
+    var tight: [34]u8 = undefined;
+    try testing.expectError(
+        error.Oversize,
+        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, &tight),
+    );
+}
+
+test "render: the edited oracle skips a head that grows past head_bytes_max" {
+    // Regression: `parseRequestHead`'s first statement asserts
+    // `head.len <= head_bytes_max`, so an edited head rendered past that
+    // ceiling (into the slack oracle buffer) would trip that assert before
+    // any error could surface — a panic reachable under `--fuzz`. The oracle
+    // guards on `rendered.len`; this input, a source exactly at the ceiling
+    // with a no-space colon (render re-adds ": ", +1 byte) plus the fixed
+    // edits, is guaranteed over it. Without the guard the call panics.
+    var source: [constants.head_bytes_max]u8 = undefined;
+    const prefix = "GET / HTTP/1.1\r\nHost: a\r\nX:";
+    @memcpy(source[0..prefix.len], prefix);
+    // Pad the value so the whole head, including the terminating CRLF, is
+    // exactly head_bytes_max bytes.
+    const value_end = constants.head_bytes_max - "\r\n\r\n".len;
+    @memset(source[prefix.len..value_end], 'x');
+    @memcpy(source[value_end..], "\r\n\r\n");
+
+    // The source is legal (head.len == head_bytes_max is within the limit).
+    var storage: parser.HeaderStorage = undefined;
+    const parsed = try parser.parseRequestHead(&source, false, &storage);
+    try testing.expectEqual(@as(u32, constants.head_bytes_max), parsed.head_len);
+    // Confirm the edited render genuinely crosses the ceiling — otherwise
+    // this test would exercise nothing. (The edit set mirrors the oracle's.)
+    const edits = [_]filter.AppliedHeaderEdit{
+        .{ .kind = .set, .name = "X-Fuzz-Set", .value = "s" },
+        .{ .kind = .add, .name = "X-Fuzz-Add", .value = "a" },
+        .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
+    };
+    var render_buf: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, &render_buf);
+    try testing.expect(rendered.len > constants.head_bytes_max);
+    // Must return cleanly instead of panicking in the reparse precondition.
+    checkRequestRenderEdited(&source);
 }
 
 test "render: nominating a protected header does not strip it" {
@@ -263,7 +393,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -281,7 +411,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -296,7 +426,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -307,7 +437,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -347,7 +477,7 @@ test "render: a head that no longer fits is Oversize" {
     const request = try parser.parseRequestHead(head, false, &storage);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, target, false, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -370,8 +500,16 @@ fn checkRequestRender(input: []const u8) void {
         .{ .path = request.target, .query = "" };
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, false, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, &.{}, false, &buffer) catch unreachable;
 
+    // The oracle buffer carries slack past `head_bytes_max` so normalization
+    // growth never truncates the comparison; production renders into an
+    // exactly-`head_bytes_max` buffer and 431s anything larger. A head that
+    // grew past that ceiling here is that oversize verdict — not a reparse
+    // input, and past the parser's own size precondition — so stop before it.
+    if (rendered.len > constants.head_bytes_max) {
+        return;
+    }
     var reparse_storage: parser.HeaderStorage = undefined;
     // A rendered head failing our own parser would mean the proxy emits
     // requests it would itself reject — the oracle's core claim.
@@ -393,6 +531,53 @@ fn checkRequestRender(input: []const u8) void {
             assert(!std.ascii.eqlIgnoreCase(header.name, hop_name));
         }
     }
+}
+
+/// Same oracle, but with a fixed §7 filter edit set applied: whatever the
+/// parser accepts must still re-parse after a set/add/remove, with the
+/// edits observably live. An edited head that outgrows the buffer is the
+/// legitimate oversize-after-edits verdict (431), not an oracle failure.
+fn checkRequestRenderEdited(input: []const u8) void {
+    var storage: parser.HeaderStorage = undefined;
+    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    if (request.method == .connect) {
+        return;
+    }
+    var scratch: [constants.head_bytes_max]u8 = undefined;
+    const target: parser.CanonicalTarget = if (request.target[0] == '/')
+        (parser.canonicalTarget(request.target, &scratch) catch return)
+    else
+        .{ .path = request.target, .query = "" };
+
+    // Names the fuzzed input cannot collide with a proxy-managed header on;
+    // config forbids editing those, so the renderer never sees them.
+    const edits = [_]filter.AppliedHeaderEdit{
+        .{ .kind = .set, .name = "X-Fuzz-Set", .value = "s" },
+        .{ .kind = .add, .name = "X-Fuzz-Add", .value = "a" },
+        .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
+    };
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = renderRequestHead(&request, target, &edits, false, &buffer) catch return;
+
+    // The appended edits can push an already-large head past `head_bytes_max`
+    // — the oversize-after-edits verdict (431 in production, which renders
+    // into an exactly-`head_bytes_max` buffer). Past that ceiling the head is
+    // not a reparse input and would trip the parser's size precondition, so
+    // stop; a reparse miss below is then only the benign headers-count
+    // overflow (source at `headers_max` plus the appended lines).
+    if (rendered.len > constants.head_bytes_max) {
+        return;
+    }
+    var reparse_storage: parser.HeaderStorage = undefined;
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch return;
+    // set always wins (its source copies are suppressed, one value
+    // appended); remove is always absent; add is always present.
+    assert(std.mem.eql(u8, parser.headerValue(reparsed.headers, "x-fuzz-set").?, "s"));
+    assert(parser.headerValue(reparsed.headers, "x-fuzz-remove") == null);
+    assert(parser.headerValue(reparsed.headers, "x-fuzz-add") != null);
+    // The edits never disturb framing or routing.
+    assert(std.meta.eql(reparsed.framing, request.framing));
+    assert(reparsed.target.len == target.path.len + target.query.len);
 }
 
 fn checkResponseRender(input: []const u8) void {
@@ -429,5 +614,6 @@ fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
     assert(input_len <= input_buffer.len);
     const input = input_buffer[0..input_len];
     checkRequestRender(input);
+    checkRequestRenderEdited(input);
     checkResponseRender(input);
 }

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -165,12 +165,23 @@ fn appendEndToEndHeaders(
     const active_nominations =
         if (nominatesRealHeader(nominations)) nominations else nominations[0..0];
 
+    // Only `set`/`remove` edits suppress source copies; `add` never does.
+    // Decide once whether any suppressing edit exists, so a request with no
+    // edits — or only `add` edits — skips the per-header suppression scan.
+    var has_suppressing_edit = false;
+    for (edits) |edit| {
+        if (edit.kind != .add) {
+            has_suppressing_edit = true;
+            break;
+        }
+    }
+
     for (headers) |header| {
         assert(header.name.len >= 1);
         if (isHopByHop(header.name, active_nominations)) {
             continue;
         }
-        if (suppressedByEdit(header.name, edits)) {
+        if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
             continue;
         }
         try staging.append(header.name);

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -33,7 +33,7 @@ pub fn route(routes: []const Route, host: ?[]const u8, path: []const u8) ?u16 {
     assert(path.len >= 1);
     assert(path[0] == '/');
     for (routes) |candidate| {
-        if (hostMatches(candidate.host, host) and matches(candidate.prefix, path)) {
+        if (hostMatches(candidate.host, host) and prefixMatches(candidate.prefix, path)) {
             return candidate.cluster_index;
         }
     }
@@ -55,7 +55,9 @@ fn hostMatches(route_host: ?[]const u8, req_host: ?[]const u8) bool {
 /// after the prefix is `/`. So `/api` matches `/api` and `/api/v1` but
 /// never `/apihost` — a string prefix that splits a segment is not a
 /// route. `/` is slash-terminated, so the root prefix is the catch-all.
-fn matches(prefix: []const u8, path: []const u8) bool {
+/// Public so filters (§7) share exactly one canonical-path prefix
+/// semantics with routing.
+pub fn prefixMatches(prefix: []const u8, path: []const u8) bool {
     assert(prefix.len >= 1);
     assert(prefix[0] == '/');
     assert(path.len >= 1);

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -886,6 +886,74 @@ test "l7: a filter rewrite changes only the forwarded path, not the route" {
     try bed.expectDrained();
 }
 
+test "l7: a header edit reaches the origin exactly once under adversarial delivery" {
+    // The §9 "edit reaches the origin exactly once" oracle under 1-byte
+    // adversarial fragmentation across seeds: no fragmentation may drop,
+    // duplicate, or corrupt the injected header.
+    const rules = [_]filter.Rule{.{
+        .match = .{},
+        .actions = &.{.{ .header_set = .{ .name = "X-Env", .value = "prod" } }},
+    }};
+    var seed: u64 = 50;
+    while (seed < 54) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .filters = &rules,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nX-Env: dev\r\nConnection: close\r\n\r\n");
+
+        try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try parser.parseRequestHead(
+            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            false,
+            &storage,
+        );
+        // The client sent dev; the edit replaced it with exactly one prod.
+        try std.testing.expectEqualStrings("prod", parser.headerValue(forwarded.headers, "x-env").?);
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a path rewrite forwards the rewritten path under adversarial delivery" {
+    // The §9 "path edit reaches the origin" oracle under 1-byte adversarial
+    // fragmentation across seeds: the origin sees the canonical rewritten
+    // path, whole, however the head was chopped up.
+    const rules = [_]filter.Rule{.{
+        .match = .{},
+        .actions = &.{.{ .rewrite_prefix = .{ .from = "/old", .to = "/new" } }},
+    }};
+    var seed: u64 = 60;
+    while (seed < 64) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .filters = &rules,
+            .route_prefix = "/old",
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /old/x HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+        try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try parser.parseRequestHead(
+            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            false,
+            &storage,
+        );
+        try std.testing.expectEqualStrings("/new/x", forwarded.target);
+        try bed.expectDrained();
+    }
+}
+
 test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {
     // Any-host route (the default): a Host-less HTTP/1.0 request still
     // routes.

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -805,6 +805,51 @@ test "l7: a filter reject survives 1-byte adversarial delivery across seeds" {
     }
 }
 
+test "l7: filter header edits reach the origin, applied once" {
+    // set X-Env: prod (client sent dev), add X-Trace, remove Cookie. The
+    // origin must see exactly the edited head, and the client the origin's
+    // response — the edit is invisible downstream.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/api" },
+        .actions = &.{
+            .{ .header_set = .{ .name = "X-Env", .value = "prod" } },
+            .{ .header_add = .{ .name = "X-Trace", .value = "on" } },
+            .{ .header_remove = "Cookie" },
+        },
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 29,
+        .filters = &rules,
+        .route_prefix = "/api",
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET /api/v1 HTTP/1.1\r\nHost: o\r\nX-Env: dev\r\nCookie: sid=1\r\nConnection: close\r\n\r\n",
+    );
+
+    // The client got the origin's response verbatim (edits are upstream).
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    // The origin saw the edited head: X-Env replaced, X-Trace added, Cookie
+    // gone, and exactly one request served.
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        false,
+        &storage,
+    );
+    try std.testing.expectEqualStrings("prod", parser.headerValue(forwarded.headers, "x-env").?);
+    try std.testing.expectEqualStrings("on", parser.headerValue(forwarded.headers, "x-trace").?);
+    try std.testing.expectEqual(@as(?[]const u8, null), parser.headerValue(forwarded.headers, "cookie"));
+    try bed.expectDrained();
+}
+
 test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {
     // Any-host route (the default): a Host-less HTTP/1.0 request still
     // routes.

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -850,6 +850,42 @@ test "l7: filter header edits reach the origin, applied once" {
     try bed.expectDrained();
 }
 
+test "l7: a filter rewrite changes only the forwarded path, not the route" {
+    // Routing keys off the original path (/old matches the route); the
+    // rewrite swaps that prefix for /new on the way out, so the origin sees
+    // a path that would NOT have matched the route — proof the rewrite
+    // touches only what is forwarded, never re-routes (§7). The query rides
+    // along verbatim.
+    const rules = [_]filter.Rule{.{
+        .match = .{},
+        .actions = &.{.{ .rewrite_prefix = .{ .from = "/old", .to = "/new" } }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 30,
+        .filters = &rules,
+        .route_prefix = "/old",
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /old/x?q=1 HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        false,
+        &storage,
+    );
+    try std.testing.expectEqualStrings("/new/x?q=1", forwarded.target);
+    try bed.expectDrained();
+}
+
 test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {
     // Any-host route (the default): a Host-less HTTP/1.0 request still
     // routes.

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 
 const config_module = @import("config.zig");
 const router = @import("http/router.zig");
+const filter = @import("http/filter.zig");
 const Io = @import("io/io.zig");
 const parser = @import("http/parser.zig");
 const Server = @import("Server.zig").Server;
@@ -358,6 +359,10 @@ const Http1Bed = struct {
         /// The single route's host scope; null is any-host. A canonical
         /// host lets a test drive host routing and its 404 (§7).
         route_host: ?[]const u8 = null,
+        /// The listener's §7 filter rules; empty by default so existing
+        /// scenarios are unfiltered. A test supplies compiled rules to
+        /// drive the filter reject/edit paths.
+        filters: []const filter.Rule = &.{},
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -372,7 +377,12 @@ const Http1Bed = struct {
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
-        bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .http }};
+        bed.listeners = .{.{
+            .bind_address = bindAddress(),
+            .routes = &bed.routes,
+            .filters = options.filters,
+            .protocol = .http,
+        }};
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
@@ -700,6 +710,99 @@ test "l7: a request to a host with no route is answered 404" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
     try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
     try bed.expectDrained();
+}
+
+test "l7: a filter reject answers its policy status before the origin is dialed" {
+    // One rule: POST under /admin is 403. The origin would answer 200,
+    // but the filter rejects before any dial, so the client sees 403 and
+    // the origin serves nothing (§7).
+    const rules = [_]filter.Rule{.{
+        .match = .{
+            .methods = blk: {
+                var set = std.EnumSet(parser.Method){};
+                set.insert(.post);
+                break :blk set;
+            },
+            .path_prefix = "/admin",
+        },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 27,
+        .filters = &rules,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("POST /admin/users HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a request the filter does not match is proxied untouched" {
+    // The same /admin rule; a GET to /public matches nothing, so it routes
+    // and reaches the origin normally — the filter is a no-op (§7).
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin", .methods = blk: {
+            var set = std.EnumSet(parser.Method){};
+            set.insert(.post);
+            break :blk set;
+        } },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 28,
+        .filters = &rules,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /public HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_filtered"));
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a filter reject survives 1-byte adversarial delivery across seeds" {
+    // A header-matched 429 must land whole however the head is chopped up.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .headers = &.{.{ .name = "X-Env", .kind = .equals, .value = "prod" }} },
+        .actions = &.{.{ .reject = 429 }},
+    }};
+    var seed: u64 = 40;
+    while (seed < 44) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .filters = &rules,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nX-Env: prod\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+        try bed.expectDrained();
+    }
 }
 
 test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const constants = @import("../constants.zig");
 const parser = @import("../http/parser.zig");
 const router = @import("../http/router.zig");
+const filter = @import("../http/filter.zig");
 const relay = @import("relay.zig");
 const upstream_module = @import("upstream.zig");
 
@@ -69,6 +70,9 @@ pub fn Conn(comptime IoType: type) type {
         /// no path to match). Set once at admission and constant for the
         /// connection's life, so it survives keep-alive turnarounds.
         routes: []const router.Route,
+        /// The listener's §7 filter rules, same lifetime as `routes`
+        /// (empty on L4 and when no filters are configured).
+        filters: []const filter.Rule,
         /// The leased upstream slot during an L7 exchange; released at
         /// teardown alongside the conn slot (§5). Null outside exchanges
         /// and on the whole L4 path.
@@ -271,8 +275,10 @@ pub fn Conn(comptime IoType: type) type {
             conn.head_len = 0;
             conn.response_pending = &.{};
             conn.cluster_index = cluster_index;
-            // L4 never routes by path; admitHttp installs the real table.
+            // L4 never routes or filters; admitHttp installs the real
+            // tables.
             conn.routes = &.{};
+            conn.filters = &.{};
             conn.upstream = null;
             conn.l7 = .{};
             conn.op_data_client_to_upstream = .{};

--- a/src/root.zig
+++ b/src/root.zig
@@ -15,6 +15,7 @@ pub const http = struct {
     pub const parser = @import("http/parser.zig");
     pub const render = @import("http/render.zig");
     pub const router = @import("http/router.zig");
+    pub const filter = @import("http/filter.zig");
     pub const proxy = @import("http/proxy.zig");
 };
 pub const Io = @import("io/io.zig");
@@ -37,6 +38,7 @@ test {
     _ = http.parser;
     _ = http.render;
     _ = http.router;
+    _ = http.filter;
     _ = http.proxy;
     _ = Io;
     _ = Server;

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -45,8 +45,10 @@ fn reasonPhrase(comptime status: u16) []const u8 {
     comptime assert(status <= 599);
     return switch (status) {
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         414 => "URI Too Long",
+        429 => "Too Many Requests",
         431 => "Request Header Fields Too Large",
         501 => "Not Implemented",
         502 => "Bad Gateway",
@@ -87,7 +89,7 @@ test "shed: every static response parses as a valid bodiless head" {
     // complete, correctly framed head whose persistence matches the
     // requested one — the same verdict a strict client would reach.
     const parser = @import("http/parser.zig");
-    inline for ([_]u16{ 400, 404, 414, 431, 501, 502, 503, 504 }) |status| {
+    inline for ([_]u16{ 400, 403, 404, 414, 429, 431, 501, 502, 503, 504 }) |status| {
         inline for ([_]Persistence{ .keep, .close }) |persistence| {
             const bytes = staticResponse(status, persistence);
             var storage: parser.HeaderStorage = undefined;


### PR DESCRIPTION
## Summary

Implements Phase 1.7 — **programmable filters** (DESIGN.md §7, "filters are data, not code"). A per-listener list of `{ match, actions }` rules, compiled at config load into immutable arena tables and *interpreted* per request — never scripted, never allocating.

- **Match** — a conjunction over the parsed head: method set, canonical host, canonical path-prefix, and header present/equals/contains. Reuses the §7 canonical forms so a filter and the router agree byte-for-byte. Cluster selection is **not** an action — routing owns the backend.
- **Actions** — a closed enum: `reject` (a §8 static status), header `set`/`add`/`remove`, and `rewrite_prefix`. No WASM/scripting (an interpreter with unbounded fuel or an embedded allocator cannot satisfy §9).
- **Where it runs** — `reject` before any relay buffer / upstream slot is acquired (like the §8 rejects); header/path edits during the existing head *render*, so nothing edits the head buffer in place and an over-budget head after edits is the existing 431. A `rewrite_prefix` changes **only the forwarded path** — routing already chose the cluster from the original canonical path, so a rewrite never re-routes and never chains (first-applicable rule wins), with a segment-correct join that never creates `//` or merges segments.
- **Limits** (`constants.zig`) — `filters_per_listener_max`, `actions_per_filter_max`, `header_matches_per_filter_max`, `header_edits_max` (the listener's total header edits, bounding the renderer's materialized edit buffer).

## Header-injection safety

Edit names are validated as RFC 9110 tokens; values as RFC 9110 field-values (no CR/LF/NUL) at load, so a compiled edit is proven injection-safe. Proxy-managed headers (hop-by-hop + `Host`/framing) are forbidden as edit targets (`FilterHeaderNameReserved`) — a filter can't smuggle a framing or persistence change past the render's own decisions.

## Slices

1. Rule/action config schema, validation, and constants.
2. The match interpreter + the `reject` action at the route phase.
3. Header-edit actions woven into the renderer + the 431-after-edits path + the reserved-name guard.
4. The `rewrite_prefix` action (forwarded path only, segment-correct join, no re-route).
5. Sim scripts + adversarial cross-seed oracles.

Plus a final commit addressing a full branch-wide code review (10 findings): two correctness fixes (`contains:""` matched everything; `filters:[]` slipped past the L4 guard), a single-source-of-truth for the reject-status set, a merged single-pass rule evaluator, and cleanup/convention items. See the commit body for the full list.

## Gates (§9)

- `zig build ci` green — unit tests, fuzz corpus, boundary lint, deterministic simulation.
- `zig fmt --check` clean.
- **100k-seed sim sweep** clean, exercising the reject / header-edit / rewrite scripts under both golden and 1-byte-adversarial delivery.
- Fuzz oracle: a rendered head after edits still re-parses (incl. the oversize-after-edits guard).
- Each slice was adversarially reviewed before commit; two real bugs were caught and fixed in review (an oracle panic in slice 3, a segment-merge path-confusion in slice 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)