### PR TITLE
Phase 2: shedding hardening + minimal resilience

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -26,7 +26,27 @@ const zoxy_http_port: u16 = 18181;
 const origin_port: u16 = 19180;
 const haproxy_port: u16 = 17180;
 const haproxy_http_port: u16 = 17181;
+const overload_http_port: u16 = 18291;
 const work_directory = ".zig-cache/zoxy-bench";
+
+/// The overload scenario's shape (§9): a second zoxy shrunk via the
+/// config `limits` block so offered load ≫ capacity is loopback-feasible,
+/// and a connection count far past its relay buffers so both §8 rungs
+/// fire — accept-RSTs at the conn wall, 503s at the relay-buffer rung.
+/// The 5xx witness is the thinnest gate (most excess dies at the conn
+/// wall first): if it flakes on a fast box, raise `overload_connections`
+/// or shrink `relay_buffers` rather than deleting the gate.
+const overload_limits = .{ .conn_slots = 64, .relay_buffers = 4, .upstream_slots = 8 };
+const overload_connections: u32 = 256;
+
+comptime {
+    // The scenario's premise, pinned: the offered connections must
+    // overwhelm the conn wall, and the relay rung must sit inside it so
+    // admitted requests still contend for buffers (the 503 witness).
+    assert(overload_connections > overload_limits.conn_slots);
+    assert(overload_limits.relay_buffers < overload_limits.conn_slots);
+    assert(overload_limits.relay_buffers >= 1);
+}
 
 const Flags = struct {
     rate: u64 = 20_000,
@@ -112,15 +132,165 @@ pub fn main(init: std.process.Init) !u8 {
     printMode("Connection: close", &close_mode);
     std.debug.print("zoxy RSS: {d} KiB -> {d} KiB\n", .{ rss_before_kb, rss_after_kb });
 
-    // Drain, not just death: SIGTERM and wait for a clean exit (§8).
-    try std.posix.kill(zoxy_child.id.?, .TERM);
-    const term = try zoxy_child.wait(io);
-    zoxy_running = false;
-    const drained_cleanly = term == .exited and term.exited == 0;
-    std.debug.print("zoxy drain: {s}\n", .{if (drained_cleanly) "clean exit" else "UNCLEAN"});
+    // The §9 overload scenario runs against its own shrunken zoxy — the
+    // primary is idle during it, so its RSS window stays clean.
+    const overload_ok = try runOverload(arena, io, &flags, origin_address, proxy_cpu);
 
-    const passed = benchPassed(rss_before_kb, rss_after_kb, &keep_alive, &close_mode, drained_cleanly);
+    const drained_cleanly = try drainChild(io, &zoxy_child, &zoxy_running, "zoxy");
+    const passed = benchPassed(rss_before_kb, rss_after_kb, &keep_alive, &close_mode, drained_cleanly) and
+        overload_ok;
     return if (passed) 0 else 1;
+}
+
+/// Drain, not just death (§8): SIGTERM, wait for a clean exit, report.
+/// Clears `running` so the caller's guarded defer cannot double-kill.
+fn drainChild(
+    io: Io,
+    child: *std.process.Child,
+    running: *bool,
+    label: []const u8,
+) !bool {
+    assert(label.len > 0);
+    assert(running.*);
+    try std.posix.kill(child.id.?, .TERM);
+    const term = try child.wait(io);
+    running.* = false;
+    const drained_cleanly = term == .exited and term.exited == 0;
+    std.debug.print("{s} drain: {s}\n", .{ label, if (drained_cleanly) "clean exit" else "UNCLEAN" });
+    return drained_cleanly;
+}
+
+/// The §9 overload scenario: offered load ≫ capacity against a zoxy
+/// whose pools are shrunk via the config `limits` block. Asserts the §8
+/// promise from the outside: flat memory, admitted work served (2xx),
+/// all excess shed with a correct status (5xx and accept-RSTs — the
+/// latter are the conn-slot wall, so zrk's connect errors are exempt
+/// from the health gate), bounded latency for what was admitted, and a
+/// clean drain. SIGUSR1 lands the counter dump in the run log first.
+fn runOverload(
+    arena: std.mem.Allocator,
+    io: Io,
+    flags: *const Flags,
+    origin_address: []const u8,
+    proxy_cpu: ?u16,
+) !bool {
+    assert(flags.duration_s >= 1);
+    assert(flags.rate >= 1);
+    var child = try spawnOverloadZoxy(arena, io, flags.zoxy_path, origin_address);
+    var running = true;
+    defer if (running) child.kill(io);
+    if (proxy_cpu) |cpu| {
+        affinity.pinChildTo(child.id.?, cpu);
+    }
+    _ = try awaitResponsive(arena, io, overload_http_port, "zoxy overload");
+
+    const rss_before_kb = try readRssKb(arena, io, child.id);
+    var config = benchConfig(overload_http_port, overload_connections, flags.rate);
+    config.duration_ns = flags.duration_s * std.time.ns_per_s;
+    const report = try zrk.runner.run(arena, io, &config, 0, null, null);
+    const rss_after_kb = try readRssKb(arena, io, child.id);
+
+    std.debug.print("-- overload (offered >> capacity) --\n", .{});
+    printReport("zoxy overload", &report);
+    std.debug.print("zoxy overload RSS: {d} KiB -> {d} KiB\n", .{ rss_before_kb, rss_after_kb });
+
+    // The counter dump (sheds, pressure engagements) lands in the run
+    // log for the human band review before the drain.
+    try std.posix.kill(child.id.?, .USR1);
+    const drained_cleanly = try drainChild(io, &child, &running, "zoxy overload");
+    return overloadPassed(rss_before_kb, rss_after_kb, &report, drained_cleanly);
+}
+
+/// The overload gates. Accept-RSTs (connect errors) are the conn-slot
+/// shed working as designed; read errors and timeouts are relay stalls
+/// and stay under 1% of completions — a shed must be fast and correct,
+/// never a hang.
+fn overloadPassed(
+    rss_before_kb: u64,
+    rss_after_kb: u64,
+    report: *const zrk.runner.Report,
+    drained_cleanly: bool,
+) bool {
+    assert(rss_before_kb > 0);
+    assert(rss_after_kb > 0);
+    const counters = &report.snapshot.counters;
+    const rss_flat = rss_after_kb <= rss_before_kb + 1024;
+    if (!rss_flat) {
+        std.debug.print("FAIL: overload zoxy RSS grew under overload\n", .{});
+    }
+    // Admitted work is served AND the excess is shed with a status: both
+    // ends of the §8 promise, witnessed in one run.
+    const served = counters.status_class[2] > 0;
+    if (!served) {
+        std.debug.print("FAIL: overload run served no 2xx at all\n", .{});
+    }
+    const shed_witnessed = counters.status_class[5] > 0;
+    if (!shed_witnessed) {
+        std.debug.print("FAIL: overload run witnessed no 5xx shed status\n", .{});
+    }
+    // Bounded latency for admitted work: every completion (2xx and fast
+    // 5xx sheds alike) landed within zrk's wire timeout, or it would be
+    // a timeout below, not a sample.
+    const stalls = counters.read_errors + counters.timeouts;
+    const stalls_ok = stalls * 100 <= counters.completed;
+    if (!stalls_ok) {
+        std.debug.print(
+            "FAIL: overload stall rate too high ({d} of {d} completed)\n",
+            .{ stalls, counters.completed },
+        );
+    }
+    if (!drained_cleanly) {
+        std.debug.print("FAIL: overload zoxy did not drain cleanly\n", .{});
+    }
+    return rss_flat and served and shed_witnessed and stalls_ok and drained_cleanly;
+}
+
+/// A second zoxy with its pools shrunk through the config `limits`
+/// block (§5) — the §8 rungs become reachable at loopback-feasible load.
+fn spawnOverloadZoxy(
+    arena: std.mem.Allocator,
+    io: Io,
+    zoxy_path: []const u8,
+    origin_address: []const u8,
+) !std.process.Child {
+    const config_path = work_directory ++ "/zoxy-overload.json";
+    const config_json = try std.fmt.allocPrint(arena,
+        \\{{
+        \\    "listeners": [
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }}
+        \\    ],
+        \\    "clusters": {{
+        \\        "origin": {{ "endpoints": ["{s}"] }}
+        \\    }},
+        \\    "timeouts": {{
+        \\        "connect_ms": 5000,
+        \\        "idle_ms": 60000,
+        \\        "drain_deadline_ms": 5000
+        \\    }},
+        \\    "limits": {{
+        \\        "conn_slots": {d},
+        \\        "relay_buffers": {d},
+        \\        "upstream_slots": {d}
+        \\    }}
+        \\}}
+        \\
+    , .{
+        overload_http_port,
+        origin_address,
+        overload_limits.conn_slots,
+        overload_limits.relay_buffers,
+        overload_limits.upstream_slots,
+    });
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
+
+    return std.process.spawn(io, .{
+        .argv = &.{ zoxy_path, config_path },
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| {
+        std.debug.print("bench: could not spawn overload {s} ({t})\n", .{ zoxy_path, err });
+        return err;
+    };
 }
 
 /// Prove every path answers before measuring; the short probes double as

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -232,7 +232,7 @@ fn overloadPassed(
     // 5xx sheds alike) landed within zrk's wire timeout, or it would be
     // a timeout below, not a sample.
     const stalls = counters.read_errors + counters.timeouts;
-    const stalls_ok = stalls * 100 <= counters.completed;
+    const stalls_ok = stalls * 100 < counters.completed;
     if (!stalls_ok) {
         std.debug.print(
             "FAIL: overload stall rate too high ({d} of {d} completed)\n",

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -71,7 +71,8 @@ constraints, not suggestions.
   in-flight completion must never be resubmitted — overlapping ops get their
   own completions.
 - **One ticking absolute-deadline timer per connection**; phase transitions
-  move the deadline. No cancel/re-arm races.
+  move the deadline — *later* for free, the single *earlier* move (an L7
+  dial tightening to the connect budget, §8) via a race-free cancel+re-arm.
 - **TCP_NODELAY always** — Nagle + delayed ACK cost warm pooled connections
   a hard 40 ms, invisible on fresh connections.
 - **Announce closes** (`Connection: close` injection per RFC 9112 §9.6) or
@@ -314,7 +315,13 @@ unmerged behind it, so the pin moves only after re-audit.
   stored deadline against `Io.now_ns`: not yet due → re-arm for the
   remainder with a fresh submit (libxev's `.rearm` return reuses the
   stale absolute time and is never used); due → the deadline action.
-  **Teardown is the one place a timer is canceled** (§5 release rule).
+  A timer is canceled in exactly **two** places: teardown (§5 release
+  rule) and an L7 dial that re-bases the head-read deadline *down* to the
+  tighter connect budget (§8) — the lazy rule moves a deadline later for
+  free but must cancel+re-arm to move it earlier. Both drain race-free:
+  the cancel op and the timer's own Canceled both land, whichever is last
+  re-arms at the stored target, and a teardown that overtakes an in-flight
+  re-base drains it through the same `isTearingDown` checks.
   libxev cancellation is internally cancel+resubmit and consumes its own
   caller-owned completion, embedded in the slot like every other op.
 - **Plain ops only.** Multishot accept/recv, buffer rings, `send_zc`,
@@ -383,7 +390,8 @@ Rules:
 - **A slot is released only when its armed-op set is empty.** Every op
   references a completion embedded in the slot, and the slot header
   tracks which are armed. Teardown is a *state*, not an event: shutdown
-  both fds, cancel the timer (the one legal cancel, §4), then wait — the
+  both fds, cancel the timer (§4 — teardown and the §8 dial re-base are
+  the only cancels), then wait — the
   last terminal completion (success, error, or cancellation) releases
   the slot. An active completion is never resubmitted (libxev's
   intrusive queues corrupt on re-enqueue), and LIFO reuse turns a

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -359,7 +359,10 @@ Three shared pools, all owned and touched only by the loop thread:
    active health checks — when they land ([PLANS.md](PLANS.md)) — close
    the parked connections of ejected endpoints.
 
-Sizing shape (illustrative defaults, all tunable):
+Sizing shape (illustrative defaults; the comptime constants are the
+hard, budget-asserted ceilings, and the config `limits` block may only
+shrink the pools below them — for capacity planning, and so the §9
+overload benchmark hits the real shed rungs at loopback-feasible load):
 
 | pool | count | unit size | subtotal |
 |---|---|---|---|
@@ -548,16 +551,27 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   owning phase module at compile time.
 - **Resilience is minimal by design:** per-request and per-try deadlines
   (head-read gets its own deadline, so a slowloris meets the clock or
-  `head_bytes_max`, whichever comes first); one free replay of a request
-  that hit a stale pooled connection — only when the reused connection
-  was dead on arrival or the first write failed immediately, and no
-  response byte was received; a request the origin may have begun
-  processing is never replayed; and round-robin → P2C endpoint pick.
-  Cluster endpoints are static socket addresses resolved once at config
-  load, never on the loop (dynamic DNS is a non-goal, §1). Circuit
-  breakers, outlier ejection, retry budgets, health checks are *deferred*
-  — the previous iteration proved them buildable in this architecture;
-  simplicity says they wait for a demonstrated need.
+  `head_bytes_max`, whichever comes first; each dial — the first try and
+  the replay's — runs under its own connect deadline); one free replay
+  of a request that hit a stale pooled connection — only when the
+  connection was a *reused* checkout, no response byte was received, and
+  the request leg never entered the body pump, so the whole try still
+  sits byte-reconstructible in the head buffer. "May have begun
+  processing" is settled as "a response byte arrived or relay chunks
+  flowed" — the standard replaying-proxy reading (Go/nginx/HAProxy),
+  applied to non-idempotent methods too: a send that landed in the
+  kernel buffer of an already-FIN'd parked connection replays, because
+  the FIN-before-checkout race is overwhelmingly the real cause. The
+  replay is spent before its try begins (no loop) and always dials
+  fresh — the endpoint's whole idle list may be stale the same way. The
+  endpoint pick is per-cluster config: `p2c` (two uniform candidates
+  from a fixed-seed PRNG, the lower leased count wins) by default, `rr`
+  for strict rotation. Cluster endpoints are static socket addresses
+  resolved once at config load, never on the loop (dynamic DNS is a
+  non-goal, §1). Circuit breakers, outlier ejection, retry budgets,
+  health checks are *deferred* — the previous iteration proved them
+  buildable in this architecture; simplicity says they wait for a
+  demonstrated need.
 
 ## 8. Load shedding — the exhaustion ladder
 
@@ -573,7 +587,7 @@ the loop thread.
 | relay buffers (L7) | request admission on a kept-alive conn | static `503` from the head buffer, then keep or close per pressure |
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7) / close (L4) |
 | worker job queue | job enqueue | shed the job's connection (TLS handshake → close) |
-| request deadline | timer completion | `504` if no response byte sent, else teardown |
+| request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
 - **Static error responses.** `400`/`404`/`414`/`431`/`501`/`503`/`504`
@@ -590,10 +604,15 @@ the loop thread.
   connection stays in the backlog, so an immediate re-arm would complete
   instantly with the same error — a tight spin. That path re-arms after
   a short backoff (`accept_retry_delay_ms`).
-- **Watermarks before walls.** Each pool exposes a high-watermark counter;
-  crossing it flips a `pressure` flag that biases decisions (stop honoring
-  downstream keep-alive, shrink idle timeouts) so the proxy sheds *idle*
-  capacity before it must shed *work*.
+- **Watermarks before walls.** Each pool flips a `pressure` flag at its
+  high watermark (ceil 3/4, released at floor 1/2 — hysteresis), one
+  rule for all three: *relay-buffer* and *conn-slot* pressure are
+  downstream pressure — the idle timeout divides and keep-alive is no
+  longer honored, so idle downstream connections return the buffers and
+  slots they pin; *upstream-pool* pressure shortens parked-connection
+  deadlines (and the sweep interval), reaping idle parked sockets so
+  their slots free for fresh dials. Each bias sheds *idle* capacity
+  before the wall must shed *work*; each engage crossing has a counter.
 - **Metrics witness every shed.** Every rung has a counter, written only
   by the loop thread as a relaxed atomic — one writer, any number of
   readers, so a metrics/admin thread can read without a data race and
@@ -739,7 +758,7 @@ src/
     render.zig        // §7 head rendering: hop-by-hop strip + close injection
     router.zig        // §7 path routing: canonical-path longest-prefix table
     proxy.zig         // L7 state machine over phases
-  balancer.zig        // upstream endpoint pick: round-robin → P2C (§7)
+  balancer.zig        // upstream endpoint pick: per-cluster rr | p2c (§7)
   shed.zig            // exhaustion ladder: decisions + static responses
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
   worker.zig          // SPMC job queue + SPSC completion rings (Phase 3)

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -88,14 +88,59 @@ behind all four gates of §9.
     against editing proxy-managed headers; (4) the `rewrite` action
     (forwarded path only, segment-correct join, no re-route); (5) sim +
     adversarial-cross-seed oracles.
-- **Phase 2 — shedding hardening + minimal resilience.** P2C pick,
-  stale-replay (a checkout that fails on first use answers 502 today),
-  per-try deadline and the §8 request-deadline 504 verdict (an expired
-  exchange tears down today), counter reconciliation invariants in
-  the sim, overload benchmark scenario (offered load ≫ capacity: assert
-  flat memory, bounded latency for admitted work, all excess shed with
-  correct status). The relay-buffer pressure watermark shipped early
-  (361213f); the remaining watermarks land here.
+- **Phase 2 — shedding hardening + minimal resilience. Implemented
+  2026-07-20 (branch `feat/resilience`).** Six slices, each behind all
+  four §9 gates:
+  - **Endpoint pick** — per-cluster config `"pick": "rr" | "p2c"`
+    (default p2c, the §7 trajectory; typo fails loudly). P2C draws two
+    distinct uniform candidates from a fixed-seed xorshift64* (the sim
+    replays every seed twice demanding identical traces — pick
+    determinism is a feature) and leases the lower per-endpoint leased
+    count, maintained by the upstream pool as a closed system over its
+    four lease transitions. Deferred: a reuse-aware tie-break (a pick
+    may dial fresh while the other candidate holds a parked conn), and
+    L4 lease tracking (L4 dials hold no Upstream slot, so p2c sees only
+    L7 load; a pure-L4 cluster can opt into `rr`).
+  - **§8 request-deadline 504** — ops are never canceled (§5), so the
+    verdict is *deferred*: mark `pending_verdict`, `shutdown(.both)` the
+    upstream socket (forcing each armed op on it to complete),
+    handler-top diverts funnel the forced completions into a settle that
+    answers the static 504 once both data ops are free. Answerable =
+    no response byte sent and no armed op on the client socket (a
+    client-side body recv cannot be forced without closing the client;
+    that stall stays a teardown). The deadline re-arms around the
+    verdict; a second expiry falls through to teardown. A timed-out L7
+    *dial* earns the same 504 (RFC 9110 §15.6.5 — the one connect
+    cancel outside teardown); a refused dial keeps its prompt 502, the
+    counters orthogonal.
+  - **Stale-replay** — a reused checkout that fails with no response
+    byte and no body-pump entered takes one free replay: dispose the
+    stale slot, re-parse conn.head (§7 bytes-are-truth), re-derive the
+    framing tracker (the coalesced excess feeds again), fresh pick,
+    fresh dial under its own per-try connect deadline — never another
+    checkout. Spent before the try begins; a second early failure is
+    502. Deferred: reaping the endpoint's whole idle list on stale
+    detection (the restarted-origin case burns one replay per parked
+    conn until the sweep).
+  - **Watermarks** — one `poolPressureOn/Off` rule (engage ceil 3/4,
+    release floor 1/2) for all three pools. Relay + conn pressure =
+    downstream pressure: idle timeout divides, keep-alive not honored.
+    Upstream pressure: parked deadlines and the sweep interval shrink.
+    Every engage crossing counted; clean sim seeds keep all watermarks
+    above the client population.
+  - **Config `limits`** — optional `{conn_slots, relay_buffers,
+    upstream_slots}`, validated 1 ≤ n ≤ the comptime ceilings (which
+    stay the budget-asserted truth); `Server.InitOptions` *is*
+    `Config.Limits`.
+  - **Overload benchmark** — a second zoxy shrunk to {64, 4, 8} under
+    256 zrk connections: flat RSS, 2xx served AND 5xx shed witnessed,
+    relay stalls < 1% (accept-RSTs exempt — they are the conn wall
+    working), SIGUSR1 counter dump, clean drain. Merge-time only.
+  - Counter reconciliation grew the verdict inequalities
+    (`l7_gateway_timeout ≤ deadline_expired`,
+    `upstream_replayed ≤ upstream_reused`), asserted by the sim under
+    every seed; the sim's adversary gained blackholed dials and a
+    `stale_reuse` origin mode.
 - **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
   activates). The stack is an **open decision under the Zig-first policy**
   (§4). Leading candidate (surveyed 2026-07-12): **picotls** (h2o/picotls)

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -1088,12 +1088,19 @@ pub fn Client(comptime IoType: type) type {
         /// reject scripts admit exactly their own verdict — and a silent
         /// client may see nothing at all.
         fn statusAllowed(script: Script, status: u16) bool {
+            // Every script that dials may also see the §8 request-deadline
+            // verdict: a mute or stalled origin (adversarial delivery can
+            // stall any of them) earns a 504 once the deadline expires with
+            // no response byte sent. Clean seeds pin the origin to `sized`
+            // and never stall, so `goldenStatus` still demands exact
+            // outcomes there.
             return switch (script) {
                 .get, .post_sized, .post_big, .post_chunked, .keepalive_pair, .pipelined, .confusion => //
-                status == 200 or status == 502 or status == 503,
+                status == 200 or status == 502 or status == 503 or status == 504,
                 // Edit and rewrite route and forward like a plain GET, so
                 // the §8 rungs and a killed dial can precede the 200.
-                .filter_edit, .filter_rewrite => status == 200 or status == 502 or status == 503,
+                .filter_edit, .filter_rewrite => //
+                status == 200 or status == 502 or status == 503 or status == 504,
                 // A reject is answered before any resource is acquired or
                 // origin dialed, so no §8 rung or dial failure can precede
                 // it — the only complete verdict is the 403.
@@ -1107,7 +1114,7 @@ pub fn Client(comptime IoType: type) type {
                 // Clean seeds pin the origin to `sized`, so they never race
                 // it and `goldenStatus` still demands the exact 400 there.
                 .post_chunked_malformed => //
-                status == 400 or status == 200 or status == 502 or status == 503,
+                status == 400 or status == 200 or status == 502 or status == 503 or status == 504,
                 .malformed_head => status == 400,
                 .oversize_uri => status == 414,
                 .connect_method => status == 501,

--- a/sim/l7.zig
+++ b/sim/l7.zig
@@ -83,6 +83,10 @@ pub const OriginMode = enum(u8) {
     /// Send the oversize-after-edits head at accept time, then drain:
     /// the render-failure race into the deferred-render path.
     instant_oversize,
+    /// Answer the sized keep-alive 200, then close: the proxy parks on
+    /// the head's promise, the FIN lands while parked, and the next
+    /// checkout meets the §5 stale connection — the §7 replay's shape.
+    stale_reuse,
 };
 
 /// What the origin verifies about every byte the proxy forwards (§7):
@@ -393,6 +397,12 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 assert(conn.phase == .head);
                 switch (conn.mode) {
                     .sized, .reset => conn.armRecv(),
+                    .stale_reuse => {
+                        // The keep-alive head parks the proxy's side; the
+                        // close after responding is the staleness itself.
+                        conn.close_after_response = true;
+                        conn.armRecv();
+                    },
                     .chunked => {
                         conn.response_bytes = chunked_response;
                         conn.armRecv();

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -190,6 +190,9 @@ const Harness = struct {
             .partial_io = true,
             .connect_delay_ns_max = random.uintAtMost(u64, 5_000_000),
             .connect_refuse_percent = random.uintAtMost(u8, 20),
+            // A blackholed dial hangs until the connect deadline — the §8
+            // dial-timeout 504 path, exercised under schedule fuzz.
+            .connect_blackhole_percent = random.uintAtMost(u8, 10),
             .reset_percent = random.uintAtMost(u8, 10),
             .kernel_pressure_percent = random.uintAtMost(u8, 8),
         };

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -198,9 +198,15 @@ const Harness = struct {
     fn deriveTopology(harness: *Harness, random: std.Random) void {
         harness.endpoints_l4 = .{originAddress()};
         harness.endpoints_http = .{httpOriginAddress()};
+        // The pick policy is drawn per seed so both enum values flow
+        // through the balancer under the schedule fuzz. Single-endpoint
+        // clusters short-circuit either policy identically today; the
+        // draw is pre-wired coverage for a multi-endpoint topology.
+        const pick: zoxy.config.Config.Cluster.Pick =
+            if (random.boolean()) .p2c else .rr;
         harness.clusters = .{
-            .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4 },
-            .{ .name = "origin-http", .endpoints = &harness.endpoints_http },
+            .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick },
+            .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick },
         };
         harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -201,15 +201,19 @@ const Harness = struct {
     fn deriveTopology(harness: *Harness, random: std.Random) void {
         harness.endpoints_l4 = .{originAddress()};
         harness.endpoints_http = .{httpOriginAddress()};
-        // The pick policy is drawn per seed so both enum values flow
-        // through the balancer under the schedule fuzz. Single-endpoint
-        // clusters short-circuit either policy identically today; the
-        // draw is pre-wired coverage for a multi-endpoint topology.
-        const pick: zoxy.config.Config.Cluster.Pick =
+        // Each cluster draws its pick policy independently so mixed
+        // rr+p2c configs (one cluster each way) flow through the balancer
+        // under the schedule fuzz, not just the two uniform pairings.
+        // Single-endpoint clusters short-circuit either policy identically
+        // today; the draw is pre-wired coverage for a multi-endpoint
+        // topology.
+        const pick_l4: zoxy.config.Config.Cluster.Pick =
+            if (random.boolean()) .p2c else .rr;
+        const pick_http: zoxy.config.Config.Cluster.Pick =
             if (random.boolean()) .p2c else .rr;
         harness.clusters = .{
-            .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick },
-            .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick },
+            .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick_l4 },
+            .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick_http },
         };
         harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -270,12 +270,19 @@ const Harness = struct {
             }
         else
             .{
+                // Clean seeds size every pool so its §8 pressure
+                // watermark (ceil of 3/4 capacity: 9 of 12) sits above
+                // the whole client population (6): a golden outcome must
+                // never meet a pressure-announced close or a shortened
+                // parked deadline — correct behavior, but not the
+                // script's exact transcript. All three flags (relay,
+                // conn, upstream) ride this margin; a clean-seed client
+                // bump must re-check it, and the upstream margin also
+                // rides the single-endpoint topology (checkout-before-
+                // dial caps acquired at the live client count — parked
+                // conns per endpoint could accumulate past it under a
+                // multi-endpoint clean topology).
                 .conn_slots = 2 * clients_max,
-                // Clean seeds size the pool so the §8 pressure watermark
-                // (ceil of 3/4 capacity) sits above the whole client
-                // population: a golden outcome must never meet a
-                // pressure-announced close, which is correct behavior
-                // but not the script's exact transcript.
                 .relay_buffers = if (harness.clean) 2 * clients_max else clients_max,
                 .upstream_slots = 2 * clients_max,
             };

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -114,7 +114,7 @@ pub fn Server(comptime IoType: type) type {
             try server.upstreams.init(arena, options.upstream_slots);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
             server.listeners_count = @intCast(config.listeners.len);
-            try server.balancer.init(arena, config);
+            server.balancer.init(config);
             server.counters = .{};
             server.draining = false;
             server.relay_pressure = false;
@@ -443,8 +443,11 @@ pub fn Server(comptime IoType: type) type {
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
             assert(conn.state == .connecting);
             conn.arm(&conn.op_connect, "connect");
+            // L4 dials hold no Upstream slot, so the load table reflects
+            // L7 leases only — the P2C draw still spreads L4 dials by the
+            // observed L7 load, and evenly when there is none.
             server.io.connect(
-                server.balancer.pick(cluster_index).address,
+                server.balancer.pick(cluster_index, &server.upstreams.leased_counts).address,
                 &conn.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -509,7 +509,11 @@ pub fn Server(comptime IoType: type) type {
             if (conn.armed.connect and !conn.armed.connect_cancel) {
                 server.armConnectCancel(conn);
             }
-            if (conn.armed.deadline) {
+            // A dial rebase (§8) may already have this timer's cancel in
+            // flight (onDeadlineRebase); submitting a second would double-arm
+            // the op. Its drain routes to teardown via the isTearingDown
+            // checks, so teardown needs no cancel of its own here.
+            if (conn.armed.deadline and !conn.armed.deadline_cancel) {
                 conn.arm(&conn.op_deadline_cancel, "deadline_cancel");
                 server.io.timerCancel(
                     &conn.op_deadline.completion,
@@ -749,6 +753,35 @@ pub fn Server(comptime IoType: type) type {
             );
         }
 
+        /// Re-base the armed deadline to the freshly stored (earlier) target
+        /// (§8): the single lazy timer never moves *earlier* once armed (§4),
+        /// so an L7 dial needing a tighter per-try connect budget than the
+        /// head-read timer cancels it here — the one deadline cancel outside
+        /// teardown. onDeadlineRebase and onDeadline re-arm at the stored
+        /// target once both the cancel and the timer's Canceled have drained
+        /// (so the cancel cannot match the fresh timer). A path that already
+        /// delivered the timer has no armed op to re-base, so it arms fresh.
+        pub fn rebaseDeadline(server: *Self, conn: *ConnType) void {
+            assert(conn.state == .l7_dialing);
+            // A prior dial's rebase cancel can still be draining if the
+            // exchange outran it across a keep-alive turnaround. It re-arms
+            // the timer at the target this dial just stored (deadline_ns is
+            // shared), so defer — a second cancel would double-arm the op.
+            if (conn.armed.deadline_cancel) return;
+            if (!conn.armed.deadline) {
+                server.armDeadline(conn);
+                return;
+            }
+            conn.arm(&conn.op_deadline_cancel, "deadline_cancel");
+            server.io.timerCancel(
+                &conn.op_deadline.completion,
+                &conn.op_deadline_cancel.completion,
+                ConnType,
+                conn,
+                onDeadlineRebase,
+            );
+        }
+
         /// Lazy tick-and-compare (§4): the stored deadline is the truth;
         /// a fire before it is due re-arms for the remainder.
         fn onDeadline(conn: *ConnType, result: Io.TimerError!void) void {
@@ -763,15 +796,48 @@ pub fn Server(comptime IoType: type) type {
                 }
                 if (server.io.nowNs() >= conn.deadline_ns) {
                     server.expireDeadline(conn);
-                } else {
+                } else if (!conn.armed.deadline_cancel) {
                     server.armDeadline(conn);
                 }
+                // else: a rebase cancel (§8) is in flight (an idle timer that
+                // fired as the dial re-based it under pressure); onDeadline-
+                // Rebase re-arms once it drains, so no fresh timer is left for
+                // the cancel to match.
             } else |err| {
                 assert(err == error.Canceled);
-                // The deadline is not a blocking op, so its Canceled
-                // delivery can arrive after closes were submitted (.closing).
-                assert(conn.isTearingDown());
+                if (conn.isTearingDown()) {
+                    // The deadline is not a blocking op, so its Canceled
+                    // delivery can arrive after closes were submitted
+                    // (.closing).
+                    server.continueTeardown(conn);
+                    return;
+                }
+                // A live Canceled means a dialUpstream rebase (§8) shortened
+                // this timer to the per-try connect budget — the one deadline
+                // cancel outside teardown. Re-arm at the stored target, but
+                // only once the cancel op has drained, so the cancel cannot
+                // match the fresh timer; otherwise onDeadlineRebase re-arms.
+                if (!conn.armed.deadline_cancel) {
+                    server.armDeadline(conn);
+                }
+            }
+        }
+
+        /// The rebase cancel's completion (§8): dialUpstream canceled the
+        /// armed head-read timer so a dial could re-base the deadline to the
+        /// tighter connect budget. This cancel and the timer's own Canceled
+        /// delivery both land; whichever arrives second (its sibling op now
+        /// free) re-arms at the stored target. Teardown overtakes both via
+        /// the isTearingDown drain, leaving the timer down for the closes.
+        fn onDeadlineRebase(conn: *ConnType) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_deadline_cancel, "deadline_cancel");
+            if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
+                return;
+            }
+            if (!conn.armed.deadline) {
+                server.armDeadline(conn);
             }
         }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -665,8 +665,7 @@ pub fn Server(comptime IoType: type) type {
                     return;
                 }
                 if (server.io.nowNs() >= conn.deadline_ns) {
-                    server.counters.increment("deadline_expired");
-                    server.beginTeardown(conn);
+                    server.expireDeadline(conn);
                 } else {
                     server.armDeadline(conn);
                 }
@@ -677,6 +676,29 @@ pub fn Server(comptime IoType: type) type {
                 assert(conn.isTearingDown());
                 server.continueTeardown(conn);
             }
+        }
+
+        /// The stored deadline is due. An L7 exchange that can still be
+        /// answered gets the §8 request-deadline verdict — 504 instead of
+        /// a silent teardown — with the deadline re-armed to bound the
+        /// verdict's own delivery: a second expiry with the verdict still
+        /// pending falls through to teardown, the escape hatch. Every
+        /// other state (L4, head read's slowloris, the static-response
+        /// drain, a pending verdict) tears down as before.
+        fn expireDeadline(server: *Self, conn: *ConnType) void {
+            assert(!conn.isTearingDown());
+            assert(!conn.armed.deadline); // Delivered; re-armed only below.
+            server.counters.increment("deadline_expired");
+            if (conn.state == .l7_exchanging and
+                conn.l7.pending_verdict == .none and
+                Proxy.expiryAnswerable(conn))
+            {
+                server.storeDeadline(conn, server.idleTimeoutMs());
+                server.armDeadline(conn);
+                Proxy.beginExpiry(server, conn);
+                return;
+            }
+            server.beginTeardown(conn);
         }
 
         fn onConnectCancel(conn: *ConnType) void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -495,7 +495,9 @@ pub fn Server(comptime IoType: type) type {
             if (conn.upstream_socket) |socket| {
                 server.io.shutdown(socket, .both);
             }
-            if (conn.armed.connect) {
+            // A dial-timeout verdict (§8) may already have a cancel in
+            // flight; submitting a second would double-arm the op.
+            if (conn.armed.connect and !conn.armed.connect_cancel) {
                 conn.arm(&conn.op_connect_cancel, "connect_cancel");
                 server.io.connectCancel(
                     &conn.op_connect.completion,
@@ -682,9 +684,13 @@ pub fn Server(comptime IoType: type) type {
         /// answered gets the §8 request-deadline verdict — 504 instead of
         /// a silent teardown — with the deadline re-armed to bound the
         /// verdict's own delivery: a second expiry with the verdict still
-        /// pending falls through to teardown, the escape hatch. Every
-        /// other state (L4, head read's slowloris, the static-response
-        /// drain, a pending verdict) tears down as before.
+        /// pending falls through to teardown, the escape hatch. A timed-
+        /// out L7 dial earns the same verdict (RFC 9110 §15.6.5: no
+        /// timely response from the upstream — a connect that never
+        /// completes is exactly that) via the one connect cancel outside
+        /// teardown; a refused dial keeps its prompt 502. Every other
+        /// state (L4, head read's slowloris, the static-response drain, a
+        /// pending verdict) tears down as before.
         fn expireDeadline(server: *Self, conn: *ConnType) void {
             assert(!conn.isTearingDown());
             assert(!conn.armed.deadline); // Delivered; re-armed only below.
@@ -698,12 +704,46 @@ pub fn Server(comptime IoType: type) type {
                 Proxy.beginExpiry(server, conn);
                 return;
             }
+            if (conn.state == .l7_dialing and conn.l7.pending_verdict == .none) {
+                // At loop-rest a dialing L7 connection always has its
+                // connect in flight, no data ops, and no response byte.
+                assert(conn.armed.connect);
+                assert(!conn.armed.connect_cancel);
+                assert(!conn.l7.response_started);
+                conn.l7.pending_verdict = .gateway_timeout;
+                server.storeDeadline(conn, server.idleTimeoutMs());
+                server.armDeadline(conn);
+                conn.arm(&conn.op_connect_cancel, "connect_cancel");
+                server.io.connectCancel(
+                    &conn.op_connect.completion,
+                    &conn.op_connect_cancel.completion,
+                    ConnType,
+                    conn,
+                    onConnectCancel,
+                );
+                return;
+            }
             server.beginTeardown(conn);
         }
 
         fn onConnectCancel(conn: *ConnType) void {
             conn.delivered(&conn.op_connect_cancel, "connect_cancel");
-            conn.server.continueTeardown(conn);
+            if (conn.isTearingDown()) {
+                conn.server.continueTeardown(conn);
+                return;
+            }
+            // A §8 dial-timeout cancel: the connect completion itself
+            // carries the verdict (it may deliver before or after this
+            // one), so there is nothing to do here. The verdict is still
+            // pending, or the 504 answer is already under way.
+            assert(conn.state == .l7_dialing or conn.state == .l7_responding or
+                conn.state == .l7_draining_request);
+            // Still dialing implies the verdict is still pending: only the
+            // connect completion's divert clears it, and that divert
+            // leaves .l7_dialing in the same callback.
+            if (conn.state == .l7_dialing) {
+                assert(conn.l7.pending_verdict == .gateway_timeout);
+            }
         }
 
         fn onDeadlineCancel(conn: *ConnType) void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -74,12 +74,10 @@ pub fn Server(comptime IoType: type) type {
         const Proxy = proxy.Proxy(IoType);
 
         /// Pool sizes are injectable so tests and the simulator can force
-        /// every exhaustion rung; production uses the §5 defaults.
-        pub const InitOptions = struct {
-            conn_slots: u32 = constants.conn_slots_max,
-            relay_buffers: u32 = constants.relay_buffers_max,
-            upstream_slots: u32 = constants.upstream_slots_max,
-        };
+        /// every exhaustion rung; production passes the config's resolved
+        /// `limits` (§5) — one type, so a new limit cannot silently
+        /// default in a hand-written bridge.
+        pub const InitOptions = config_module.Config.Limits;
 
         const ListenerState = struct {
             server: *Self,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -507,14 +507,7 @@ pub fn Server(comptime IoType: type) type {
             // A dial-timeout verdict (§8) may already have a cancel in
             // flight; submitting a second would double-arm the op.
             if (conn.armed.connect and !conn.armed.connect_cancel) {
-                conn.arm(&conn.op_connect_cancel, "connect_cancel");
-                server.io.connectCancel(
-                    &conn.op_connect.completion,
-                    &conn.op_connect_cancel.completion,
-                    ConnType,
-                    conn,
-                    onConnectCancel,
-                );
+                server.armConnectCancel(conn);
             }
             if (conn.armed.deadline) {
                 conn.arm(&conn.op_deadline_cancel, "deadline_cancel");
@@ -674,6 +667,12 @@ pub fn Server(comptime IoType: type) type {
             endpoint_index: u16,
         ) ?*upstream_module.UpstreamPool(IoType).Upstream {
             const leased = server.upstreams.acquire(cluster_index, endpoint_index) orelse return null;
+            // The pool honored the request: a freshly leased slot is
+            // unparked and carries the identity the pressure recompute and
+            // the P2C load table now read back.
+            assert(!leased.parked);
+            assert(leased.cluster_index == cluster_index);
+            assert(leased.endpoint_index == endpoint_index);
             server.updateUpstreamPressure();
             return leased;
         }
@@ -682,6 +681,10 @@ pub fn Server(comptime IoType: type) type {
             server: *Self,
             leased: *upstream_module.UpstreamPool(IoType).Upstream,
         ) void {
+            // A parked slot must be unparked before release (its idle-list
+            // links would dangle), and at least this slot is leased.
+            assert(!leased.parked);
+            assert(server.upstreams.leasedCount() >= 1);
             server.upstreams.release(leased);
             server.updateUpstreamPressure();
         }
@@ -791,7 +794,11 @@ pub fn Server(comptime IoType: type) type {
                 conn.l7.pending_verdict == .none and
                 Proxy.expiryAnswerable(conn))
             {
-                server.storeDeadline(conn, server.idleTimeoutMs());
+                // The verdict grace bounds the escape hatch, not idle
+                // shedding: use the fixed configured idle timeout, never the
+                // pressure-biased one (which collapses toward 1ms and could
+                // tear the verdict down before its forced completions land).
+                server.storeDeadline(conn, server.config.idle_timeout_ms);
                 server.armDeadline(conn);
                 Proxy.beginExpiry(server, conn);
                 return;
@@ -803,19 +810,31 @@ pub fn Server(comptime IoType: type) type {
                 assert(!conn.armed.connect_cancel);
                 assert(!conn.l7.response_started);
                 conn.l7.pending_verdict = .gateway_timeout;
-                server.storeDeadline(conn, server.idleTimeoutMs());
+                // Same fixed grace as the exchange verdict above.
+                server.storeDeadline(conn, server.config.idle_timeout_ms);
                 server.armDeadline(conn);
-                conn.arm(&conn.op_connect_cancel, "connect_cancel");
-                server.io.connectCancel(
-                    &conn.op_connect.completion,
-                    &conn.op_connect_cancel.completion,
-                    ConnType,
-                    conn,
-                    onConnectCancel,
-                );
+                server.armConnectCancel(conn);
                 return;
             }
             server.beginTeardown(conn);
+        }
+
+        /// The connect cancel arm+submit shared by teardown and the §8
+        /// dial-timeout verdict — the two paths that abort an in-flight
+        /// dial (§4: the one cancel outside data-op drain). Callers guard
+        /// the double-arm themselves: a verdict cancel may already be in
+        /// flight when teardown starts.
+        fn armConnectCancel(server: *Self, conn: *ConnType) void {
+            assert(conn.armed.connect);
+            assert(!conn.armed.connect_cancel);
+            conn.arm(&conn.op_connect_cancel, "connect_cancel");
+            server.io.connectCancel(
+                &conn.op_connect.completion,
+                &conn.op_connect_cancel.completion,
+                ConnType,
+                conn,
+                onConnectCancel,
+            );
         }
 
         fn onConnectCancel(conn: *ConnType) void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -47,11 +47,17 @@ pub fn Server(comptime IoType: type) type {
         balancer: Balancer,
         counters: counters_module.Counters,
         draining: bool,
-        /// §8 watermark state for the relay-buffer pool: set once the pool
-        /// crosses its high watermark, cleared once it drains back below
-        /// the low one (hysteresis). Biases idle timeouts shorter so quiet
-        /// connections return their buffers before the wall is reached.
+        /// §8 watermark state, one flag per pool: set once a pool crosses
+        /// its high watermark, cleared once it drains back below the low
+        /// one (hysteresis, `constants.poolPressureOn/Off`). Relay and
+        /// conn pressure bias downstream capacity — shorter idle timeouts
+        /// and keep-alive no longer honored — so quiet connections return
+        /// their buffers and slots before the wall is reached; upstream
+        /// pressure shortens parked-connection deadlines so idle parked
+        /// sockets free their slots for fresh dials before the 503 wall.
         relay_pressure: bool,
+        conn_pressure: bool,
+        upstream_pressure: bool,
         drain_deadline_completion: IoType.Completion,
         /// The one timer covering every parked upstream (§5): a parked
         /// connection holds no armed op, so this sweep compares stored
@@ -118,6 +124,8 @@ pub fn Server(comptime IoType: type) type {
             server.counters = .{};
             server.draining = false;
             server.relay_pressure = false;
+            server.conn_pressure = false;
+            server.upstream_pressure = false;
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
@@ -215,7 +223,7 @@ pub fn Server(comptime IoType: type) type {
                 if (!reap_all and upstream.deadline_ns > now) continue;
                 server.upstreams.unpark(upstream);
                 server.io.closeNow(upstream.socket);
-                server.upstreams.release(upstream);
+                server.releaseUpstream(upstream);
                 if (!reap_all) {
                     server.counters.increment("upstream_idle_reaped");
                 }
@@ -231,7 +239,7 @@ pub fn Server(comptime IoType: type) type {
             if (server.upstream_sweep_armed) return;
             if (server.upstreams.idle_count == 0) return;
             server.upstream_sweep_armed = true;
-            const interval_ms = @max(server.idleTimeoutMs() / 2, 1);
+            const interval_ms = @max(server.parkedTimeoutMs() / 2, 1);
             server.io.timerStart(
                 &server.upstream_sweep_completion,
                 @as(u64, interval_ms) * std.time.ns_per_ms,
@@ -348,11 +356,13 @@ pub fn Server(comptime IoType: type) type {
         /// way when slots run out, so the rung lives in one place.
         fn admitConn(server: *Self, client_socket: IoType.Socket) ?*ConnType {
             assert(!server.draining);
-            return server.conns.acquire() orelse {
+            const conn = server.conns.acquire() orelse {
                 server.counters.increment("shed_conn_slots");
                 shed.closeWithRst(IoType, server.io, client_socket);
                 return null;
             };
+            server.updateConnPressure();
+            return conn;
         }
 
         /// The shared admission tail (§8 single choke point): counting,
@@ -386,6 +396,7 @@ pub fn Server(comptime IoType: type) type {
             const conn = server.admitConn(client_socket) orelse return;
             const buffer = server.relay_buffers.acquire() orelse {
                 server.conns.release(conn);
+                server.updateConnPressure();
                 server.counters.increment("shed_relay_buffers");
                 shed.closeQuietly(IoType, server.io, client_socket);
                 return;
@@ -571,10 +582,11 @@ pub fn Server(comptime IoType: type) type {
             // close_upstream, so the slot is inert by the time the armed
             // set empties (§5). Parking replaces this with reuse later.
             if (conn.upstream) |leased| {
-                server.upstreams.release(leased);
+                server.releaseUpstream(leased);
                 conn.upstream = null;
             }
             server.conns.release(conn);
+            server.updateConnPressure();
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
         }
@@ -592,34 +604,116 @@ pub fn Server(comptime IoType: type) type {
             }
         }
 
-        /// §8 watermarks before walls: recompute the relay-buffer pressure
-        /// flag with hysteresis after every acquire/release. The engage
-        /// crossing is witnessed; the wall (admit-time shed) still backs it
-        /// up if pressure fails to relieve the load in time.
-        fn updateRelayPressure(server: *Self) void {
-            const held = server.relay_buffers.acquired_count;
-            const capacity: u32 = @intCast(server.relay_buffers.slots.len);
-            if (server.relay_pressure) {
-                if (held <= constants.relayPressureOff(capacity)) {
-                    server.relay_pressure = false;
+        /// §8 watermarks before walls: recompute one pool's pressure flag
+        /// with hysteresis after an acquire/release. The engage crossing
+        /// is witnessed by its counter; the wall (the pool's shed rung)
+        /// still backs it up if pressure fails to relieve the load in
+        /// time. One rule for all three pools.
+        fn updatePressureFlag(
+            server: *Self,
+            flag: *bool,
+            held: u32,
+            capacity: u32,
+            comptime counter: []const u8,
+        ) void {
+            assert(held <= capacity);
+            // The comptime block pins the watermark shape at production
+            // size only; these pin it for every injected pool size too.
+            assert(constants.poolPressureOn(capacity) > constants.poolPressureOff(capacity));
+            assert(constants.poolPressureOn(capacity) <= capacity);
+            if (flag.*) {
+                if (held <= constants.poolPressureOff(capacity)) {
+                    flag.* = false;
                 }
-            } else if (held >= constants.relayPressureOn(capacity)) {
-                server.relay_pressure = true;
-                server.counters.increment("relay_pressure_engaged");
+            } else if (held >= constants.poolPressureOn(capacity)) {
+                flag.* = true;
+                server.counters.increment(counter);
             }
         }
 
-        /// The idle timeout to apply now, shortened under relay-buffer
-        /// pressure so quiet connections return their buffers sooner (§8).
-        /// Only the idle deadline is biased — the connect deadline is a
-        /// correctness bound and stays fixed. Because a timer never moves
-        /// *earlier* once armed (§4), this reaches a connection at its next
-        /// deadline store (activity or half-close), not retroactively; the
-        /// admit-time wall covers connections that never transact again.
+        fn updateRelayPressure(server: *Self) void {
+            server.updatePressureFlag(
+                &server.relay_pressure,
+                server.relay_buffers.acquired_count,
+                @intCast(server.relay_buffers.slots.len),
+                "relay_pressure_engaged",
+            );
+        }
+
+        fn updateConnPressure(server: *Self) void {
+            server.updatePressureFlag(
+                &server.conn_pressure,
+                server.conns.acquired_count,
+                @intCast(server.conns.slots.len),
+                "conn_pressure_engaged",
+            );
+        }
+
+        fn updateUpstreamPressure(server: *Self) void {
+            server.updatePressureFlag(
+                &server.upstream_pressure,
+                server.upstreams.slot_pool.acquired_count,
+                @intCast(server.upstreams.slot_pool.slots.len),
+                "upstream_pressure_engaged",
+            );
+        }
+
+        /// Any pressure that downstream keep-alive holds capacity against
+        /// (§8): an idle downstream connection pins a conn slot, and its
+        /// next body relay claims a relay buffer. Public for the L7
+        /// render's persistence decision.
+        pub fn downstreamPressured(server: *const Self) bool {
+            return server.relay_pressure or server.conn_pressure;
+        }
+
+        /// The §8 upstream-pool acquire/release pair: the pressure flag
+        /// recomputes on exactly the transitions that move
+        /// `acquired_count` (park/checkout do not), so the callers can
+        /// never miss a crossing.
+        pub fn acquireUpstream(
+            server: *Self,
+            cluster_index: u16,
+            endpoint_index: u16,
+        ) ?*upstream_module.UpstreamPool(IoType).Upstream {
+            const leased = server.upstreams.acquire(cluster_index, endpoint_index) orelse return null;
+            server.updateUpstreamPressure();
+            return leased;
+        }
+
+        pub fn releaseUpstream(
+            server: *Self,
+            leased: *upstream_module.UpstreamPool(IoType).Upstream,
+        ) void {
+            server.upstreams.release(leased);
+            server.updateUpstreamPressure();
+        }
+
+        /// The idle timeout to apply now, shortened under downstream
+        /// pressure so quiet connections return their buffers and slots
+        /// sooner (§8). Only the idle deadline is biased — the connect
+        /// deadline is a correctness bound and stays fixed. Because a
+        /// timer never moves *earlier* once armed (§4), this reaches a
+        /// connection at its next deadline store (activity or
+        /// half-close), not retroactively; the admit-time wall covers
+        /// connections that never transact again.
         pub fn idleTimeoutMs(server: *const Self) u32 {
             const configured = server.config.idle_timeout_ms;
-            if (!server.relay_pressure) return configured;
-            return @max(configured / constants.relay_pressure_idle_divisor, 1);
+            if (!server.downstreamPressured()) return configured;
+            return @max(configured / constants.pressure_idle_divisor, 1);
+        }
+
+        /// The deadline for a connection parked from now on, further
+        /// shortened under upstream pressure so idle parked sockets free
+        /// their slots for fresh dials before the 503 wall (§8). It
+        /// bases on `idleTimeoutMs`, so downstream pressure alone already
+        /// shortens parked deadlines — a deliberate cross-pool coupling:
+        /// under any pressure, idle capacity of every kind reaps sooner.
+        /// Lazy like the idle bias: it reaches a connection at its next
+        /// park, never retroactively.
+        pub fn parkedTimeoutMs(server: *const Self) u32 {
+            const base = server.idleTimeoutMs();
+            if (!server.upstream_pressure) return base;
+            return @max(base / constants.pressure_idle_divisor, 1);
         }
 
         /// Public for the relay: activity pushes the idle deadline out;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -5,10 +5,10 @@
 //! choke point. Admission forks on the listener's protocol: an `l4`
 //! listener runs the strict TCP relay (`net/relay.zig`), an `http`
 //! listener runs the L7 state machine (`http/proxy.zig`); the shared
-//! accept gate, deadline, and teardown machinery serve both. The L7
-//! request path is filling in slice by slice — head ingestion and the
-//! static-response rejects are in; the upstream leg follows — so a valid
-//! L7 request currently tears down once its head is parsed.
+//! accept gate, deadline, and teardown machinery serve both, as do the
+//! §8 pressure watermarks (one rule, three pools) and the deadline's
+//! request-expiry verdict fork (§8: 504 when answerable, teardown
+//! otherwise).
 
 const std = @import("std");
 

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -1,34 +1,46 @@
 //! Upstream endpoint selection (DESIGN.md §7): the load-balancing policy
 //! kept behind a seam so the serving path never hardcodes *how* an
 //! endpoint is chosen — it only asks "which endpoint for this cluster?".
-//! Today's policy is round-robin; the design's trajectory is round-robin
-//! → P2C (§7), and that evolution lands as a change here, not in Server.
-//! The policy owns whatever per-cluster state it needs — a round-robin
-//! cursor now — and resolves a cluster index to the endpoint to dial.
+//! Two policies, selected per cluster in the config (§5 parse-once):
+//! `rr` rotates a per-cluster cursor, `p2c` draws two distinct candidates
+//! uniformly and leases the calmer one. P2C's load is the upstream pool's
+//! per-endpoint leased count, passed in by the caller — the balancer owns
+//! the draw, the pool owns the truth. A single-endpoint cluster
+//! short-circuits either policy without touching its state.
 
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const constants = @import("constants.zig");
+const upstream = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
 
 pub const Balancer = struct {
     config: *const config_module.Config,
-    /// Per-cluster round-robin cursor. u64 so it never wraps in any
-    /// realistic process lifetime — a u16 wrap reset the rotation phase
-    /// and double-picked one endpoint for non-power-of-two cluster sizes.
-    cursors: []u64,
+    /// Per-cluster round-robin cursors, used by `.rr` clusters only.
+    /// u64 so a cursor never wraps in any realistic process lifetime — a
+    /// u16 wrap reset the rotation phase and double-picked one endpoint
+    /// for non-power-of-two cluster sizes. Fixed at the config ceiling:
+    /// 16 × 8 bytes of static state beats an arena allocation.
+    cursors: [constants.clusters_max]u64,
+    /// xorshift64* draw state, used by `.p2c` clusters only. Seeded from
+    /// a fixed named constant, never the clock: the simulator replays
+    /// every seed twice and demands byte-identical traces (§9), and load
+    /// balancing needs spread, not secrecy — determinism is a feature.
+    pick_state: u64,
 
-    /// Cursors are arena-owned and sized to the cluster count, so a pick
-    /// is a bounds-checked index, never an allocation on the loop.
-    pub fn init(
-        balancer: *Balancer,
-        arena: std.mem.Allocator,
-        config: *const config_module.Config,
-    ) error{OutOfMemory}!void {
+    /// Any nonzero constant seeds xorshift64* soundly; this one is the
+    /// 64-bit golden-ratio constant, chosen for being recognizable.
+    const pick_seed: u64 = 0x9E3779B97F4A7C15;
+
+    pub fn init(balancer: *Balancer, config: *const config_module.Config) void {
+        assert(config.clusters.len >= 1);
+        assert(config.clusters.len <= constants.clusters_max);
         balancer.config = config;
-        balancer.cursors = try arena.alloc(u64, config.clusters.len);
-        @memset(balancer.cursors, 0);
+        @memset(&balancer.cursors, 0);
+        balancer.pick_state = pick_seed;
+        assert(balancer.pick_state != 0); // xorshift64* cycles on nonzero state.
     }
 
     /// A pick names the endpoint both ways: the address to dial and the
@@ -38,64 +50,250 @@ pub const Balancer = struct {
         endpoint_index: u16,
     };
 
-    /// Choose the next endpoint to dial for `cluster_index`, advancing the
-    /// policy's state. Round-robin: the cursor modulo the endpoint count,
-    /// then incremented — a validated config guarantees at least one
-    /// endpoint, so the modulo is always defined.
-    pub fn pick(balancer: *Balancer, cluster_index: u16) Pick {
-        assert(cluster_index < balancer.cursors.len);
+    /// Choose the endpoint to dial for `cluster_index` under the
+    /// cluster's configured policy. `leased_counts` is the pool's
+    /// per-endpoint load table (indexed by `upstream.endpointKey`),
+    /// consulted by p2c and ignored by rr. Bounded work, no allocation,
+    /// and a validated config guarantees at least one endpoint.
+    pub fn pick(
+        balancer: *Balancer,
+        cluster_index: u16,
+        leased_counts: *const [upstream.endpoint_keys_max]u16,
+    ) Pick {
+        assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
         assert(cluster.endpoints.len >= 1);
-        const endpoint_index: u16 =
+        assert(cluster.endpoints.len <= constants.endpoints_per_cluster_max);
+        if (cluster.endpoints.len == 1) {
+            // Neither a rotation nor a draw: single-endpoint clusters
+            // stay branch-cheap and policy state is untouched.
+            return .{ .address = cluster.endpoints[0], .endpoint_index = 0 };
+        }
+        const chosen = switch (cluster.pick) {
+            .rr => balancer.pickRoundRobin(cluster_index, cluster),
+            .p2c => balancer.pickPowerOfTwo(cluster_index, cluster, leased_counts),
+        };
+        assert(chosen < cluster.endpoints.len);
+        return .{
+            .address = cluster.endpoints[chosen],
+            .endpoint_index = chosen,
+        };
+    }
+
+    /// Strict rotation: the cursor modulo the endpoint count, then
+    /// incremented — every endpoint sees exactly its share, in order.
+    fn pickRoundRobin(
+        balancer: *Balancer,
+        cluster_index: u16,
+        cluster: *const config_module.Config.Cluster,
+    ) u16 {
+        assert(cluster.pick == .rr);
+        assert(cluster.endpoints.len >= 2); // pick() short-circuited 1.
+        const chosen: u16 =
             @intCast(balancer.cursors[cluster_index] % cluster.endpoints.len);
         balancer.cursors[cluster_index] += 1;
-        assert(endpoint_index < cluster.endpoints.len);
-        return .{
-            .address = cluster.endpoints[endpoint_index],
-            .endpoint_index = endpoint_index,
-        };
+        assert(chosen < cluster.endpoints.len);
+        return chosen;
+    }
+
+    /// P2C: two distinct uniform candidates, the lower leased count
+    /// wins, a tie goes to the first.
+    fn pickPowerOfTwo(
+        balancer: *Balancer,
+        cluster_index: u16,
+        cluster: *const config_module.Config.Cluster,
+        leased_counts: *const [upstream.endpoint_keys_max]u16,
+    ) u16 {
+        assert(cluster.pick == .p2c);
+        const endpoint_count = cluster.endpoints.len;
+        assert(endpoint_count >= 2); // pick() short-circuited 1.
+        const first: u16 = @intCast(balancer.next() % endpoint_count);
+        var second: u16 = @intCast(balancer.next() % (endpoint_count - 1));
+        // Skip past `first`, mapping the (n-1)-range draw onto the other
+        // n-1 endpoints uniformly.
+        if (second >= first) {
+            second += 1;
+        }
+        assert(first != second);
+        assert(second < endpoint_count);
+        const first_load = leased_counts[upstream.endpointKey(cluster_index, first)];
+        const second_load = leased_counts[upstream.endpointKey(cluster_index, second)];
+        return if (second_load < first_load) second else first;
+    }
+
+    /// xorshift64* (Vigna): the full-period 64-bit shift generator with a
+    /// multiplicative output scramble — plenty for candidate draws, one
+    /// mul and three shifts on the pick path. The modulo bias of a draw
+    /// is ≤ 2⁻⁵⁸ for the ≤ 64 endpoints a cluster may hold — negligible.
+    fn next(balancer: *Balancer) u64 {
+        assert(balancer.pick_state != 0);
+        var x = balancer.pick_state;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        balancer.pick_state = x;
+        assert(x != 0); // Nonzero state maps to nonzero state.
+        return x *% 0x2545F4914F6CDD1D;
     }
 };
 
-test "balancer: round-robin cycles endpoints and wraps per cluster" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
+const test_counts_len = upstream.endpoint_keys_max;
 
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
-
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
-    const one = [_]std.Io.net.IpAddress{solo};
-    const clusters = [_]config_module.Config.Cluster{
-        .{ .name = "trio", .endpoints = &trio },
-        .{ .name = "one", .endpoints = &one },
-    };
-    const config: config_module.Config = .{
+fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Config {
+    return .{
         .listeners = &.{},
-        .clusters = &clusters,
+        .clusters = clusters,
         .connect_timeout_ms = 1,
         .idle_timeout_ms = 1,
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
     };
+}
+
+test "balancer: rr cycles endpoints and wraps per cluster" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
 
     var balancer: Balancer = undefined;
-    try balancer.init(arena, &config);
+    balancer.init(&config);
 
-    // Cluster 0 rotates a → b → c and wraps back to a; cluster 1 keeps
-    // its own cursor and always returns its single endpoint. Address and
-    // index name the same endpoint.
-    const expected = [_]std.Io.net.IpAddress{ a, b, c, a, b };
-    const expected_indexes = [_]u16{ 0, 1, 2, 0, 1 };
-    for (expected, expected_indexes) |want, want_index| {
-        const picked = balancer.pick(0);
-        try std.testing.expectEqual(want, picked.address);
+    // Rotation is exact whatever the load table says: rr ignores it.
+    var counts = [_]u16{0} ** test_counts_len;
+    counts[upstream.endpointKey(0, 0)] = 100;
+    const expected = [_]u16{ 0, 1, 2, 0, 1 };
+    for (expected) |want_index| {
+        const picked = balancer.pick(0, &counts);
         try std.testing.expectEqual(want_index, picked.endpoint_index);
-        const solo_picked = balancer.pick(1);
-        try std.testing.expectEqual(solo, solo_picked.address);
-        try std.testing.expectEqual(@as(u16, 0), solo_picked.endpoint_index);
+        try std.testing.expectEqual(trio[want_index], picked.address);
+    }
+}
+
+test "balancer: a single-endpoint cluster short-circuits without a draw" {
+    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
+    const one = [_]std.Io.net.IpAddress{solo};
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "one", .endpoints = &one },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+    const state_before = balancer.pick_state;
+
+    const counts = [_]u16{0} ** test_counts_len;
+    var round: u32 = 0;
+    while (round < 10) : (round += 1) {
+        const picked = balancer.pick(0, &counts);
+        try std.testing.expectEqual(solo, picked.address);
+        try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
+    }
+    // The PRNG state never advanced: no draw was spent.
+    try std.testing.expectEqual(state_before, balancer.pick_state);
+}
+
+test "balancer: p2c prefers the less-loaded of its two candidates" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Endpoint 1 is drowning; 0 and 2 are idle. Whatever pair is drawn,
+    // the pick must never be the drowning endpoint: any pair containing
+    // it also contains an idle endpoint that wins the comparison.
+    var counts = [_]u16{0} ** test_counts_len;
+    counts[upstream.endpointKey(0, 1)] = 100;
+    var round: u32 = 0;
+    while (round < 200) : (round += 1) {
+        const picked = balancer.pick(0, &counts);
+        try std.testing.expect(picked.endpoint_index != 1);
+    }
+}
+
+test "balancer: p2c spreads across endpoints under equal load" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // With every count equal the tie rule keeps the first candidate — a
+    // uniform draw — so all endpoints must be hit over a modest run.
+    const counts = [_]u16{0} ** test_counts_len;
+    var hits = [_]u32{0} ** 3;
+    var round: u32 = 0;
+    while (round < 300) : (round += 1) {
+        const picked = balancer.pick(0, &counts);
+        hits[picked.endpoint_index] += 1;
+    }
+    for (hits) |hit_count| {
+        try std.testing.expect(hit_count >= 1);
+    }
+}
+
+test "balancer: same seed, same picks — the p2c draw is deterministic" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var left: Balancer = undefined;
+    left.init(&config);
+    var right: Balancer = undefined;
+    right.init(&config);
+
+    // The simulator replays every seed twice and hashes the traces (§9);
+    // two same-seed balancers must agree draw for draw.
+    const counts = [_]u16{0} ** test_counts_len;
+    var round: u32 = 0;
+    while (round < 100) : (round += 1) {
+        try std.testing.expectEqual(
+            left.pick(0, &counts).endpoint_index,
+            right.pick(0, &counts).endpoint_index,
+        );
+    }
+}
+
+test "balancer: policies keep independent state across clusters" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "rotating", .endpoints = &pair, .pick = .rr },
+        .{ .name = "drawing", .endpoints = &pair, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Interleaving a p2c cluster's draws must not perturb the rr
+    // cluster's rotation: cursor and PRNG are separate state.
+    const counts = [_]u16{0} ** test_counts_len;
+    const expected = [_]u16{ 0, 1, 0, 1, 0 };
+    for (expected) |want_index| {
+        try std.testing.expectEqual(want_index, balancer.pick(0, &counts).endpoint_index);
+        _ = balancer.pick(1, &counts);
     }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -59,6 +59,16 @@ pub const Config = struct {
     pub const Cluster = struct {
         name: []const u8,
         endpoints: []const std.Io.net.IpAddress,
+        /// The §7 endpoint-pick policy the balancer runs for this
+        /// cluster. The JSON field is optional and defaults to `p2c` —
+        /// the design's trajectory (§7: round-robin → P2C) — with `rr`
+        /// kept for strict rotation (predictable spread, cache warming).
+        pick: Pick = .p2c,
+
+        pub const Pick = enum(u1) {
+            rr,
+            p2c,
+        };
     };
 };
 
@@ -73,6 +83,7 @@ pub const ValidationError = error{
     ClustersEmpty,
     ClustersOverLimit,
     ClusterNameDuplicate,
+    ClusterPickUnknown,
     ListenerClusterOrRoutes,
     ListenerL4Routes,
     RoutesEmpty,
@@ -200,6 +211,9 @@ const RouteJson = struct {
 
 const ClusterJson = struct {
     endpoints: []const []const u8,
+    /// Optional §7 pick policy; absent means `p2c` (the design's
+    /// trajectory), `rr` opts back into strict rotation.
+    pick: []const u8 = "p2c",
 };
 
 const TimeoutsJson = struct {
@@ -286,6 +300,7 @@ fn resolveClusters(
         clusters[index] = .{
             .name = entry.name,
             .endpoints = try resolveEndpoints(arena, entry.cluster.endpoints),
+            .pick = try pickOf(entry.cluster.pick),
         };
     }
     assert(clusters.len == count);
@@ -725,6 +740,18 @@ fn validateRoutePrefix(prefix: []const u8) ParseError!void {
     }
 }
 
+/// The closed pick-policy vocabulary; anything else is its own error so
+/// a typo ("pc2") fails loudly instead of silently balancing as p2c.
+fn pickOf(literal: []const u8) error{ClusterPickUnknown}!Config.Cluster.Pick {
+    if (std.mem.eql(u8, literal, "rr")) {
+        return .rr;
+    }
+    if (std.mem.eql(u8, literal, "p2c")) {
+        return .p2c;
+    }
+    return error.ClusterPickUnknown;
+}
+
 /// The closed protocol vocabulary; anything else is its own error so a
 /// typo ("htpp") fails loudly instead of silently relaying as L4.
 fn protocolOf(literal: []const u8) error{ListenerProtocolUnknown}!Config.Listener.Protocol {
@@ -1058,6 +1085,30 @@ test "config: a filter set over the header-edit budget is rejected" {
     const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"cluster\":\"a\",\"filters\":[" ++ rules ++ "]}]," ++ tail;
     try expectParseError(error.FilterHeaderEditsOverLimit, json);
+}
+
+test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
+    // Explicit rr and p2c both resolve; absent defaults to p2c.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"pick":"rr"},
+            \\   "b":{"endpoints":["127.0.0.1:3"],"pick":"p2c"},
+            \\   "c":{"endpoints":["127.0.0.1:4"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(Config.Cluster.Pick.rr, parsed.clusters[0].pick);
+        try std.testing.expectEqual(Config.Cluster.Pick.p2c, parsed.clusters[1].pick);
+        try std.testing.expectEqual(Config.Cluster.Pick.p2c, parsed.clusters[2].pick);
+    }
+    // A typo must not silently balance as the default.
+    try expectParseError(error.ClusterPickUnknown,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"pick":"pc2"}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,6 +31,18 @@ pub const Config = struct {
     /// where zero is legal (an unbounded connection age), so it is optional
     /// in the JSON and defaults off.
     max_lifetime_ms: u32,
+    /// Effective pool sizes (§5, §8). The comptime constants stay the
+    /// hard, budget-asserted ceilings; config may only shrink below them
+    /// — for capacity planning, and so the overload benchmark can hit
+    /// the real shed rungs at loopback-feasible load. Defaulted so the
+    /// test beds' literal configs keep the full pools.
+    limits: Limits = .{},
+
+    pub const Limits = struct {
+        conn_slots: u32 = constants.conn_slots_max,
+        relay_buffers: u32 = constants.relay_buffers_max,
+        upstream_slots: u32 = constants.upstream_slots_max,
+    };
 
     pub const Listener = struct {
         bind_address: std.Io.net.IpAddress,
@@ -112,6 +124,10 @@ pub const ValidationError = error{
     EndpointPortZero,
     TimeoutZero,
     TimeoutOverLimit,
+    LimitConnSlotsOutOfRange,
+    LimitRelayBuffersOutOfRange,
+    LimitRelayBuffersOverConnSlots,
+    LimitUpstreamSlotsOutOfRange,
 };
 
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
@@ -129,6 +145,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     const clusters = try resolveClusters(arena, &parsed.clusters);
     const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     try validateTimeouts(&parsed.timeouts);
+    const limits = try resolveLimits(&parsed.limits);
 
     assert(listeners.len >= 1);
     assert(clusters.len >= 1);
@@ -139,6 +156,38 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .idle_timeout_ms = parsed.timeouts.idle_ms,
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
+        .limits = limits,
+    };
+}
+
+/// Resolve the effective pool sizes (§5, §8): the comptime constants are
+/// the hard, budget-asserted ceilings — config may only shrink below
+/// them, never grow past them, and never to zero. An unspecified
+/// relay-buffer count derives from the effective conn slots (a buffer
+/// beyond the slot count could never be acquired); a *specified* count
+/// above them is a contradiction and fails loudly.
+fn resolveLimits(limits_json: *const LimitsJson) ValidationError!Config.Limits {
+    const conn_slots = limits_json.conn_slots orelse constants.conn_slots_max;
+    if (conn_slots < 1 or conn_slots > constants.conn_slots_max) {
+        return error.LimitConnSlotsOutOfRange;
+    }
+    const relay_buffers = limits_json.relay_buffers orelse
+        @min(constants.relay_buffers_max, conn_slots);
+    if (relay_buffers < 1 or relay_buffers > constants.relay_buffers_max) {
+        return error.LimitRelayBuffersOutOfRange;
+    }
+    if (relay_buffers > conn_slots) {
+        return error.LimitRelayBuffersOverConnSlots;
+    }
+    const upstream_slots = limits_json.upstream_slots orelse constants.upstream_slots_max;
+    if (upstream_slots < 1 or upstream_slots > constants.upstream_slots_max) {
+        return error.LimitUpstreamSlotsOutOfRange;
+    }
+    assert(relay_buffers <= conn_slots);
+    return .{
+        .conn_slots = conn_slots,
+        .relay_buffers = relay_buffers,
+        .upstream_slots = upstream_slots,
     };
 }
 
@@ -146,6 +195,15 @@ const ConfigJson = struct {
     listeners: []const ListenerJson,
     clusters: ClustersJson,
     timeouts: TimeoutsJson,
+    /// Optional pool shrinks (§5, §8); absent fields keep the comptime
+    /// ceilings.
+    limits: LimitsJson = .{},
+};
+
+const LimitsJson = struct {
+    conn_slots: ?u32 = null,
+    relay_buffers: ?u32 = null,
+    upstream_slots: ?u32 = null,
 };
 
 const ListenerJson = struct {
@@ -1109,6 +1167,67 @@ test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"pick":"pc2"}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
     );
+}
+
+test "config: limits shrink pools below the ceilings, never past them" {
+    // Partial limits: relay buffers derive from the effective conn slots.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1},
+            \\ "limits":{"conn_slots":64}}
+        );
+        try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
+        try std.testing.expectEqual(@as(u32, 64), parsed.limits.relay_buffers);
+        try std.testing.expectEqual(constants.upstream_slots_max, parsed.limits.upstream_slots);
+    }
+    // Full limits resolve verbatim; absent block keeps the ceilings.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1},
+            \\ "limits":{"conn_slots":64,"relay_buffers":8,"upstream_slots":8}}
+        );
+        try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
+        try std.testing.expectEqual(@as(u32, 8), parsed.limits.relay_buffers);
+        try std.testing.expectEqual(@as(u32, 8), parsed.limits.upstream_slots);
+    }
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(constants.conn_slots_max, parsed.limits.conn_slots);
+        try std.testing.expectEqual(constants.relay_buffers_max, parsed.limits.relay_buffers);
+        try std.testing.expectEqual(constants.upstream_slots_max, parsed.limits.upstream_slots);
+    }
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1},
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}],";
+    // Zero and over-ceiling both fail loudly, each with its own error.
+    try expectParseError(error.LimitConnSlotsOutOfRange, head ++ tail ++ "\"limits\":{\"conn_slots\":0}}");
+    try expectParseError(error.LimitConnSlotsOutOfRange, head ++ tail ++ "\"limits\":{\"conn_slots\":99999}}");
+    try expectParseError(error.LimitRelayBuffersOutOfRange, head ++ tail ++ "\"limits\":{\"relay_buffers\":0}}");
+    // Over-ceiling relay buffers alone hit the range check, not the
+    // conn-slot contradiction — the range check has precedence.
+    try expectParseError(error.LimitRelayBuffersOutOfRange, head ++ tail ++ "\"limits\":{\"relay_buffers\":99999}}");
+    try expectParseError(error.LimitUpstreamSlotsOutOfRange, head ++ tail ++ "\"limits\":{\"upstream_slots\":0}}");
+    try expectParseError(error.LimitUpstreamSlotsOutOfRange, head ++ tail ++ "\"limits\":{\"upstream_slots\":99999}}");
+    // A specified relay-buffer count above the conn slots is a
+    // contradiction, not a derivable default.
+    try expectParseError(error.LimitRelayBuffersOverConnSlots, head ++ tail ++
+        "\"limits\":{\"conn_slots\":4,\"relay_buffers\":8}}");
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,9 +72,10 @@ pub const Config = struct {
         name: []const u8,
         endpoints: []const std.Io.net.IpAddress,
         /// The §7 endpoint-pick policy the balancer runs for this
-        /// cluster. The JSON field is optional and defaults to `p2c` —
-        /// the design's trajectory (§7: round-robin → P2C) — with `rr`
-        /// kept for strict rotation (predictable spread, cache warming).
+        /// cluster. The JSON field is optional and defaults to `p2c`
+        /// (the §7 default), with `rr` kept for strict rotation
+        /// (predictable spread, cache warming, pure-L4 clusters whose
+        /// load p2c cannot see).
         pick: Pick = .p2c,
 
         pub const Pick = enum(u1) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -802,13 +802,8 @@ fn validateRoutePrefix(prefix: []const u8) ParseError!void {
 /// The closed pick-policy vocabulary; anything else is its own error so
 /// a typo ("pc2") fails loudly instead of silently balancing as p2c.
 fn pickOf(literal: []const u8) error{ClusterPickUnknown}!Config.Cluster.Pick {
-    if (std.mem.eql(u8, literal, "rr")) {
-        return .rr;
-    }
-    if (std.mem.eql(u8, literal, "p2c")) {
-        return .p2c;
-    }
-    return error.ClusterPickUnknown;
+    return std.meta.stringToEnum(Config.Cluster.Pick, literal) orelse
+        error.ClusterPickUnknown;
 }
 
 /// The closed protocol vocabulary; anything else is its own error so a

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -231,21 +231,31 @@ comptime {
     ));
 }
 
-/// Total pool memory as a closed-form function of the limits. Slot sizes
-/// are runtime parameters because `Conn` is generic over the Io backend;
-/// the composition site passes `@sizeOf` of the concrete types and
-/// main.zig prints the result at startup (§5).
+/// Total pool memory as a closed-form function of the *effective* pool
+/// sizes (the config `limits` block may shrink them below the ceilings,
+/// §5). Slot sizes are runtime parameters because `Conn` is generic over
+/// the Io backend; the composition site passes `@sizeOf` of the concrete
+/// types and main.zig prints the result at startup.
 pub fn memoryBytesTotal(
+    conn_slots: u32,
     conn_bytes: u64,
+    relay_buffers: u32,
     relay_buffer_pair_bytes: u64,
+    upstream_slots: u32,
     upstream_bytes: u64,
 ) u64 {
+    assert(conn_slots >= 1);
+    assert(conn_slots <= conn_slots_max);
+    assert(relay_buffers >= 1);
+    assert(relay_buffers <= relay_buffers_max);
+    assert(upstream_slots >= 1);
+    assert(upstream_slots <= upstream_slots_max);
     assert(conn_bytes > 0);
     assert(relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
     assert(upstream_bytes >= head_bytes_max);
-    const total = conn_slots_max * conn_bytes +
-        relay_buffers_max * relay_buffer_pair_bytes +
-        upstream_slots_max * upstream_bytes;
+    const total = @as(u64, conn_slots) * conn_bytes +
+        @as(u64, relay_buffers) * relay_buffer_pair_bytes +
+        @as(u64, upstream_slots) * upstream_bytes;
     assert(total > 0);
     return total;
 }
@@ -274,12 +284,22 @@ test "budgets: memory total matches the closed form" {
     const conn_bytes: u64 = 10240;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
     const upstream_bytes: u64 = head_bytes_max + 64;
-    const expected = @as(u64, conn_slots_max) * conn_bytes +
+    // At the ceilings and at a shrunken (config-limits) shape alike.
+    const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes;
+    try std.testing.expectEqual(expected_max, memoryBytesTotal(
+        conn_slots_max,
+        conn_bytes,
+        relay_buffers_max,
+        pair_bytes,
+        upstream_slots_max,
+        upstream_bytes,
+    ));
+    const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
     try std.testing.expectEqual(
-        expected,
-        memoryBytesTotal(conn_bytes, pair_bytes, upstream_bytes),
+        expected_small,
+        memoryBytesTotal(64, conn_bytes, 8, pair_bytes, 8, upstream_bytes),
     );
 }
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -207,6 +207,10 @@ comptime {
     assert(headers_max >= 8);
     assert(host_bytes_max >= 1);
     assert(upstream_slots_max >= 1);
+    // The upstream pool's per-endpoint leased counts are u16: a bump past
+    // this ceiling would wrap them in ReleaseFast and silently corrupt
+    // the P2C load signal.
+    assert(upstream_slots_max <= std.math.maxInt(u16));
     assert(chunked_line_bytes_max >= 32);
     assert(chunked_line_bytes_max <= relay_buffer_bytes);
     assert(chunked_trailer_bytes_max >= chunked_line_bytes_max);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -39,27 +39,30 @@ pub const relay_buffers_max: u32 = conn_slots_max;
 /// LAN paths this proxy targets.
 pub const relay_buffer_bytes: u32 = 4 * 1024;
 
-/// §8 "watermarks before walls": the relay-buffer pool flips a pressure
-/// flag before it hits the wall so the proxy sheds *idle* capacity —
-/// shorter idle timeouts — before it must shed *work*. Hysteresis keeps
-/// the flag from flapping around a single threshold: engage at the high
+/// §8 "watermarks before walls": each pool flips a pressure flag before
+/// it hits the wall so the proxy sheds *idle* capacity — shorter idle
+/// timeouts, keep-alive no longer honored, parked connections reaped
+/// sooner — before it must shed *work*. One rule for all three pools
+/// (relay buffers, conn slots, upstream slots). Hysteresis keeps a flag
+/// from flapping around a single threshold: engage at the high
 /// watermark, release only after draining back to the low one. Both are
-/// fractions of the *live* pool capacity, so an injected test pool and the
-/// production pool obey one rule. `On` uses ceil so a full pool always
-/// counts as pressured; `Off` uses floor so the gap is non-empty for every
-/// capacity >= 1.
-pub fn relayPressureOn(capacity: u32) u32 {
+/// fractions of the *live* pool capacity, so an injected test pool and
+/// the production pool obey one rule. `On` uses ceil so a full pool
+/// always counts as pressured; `Off` uses floor so the gap is non-empty
+/// for every capacity >= 1.
+pub fn poolPressureOn(capacity: u32) u32 {
     return (capacity * 3 + 3) / 4;
 }
-pub fn relayPressureOff(capacity: u32) u32 {
+pub fn poolPressureOff(capacity: u32) u32 {
     return capacity / 2;
 }
 
-/// Under relay-buffer pressure the idle timeout is divided by this, reaping
-/// quiet connections sooner to return their buffers (§8). The result is
+/// Under pool pressure the idle timeout (and, for upstream pressure, the
+/// parked-connection deadline) is divided by this, reaping quiet
+/// connections sooner to return their resources (§8). The result is
 /// clamped to >= 1 ms so `storeDeadline`'s invariant holds even when the
 /// configured idle timeout is already small.
-pub const relay_pressure_idle_divisor: u32 = 4;
+pub const pressure_idle_divisor: u32 = 4;
 
 /// Upper bound on one L7 request or response head, including the final
 /// CRLF — the size of a connection slot's head buffer (§5). A request
@@ -202,7 +205,7 @@ comptime {
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);
     assert(accept_retry_delay_ms >= 1);
-    assert(relay_pressure_idle_divisor >= 2);
+    assert(pressure_idle_divisor >= 2);
     assert(head_bytes_max >= 1024);
     assert(headers_max >= 8);
     assert(host_bytes_max >= 1);
@@ -216,8 +219,8 @@ comptime {
     assert(chunked_trailer_bytes_max >= chunked_line_bytes_max);
     // The watermarks must leave a hysteresis gap and never engage above
     // the pool's own capacity, checked at the production size.
-    assert(relayPressureOn(relay_buffers_max) > relayPressureOff(relay_buffers_max));
-    assert(relayPressureOn(relay_buffers_max) <= relay_buffers_max);
+    assert(poolPressureOn(relay_buffers_max) > poolPressureOff(relay_buffers_max));
+    assert(poolPressureOn(relay_buffers_max) <= relay_buffers_max);
     // The conn-slot ceiling is derived, not chosen: the largest slot
     // count whose worst-case ops fit the ¾-CQ budget after the fixed
     // ops and the parked-upstream reservation are carved out (§8).
@@ -259,12 +262,12 @@ test "pressure: relay watermarks have a hysteresis gap at every capacity" {
     // tests inject as well as the production size — no flapping, never a
     // threshold the pool cannot reach.
     for ([_]u32{ 1, 2, 3, 4, 8, relay_buffers_max }) |capacity| {
-        try std.testing.expect(relayPressureOn(capacity) > relayPressureOff(capacity));
-        try std.testing.expect(relayPressureOn(capacity) <= capacity);
+        try std.testing.expect(poolPressureOn(capacity) > poolPressureOff(capacity));
+        try std.testing.expect(poolPressureOn(capacity) <= capacity);
     }
     // A full pool is always pressured; an empty pool never is.
-    try std.testing.expectEqual(@as(u32, 3), relayPressureOn(4));
-    try std.testing.expectEqual(@as(u32, 2), relayPressureOff(4));
+    try std.testing.expectEqual(@as(u32, 3), poolPressureOn(4));
+    try std.testing.expectEqual(@as(u32, 2), poolPressureOff(4));
 }
 
 test "budgets: memory total matches the closed form" {

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -52,6 +52,11 @@ pub const Counters = struct {
     /// answered 502 (§7, §8). A stale parked connection detected at
     /// checkout lands here too until Phase 2's free replay.
     l7_bad_gateway: Value = Value.init(0),
+    /// The §8 request-deadline verdict: the deadline expired mid-exchange
+    /// with no response byte sent, answered 504. A verdict, not a shed —
+    /// the connection completes normally — but every one rides a
+    /// `deadline_expired`, an inequality `reconcile` asserts.
+    l7_gateway_timeout: Value = Value.init(0),
     /// Completed L7 exchanges: a parsed origin response relayed back.
     l7_responses: Value = Value.init(0),
     /// Exchanges served over a parked upstream connection instead of a
@@ -103,6 +108,9 @@ pub const Counters = struct {
             counters.get("shed_draining");
         assert(completed <= admitted);
         assert(admitted <= accepted);
+        // Every 504 verdict rides a deadline expiry (§8) — the verdict
+        // path increments both, the teardown path only the expiry.
+        assert(counters.get("l7_gateway_timeout") <= counters.get("deadline_expired"));
         const flow_holds = admitted == completed + active_count;
         const gate_holds = accepted == admitted + shed;
         return flow_holds and gate_holds;

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -19,10 +19,13 @@ pub const Counters = struct {
     shed_conn_slots: Value = Value.init(0),
     /// §8 rung: relay buffers exhausted at admission → close.
     shed_relay_buffers: Value = Value.init(0),
-    /// §8 "watermarks before walls": relay-buffer pressure engaged
-    /// (false→true crossings of the high watermark). Not a shed — a bias
-    /// that precedes the wall — so it stays out of `reconcile`.
+    /// §8 "watermarks before walls": pool pressure engaged (false→true
+    /// crossings of a pool's high watermark), one counter per pool. Not
+    /// sheds — biases that precede the walls — so they stay out of
+    /// `reconcile`.
     relay_pressure_engaged: Value = Value.init(0),
+    conn_pressure_engaged: Value = Value.init(0),
+    upstream_pressure_engaged: Value = Value.init(0),
     /// §8 rung: request/idle deadline fired → teardown.
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -49,8 +49,8 @@ pub const Counters = struct {
     l7_shed_relay_buffers: Value = Value.init(0),
     l7_shed_upstream_slots: Value = Value.init(0),
     /// Upstream leg failed before any response byte reached the client:
-    /// answered 502 (§7, §8). A stale parked connection detected at
-    /// checkout lands here too until Phase 2's free replay.
+    /// answered 502 (§7, §8). A spent-replay second failure lands here
+    /// too — the one free §7 replay never loops.
     l7_bad_gateway: Value = Value.init(0),
     /// The §8 request-deadline verdict: the deadline expired mid-exchange
     /// with no response byte sent, answered 504. A verdict, not a shed —
@@ -62,6 +62,10 @@ pub const Counters = struct {
     /// Exchanges served over a parked upstream connection instead of a
     /// fresh dial — the §3 reuse win, witnessed.
     upstream_reused: Value = Value.init(0),
+    /// A reused connection was stale (dead on arrival, no response byte)
+    /// and its request took the one free §7 replay on a fresh dial.
+    /// Every replay rides a reuse — an inequality `reconcile` asserts.
+    upstream_replayed: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
@@ -111,6 +115,9 @@ pub const Counters = struct {
         // Every 504 verdict rides a deadline expiry (§8) — the verdict
         // path increments both, the teardown path only the expiry.
         assert(counters.get("l7_gateway_timeout") <= counters.get("deadline_expired"));
+        // Every §7 replay rides a checkout: only a reused connection's
+        // early failure is blamed on staleness.
+        assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));
         const flow_holds = admitted == completed + active_count;
         const gate_holds = accepted == admitted + shed;
         return flow_holds and gate_holds;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -290,7 +290,7 @@ pub fn Proxy(comptime IoType: type) type {
             // beats a fresh dial. A close that slipped through while it
             // was parked surfaces as a failure on first use — answered
             // 502 until Phase 2's free replay (docs/PLANS.md).
-            const pick = server.balancer.pick(conn.cluster_index);
+            const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 conn.upstream = parked;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -332,6 +332,21 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_dialing);
+            if (conn.l7.pending_verdict != .none) {
+                // The §8 dial-timeout verdict: the deadline canceled this
+                // connect. Whatever the result — the expected Canceled, a
+                // genuine failure, or a success that raced the cancel —
+                // the dial is condemned; a socket that arrived anyway is
+                // attached so respond's upstream disposal closes it.
+                assert(conn.l7.pending_verdict == .gateway_timeout);
+                conn.l7.pending_verdict = .none;
+                if (result) |socket| {
+                    conn.upstream.?.socket = socket;
+                    conn.upstream_socket = socket;
+                } else |_| {}
+                respond(server, conn, 504, "l7_gateway_timeout");
+                return;
+            }
             const socket = result catch {
                 server.counters.increment("upstream_connect_failed");
                 respond(server, conn, 502, "l7_bad_gateway");

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -321,7 +321,12 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
             conn.state = .l7_dialing;
+            // The head-read/idle timer is already armed; re-base it to the
+            // tighter per-try connect budget so a hung origin fires the §8
+            // 504 at connect_timeout, not idle_timeout (§4: the lazy timer
+            // never moves earlier on its own).
             server.storeDeadline(conn, server.config.connect_timeout_ms);
+            server.rebaseDeadline(conn);
             conn.arm(&conn.op_connect, "connect");
             server.io.connect(
                 pick.address,
@@ -1178,7 +1183,15 @@ pub fn Proxy(comptime IoType: type) type {
         fn resetForNextRequest(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.upstream == null);
-            assert(conn.armedCount() <= 1); // Only the deadline timer.
+            // The exchange is fully settled: no data or dial ops in flight.
+            // The lazy deadline timer stays armed across the turnaround (§4),
+            // and a dial rebase (§8) cancel may still be draining if the
+            // exchange outran it — both re-establish the next idle deadline.
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.armed.connect);
+            assert(!conn.armed.connect_cancel);
+            assert(conn.armed.deadline or conn.armed.deadline_cancel);
             server.releaseRelayBuffer(conn.relay_buffer.?);
             conn.relay_buffer = null;
             conn.head_len = 0;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -418,6 +418,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.request_leg == .sending_head);
             const l7 = &conn.l7;
             assert(l7.request_head_sent < l7.rendered_request_len);
+            l7.request_op_on_client = false; // A send on the upstream socket.
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
@@ -438,6 +439,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_head);
+            if (conn.l7.pending_verdict != .none) {
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const sent = result catch |err| {
                 server.witnessKernelPressure(err);
                 upstreamFailed(server, conn);
@@ -501,6 +506,7 @@ pub fn Proxy(comptime IoType: type) type {
             const direction = &conn.directions[0];
             assert(direction.sent_len < direction.transfer_len);
             const base = conn.l7.request_head_len;
+            conn.l7.request_op_on_client = false; // A send on the upstream socket.
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
@@ -521,6 +527,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_body_excess);
+            if (conn.l7.pending_verdict != .none) {
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const sent = result catch |err| {
                 server.witnessKernelPressure(err);
                 upstreamFailed(server, conn);
@@ -565,6 +575,9 @@ pub fn Proxy(comptime IoType: type) type {
         fn armRequestBodyRecv(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .pumping_body);
+            // A recv on the CLIENT socket: an expiry cannot force it, so
+            // the deadline verdict is unanswerable while this op is armed.
+            conn.l7.request_op_on_client = true;
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
@@ -585,6 +598,9 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .pumping_body);
+            // A client-side recv is never armed under a pending verdict:
+            // expiry is unanswerable then, and a verdict arms nothing.
+            assert(conn.l7.pending_verdict == .none);
             const received = result catch |err| {
                 // EOF mid-body is a truncated request; any failure here
                 // dooms the exchange in the client's own direction.
@@ -612,6 +628,9 @@ pub fn Proxy(comptime IoType: type) type {
             } else {
                 assert(feed.done);
                 conn.l7.request_leg = .done;
+                // The delivered recv was the flag's referent; keep the
+                // flag self-descriptive now that no request op is armed.
+                conn.l7.request_op_on_client = false;
             }
         }
 
@@ -619,6 +638,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             const direction = &conn.directions[0];
             assert(direction.sent_len < direction.transfer_len);
+            conn.l7.request_op_on_client = false; // A send on the upstream socket.
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
@@ -639,6 +659,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .pumping_body);
+            if (conn.l7.pending_verdict != .none) {
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const sent = result catch |err| {
                 server.witnessKernelPressure(err);
                 upstreamFailed(server, conn);
@@ -694,6 +718,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .awaiting_head);
+            if (conn.l7.pending_verdict != .none) {
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const received = result catch |err| {
                 server.witnessKernelPressure(err);
                 upstreamFailed(server, conn);
@@ -863,6 +891,9 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .sending_head);
+            // response_started blocks the verdict, so none is pending in
+            // any response-send handler (negative space).
+            assert(conn.l7.pending_verdict == .none);
             const sent = result catch |err| {
                 // The client is gone; nothing to answer anyone.
                 server.witnessKernelPressure(err);
@@ -913,6 +944,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .sending_body_excess);
+            assert(conn.l7.pending_verdict == .none); // response_started.
             const sent = result catch |err| {
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
@@ -964,6 +996,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .pumping_body);
+            assert(conn.l7.pending_verdict == .none); // response_started.
             const received = result catch |err| {
                 if (err == error.EndOfStream) {
                     if (conn.l7.response_framing == .until_close) {
@@ -1020,6 +1053,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .pumping_body);
+            assert(conn.l7.pending_verdict == .none); // response_started.
             const sent = result catch |err| {
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
@@ -1116,6 +1150,64 @@ pub fn Proxy(comptime IoType: type) type {
             conn.state = .l7_reading_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
             armHeadRecv(server, conn);
+        }
+
+        /// Whether an expired exchange can still be answered 504 (§8): no
+        /// response byte sent, and no armed op held on the *client* socket
+        /// — a client-side recv cannot be forced without closing the very
+        /// client the verdict would answer, and a stalled request body is
+        /// the client's own stall anyway. In the deferred-render window an
+        /// origin response may already sit parsed but unsent; it is
+        /// discarded — no byte of it reached the client, and the exchange
+        /// it belonged to could not complete regardless.
+        pub fn expiryAnswerable(conn: *const ConnType) bool {
+            assert(conn.state == .l7_exchanging);
+            if (conn.l7.response_started) {
+                return false;
+            }
+            if (conn.armed.data_client_to_upstream and conn.l7.request_op_on_client) {
+                return false;
+            }
+            return true;
+        }
+
+        /// Begin the §8 request-deadline verdict. Ops are never canceled
+        /// (§5) — they are *forced*: shutting the upstream socket down
+        /// makes each armed op on it complete with an error its handler
+        /// diverts to `settlePendingVerdict`. In `.l7_exchanging` at least
+        /// one data op is always armed (each leg holds its op while it
+        /// waits), so the verdict always settles in a forced completion,
+        /// never inline here.
+        pub fn beginExpiry(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.pending_verdict == .none);
+            assert(expiryAnswerable(conn));
+            assert(conn.armed.data_client_to_upstream or
+                conn.armed.data_upstream_to_client);
+            conn.l7.pending_verdict = .gateway_timeout;
+            server.io.shutdown(conn.upstream_socket.?, .both);
+        }
+
+        /// A completion landed with a verdict pending: once the last data
+        /// op settles, act on it. The forced op's result — error or a
+        /// racing data delivery already in flight — is deliberately
+        /// ignored, the exchange is condemned either way; and because the
+        /// divert runs before any error handling, a forced EPIPE never
+        /// pollutes the kernel-pressure witness.
+        fn settlePendingVerdict(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.pending_verdict != .none);
+            if (conn.armed.data_client_to_upstream or
+                conn.armed.data_upstream_to_client)
+            {
+                return; // The sibling's forced completion re-enters here.
+            }
+            const verdict = conn.l7.pending_verdict;
+            conn.l7.pending_verdict = .none;
+            switch (verdict) {
+                .none => unreachable,
+                .gateway_timeout => respond(server, conn, 504, "l7_gateway_timeout"),
+            }
         }
 
         /// The upstream leg failed. Answer 502 only when the client has

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -317,7 +317,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head or conn.state == .l7_exchanging);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
-            conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
+            conn.upstream = server.acquireUpstream(conn.cluster_index, pick.endpoint_index) orelse {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
             conn.state = .l7_dialing;
@@ -845,13 +845,16 @@ pub fn Proxy(comptime IoType: type) type {
 
             // The §8 persistence decision, made once and honored: honor
             // the client's ask unless pipelining, pressure, or drain says
-            // otherwise — then announce whatever was decided (§2). An
-            // until-close body forces the close unconditionally: the FIN
-            // is the only thing delimiting the relayed body for the
-            // client, exactly as it delimited it for us.
+            // otherwise — then announce whatever was decided (§2).
+            // Downstream pressure — relay buffers or conn slots near their
+            // walls — stops honoring keep-alive so idle capacity returns
+            // (§8 watermarks). An until-close body forces the close
+            // unconditionally: the FIN is the only thing delimiting the
+            // relayed body for the client, exactly as it delimited it
+            // for us.
             const keep_downstream = conn.l7.client_keep_alive and
                 !conn.l7.client_pipelined and !server.draining and
-                !server.relay_pressure and response.framing != .until_close;
+                !server.downstreamPressured() and response.framing != .until_close;
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const rendered = render.renderResponseHead(
@@ -1137,14 +1140,16 @@ pub fn Proxy(comptime IoType: type) type {
         /// Park the leased upstream on its endpoint's idle list (§5): the
         /// socket stays open with no armed op, the stored deadline hands
         /// reaping to the Server's sweep, and the conn detaches so its
-        /// teardown cannot close a connection it no longer owns.
+        /// teardown cannot close a connection it no longer owns. Under
+        /// upstream pressure the parked deadline shortens (§8 watermarks)
+        /// so idle parked sockets free their slots before the 503 wall.
         fn parkUpstream(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             const upstream = conn.upstream.?;
             assert(!upstream.parked);
             server.upstreams.park(upstream);
             upstream.deadline_ns = server.io.nowNs() +
-                @as(u64, server.idleTimeoutMs()) * std.time.ns_per_ms;
+                @as(u64, server.parkedTimeoutMs()) * std.time.ns_per_ms;
             server.ensureUpstreamSweep();
             conn.upstream = null;
             conn.upstream_socket = null;
@@ -1159,7 +1164,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.armed.data_upstream_to_client);
             if (conn.upstream) |leased| {
                 server.io.closeNow(conn.upstream_socket.?);
-                server.upstreams.release(leased);
+                server.releaseUpstream(leased);
                 conn.upstream = null;
                 conn.upstream_socket = null;
             }
@@ -1292,7 +1297,7 @@ pub fn Proxy(comptime IoType: type) type {
             const stale = conn.upstream.?;
             assert(stale.head_len == 0);
             server.io.closeNow(conn.upstream_socket.?);
-            server.upstreams.release(stale);
+            server.releaseUpstream(stale);
             conn.upstream = null;
             conn.upstream_socket = null;
             server.counters.increment("upstream_replayed");
@@ -1386,7 +1391,7 @@ pub fn Proxy(comptime IoType: type) type {
                 if (conn.upstream_socket) |socket| {
                     server.io.closeNow(socket);
                 }
-                server.upstreams.release(leased);
+                server.releaseUpstream(leased);
                 conn.upstream = null;
                 conn.upstream_socket = null;
             }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -19,8 +19,9 @@
 //! later request — §3's shared-pool win), and the downstream connection
 //! honors what its rendered response announced (§2), going idle at the
 //! cost of a slot + head buffer only (§5). Pipelining is unsupported
-//! (first response, then an announced close); the stale-checkout free
-//! replay and the §8 504 deadline verdict are Phase 2 (docs/PLANS.md).
+//! (first response, then an announced close). A stale checkout takes one
+//! free replay on a fresh dial (§7), and an expired exchange or dial
+//! that can still be answered gets the §8 request-deadline 504 verdict.
 //!
 //! Buffer ownership rotates, never overlaps: conn.head holds the request
 //! head until it is rendered, then stages the rendered response head;
@@ -30,6 +31,7 @@
 
 const std = @import("std");
 
+const Balancer = @import("../balancer.zig").Balancer;
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
 const Io = @import("../io/io.zig");
@@ -288,14 +290,15 @@ pub fn Proxy(comptime IoType: type) type {
 
             // The §3 reuse win: a parked connection to the picked endpoint
             // beats a fresh dial. A close that slipped through while it
-            // was parked surfaces as a failure on first use — answered
-            // 502 until Phase 2's free replay (docs/PLANS.md).
+            // was parked surfaces as a failure on first use — absorbed by
+            // the §7 free replay (`upstreamFailed`).
             const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 conn.upstream = parked;
                 conn.upstream_socket = parked.socket;
                 parked.head_len = 0;
+                conn.l7.upstream_was_reused = true;
                 conn.state = .l7_dialing;
                 // No await happened: this runs in the same callback as the
                 // parse whose result is still live, so the reuse path —
@@ -303,6 +306,17 @@ pub fn Proxy(comptime IoType: type) type {
                 renderRequestAndStartLegs(server, conn, request);
                 return;
             }
+            dialUpstream(server, conn, pick);
+        }
+
+        /// Acquire a fresh slot and dial `pick` under the per-try connect
+        /// deadline (§8) — shared by the first try (`routeRequest`) and
+        /// the §7 stale replay (`beginReplay`), so both tries dial
+        /// identically.
+        fn dialUpstream(server: *ServerType, conn: *ConnType, pick: Balancer.Pick) void {
+            assert(conn.state == .l7_reading_head or conn.state == .l7_exchanging);
+            assert(conn.upstream == null);
+            assert(conn.upstream_socket == null);
             conn.upstream = server.upstreams.acquire(conn.cluster_index, pick.endpoint_index) orelse {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
@@ -583,6 +597,9 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.l7.request_leg = .done;
             } else {
                 conn.l7.request_leg = .pumping_body;
+                // Relay chunks will flow and be overwritten: from here the
+                // try is no longer reconstructible — no replay (§7).
+                conn.l7.request_body_pumped = true;
                 armRequestBodyRecv(server, conn);
             }
         }
@@ -1222,10 +1239,94 @@ pub fn Proxy(comptime IoType: type) type {
             switch (verdict) {
                 .none => unreachable,
                 .gateway_timeout => respond(server, conn, 504, "l7_gateway_timeout"),
+                .replay => beginReplay(server, conn),
             }
         }
 
-        /// The upstream leg failed. Answer 502 only when the client has
+        /// Whether a failed try may take the one free §7 replay: the
+        /// connection was a checkout (only a *reused* connection's early
+        /// failure is blamed on staleness — a fresh dial's failure is the
+        /// origin's own), the replay is unspent, no response byte was
+        /// received, and the request leg never entered the body pump — the
+        /// whole try (head, and any body that arrived coalesced with it)
+        /// then still sits intact in conn.head, byte-for-byte
+        /// reconstructible. Once relay-buffer chunks flowed they were
+        /// overwritten and the origin may have consumed them: no replay.
+        /// This covers the dominant real case — a GET whose head send
+        /// landed in the kernel buffer while the parked origin's FIN was
+        /// already in flight, surfacing as EOF at the response recv with
+        /// the request leg already done.
+        fn replayEligible(conn: *const ConnType) bool {
+            assert(conn.state == .l7_exchanging);
+            if (!conn.l7.upstream_was_reused) {
+                return false;
+            }
+            if (conn.l7.replay_used) {
+                return false;
+            }
+            if (conn.l7.response_started) {
+                return false;
+            }
+            if (conn.upstream.?.head_len != 0) {
+                return false; // A response byte arrived: the origin spoke.
+            }
+            if (conn.l7.request_body_pumped) {
+                return false; // Relay chunks flowed; not reconstructible.
+            }
+            assert(conn.l7.request_leg != .idle);
+            assert(conn.l7.request_leg != .pumping_body); // Implied by the flag.
+            return true;
+        }
+
+        /// Take the one free replay: dispose the stale connection and run
+        /// the fresh-dial try from the same client bytes. The verdict is
+        /// already cleared; the caller (settle) proved both data ops free.
+        fn beginReplay(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.pending_verdict == .none);
+            assert(conn.l7.replay_used); // Spent before the try began.
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.l7.response_started);
+            assert(conn.relay_buffer != null); // Retained across the replay.
+            const stale = conn.upstream.?;
+            assert(stale.head_len == 0);
+            server.io.closeNow(conn.upstream_socket.?);
+            server.upstreams.release(stale);
+            conn.upstream = null;
+            conn.upstream_socket = null;
+            server.counters.increment("upstream_replayed");
+            // Rebuild the per-try state from the §7 source of truth — the
+            // client's bytes, intact in conn.head (the eligible legs sent
+            // only from it). The same bytes parsed at routing, so this
+            // cannot fail; the framing tracker MUST re-derive from the
+            // parse — the coalesced excess was already fed once and will
+            // be fed again on the fresh try.
+            var storage: parser.HeaderStorage = undefined;
+            const request = parser.parseRequestHead(
+                conn.head[0..conn.head_len],
+                false,
+                &storage,
+            ) catch unreachable;
+            assert(request.head_len == conn.l7.request_head_len);
+            conn.l7 = .{
+                .request_method = conn.l7.request_method,
+                .request_framing = framingFromParsed(request.framing),
+                .request_head_len = conn.l7.request_head_len,
+                .client_keep_alive = conn.l7.client_keep_alive,
+                .replay_used = true,
+                // upstream_was_reused stays default-false: the replay try
+                // is a fresh dial, and a second early failure answers 502.
+            };
+            conn.directions = .{ .{}, .{} };
+            // A fresh pick and a fresh dial — never another checkout (§7):
+            // the endpoint's whole idle list may be stale the same way.
+            const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
+            dialUpstream(server, conn, pick);
+        }
+
+        /// The upstream leg failed. A stale checkout takes its one free
+        /// replay (§7); otherwise answer 502 only when the client has
         /// seen no response byte and both data ops are free — the static
         /// response and its lingering drain need them, and ops are never
         /// canceled (§5). Otherwise the only honest outcome is teardown: a
@@ -1233,6 +1334,17 @@ pub fn Proxy(comptime IoType: type) type {
         /// completion the answer would need.
         fn upstreamFailed(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
+            assert(conn.l7.pending_verdict == .none); // Handlers divert first.
+            if (replayEligible(conn)) {
+                conn.l7.pending_verdict = .replay;
+                conn.l7.replay_used = true; // Spent now: a loop is impossible.
+                // Force the sibling op, if armed (the response recv during
+                // an excess send); settle acts immediately when both are
+                // already free (the head-send failure case).
+                server.io.shutdown(conn.upstream_socket.?, .both);
+                settlePendingVerdict(server, conn);
+                return;
+            }
             if (conn.l7.response_started or conn.armed.data_client_to_upstream or
                 conn.armed.data_upstream_to_client)
             {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -164,6 +164,9 @@ const HttpOrigin = struct {
     listening: bool = false,
     response: []const u8 = "",
     close_after_response: bool = false,
+    /// Read the whole request, then never answer — the stalled origin
+    /// that drives the §8 request-deadline 504 verdict.
+    mute: bool = false,
     conn: OConn = .{},
     accepted: bool = false,
     requests_served: u32 = 0,
@@ -238,6 +241,11 @@ const HttpOrigin = struct {
                 return;
             }
             oconn.request_complete = true;
+            if (oconn.origin.mute) {
+                // The stalled origin: request read in full, no answer, no
+                // armed op — the proxy's deadline is the only way out.
+                return;
+            }
             oconn.armSend();
         }
 
@@ -353,6 +361,8 @@ const Http1Bed = struct {
         origin_response: []const u8 = "",
         origin_listens: bool = true,
         origin_closes: bool = false,
+        /// The origin reads the whole request and never answers (§8 504).
+        origin_mute: bool = false,
         /// The single route's prefix; "/" is the catch-all. A narrower
         /// prefix lets a test drive the no-route 404 path (§7).
         route_prefix: []const u8 = "/",
@@ -400,6 +410,7 @@ const Http1Bed = struct {
         bed.origin = .{
             .response = options.origin_response,
             .close_after_response = options.origin_closes,
+            .mute = options.origin_mute,
         };
         if (options.origin_listens) {
             try bed.origin.start(&bed.sim_io, originAddress());
@@ -1127,6 +1138,95 @@ test "l7: the head-read deadline reaps a slowloris that never completes" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try bed.expectDrained();
+}
+
+test "l7: a mute origin earns the §8 request-deadline 504 verdict" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 70, .origin_mute = true });
+    defer bed.tearDown();
+
+    // The origin reads the request and never answers: the request
+    // deadline expires with no response byte sent, the armed response
+    // recv is forced by the upstream shutdown, and the client is
+    // answered the exact 504 static response instead of a silent close.
+    try bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    try bed.expectDrained();
+}
+
+test "l7: a client stalling its own body is torn down, never answered 504" {
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 71, .origin_response = response });
+    defer bed.tearDown();
+
+    // The client announces a 10-byte body but sends only 3: the request
+    // leg parks a recv on the CLIENT socket, which no verdict can force
+    // without closing the very client it would answer — the stall is the
+    // client's own, so expiry stays a teardown (§8).
+    try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nContent-Length: 10\r\n\r\nabc");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_gateway_timeout"));
+    try bed.expectDrained();
+}
+
+test "l7: a response already started forfeits the 504 — teardown only" {
+    // The origin sends a complete head but only half its announced body,
+    // then stalls: response_started blocks the verdict (a 504 appended
+    // to a half-relayed 200 would corrupt the stream), so the expiry
+    // tears down and the client sees the truncation.
+    const partial = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nhello";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 72, .origin_response = partial });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /truncated HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    // The head and the partial body arrived — and nothing else: no 504
+    // bytes were mixed into the condemned stream.
+    try std.testing.expect(std.mem.indexOf(u8, bed.client.response(), "200 OK") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bed.client.response(), "504") == null);
+    try std.testing.expect(std.mem.endsWith(u8, bed.client.response(), "hello"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_gateway_timeout"));
+    try bed.expectDrained();
+}
+
+test "l7: the 504 verdict path allocates nothing after init" {
+    // §9 zero-alloc gate for the pending-verdict machinery: the forced
+    // completion, the settle, and the static 504 answer must all run
+    // without an allocation. Counting run, then a failing run pinned to
+    // the init count.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var bed: Http1Bed = undefined;
+    try bed.setUp(failing.allocator(), .{ .seed = 73, .origin_mute = true });
+    defer bed.tearDown();
+    const allocations_after_init = failing.allocations;
+    try bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+    try bed.expectDrained();
+    // The verdict must actually have fired, or this gates nothing.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try std.testing.expectEqual(allocations_after_init, failing.allocations);
+
+    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = allocations_after_init,
+    });
+    var strict_bed: Http1Bed = undefined;
+    try strict_bed.setUp(strict.allocator(), .{ .seed = 73, .origin_mute = true });
+    defer strict_bed.tearDown();
+    try strict_bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+    try strict_bed.expectDrained();
 }
 
 test "l7: a single close-terminated exchange allocates nothing after init" {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1106,6 +1106,32 @@ test "l7: an unreachable origin is answered 502" {
     try bed.expectDrained();
 }
 
+test "l7: a dial that never completes is answered 504, not 502" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 74, .origin_listens = false });
+    defer bed.tearDown();
+
+    // A blackholed origin: the connect neither succeeds nor refuses, so
+    // only the connect deadline can end the dial — the §8 request-
+    // deadline verdict (RFC 9110 §15.6.5: no timely response from the
+    // upstream), distinct from the refused dial's prompt 502.
+    bed.sim_io.blackholeAddress(Http1Bed.originAddress());
+
+    try bed.exchange("GET /unreachable HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // A timeout is not a dial failure: the counters stay orthogonal.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    try bed.expectDrained();
+}
+
 test "l7: rejects survive 1-byte adversarial delivery across seeds" {
     var seed: u64 = 1;
     while (seed <= 15) : (seed += 1) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -361,6 +361,10 @@ const Http1Bed = struct {
     drain_timer_completion: SimIo.Completion,
 
     const idle_timeout_ms: u32 = 1000;
+    /// Deliberately 20× tighter than the idle timeout so a test can witness
+    /// the §8 dial re-base: a hung L7 dial must fire 504 at this budget, not
+    /// the far looser head-read/idle deadline (finding #1).
+    const connect_timeout_ms: u32 = 50;
 
     fn bindAddress() std.Io.net.IpAddress {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8080") catch unreachable;
@@ -418,7 +422,7 @@ const Http1Bed = struct {
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
-            .connect_timeout_ms = 50,
+            .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
@@ -1129,7 +1133,7 @@ test "l7: an unreachable origin is answered 502" {
     try bed.expectDrained();
 }
 
-test "l7: a dial that never completes is answered 504, not 502" {
+test "l7: a hung dial fires 504 at the connect budget, not the idle timeout" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{ .seed = 74, .origin_listens = false });
     defer bed.tearDown();
@@ -1140,6 +1144,7 @@ test "l7: a dial that never completes is answered 504, not 502" {
     // upstream), distinct from the refused dial's prompt 502.
     bed.sim_io.blackholeAddress(Http1Bed.originAddress());
 
+    const start_ns = bed.sim_io.nowNs();
     try bed.exchange("GET /unreachable HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
@@ -1152,6 +1157,12 @@ test "l7: a dial that never completes is answered 504, not 502" {
     // A timeout is not a dial failure: the counters stay orthogonal.
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_connect_failed"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    // Finding #1 (§8): the dial re-bases the head-read/idle timer to the
+    // per-try connect budget, so the verdict lands at connect_timeout_ms —
+    // never the 20×-looser idle_timeout_ms the head read was armed under.
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+    try std.testing.expect(elapsed_ms >= Http1Bed.connect_timeout_ms);
+    try std.testing.expect(elapsed_ms < Http1Bed.idle_timeout_ms);
     try bed.expectDrained();
 }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -381,6 +381,10 @@ const Http1Bed = struct {
         /// The origin closes the second accepted connection at accept —
         /// the replayed try fails too, pinning the one-replay budget.
         close_second_at_accept: bool = false,
+        /// Pool sizes, injectable so a test can cross the §8 watermarks.
+        conn_slots: u32 = 4,
+        relay_buffers: u32 = 2,
+        upstream_slots: u32 = 2,
         /// The single route's prefix; "/" is the catch-all. A narrower
         /// prefix lets a test drive the no-route 404 path (§7).
         route_prefix: []const u8 = "/",
@@ -420,9 +424,9 @@ const Http1Bed = struct {
             .max_lifetime_ms = 0,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
-            .conn_slots = 4,
-            .relay_buffers = 2,
-            .upstream_slots = 2,
+            .conn_slots = options.conn_slots,
+            .relay_buffers = options.relay_buffers,
+            .upstream_slots = options.upstream_slots,
         });
         try bed.server.start();
         bed.origin = .{
@@ -1447,6 +1451,62 @@ test "l7: a pipelining client gets its first response, then the close" {
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
+test "l7: keep-alive is not honored under conn-slot pressure" {
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 90,
+        .origin_response = response,
+        .conn_slots = 2,
+    });
+    defer bed.tearDown();
+
+    // Two concurrent clients fill both conn slots — the §8 watermark
+    // engages — so a keep-alive ask is answered with an announced close:
+    // idle downstream connections are exactly the capacity under
+    // pressure.
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expect(bed.server.counters.get("conn_pressure_engaged") >= 1);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        bed.client2.response(),
+        "Connection: close",
+    ) != null);
+    try std.testing.expect(!bed.server.conn_pressure); // Cleared on drain.
+    try bed.expectDrained();
+}
+
+test "l7: parked deadlines shorten under upstream pressure" {
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 91,
+        .origin_response = response,
+    });
+    defer bed.tearDown();
+
+    // Two concurrent exchanges lease both upstream slots — the §8
+    // watermark engages — so both connections park under a shortened
+    // deadline (idle/4, or idle/16 while relay pressure transiently
+    // overlaps) and the sweep reaps them well before the drain timer at
+    // the full idle timeout. Without the bias the parked deadline would
+    // be the full idle timeout and the reap count zero.
+    bed.client.drain_on_finish = false;
+    bed.client2.drain_on_finish = false;
+    bed.armDrainTimer(Http1Bed.idle_timeout_ms);
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expect(bed.server.counters.get("upstream_pressure_engaged") >= 1);
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("upstream_idle_reaped"));
+    try std.testing.expect(!bed.server.upstream_pressure); // Cleared by the reaps.
     try bed.expectDrained();
 }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -154,9 +154,9 @@ const HttpClient = struct {
 /// forwarded) and answers each with the canned `response`. It keeps its
 /// connection alive between requests — parked upstream connections come
 /// back to it — unless `close_after_response` scripts the origin-side
-/// close (until-close bodies, and the stale-parked scenario). One
-/// connection per scenario: a second accept trips an assert, which is
-/// itself the reuse witness.
+/// close (until-close bodies, and the stale-parked scenario). Two
+/// connections per scenario: the second accept serves the §7 replay's
+/// fresh dial; tests that must prove reuse assert `accepted_count == 1`.
 const HttpOrigin = struct {
     io: *SimIo = undefined,
     listener: SimIo.Listener = undefined,
@@ -167,8 +167,13 @@ const HttpOrigin = struct {
     /// Read the whole request, then never answer — the stalled origin
     /// that drives the §8 request-deadline 504 verdict.
     mute: bool = false,
-    conn: OConn = .{},
-    accepted: bool = false,
+    /// Close the second accepted connection immediately: the replayed
+    /// try fails too, pinning the one-replay budget (§7).
+    close_second_at_accept: bool = false,
+    /// Two connections: the second accept serves the §7 replay's fresh
+    /// dial. Tests that must prove reuse assert `accepted_count == 1`.
+    conns: [2]OConn = .{ .{}, .{} },
+    accepted_count: u32 = 0,
     requests_served: u32 = 0,
 
     const OConn = struct {
@@ -303,21 +308,31 @@ const HttpOrigin = struct {
             assert(err == error.Canceled);
             return;
         };
-        assert(!origin.accepted);
-        origin.accepted = true;
-        origin.conn.origin = origin;
-        origin.conn.socket = socket;
-        origin.conn.armRecv();
+        assert(origin.accepted_count < origin.conns.len);
+        const oconn = &origin.conns[origin.accepted_count];
+        origin.accepted_count += 1;
+        if (origin.close_second_at_accept and origin.accepted_count == 2) {
+            // The replay's fresh dial meets an instant close: its try
+            // fails with no response byte, and no second replay exists.
+            origin.io.closeNow(socket);
+            oconn.closed = true;
+            return;
+        }
+        oconn.origin = origin;
+        oconn.socket = socket;
+        oconn.armRecv();
         origin.armAccept();
     }
 
-    /// Close a still-open origin-side connection at scenario end so the
-    /// socket leak check is exact — its EOF delivery may race the loop
+    /// Close still-open origin-side connections at scenario end so the
+    /// socket leak check is exact — their EOF delivery may race the loop
     /// stop (the L4 harness does the same).
     fn closeRemaining(origin: *HttpOrigin) void {
-        if (origin.accepted and !origin.conn.closed) {
-            origin.io.closeNow(origin.conn.socket);
-            origin.conn.closed = true;
+        for (origin.conns[0..origin.accepted_count]) |*oconn| {
+            if (!oconn.closed) {
+                origin.io.closeNow(oconn.socket);
+                oconn.closed = true;
+            }
         }
     }
 
@@ -363,6 +378,9 @@ const Http1Bed = struct {
         origin_closes: bool = false,
         /// The origin reads the whole request and never answers (§8 504).
         origin_mute: bool = false,
+        /// The origin closes the second accepted connection at accept —
+        /// the replayed try fails too, pinning the one-replay budget.
+        close_second_at_accept: bool = false,
         /// The single route's prefix; "/" is the catch-all. A narrower
         /// prefix lets a test drive the no-route 404 path (§7).
         route_prefix: []const u8 = "/",
@@ -411,6 +429,7 @@ const Http1Bed = struct {
             .response = options.origin_response,
             .close_after_response = options.origin_closes,
             .mute = options.origin_mute,
+            .close_second_at_accept = options.close_second_at_accept,
         };
         if (options.origin_listens) {
             try bed.origin.start(&bed.sim_io, originAddress());
@@ -591,10 +610,10 @@ test "l7: a GET is proxied and the origin's response relayed back" {
         bed.client.response(),
     );
     // The origin received the request, rewritten with Connection: close.
-    try std.testing.expect(bed.origin.conn.request_complete);
+    try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
     const forwarded = try parser.parseRequestHead(
-        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         &storage,
     );
@@ -624,7 +643,7 @@ test "l7: the origin sees the canonical path, query verbatim (§7)" {
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     var storage: parser.HeaderStorage = undefined;
     const forwarded = try parser.parseRequestHead(
-        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         &storage,
     );
@@ -851,7 +870,7 @@ test "l7: filter header edits reach the origin, applied once" {
     try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
     var storage: parser.HeaderStorage = undefined;
     const forwarded = try parser.parseRequestHead(
-        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         &storage,
     );
@@ -889,7 +908,7 @@ test "l7: a filter rewrite changes only the forwarded path, not the route" {
     try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
     var storage: parser.HeaderStorage = undefined;
     const forwarded = try parser.parseRequestHead(
-        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         &storage,
     );
@@ -921,7 +940,7 @@ test "l7: a header edit reaches the origin exactly once under adversarial delive
         try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
         var storage: parser.HeaderStorage = undefined;
         const forwarded = try parser.parseRequestHead(
-            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
             false,
             &storage,
         );
@@ -956,7 +975,7 @@ test "l7: a path rewrite forwards the rewritten path under adversarial delivery"
         try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
         var storage: parser.HeaderStorage = undefined;
         const forwarded = try parser.parseRequestHead(
-            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
             false,
             &storage,
         );
@@ -1013,14 +1032,14 @@ test "l7: a POST body is forwarded and a sized response returned, byte-exact und
             bed.client.response(),
         );
         // The origin received the whole 11-byte body after the head.
-        try std.testing.expect(bed.origin.conn.request_complete);
+        try std.testing.expect(bed.origin.conns[0].request_complete);
         var storage: parser.HeaderStorage = undefined;
         const forwarded = try parser.parseRequestHead(
-            bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
             false,
             &storage,
         );
-        const body = bed.origin.conn.request_buffer[forwarded.head_len..bed.origin.conn.request_len];
+        const body = bed.origin.conns[0].request_buffer[forwarded.head_len..bed.origin.conns[0].request_len];
         try std.testing.expectEqualStrings("hello world", body);
         try bed.expectDrained();
     }
@@ -1054,14 +1073,14 @@ test "l7: a body coalesced with the head, larger than a relay buffer, forwards i
         bed.client.response(),
     );
     // The origin received the whole 6000-byte body byte-for-byte.
-    try std.testing.expect(bed.origin.conn.request_complete);
+    try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
     const forwarded = try parser.parseRequestHead(
-        bed.origin.conn.request_buffer[0..bed.origin.conn.request_len],
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         &storage,
     );
-    const forwarded_body = bed.origin.conn.request_buffer[forwarded.head_len..bed.origin.conn.request_len];
+    const forwarded_body = bed.origin.conns[0].request_buffer[forwarded.head_len..bed.origin.conns[0].request_len];
     try std.testing.expectEqualStrings(request[head.len..request_len], forwarded_body);
     try bed.expectDrained();
 }
@@ -1381,6 +1400,8 @@ test "l7: a parked upstream connection is reused across client connections" {
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("admitted"));
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("completed"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    // One origin connection served both requests — the reuse witness.
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
     try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
     try bed.expectDrained();
 }
@@ -1429,12 +1450,13 @@ test "l7: a pipelining client gets its first response, then the close" {
     try bed.expectDrained();
 }
 
-test "l7: a stale parked connection is answered 502 until Phase 2's replay" {
+test "l7: a stale parked connection is replayed for free on a fresh dial" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 54,
         // The origin's response claims keep-alive, but it closes right
-        // after — the §5 stale-parked scenario, detected on first use.
+        // after — the §5 stale-parked scenario, detected on first use
+        // and absorbed by the §7 free replay.
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         .origin_closes = true,
     });
@@ -1444,12 +1466,145 @@ test "l7: a stale parked connection is answered 502 until Phase 2's replay" {
     bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
     try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
 
+    // The second client's request hit the stale checkout, replayed onto
+    // a fresh dial, and was served — no 502 reaches anyone.
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client2.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    // Two origin connections served the two requests: the stale one and
+    // the replay's fresh dial.
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.accepted_count);
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a replayed POST re-sends its coalesced body intact" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 55,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_closes = true,
+    });
+    defer bed.tearDown();
+
+    // The second request carries a body that arrives coalesced with its
+    // head: the replay must re-derive the framing from the re-parse and
+    // re-feed the excess — double-consuming it would corrupt the body.
+    bed.client.next = &bed.client2;
+    bed.client2.request = "POST /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n" ++
+        "Content-Length: 5\r\n\r\nhello";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+    // The replay's connection received the whole POST — head and body —
+    // byte-intact.
+    const replay_conn = &bed.origin.conns[1];
+    try std.testing.expect(replay_conn.request_complete);
+    const forwarded = replay_conn.request_buffer[0..replay_conn.request_len];
+    try std.testing.expect(std.mem.startsWith(u8, forwarded, "POST /b HTTP/1.1\r\n"));
+    try std.testing.expect(std.mem.endsWith(u8, forwarded, "\r\n\r\nhello"));
+    try bed.expectDrained();
+}
+
+test "l7: the replay budget is one — a second early failure answers 502" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 56,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_closes = true,
+        .close_second_at_accept = true,
+    });
+    defer bed.tearDown();
+
+    // The stale checkout replays onto a fresh dial, which the origin
+    // closes at accept: that try fails with no response byte too — but
+    // the replay is spent and the fresh dial was never a reuse, so the
+    // §7 rule answers 502 rather than looping.
+    bed.client.next = &bed.client2;
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
     try std.testing.expectEqualStrings(
         "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
         bed.client2.response(),
     );
-    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.accepted_count);
     try bed.expectDrained();
+}
+
+test "l7: the stale replay survives 1-byte adversarial delivery across seeds" {
+    var seed: u64 = 80;
+    while (seed <= 83) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+            .origin_closes = true,
+        });
+        defer bed.tearDown();
+
+        bed.client.next = &bed.client2;
+        bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+        try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+            bed.client2.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: the replay path allocates nothing after init" {
+    // §9 zero-alloc gate for the §7 replay: stale detection, slot
+    // disposal, the re-parse, and the fresh dial must all run without an
+    // allocation. Counting run, then a failing run pinned to the count.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    const second_request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    const first_request = "GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var bed: Http1Bed = undefined;
+    try bed.setUp(failing.allocator(), .{
+        .seed = 57,
+        .origin_response = response,
+        .origin_closes = true,
+    });
+    defer bed.tearDown();
+    const allocations_after_init = failing.allocations;
+    bed.client.next = &bed.client2;
+    bed.client2.request = second_request;
+    try bed.exchange(first_request);
+    try bed.expectDrained();
+    // The replay must actually have fired, or this gates nothing.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+    try std.testing.expectEqual(allocations_after_init, failing.allocations);
+
+    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = allocations_after_init,
+    });
+    var strict_bed: Http1Bed = undefined;
+    try strict_bed.setUp(strict.allocator(), .{
+        .seed = 57,
+        .origin_response = response,
+        .origin_closes = true,
+    });
+    defer strict_bed.tearDown();
+    strict_bed.client.next = &strict_bed.client2;
+    strict_bed.client2.request = second_request;
+    try strict_bed.exchange(first_request);
+    try strict_bed.expectDrained();
 }

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -301,7 +301,8 @@ pub fn connect(
                     // A routing failure and a dial timeout are both "the
                     // endpoint could not be reached" — distinct from
                     // kernel-pressure/unknown (Unexpected), so upstream
-                    // health logic (Phase 2) can tell them apart.
+                    // health logic (deferred, docs/PLANS.md) can tell
+                    // them apart.
                     error.HostUnreachable => error.Unreachable,
                     error.TimedOut, error.ConnectionTimedOut => error.Unreachable,
                     error.Canceled => error.Canceled,

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,7 +46,7 @@ pub fn main(init: std.process.Init) !void {
 
     try global_io.init(arena);
     var server: ServerXev = undefined;
-    try server.init(arena, &global_io, &config, .{});
+    try server.init(arena, &global_io, &config, config.limits);
     try server.start();
     installSignalHandlers();
 
@@ -77,9 +77,16 @@ fn ensureFdBudget() !void {
 fn printBudgets(io: std.Io, config: *const zoxy.config.Config) !void {
     const constants = zoxy.constants;
     const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
+    // Pool memory reflects the *effective* limits (config may shrink the
+    // pools below the comptime ceilings, §5); fds and ring stay the
+    // comptime worst-case budgets — the asserted ceilings.
+    const limits = config.limits;
     const memory_total = constants.memoryBytesTotal(
+        limits.conn_slots,
         @sizeOf(ServerXev.ConnType),
+        limits.relay_buffers,
         @sizeOf(zoxy.RelayBuffer),
+        limits.upstream_slots,
         @sizeOf(UpstreamType),
     );
     var buffer: [1024]u8 = undefined;
@@ -95,11 +102,11 @@ fn printBudgets(io: std.Io, config: *const zoxy.config.Config) !void {
         \\
     , .{
         memory_total / 1024,
-        constants.conn_slots_max,
+        limits.conn_slots,
         @sizeOf(ServerXev.ConnType),
-        constants.relay_buffers_max,
+        limits.relay_buffers,
         @sizeOf(zoxy.RelayBuffer),
-        constants.upstream_slots_max,
+        limits.upstream_slots,
         @sizeOf(UpstreamType),
         constants.fds_max,
         constants.ring_entries,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -184,6 +184,16 @@ pub fn Conn(comptime IoType: type) type {
             /// True once any response byte reached the client — the §8
             /// verdict split between answering 502 and plain teardown.
             response_started: bool = false,
+            /// A verdict decided while data ops were still armed, acted on
+            /// when the last one settles: ops are never canceled (§5), they
+            /// are *forced* — the upstream socket is shut down and each
+            /// armed op completes with an error its handler diverts on.
+            pending_verdict: PendingVerdict = .none,
+            /// The armed request-leg op is a recv on the CLIENT socket
+            /// (the body pump). Such an op cannot be forced without closing
+            /// the client the verdict would answer, so expiry stays a
+            /// teardown then — the stall is the client's own body (§8).
+            request_op_on_client: bool = false,
             /// The client's persistence ask (RFC 9112 §9), captured at
             /// routing; the render-time decision may still announce close
             /// (pressure, drain, §8).
@@ -211,6 +221,13 @@ pub fn Conn(comptime IoType: type) type {
                 sending_body_excess,
                 pumping_body,
                 done,
+            };
+
+            /// The deferred §8 verdicts (`gateway_timeout` now; replay in
+            /// Phase 2's stale-replay slice extends this).
+            pub const PendingVerdict = enum(u8) {
+                none,
+                gateway_timeout,
             };
         };
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -210,6 +210,17 @@ pub fn Conn(comptime IoType: type) type {
             /// exchange completes and the connection closes, dropping the
             /// early bytes (§2 note; clients recover per RFC).
             client_pipelined: bool = false,
+            /// This try runs over a checked-out parked connection (§5) —
+            /// the precondition for the §7 stale replay: only a *reused*
+            /// connection's early failure is blamed on staleness.
+            upstream_was_reused: bool = false,
+            /// The request leg entered the body pump: relay-buffer chunks
+            /// flowed and were overwritten, so the try is no longer
+            /// reconstructible from conn.head — replay is off the table.
+            request_body_pumped: bool = false,
+            /// The one free replay is spent (§7): a failure on the replay
+            /// try answers 502 like any other, never a second replay.
+            replay_used: bool = false,
 
             pub const Leg = enum(u8) {
                 idle,
@@ -223,11 +234,13 @@ pub fn Conn(comptime IoType: type) type {
                 done,
             };
 
-            /// The deferred §8 verdicts (`gateway_timeout` now; replay in
-            /// Phase 2's stale-replay slice extends this).
+            /// The deferred verdicts: the §8 request-deadline 504 and the
+            /// §7 stale-replay retry, both settled once the last armed
+            /// data op is forced to completion.
             pub const PendingVerdict = enum(u8) {
                 none,
                 gateway_timeout,
+                replay,
             };
         };
 

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -23,7 +23,7 @@ const idle_none: u32 = std.math.maxInt(u32);
 
 /// Idle lists are indexed by the flattened endpoint key, so the head
 /// array covers the worst-case config shape.
-const endpoint_keys_max: u32 =
+pub const endpoint_keys_max: u32 =
     @as(u32, constants.clusters_max) * constants.endpoints_per_cluster_max;
 
 pub fn UpstreamPool(comptime IoType: type) type {
@@ -32,6 +32,11 @@ pub fn UpstreamPool(comptime IoType: type) type {
         idle_heads: [endpoint_keys_max]u32,
         /// Parked slots across all endpoints; leased = acquired − idle.
         idle_count: u32,
+        /// Slots leased per endpoint — the §7 P2C load signal: a lease
+        /// is a request in flight against that endpoint, so the balancer
+        /// compares two candidates' counts and picks the calmer one.
+        /// u16 holds the whole pool (`upstream_slots_max` ≤ 65535).
+        leased_counts: [endpoint_keys_max]u16,
 
         const Self = @This();
 
@@ -74,6 +79,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             try pool.slot_pool.init(arena, count);
             @memset(&pool.idle_heads, idle_none);
             pool.idle_count = 0;
+            @memset(&pool.leased_counts, 0);
             assert(pool.slot_pool.slots.len == count);
             assert(pool.leasedCount() == 0);
         }
@@ -92,6 +98,9 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.idle_prev = idle_none;
             upstream.head_len = 0;
             upstream.deadline_ns = 0;
+            const key = endpointKey(cluster_index, endpoint_index);
+            pool.leased_counts[key] += 1;
+            assert(pool.leased_counts[key] <= pool.slot_pool.slots.len);
             assert(pool.idle_count < pool.slot_pool.acquired_count);
             return upstream;
         }
@@ -113,6 +122,10 @@ pub fn UpstreamPool(comptime IoType: type) type {
             pool.idle_heads[key] = index;
             upstream.parked = true;
             pool.idle_count += 1;
+            // Parked is not leased: the P2C load signal counts only slots
+            // actually serving a request.
+            assert(pool.leased_counts[key] >= 1);
+            pool.leased_counts[key] -= 1;
             assert(pool.idle_count <= pool.slot_pool.acquired_count);
         }
 
@@ -156,6 +169,10 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.idle_prev = idle_none;
             upstream.parked = false;
             pool.idle_count -= 1;
+            // Back to leased — both for a checkout (serving again) and,
+            // transiently, for the reap path (its release decrements).
+            pool.leased_counts[key] += 1;
+            assert(pool.leased_counts[key] <= pool.slot_pool.slots.len);
         }
 
         /// Returns a leased slot to the free list at connection
@@ -165,6 +182,9 @@ pub fn UpstreamPool(comptime IoType: type) type {
             assert(!upstream.parked);
             assert(upstream.idle_next == idle_none);
             assert(upstream.idle_prev == idle_none);
+            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+            assert(pool.leased_counts[key] >= 1);
+            pool.leased_counts[key] -= 1;
             pool.slot_pool.release(upstream);
             assert(pool.idle_count <= pool.slot_pool.acquired_count);
         }
@@ -184,7 +204,9 @@ pub fn UpstreamPool(comptime IoType: type) type {
     };
 }
 
-fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
+/// Flattened per-endpoint key into `idle_heads`/`leased_counts`. Public so
+/// the balancer indexes the same load table the pool maintains (§7 P2C).
+pub fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
     assert(cluster_index < constants.clusters_max);
     assert(endpoint_index < constants.endpoints_per_cluster_max);
     return @as(u32, cluster_index) * constants.endpoints_per_cluster_max + endpoint_index;
@@ -310,6 +332,47 @@ test "upstream: exhaustion is a shed signal, parked slots stay counted" {
     pool.release(first);
     try std.testing.expectEqual(second, pool.checkout(0, 1).?);
     pool.release(second);
+    try std.testing.expect(pool.isFullyReleased());
+}
+
+test "upstream: leased counts track every lease transition per endpoint" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var pool: TestPool = undefined;
+    try pool.init(arena_state.allocator(), 4);
+    const key_a = endpointKey(0, 0);
+    const key_b = endpointKey(0, 1);
+
+    // Fresh dials lease against their own endpoints.
+    const first = pool.acquire(0, 0).?;
+    const second = pool.acquire(0, 0).?;
+    const other = pool.acquire(0, 1).?;
+    try std.testing.expectEqual(@as(u16, 2), pool.leased_counts[key_a]);
+    try std.testing.expectEqual(@as(u16, 1), pool.leased_counts[key_b]);
+
+    // Parking returns the lease; checkout takes it again.
+    pool.park(first);
+    try std.testing.expectEqual(@as(u16, 1), pool.leased_counts[key_a]);
+    const reused = pool.checkout(0, 0).?;
+    try std.testing.expectEqual(first, reused);
+    try std.testing.expectEqual(@as(u16, 2), pool.leased_counts[key_a]);
+
+    // The reap path (unpark from parked, then release) nets to zero.
+    pool.park(second);
+    try std.testing.expectEqual(@as(u16, 1), pool.leased_counts[key_a]);
+    pool.unpark(second);
+    try std.testing.expectEqual(@as(u16, 2), pool.leased_counts[key_a]);
+    pool.release(second);
+    try std.testing.expectEqual(@as(u16, 1), pool.leased_counts[key_a]);
+
+    // Releases drain both endpoints back to zero, agreeing with the
+    // pool-wide count the whole way down.
+    try std.testing.expectEqual(pool.leasedCount(), @as(u32, pool.leased_counts[key_a]) +
+        pool.leased_counts[key_b]);
+    pool.release(reused);
+    pool.release(other);
+    try std.testing.expectEqual(@as(u16, 0), pool.leased_counts[key_a]);
+    try std.testing.expectEqual(@as(u16, 0), pool.leased_counts[key_b]);
     try std.testing.expect(pool.isFullyReleased());
 }
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -536,9 +536,35 @@ test "server: relay-buffer pressure engages before the wall and drains clean" {
     try bed.expectDrained();
 }
 
+test "server: conn-slot pressure engages before the wall and drains clean" {
+    // Four L4 connections hold all four conn slots (their dials are
+    // black-holed, so each lives to its connect deadline). Crossing the
+    // 3/4 high watermark flips the conn-pressure flag; it clears again
+    // as the pool drains, and every counter still reconciles.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .server = .{ .conn_slots = 4, .relay_buffers = 4 },
+        .sim = .{ .seed = 73 },
+    });
+    defer bed.tearDown();
+
+    bed.sim_io.blackholeAddress(TestBed.originAddress());
+    bed.startClients(4, false);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 4), bed.server.counters.get("admitted"));
+    try std.testing.expect(bed.server.counters.get("conn_pressure_engaged") >= 1);
+    // Pressure is a transient bias, not a terminal state.
+    try std.testing.expect(!bed.server.conn_pressure);
+    try std.testing.expectEqual(@as(u64, 4), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
 test "server: idle timeout shortens under pressure, is full otherwise" {
-    // The pure selection rule the pressure flag drives: full timeout when
-    // relaxed, divided (floored at 1 ms) when pressured.
+    // The pure selection rules the pressure flags drive: full timeouts
+    // when relaxed; the idle timeout divides under either downstream
+    // pressure (relay or conn); the parked deadline divides again under
+    // upstream pressure — each floored at 1 ms.
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .sim = .{ .seed = 72 },
@@ -546,14 +572,25 @@ test "server: idle timeout shortens under pressure, is full otherwise" {
     });
     defer bed.tearDown();
 
-    try std.testing.expect(!bed.server.relay_pressure);
+    try std.testing.expect(!bed.server.downstreamPressured());
     try std.testing.expectEqual(@as(u32, 1000), bed.server.idleTimeoutMs());
+    try std.testing.expectEqual(@as(u32, 1000), bed.server.parkedTimeoutMs());
     bed.server.relay_pressure = true;
-    try std.testing.expectEqual(
-        @as(u32, 1000 / 4),
-        bed.server.idleTimeoutMs(),
-    );
+    try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.idleTimeoutMs());
     bed.server.relay_pressure = false;
+    bed.server.conn_pressure = true;
+    try std.testing.expect(bed.server.downstreamPressured());
+    try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.idleTimeoutMs());
+    bed.server.conn_pressure = false;
+    // Upstream pressure biases only the parked deadline, not the idle
+    // timeout; under both it compounds.
+    bed.server.upstream_pressure = true;
+    try std.testing.expectEqual(@as(u32, 1000), bed.server.idleTimeoutMs());
+    try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.parkedTimeoutMs());
+    bed.server.conn_pressure = true;
+    try std.testing.expectEqual(@as(u32, 1000 / 16), bed.server.parkedTimeoutMs());
+    bed.server.conn_pressure = false;
+    bed.server.upstream_pressure = false;
 }
 
 test "server: refused upstream tears the connection down and is counted" {


### PR DESCRIPTION
## Phase 2 — shedding hardening + minimal resilience

Implements the Phase 2 plan from `docs/PLANS.md`: P2C endpoint pick, the §8
request-deadline 504 verdicts (exchange **and** dial), stale-replay, the
remaining pressure watermarks, a config `limits` block, and the overload
benchmark — followed by a full code-review pass.

### Slices (one commit each, dependency order)

- **`feat(balancer)` — §7 configurable endpoint pick.** Per-cluster
  `"pick": "rr" | "p2c"` (default p2c); fixed-seed xorshift for a
  deterministic, replayable balancer. Single-endpoint clusters short-circuit.
- **`feat(l7)` — §8 request-deadline 504 verdict.** Pending-verdict machinery:
  an expired exchange with no response byte on the wire is forced via
  `shutdown(.both)` (ops are never canceled, §5) and answered 504 once both
  data ops drain, instead of a silent teardown.
- **`feat(l7)` — §8 dial-timeout 504.** A never-completing connect reads as
  504 (RFC 9110 §15.6.5); refused/unreachable dials keep their prompt 502.
  The one connect cancel outside teardown.
- **`feat(l7)` — §7 stale-replay.** A reused upstream that fails on first use,
  with no response byte seen and the request leg still reconstructible from
  the client's bytes, takes one free replay over a fresh dial — no longer an
  automatic 502.
- **`feat(server)` — §8 conn-slot and upstream-pool pressure watermarks.**
  Both recomputed at acquire/release with hysteresis; biases shorten idle and
  parked deadlines and announce `Connection: close` under pressure.
- **`feat(config)` — §5 limits block + §9 overload benchmark.** Optional
  `{conn_slots, relay_buffers, upstream_slots}` (comptime constants stay the
  hard ceiling, config may only shrink); an overload bench scenario witnesses
  the real 503 rungs under a flat-RSS gate.

### Code-review pass (final two commits)

A high-effort review of the branch surfaced 10 findings; all are fixed:

- **Finding 1 (confirmed, architectural) — L7 dial deadline re-base.** The single
  lazy timer never moves *earlier* once armed (§4), so a hung L7 dial fired
  its 504 at `idle_timeout`, not the tighter `connect_timeout` the head-read
  timer was armed under. `dialUpstream` now cancels + re-arms the timer down
  to the connect budget — a second, non-teardown deadline cancel. Race-free by
  one invariant: **the timer is never re-armed while its cancel is in flight.**
  Overlapping rebases across a keep-alive turnaround defer to the in-flight
  cancel; teardown drains an in-flight rebase through the `isTearingDown`
  checks. This also fixed a latent bug in `resetForNextRequest`'s quiescence
  assert (a draining rebase cancel can outlive the exchange). DESIGN.md §4/§5
  updated to record the second cancel site.
- **Findings 2–10 (cleanups + correctness):** verdict-grace bound to the fixed idle
  timeout (not the pressure-biased one), `armConnectCancel` extraction,
  upstream acquire/release asserts, `pickOf` via `std.meta.stringToEnum`,
  bench stall gate tightened to `<`, sim draws each cluster's pick policy
  independently.

### Verification

- `zig build ci` (unit + fuzz corpus + boundary lint + 64-seed sim) — green.
- `zig fmt --check` — clean.
- **240,000 sim seeds** green across the schedule fuzz (the new verdict/replay
  and dial-rebase races live here).
- Finding 1's fix is **mutation-verified**: a virtual-clock witness asserts
  the 504 lands within `[connect_timeout_ms, idle_timeout_ms)`; neutralizing
  the rebase fails exactly that bound.
- `tiger-style-reviewer` on the final diff: no violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
