### PR TITLE
Generate config JSON Schema and ship it as a release asset (#53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,13 @@ jobs:
             echo "::endgroup::"
           done
 
+          # The config JSON Schema is target-independent, so emit it once
+          # (§5). It is generated from the Zig config definitions, never
+          # committed; shipping it here as an asset keeps a single source of
+          # truth. The sha256sum step below checksums it with the archives.
+          devenv shell -- zig build schema
+          cp zig-out/config.schema.json "dist/zoxy-$version-config.schema.json"
+
           ( cd dist && sha256sum * > SHA256SUMS.txt )
           ls -la dist
 

--- a/build.zig
+++ b/build.zig
@@ -97,6 +97,29 @@ pub fn build(b: *std.Build) void {
     const sim_step = b.step("sim", "Deterministic simulation: -- [seed] [iterations] | fuzz");
     sim_step.dependOn(&sim_run.step);
 
+    // §5 config schema: a standalone tool renders the JSON Schema derived
+    // from the config definitions (constants + the source enums), and
+    // `zig build schema` installs it as zig-out/config.schema.json for the
+    // release workflow to ship as an asset. Deliberately not wired into
+    // `ci`: the emitter's own tests run under `test`; the file itself is a
+    // release-only artifact, so nothing here needs to gate every change.
+    const schema_exe = b.addExecutable(.{
+        .name = "zoxy-schema",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/schema.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zoxy", .module = zoxy_module },
+            },
+        }),
+    });
+    const schema_run = b.addRunArtifact(schema_exe);
+    const schema_output = schema_run.captureStdOut(.{ .basename = "config.schema.json" });
+    const schema_install = b.addInstallFile(schema_output, "config.schema.json");
+    const schema_step = b.step("schema", "Emit the config JSON Schema to zig-out/config.schema.json");
+    schema_step.dependOn(&schema_install.step);
+
     // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash),
     // and the zoxy under test is a ReleaseFast build — matching the
     // shipped binary — whatever -Doptimize says. ReleaseFast selects the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -387,6 +387,18 @@ Rules:
   relays (§6).
 - **The config arena is the only allocating region** — parse-once,
   immutable, shared read-only. (Carried verbatim; it worked.)
+- **The config surface has a generated JSON Schema.** `zig build schema`
+  reflects over the `*Json` parse structs and their co-located metadata
+  (`src/config_schema.zig`) to emit a draft 2020-12 schema — structure,
+  `required`, `additionalProperties: false` (the parser is strict), enums,
+  and every numeric bound traced back to `src/constants.zig`. It is a
+  release-only asset, never committed (so it cannot drift); the emitter's
+  tests run under `zig build ci`, and `assert_meta_matches` fails the build
+  if a field lacks schema metadata. It intentionally stops at what JSON
+  Schema can express: the loader's semantic checks (canonical
+  prefixes/hosts, address literals, reserved header names, port ≠ 0) and
+  the "exactly one of" forks stay the loader's job, so passing the schema
+  means well-shaped, not accepted.
 - **A slot is released only when its armed-op set is empty.** Every op
   references a completion embedded in the slot, and the slot header
   tracks which are armed. Teardown is a *state*, not an event: shutdown

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -244,3 +244,9 @@ queue, in rough value order:
   (§8).
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
+- Config JSON Schema — the generator ships (`zig build schema`, reflected
+  from the config definitions, released as an asset per §5). Deferred until
+  there is a reason: host it at its stable `$id`
+  (`https://zoxy.io/schema/config.schema.json`) and add a `"$schema"`
+  pointer to `config/example.json` once it resolves; an optional
+  `zoxy --schema` subcommand so the shipped binary can emit its own schema.

--- a/src/config.zig
+++ b/src/config.zig
@@ -192,22 +192,67 @@ fn resolveLimits(limits_json: *const LimitsJson) ValidationError!Config.Limits {
     };
 }
 
-const ConfigJson = struct {
+// The strict parser binds JSON to these `*Json` DTOs. Each carries the
+// schema metadata reflection cannot infer — prose (`schema_doc`, per-field
+// `.desc`), closed vocabularies (`.enum_type`, `.int_values`, `.items`),
+// and numeric bounds (`.minimum`/`.maximum`/`.min_items`/…) — co-located
+// with the fields so the two never drift. `assert_meta_matches` (below)
+// cross-checks metadata against the real fields at comptime, and
+// `config_schema.zig` walks the same DTOs to emit the JSON Schema. Public
+// so the emitter and its tests can reflect over the real wire shape.
+pub const ConfigJson = struct {
     listeners: []const ListenerJson,
     clusters: ClustersJson,
     timeouts: TimeoutsJson,
     /// Optional pool shrinks (§5, §8); absent fields keep the comptime
     /// ceilings.
     limits: LimitsJson = .{},
+
+    pub const schema_doc =
+        "Startup config for the zoxy L4/L7 proxy. Encodes structure, enums, " ++
+        "and numeric bounds; semantic checks (canonical route prefixes/hosts, " ++
+        "IP:port literal parsing, reserved header names, endpoint port != 0) " ++
+        "are enforced by the loader and are not expressible in JSON Schema.";
+    pub const schema_fields = .{
+        .listeners = .{
+            .desc = "Sockets the proxy accepts connections on.",
+            .min_items = 1,
+            .max_items = constants.listeners_max,
+        },
+        .clusters = .{ .desc = "Named upstream clusters, keyed by cluster name." },
+        .timeouts = .{ .desc = "Connection lifecycle deadlines (milliseconds)." },
+        .limits = .{ .desc = "Optional pool shrinks; absent keeps the compiled ceilings." },
+    };
 };
 
-const LimitsJson = struct {
+pub const LimitsJson = struct {
     conn_slots: ?u32 = null,
     relay_buffers: ?u32 = null,
     upstream_slots: ?u32 = null,
+
+    pub const schema_doc =
+        "Optional pool shrinks; absent keeps the compiled ceilings. Config " ++
+        "may only shrink a pool below its ceiling, never grow it.";
+    pub const schema_fields = .{
+        .conn_slots = .{
+            .desc = "Concurrent connection slots.",
+            .minimum = 1,
+            .maximum = constants.conn_slots_max,
+        },
+        .relay_buffers = .{
+            .desc = "Relay buffer pairs (bounds concurrent L4 and L7 body relays).",
+            .minimum = 1,
+            .maximum = constants.relay_buffers_max,
+        },
+        .upstream_slots = .{
+            .desc = "Shared upstream connection slots.",
+            .minimum = 1,
+            .maximum = constants.upstream_slots_max,
+        },
+    };
 };
 
-const ListenerJson = struct {
+pub const ListenerJson = struct {
     bind: []const u8,
     /// Exactly one of `cluster` (sugar for a single catch-all route) or
     /// `routes` (an explicit §7 path table) must be present.
@@ -217,71 +262,203 @@ const ListenerJson = struct {
     filters: ?[]const FilterJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
+
+    pub const schema_doc =
+        "One accepting socket. Exactly one of `cluster` or `routes` selects " ++
+        "the upstream — that fork is enforced by the loader, not this schema.";
+    pub const schema_fields = .{
+        .bind = .{ .desc = "IP:port literal to bind (hostnames are rejected — DNS is a non-goal)." },
+        .cluster = .{ .desc = "Sugar for a single catch-all route to this cluster; mutually exclusive with routes." },
+        .routes = .{
+            .desc = "Explicit longest-prefix route table (http listeners only).",
+            .min_items = 1,
+            .max_items = constants.routes_max,
+        },
+        .filters = .{
+            .desc = "Request filter rules, evaluated top-down (http listeners only).",
+            .max_items = constants.filters_per_listener_max,
+        },
+        .protocol = .{
+            .desc = "What the listener speaks: l4 relays bytes blindly, http runs the reverse-proxy state machine.",
+            .enum_type = Config.Listener.Protocol,
+        },
+    };
 };
 
-const FilterJson = struct {
+pub const FilterJson = struct {
     match: MatchJson = .{},
     actions: []const ActionJson,
+
+    pub const schema_doc = "One filter rule: a match predicate and the actions applied when it matches.";
+    pub const schema_fields = .{
+        .match = .{ .desc = "Match predicate; absent fields match anything." },
+        .actions = .{
+            .desc = "Actions applied in order when the rule matches.",
+            .min_items = 1,
+            .max_items = constants.actions_per_filter_max,
+        },
+    };
 };
 
-const MatchJson = struct {
+pub const MatchJson = struct {
     /// Registered method tokens (uppercase); absent = any method.
     method: ?[]const []const u8 = null,
     host: ?[]const u8 = null,
     path_prefix: ?[]const u8 = null,
     headers: ?[]const HeaderMatchJson = null,
+
+    pub const schema_doc = "Request-match predicate; every absent field matches anything.";
+    pub const schema_fields = .{
+        .method = .{
+            .desc = "Registered request-method tokens; absent matches any method.",
+            .min_items = 1,
+            .items = SchemaItems.http_method,
+        },
+        .host = .{ .desc = "Canonical host to match; absent matches any host." },
+        .path_prefix = .{ .desc = "Canonical origin-form path prefix; must start with a slash." },
+        .headers = .{
+            .desc = "Header predicates; all must match.",
+            .max_items = constants.header_matches_per_filter_max,
+        },
+    };
 };
 
-const HeaderMatchJson = struct {
+pub const HeaderMatchJson = struct {
     name: []const u8,
     /// Exactly one of these selects the predicate kind.
     present: ?bool = null,
     equals: ?[]const u8 = null,
     contains: ?[]const u8 = null,
+
+    pub const schema_doc =
+        "One header predicate. Exactly one of `present`/`equals`/`contains` " ++
+        "selects the kind — that fork is enforced by the loader.";
+    pub const schema_fields = .{
+        .name = .{ .desc = "Header field name (matched case-insensitively)." },
+        .present = .{
+            .desc = "Matches when the header is present (present: false is rejected).",
+            .const_true = true,
+        },
+        .equals = .{ .desc = "Matches when the header value equals this string." },
+        .contains = .{
+            .desc = "Matches when the header value contains this substring.",
+            .min_length = 1,
+        },
+    };
 };
 
 /// One action object carries exactly one field (the action's kind), the
 /// same "struct of optionals, validate exactly-one" shape the listener's
 /// cluster/routes fork uses — no JSON union parsing.
-const ActionJson = struct {
+pub const ActionJson = struct {
     reject: ?u16 = null,
     header_set: ?HeaderEditJson = null,
     header_add: ?HeaderEditJson = null,
     header_remove: ?[]const u8 = null,
     rewrite_prefix: ?RewriteJson = null,
+
+    pub const schema_doc =
+        "One filter action. Exactly one field is set — the action's kind — " ++
+        "and that fork is enforced by the loader.";
+    pub const schema_fields = .{
+        .reject = .{
+            .desc = "Reject the request with this status code.",
+            .int_values = &filter.reject_statuses,
+        },
+        .header_set = .{ .desc = "Set (replace) a request header." },
+        .header_add = .{ .desc = "Append a request header." },
+        .header_remove = .{ .desc = "Remove a request header by name." },
+        .rewrite_prefix = .{ .desc = "Rewrite the request path prefix before proxying." },
+    };
 };
 
-const HeaderEditJson = struct {
+pub const HeaderEditJson = struct {
     name: []const u8,
     value: []const u8,
+
+    pub const schema_doc = "A header name/value pair for header_set / header_add.";
+    pub const schema_fields = .{
+        .name = .{ .desc = "Header field name." },
+        .value = .{ .desc = "Header field value." },
+    };
 };
 
-const RewriteJson = struct {
+pub const RewriteJson = struct {
     from: []const u8,
     to: []const u8,
+
+    pub const schema_doc = "A path-prefix rewrite: strip `from`, prepend `to`.";
+    pub const schema_fields = .{
+        .from = .{ .desc = "Canonical path prefix to strip; must start with a slash." },
+        .to = .{ .desc = "Canonical path prefix to prepend; must start with a slash." },
+    };
 };
 
-const RouteJson = struct {
+pub const RouteJson = struct {
     /// Optional §7 host scope; absent means the route matches any host.
     host: ?[]const u8 = null,
     prefix: []const u8,
     cluster: []const u8,
+
+    pub const schema_doc = "One longest-prefix route entry.";
+    pub const schema_fields = .{
+        .host = .{ .desc = "Canonical host scope; absent matches any host." },
+        .prefix = .{ .desc = "Canonical origin-form path prefix; must start with a slash." },
+        .cluster = .{ .desc = "Name of the cluster matching requests route to." },
+    };
 };
 
-const ClusterJson = struct {
+pub const ClusterJson = struct {
     endpoints: []const []const u8,
     /// Optional §7 pick policy; absent means `p2c` (the design's
     /// trajectory), `rr` opts back into strict rotation.
     pick: []const u8 = "p2c",
+
+    pub const schema_doc = "One upstream cluster: its endpoints and pick policy.";
+    pub const schema_fields = .{
+        .endpoints = .{
+            .desc = "IP:port endpoint literals (port must be non-zero).",
+            .min_items = 1,
+            .max_items = constants.endpoints_per_cluster_max,
+        },
+        .pick = .{
+            .desc = "Endpoint-pick policy: p2c (power-of-two-choices) or rr (strict round-robin).",
+            .enum_type = Config.Cluster.Pick,
+        },
+    };
 };
 
-const TimeoutsJson = struct {
+pub const TimeoutsJson = struct {
     connect_ms: u32,
     idle_ms: u32,
     drain_deadline_ms: u32,
     /// Optional: absent or `0` means "no cap" (§6). The default keeps every
     /// pre-existing config valid and leaves max-lifetime opt-in.
     max_lifetime_ms: u32 = 0,
+
+    pub const schema_doc = "Connection lifecycle deadlines, in milliseconds.";
+    pub const schema_fields = .{
+        .connect_ms = .{
+            .desc = "Per-try upstream connect budget.",
+            .minimum = 1,
+            .maximum = constants.timeout_ms_max,
+        },
+        .idle_ms = .{
+            .desc = "Idle / head-read deadline.",
+            .minimum = 1,
+            .maximum = constants.timeout_ms_max,
+        },
+        .drain_deadline_ms = .{
+            .desc = "Graceful-drain deadline on shutdown.",
+            .minimum = 1,
+            .maximum = constants.timeout_ms_max,
+        },
+        .max_lifetime_ms = .{
+            .desc = "Absolute connection-age cap; 0 disables it.",
+            .minimum = 0,
+            .maximum = constants.timeout_ms_max,
+        },
+    };
 };
 
 /// JSON object map of cluster name → cluster, parsed into a bounded array
@@ -289,7 +466,7 @@ const TimeoutsJson = struct {
 /// silently keep the last duplicate — negative space we refuse to have).
 /// Bodies past the capacity are skipped but counted, so the over-limit
 /// error stays distinct from a syntax error.
-const ClustersJson = struct {
+pub const ClustersJson = struct {
     entries: [constants.clusters_max]Entry,
     seen_count: u32,
 
@@ -337,11 +514,81 @@ const ClustersJson = struct {
     }
 };
 
+/// Marker for array-item vocabularies reflection can't infer from the
+/// element type alone. `http_method` means "the items are the registered
+/// HTTP method tokens", which `config_schema.zig` emits as a token enum.
+pub const SchemaItems = enum { http_method };
+
+/// The attribute keys a `schema_fields` entry may carry beyond `.desc`.
+/// `assert_meta_matches` rejects any other key at comptime, so a typo'd
+/// attribute is a compile error, not silently-ignored data.
+const schema_attributes = [_][]const u8{
+    "desc",       "minimum",    "maximum",   "min_items",  "max_items",
+    "min_length", "const_true", "enum_type", "int_values", "items",
+};
+
+/// Cross-check a DTO's schema metadata against its real fields at comptime:
+/// every field needs an entry (so adding a field without documenting it
+/// fails the build — this is what makes schema coverage *structural* rather
+/// than a runtime test that can silently pass), every entry needs a `.desc`
+/// and must map to a real field, and every attribute must be a known key.
+/// Run on each `dto_types` entry below and again by the schema emitter.
+pub fn assert_meta_matches(comptime T: type) void {
+    @setEvalBranchQuota(50_000);
+    if (!@hasDecl(T, "schema_doc")) {
+        @compileError(@typeName(T) ++ " is missing pub const schema_doc");
+    }
+    if (!@hasDecl(T, "schema_fields")) {
+        @compileError(@typeName(T) ++ " is missing pub const schema_fields");
+    }
+    const Meta = @TypeOf(T.schema_fields);
+    // Every field has a documented, described entry.
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (!@hasField(Meta, field.name)) {
+            @compileError(@typeName(T) ++ "." ++ field.name ++ " has no schema_fields entry");
+        }
+        const entry = @field(T.schema_fields, field.name);
+        if (!@hasField(@TypeOf(entry), "desc")) {
+            @compileError(@typeName(T) ++ "." ++ field.name ++ " schema entry is missing .desc");
+        }
+    }
+    // Every entry maps to a real field and carries only known attributes.
+    inline for (@typeInfo(Meta).@"struct".fields) |entry_field| {
+        if (!@hasField(T, entry_field.name)) {
+            @compileError(@typeName(T) ++ " schema_fields entry '" ++ entry_field.name ++ "' has no matching field");
+        }
+        const entry = @field(T.schema_fields, entry_field.name);
+        inline for (@typeInfo(@TypeOf(entry)).@"struct".fields) |attr| {
+            comptime var known = false;
+            inline for (schema_attributes) |name| {
+                if (comptime std.mem.eql(u8, name, attr.name)) known = true;
+            }
+            if (!known) {
+                @compileError(@typeName(T) ++ "." ++ entry_field.name ++ " has unknown schema attribute '" ++ attr.name ++ "'");
+            }
+        }
+    }
+}
+
+/// Every plain-struct DTO the schema reflects over. `ClustersJson` is a
+/// custom map, handled specially by the emitter, so it is not here. The
+/// block below runs `assert_meta_matches` on each at comptime, so the
+/// metadata cannot drift from the fields whether or not the emitter builds.
+pub const dto_types = .{
+    ConfigJson,  ListenerJson,    RouteJson,    FilterJson,
+    MatchJson,   HeaderMatchJson, ActionJson,   HeaderEditJson,
+    RewriteJson, ClusterJson,     TimeoutsJson, LimitsJson,
+};
+
+comptime {
+    for (dto_types) |T| assert_meta_matches(T);
+}
+
 fn resolveClusters(
     arena: std.mem.Allocator,
     clusters_json: *const ClustersJson,
 ) ParseError![]const Config.Cluster {
-    if (clusters_json.seen_count == 0) {
+    if (clusters_json.seen_count < constants.clusters_min) {
         return error.ClustersEmpty;
     }
     if (clusters_json.seen_count > constants.clusters_max) {

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -1,0 +1,371 @@
+//! JSON Schema (draft 2020-12) for the startup config, emitted by reflecting
+//! over the very `*Json` DTOs the loader parses (see `config.zig`). Structure
+//! comes from `@typeInfo`; the un-reflectable parts — prose, numeric bounds,
+//! and the closed vocabularies (`protocol`, `pick`, filter `method` tokens,
+//! filter `reject` statuses) — come from the DTOs' co-located `schema_doc`/
+//! `schema_fields` metadata, cross-checked against the fields at comptime by
+//! `config.assert_meta_matches`. Bounds trace to `constants.zig` and vocab to
+//! the same Zig enums/arrays the loader validates against, so the schema
+//! cannot drift from the code. `zig build schema` writes it to
+//! `zig-out/config.schema.json`; the release workflow ships it as an asset.
+//!
+//! What JSON Schema *can* express is emitted: structure, `required`,
+//! `additionalProperties: false` (the parser rejects unknown fields), enums,
+//! and numeric ranges. What it *cannot* — the loader's semantic validations
+//! (canonical route prefixes/hosts, IP:port literal parsing, reserved header
+//! names, endpoint port != 0) and the "exactly one of" forks (listener
+//! cluster/routes, header-match kind, action kind) — stays the loader's job.
+//! A config that passes this schema is well-shaped, not necessarily accepted.
+
+const std = @import("std");
+
+const config = @import("config.zig");
+const constants = @import("constants.zig");
+const filter = @import("http/filter.zig");
+const parser = @import("http/parser.zig");
+
+const assert = std.debug.assert;
+
+const Writer = std.Io.Writer;
+const Stringify = std.json.Stringify;
+const Protocol = config.Config.Listener.Protocol;
+const Pick = config.Config.Cluster.Pick;
+
+/// Emit the whole schema document, pretty-printed (it is a shipped,
+/// human-read artifact). `std.json.Stringify` owns all punctuation, quoting,
+/// and escaping; this file only decides structure. Deterministic: every loop
+/// walks fields/enums in declaration order.
+pub fn writeSchema(w: *Writer) Writer.Error!void {
+    // The generated vocabularies are closed and non-empty; an empty enum
+    // could never be satisfied, so guard the shapes at comptime.
+    comptime assert(@typeInfo(Protocol).@"enum".fields.len >= 1);
+    comptime assert(@typeInfo(Pick).@"enum".fields.len >= 1);
+    comptime assert(filter.reject_statuses.len >= 1);
+
+    var out: Stringify = .{ .writer = w, .options = .{ .whitespace = .indent_2 } };
+    try out.beginObject();
+    try out.objectField("$schema");
+    try out.write("https://json-schema.org/draft/2020-12/schema");
+    try out.objectField("$id");
+    try out.write("https://zoxy.io/schema/config.schema.json");
+    try out.objectField("title");
+    try out.write("zoxy configuration");
+    // The root object's own body (type/description/properties/...) is
+    // appended into the still-open object begun above.
+    try writeObjectBody(&out, config.ConfigJson, true);
+    try out.endObject();
+    try w.writeByte('\n');
+}
+
+/// Append an object schema's body — `type`, optional `description`,
+/// `properties`, `required`, `additionalProperties: false` — into the
+/// currently-open object. `with_doc` emits `T.schema_doc` as the
+/// description; callers that supply their own description (a named field or
+/// map value) pass `false`. `required` is exactly the fields with no Zig
+/// default, so the schema's required set is derived, never hand-listed.
+fn writeObjectBody(out: *Stringify, comptime T: type, comptime with_doc: bool) Writer.Error!void {
+    comptime config.assert_meta_matches(T);
+    const fields = @typeInfo(T).@"struct".fields;
+    comptime assert(fields.len >= 1);
+
+    try out.objectField("type");
+    try out.write("object");
+    if (with_doc) {
+        try out.objectField("description");
+        try out.write(T.schema_doc);
+    }
+
+    try out.objectField("properties");
+    try out.beginObject();
+    inline for (fields) |field| {
+        try out.objectField(field.name);
+        try writeFieldSchema(out, T, field);
+    }
+    try out.endObject();
+
+    try out.objectField("required");
+    try out.beginArray();
+    inline for (fields) |field| {
+        if (comptime field.defaultValue() == null) try out.write(field.name);
+    }
+    try out.endArray();
+
+    try out.objectField("additionalProperties");
+    try out.write(false);
+}
+
+/// Emit one field's schema object: its `description` (from metadata),
+/// its type-derived shape, and a scalar `default` when the Zig field has a
+/// non-optional default (optionals default to null — noise we omit).
+fn writeFieldSchema(
+    out: *Stringify,
+    comptime T: type,
+    comptime field: std.builtin.Type.StructField,
+) Writer.Error!void {
+    const meta = @field(T.schema_fields, field.name);
+    const Base = comptime optionalChild(field.type);
+
+    try out.beginObject();
+    try out.objectField("description");
+    try out.write(meta.desc);
+
+    switch (@typeInfo(Base)) {
+        .@"struct" => if (Base == config.ClustersJson)
+            try writeClustersMap(out)
+        else
+            // Nested object; its description is the field's, written above.
+            try writeObjectBody(out, Base, false),
+        else => try writeShape(out, Base, meta),
+    }
+
+    if (comptime @typeInfo(field.type) != .optional) {
+        if (comptime field.defaultValue()) |default| {
+            switch (@typeInfo(Base)) {
+                .int => {
+                    try out.objectField("default");
+                    try out.write(default);
+                },
+                .pointer => |ptr| if (comptime ptr.child == u8) {
+                    try out.objectField("default");
+                    try out.write(default);
+                },
+                else => {},
+            }
+        }
+    }
+
+    try out.endObject();
+}
+
+/// Emit the type-derived shape keys (everything but `description`) for a
+/// scalar/array field into the currently-open field object. Struct-typed
+/// fields never reach here — `writeFieldSchema` routes them to
+/// `writeObjectBody`/`writeClustersMap`.
+fn writeShape(out: *Stringify, comptime Base: type, comptime meta: anytype) Writer.Error!void {
+    switch (@typeInfo(Base)) {
+        .bool => {
+            if (comptime @hasField(@TypeOf(meta), "const_true")) {
+                comptime assert(meta.const_true);
+                try out.objectField("const");
+                try out.write(true);
+            } else {
+                try out.objectField("type");
+                try out.write("boolean");
+            }
+        },
+        .int => {
+            if (comptime @hasField(@TypeOf(meta), "int_values")) {
+                try out.objectField("enum");
+                try out.beginArray();
+                for (meta.int_values) |value| try out.write(value);
+                try out.endArray();
+            } else {
+                comptime assert(meta.minimum <= meta.maximum);
+                try out.objectField("type");
+                try out.write("integer");
+                try out.objectField("minimum");
+                try out.write(meta.minimum);
+                try out.objectField("maximum");
+                try out.write(meta.maximum);
+            }
+        },
+        .pointer => |ptr| if (comptime ptr.child == u8)
+            try writeStringShape(out, meta)
+        else
+            try writeArrayShape(out, ptr.child, meta),
+        else => comptime unreachable,
+    }
+}
+
+/// A `[]const u8` field: a plain string, or a closed enum when the metadata
+/// names a source enum (`protocol`, `pick`).
+fn writeStringShape(out: *Stringify, comptime meta: anytype) Writer.Error!void {
+    if (comptime @hasField(@TypeOf(meta), "enum_type")) {
+        try writeEnum(out, meta.enum_type);
+        return;
+    }
+    try out.objectField("type");
+    try out.write("string");
+    if (comptime @hasField(@TypeOf(meta), "min_length")) {
+        comptime assert(meta.min_length >= 1);
+        try out.objectField("minLength");
+        try out.write(meta.min_length);
+    }
+}
+
+/// A slice field (`[]const Child`): an array with optional length bounds and
+/// an `items` schema for the element type.
+fn writeArrayShape(out: *Stringify, comptime Child: type, comptime meta: anytype) Writer.Error!void {
+    try out.objectField("type");
+    try out.write("array");
+    if (comptime @hasField(@TypeOf(meta), "min_items")) {
+        comptime assert(meta.min_items >= 1); // a minItems of 0 is vacuous — a typo, not a bound
+        try out.objectField("minItems");
+        try out.write(meta.min_items);
+    }
+    if (comptime @hasField(@TypeOf(meta), "max_items")) {
+        try out.objectField("maxItems");
+        try out.write(meta.max_items);
+    }
+    if (comptime @hasField(@TypeOf(meta), "min_items") and @hasField(@TypeOf(meta), "max_items")) {
+        comptime assert(meta.min_items <= meta.max_items);
+    }
+    try out.objectField("items");
+    try out.beginObject();
+    try writeItems(out, Child, meta);
+    try out.endObject();
+}
+
+/// Emit an array's `items` body into the currently-open items object: a
+/// nested object schema for struct elements, the method-token enum when the
+/// metadata marks it, or a plain string otherwise.
+fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Writer.Error!void {
+    switch (@typeInfo(Child)) {
+        .@"struct" => try writeObjectBody(out, Child, true),
+        .pointer => |ptr| {
+            comptime assert(ptr.child == u8);
+            if (comptime @hasField(@TypeOf(meta), "items")) {
+                comptime assert(meta.items == .http_method); // the only marker we define
+                try writeMethodEnum(out);
+            } else {
+                try out.objectField("type");
+                try out.write("string");
+            }
+        },
+        else => comptime unreachable,
+    }
+}
+
+/// An `"enum"` array of an enum type's field names — the same closed
+/// vocabulary the loader accepts, since the field names ARE the JSON tokens
+/// (`protocol` via a literal match, `pick` via `std.meta.stringToEnum`).
+fn writeEnum(out: *Stringify, comptime Enum: type) Writer.Error!void {
+    const fields = @typeInfo(Enum).@"enum".fields;
+    comptime assert(fields.len >= 1);
+    try out.objectField("enum");
+    try out.beginArray();
+    inline for (fields) |field| try out.write(field.name);
+    try out.endArray();
+}
+
+/// The filter `method` vocabulary as an `"enum"` array: the registered
+/// request-method tokens, which are exactly the uppercased `parser.Method`
+/// field names minus the `extension` catch-all (which names no token). A
+/// test pins this against `parser.methodFromToken`.
+fn writeMethodEnum(out: *Stringify) Writer.Error!void {
+    try out.objectField("enum");
+    try out.beginArray();
+    comptime var emitted = false;
+    inline for (@typeInfo(parser.Method).@"enum".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, "extension")) continue;
+        try out.write(upperToken(field.name));
+        emitted = true;
+    }
+    try out.endArray();
+    comptime assert(emitted); // at least one real method token exists
+}
+
+/// The clusters map: a name-keyed object whose values are cluster schemas,
+/// bounded by `clusters_max`. The DTO is a custom parser (not a plain
+/// struct), so its shape is emitted here rather than reflected.
+fn writeClustersMap(out: *Stringify) Writer.Error!void {
+    comptime assert(constants.clusters_max >= constants.clusters_min);
+    try out.objectField("type");
+    try out.write("object");
+    try out.objectField("minProperties");
+    try out.write(constants.clusters_min);
+    try out.objectField("maxProperties");
+    try out.write(constants.clusters_max);
+    try out.objectField("additionalProperties");
+    try out.beginObject();
+    try writeObjectBody(out, config.ClusterJson, true);
+    try out.endObject();
+}
+
+/// The non-optional element type of `T`, or `T` itself if it is not an
+/// optional. Optionality only affects `required`, never the field's shape.
+fn optionalChild(comptime T: type) type {
+    return switch (@typeInfo(T)) {
+        .optional => |opt| opt.child,
+        else => T,
+    };
+}
+
+/// Uppercase a method enum field name into its wire token. `name` is
+/// comptime (it fixes the array length), but the body runs at either phase,
+/// so the method-enum test can call it at runtime too.
+fn upperToken(comptime name: []const u8) [name.len]u8 {
+    var buffer: [name.len]u8 = undefined;
+    for (name, 0..) |byte, index| buffer[index] = std.ascii.toUpper(byte);
+    return buffer;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Render the schema into `buffer` and return the written slice. The document
+/// is a few KiB; callers size their buffers well above that. A too-small
+/// buffer fails the render with `error.WriteFailed` (a fixed writer does not
+/// spill), so truncation surfaces as a test failure rather than silent loss.
+fn renderInto(buffer: []u8) Writer.Error![]const u8 {
+    var w = Writer.fixed(buffer);
+    try writeSchema(&w);
+    return w.buffered();
+}
+
+test "config_schema: the emitted document is valid, documented JSON" {
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer parsed.deinit();
+    const root = parsed.value;
+    try std.testing.expect(root == .object);
+    try std.testing.expect(root.object.get("$schema") != null);
+    try std.testing.expect(root.object.get("$id") != null);
+    // A draft-2020-12 object schema that names its fields — the shape every
+    // consumer keys off. `additionalProperties: false` mirrors the strict
+    // parser (`ignore_unknown_fields = false`).
+    try std.testing.expectEqualStrings("object", root.object.get("type").?.string);
+    try std.testing.expect(root.object.get("properties").?.object.count() >= 1);
+    try std.testing.expectEqual(false, root.object.get("additionalProperties").?.bool);
+}
+
+test "config_schema: emission is deterministic" {
+    var buffer_a: [64 * 1024]u8 = undefined;
+    var buffer_b: [64 * 1024]u8 = undefined;
+    // Same inputs, twice: field/enum order is declaration order, so the two
+    // renders must be byte-identical (the release asset is reproducible).
+    try std.testing.expectEqualStrings(try renderInto(&buffer_a), try renderInto(&buffer_b));
+}
+
+test "config_schema: the shipped example's top-level keys are all declared" {
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var schema = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer schema.deinit();
+    const properties = schema.value.object.get("properties").?.object;
+
+    const example = @embedFile("example_config");
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, example, .{});
+    defer parsed.deinit();
+    var it = parsed.value.object.iterator();
+    while (it.next()) |entry| {
+        try std.testing.expect(properties.get(entry.key_ptr.*) != null);
+    }
+}
+
+test "config_schema: the method enum matches what the parser accepts" {
+    // Every token the schema emits must be one the loader resolves, and no
+    // more than the registered methods (extension names no token).
+    var accepted: u32 = 0;
+    inline for (@typeInfo(parser.Method).@"enum".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, "extension")) continue;
+        const token = upperToken(field.name);
+        try std.testing.expect(parser.methodFromToken(&token) != null);
+        accepted += 1;
+    }
+    try std.testing.expectEqual(@as(u32, @typeInfo(parser.Method).@"enum".fields.len - 1), accepted);
+    try std.testing.expect(parser.methodFromToken("NOTAMETHOD") == null);
+}

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -134,6 +134,11 @@ pub const config_bytes_max: u32 = 256 * 1024;
 /// Upper bound on configured clusters.
 pub const clusters_max: u16 = 16;
 
+/// Lower bound on configured clusters: a config with no cluster can route
+/// nowhere, so the loader rejects an empty map and the config JSON Schema
+/// emits it as `minProperties`.
+pub const clusters_min: u16 = 1;
+
 /// Upper bound on endpoints in one cluster.
 pub const endpoints_per_cluster_max: u16 = 64;
 
@@ -194,7 +199,8 @@ comptime {
     assert(in_flight_ops_max <= completion_queue_entries);
     assert(conn_slots_max - 1 <= std.math.maxInt(u16));
     assert(relay_buffer_bytes >= 512);
-    assert(clusters_max >= 1);
+    assert(clusters_min >= 1);
+    assert(clusters_max >= clusters_min);
     assert(endpoints_per_cluster_max >= 1);
     assert(routes_max >= 1);
     assert(filters_per_listener_max >= 1);

--- a/src/root.zig
+++ b/src/root.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 
 pub const balancer = @import("balancer.zig");
 pub const config = @import("config.zig");
+pub const config_schema = @import("config_schema.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
 /// L7 HTTP/1.1 modules (§7). `parser` wraps the vendored hparse behind
@@ -33,6 +34,7 @@ pub const testing = struct {
 test {
     _ = balancer;
     _ = config;
+    _ = config_schema;
     _ = constants;
     _ = counters;
     _ = http.parser;

--- a/tools/schema.zig
+++ b/tools/schema.zig
@@ -1,0 +1,16 @@
+//! `zig build schema` entry point: render the config JSON Schema to stdout
+//! so the build step can capture it into zig-out/config.schema.json for the
+//! release workflow to ship. All content is derived from the config
+//! definitions — see src/config_schema.zig.
+
+const std = @import("std");
+
+const zoxy = @import("zoxy");
+
+pub fn main(init: std.process.Init) !void {
+    var buffer: [4096]u8 = undefined;
+    var file_writer: std.Io.File.Writer = .init(.stdout(), init.io, &buffer);
+    const writer = &file_writer.interface;
+    try zoxy.config_schema.writeSchema(writer);
+    try writer.flush();
+}


### PR DESCRIPTION
Closes #53.

Editors give no autocompletion for the config JSON and docs must be hand-written, because the config surface has no machine-readable schema. This adds one, **derived from the config definitions** so it cannot drift from the code, and ships it as a release asset.

## Design decision (settled)

Release-artifact only: the schema is generated at build time and uploaded on tagged releases. **Nothing is committed to the repo and there is no CI drift gate** — generator *correctness* is covered by ordinary unit tests under `zig build ci`, and field coverage is enforced *structurally* at comptime (see below).

## Slice 1 — the generator (`a0f7294`)

- **`src/config_schema.zig`** (new): a reflection generator. It walks the `*Json` parse structs via comptime `@typeInfo` for structure and `required` (a field is required iff it has no default), and pulls the un-reflectable parts — prose, enum vocabularies, numeric bounds — from co-located metadata. Emits a draft 2020-12 schema via `std.json.Stringify` (no hand-authored punctuation or escaping). It intentionally stops at what JSON Schema can express: the loader's semantic checks (canonical prefixes/hosts, address literals, reserved header names, port ≠ 0) and the "exactly one of" forks stay the loader's job — passing the schema means *well-shaped*, not *accepted*.
- **`src/config.zig`**: each DTO struct carries `schema_doc` + `schema_fields` metadata; `assert_meta_matches` cross-checks it against the real fields at comptime, so an undocumented field, a missing `.desc`, or an unknown attribute is a **compile error**. This makes field coverage structural — it replaces a runtime coverage-guard that could silently pass.
- Enums/bounds all trace to code: `protocol`→`["l4","http"]`, `pick`→`["rr","p2c"]`, filter `reject`→`[400,403,404,429]`, method tokens from `parser`, and every numeric bound from `src/constants.zig`. Added `constants.clusters_min` (with `clusters_min ≥ 1` / `clusters_max ≥ clusters_min` asserts) so the clusters-map `minProperties` is a named limit, referenced by both the emitter and the loader.
- **`tools/schema.zig`** + **`build.zig`** `schema` step: emits `zig-out/config.schema.json`. Not wired into `ci` — only the emitter's tests run there.
- Tests: emitted text is valid JSON; emission is deterministic; the shipped example config's top-level keys all resolve to declared properties; the method enum matches `parser` exactly.

## Slice 2 — release wiring + docs (`749f523`)

- **`.github/workflows/release.yml`**: after the per-target build loop, `zig build schema` once (it's target-independent) → `dist/zoxy-$version-config.schema.json`. The existing `sha256sum *` checksums it and `action-gh-release` uploads it.
- **`docs/DESIGN.md` §5** and **`docs/PLANS.md`**: document the release-only surface and record deferred follow-ups (host at the `$id` URL, add a `"$schema"` pointer to the example config, optional `zoxy --schema` subcommand).

## Verification

- `zig build ci` green (unit tests incl. the four generator tests, boundary lint, sim: 64 seeds).
- `zig build schema` → `zig-out/config.schema.json` (12,513 bytes); verified bounds, enums, derived `required`, `additionalProperties: false`, and scalar defaults against the config definitions.
- `zig fmt --check src scripts build.zig build.zig.zon tools/schema.zig` clean.
- `tiger-style-reviewer` run on each slice: no open violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)