### PR TITLE
ci(release): use the HOMEBREW_TAP_DEPLOY_KEY secret name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Update Homebrew formula
         env:
-          HOMEBREW_TAP_SSH_KEY: ${{ secrets.HOMEBREW_TAP_SSH_KEY }}
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
         run: |
           set -euo pipefail
           version="${{ steps.ver.outputs.version }}"
@@ -100,7 +100,7 @@ jobs:
           sha_x86_64_linux=$(grep  "zoxy-$version-x86_64-linux.tar.gz"  dist/SHA256SUMS.txt | awk '{print $1}')
 
           mkdir -p ~/.ssh
-          echo "$HOMEBREW_TAP_SSH_KEY" > ~/.ssh/deploy_key
+          echo "$HOMEBREW_TAP_DEPLOY_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"


### PR DESCRIPTION
The `v0.0.0` release published fine, but the **Update Homebrew formula** step failed:

```
HOMEBREW_TAP_SSH_KEY:                                    ← empty
Load key "/home/runner/.ssh/deploy_key": error in libcrypto
git@github.com: Permission denied (publickey).  (exit 128)
```

Root cause: the workflow referenced `secrets.HOMEBREW_TAP_SSH_KEY`, but the actual repo secret is named `HOMEBREW_TAP_DEPLOY_KEY`. The missing secret resolved to an empty string, which got written to `~/.ssh/deploy_key` and failed to load, so the tap clone/push was denied. The GitHub Release and all assets were unaffected (that step runs earlier).

Fix: point both the `env:` mapping and the shell reference at `HOMEBREW_TAP_DEPLOY_KEY`.

Once merged, I'll re-trigger the release for `v0.0.0` via `workflow_dispatch` so the corrected tap step runs (it rebuilds the targets and re-publishes the same assets, then updates `zoxy-io/homebrew-tap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)