### PR TITLE
fix(l7): suppress keep-alive under relay pressure only (§8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -627,12 +627,20 @@ the loop thread.
 - **Watermarks before walls.** Each pool flips a `pressure` flag at its
   high watermark (ceil 3/4, released at floor 1/2 — hysteresis), one
   rule for all three: *relay-buffer* and *conn-slot* pressure are
-  downstream pressure — the idle timeout divides and keep-alive is no
-  longer honored, so idle downstream connections return the buffers and
-  slots they pin; *upstream-pool* pressure shortens parked-connection
-  deadlines (and the sweep interval), reaping idle parked sockets so
-  their slots free for fresh dials. Each bias sheds *idle* capacity
-  before the wall must shed *work*; each engage crossing has a counter.
+  downstream pressure — the idle timeout divides, so idle downstream
+  connections return the buffers and slots they pin. *Relay-buffer*
+  pressure alone also stops honoring keep-alive, because the next
+  request on a kept-alive connection claims a relay buffer. Conn-slot
+  pressure never suppresses keep-alive: a conn pool held by serving
+  connections is the steady state of a keep-alive workload, and closing
+  them churns the whole population into synchronized reconnect waves
+  (measured — IMPLEMENTATION_NOTES.md "Occupancy is not overload");
+  slot scarcity is answered by the idle division and the admit-time
+  RST wall, the same norm nginx and haproxy follow. *Upstream-pool*
+  pressure shortens parked-connection deadlines (and the sweep
+  interval), reaping idle parked sockets so their slots free for fresh
+  dials. Each bias sheds *idle* capacity before the wall must shed
+  *work*; each engage crossing has a counter.
 - **Metrics witness every shed.** Every rung has a counter, written only
   by the loop thread as a relaxed atomic — one writer, any number of
   readers, so a metrics/admin thread can read without a data race and

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -116,6 +116,28 @@ the orderly failures (EOF, RST) are peeled off first. SimIo grew a
 one-shot `kernel_pressure` fault and a `kernel_pressure_percent`
 adversary knob to exercise the rung.
 
+## Occupancy is not overload — conn-pressure keep-alive kill reverted (#57)
+
+The v0.0.0 watermark design (#54) suppressed downstream keep-alive under
+*conn-slot* pressure as well as relay pressure. Cloud bench, 2026-07-20,
+CONNECTIONS=1024 against `conn_slots_max` 1020: the population sits
+permanently above the ¾ engage mark (765), the flag limit-cycles between
+765 and the 510 release floor, and every response rendered while engaged
+announces `Connection: close` — ~500-connection synchronized
+close/reconnect waves, proxy-VM accepts at ~1400/s against a ~38/s
+baseline, a seconds-long coordinated-omission latency tail, zero errors
+reported. The same rig at CONNECTIONS=500 (below the release floor) was
+clean, isolating the flag as the cause.
+
+Verdict (settled): conn-pool occupancy cannot distinguish a healthy
+keep-alive population from imminent exhaustion — for a keep-alive
+workload, high occupancy *is* the steady state, and closing serving
+connections converts pressure into churn. Keep-alive suppression is now
+relay-pressure only (`Server.keepAliveSuppressed`); conn-slot scarcity
+is answered by the idle-timeout division plus the accept-time RST wall —
+the nginx/haproxy norm: never close an established keep-alive connection
+to admit a newcomer.
+
 ## Phase 0 baselines (2026-07-10/11)
 
 - Debug-build zoxy over loopback (`zig build bench`, nginx origin, rate

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -50,11 +50,13 @@ pub fn Server(comptime IoType: type) type {
         /// §8 watermark state, one flag per pool: set once a pool crosses
         /// its high watermark, cleared once it drains back below the low
         /// one (hysteresis, `constants.poolPressureOn/Off`). Relay and
-        /// conn pressure bias downstream capacity — shorter idle timeouts
-        /// and keep-alive no longer honored — so quiet connections return
-        /// their buffers and slots before the wall is reached; upstream
-        /// pressure shortens parked-connection deadlines so idle parked
-        /// sockets free their slots for fresh dials before the 503 wall.
+        /// conn pressure shorten the idle timeout so quiet connections
+        /// return their buffers and slots before the wall is reached;
+        /// relay pressure alone also stops honoring keep-alive
+        /// (`keepAliveSuppressed` — conn-slot occupancy stays out, #57);
+        /// upstream pressure shortens parked-connection deadlines so idle
+        /// parked sockets free their slots for fresh dials before the
+        /// 503 wall.
         relay_pressure: bool,
         conn_pressure: bool,
         upstream_pressure: bool,
@@ -653,12 +655,24 @@ pub fn Server(comptime IoType: type) type {
             );
         }
 
-        /// Any pressure that downstream keep-alive holds capacity against
-        /// (§8): an idle downstream connection pins a conn slot, and its
-        /// next body relay claims a relay buffer. Public for the L7
-        /// render's persistence decision.
+        /// Any pressure an *idle* downstream connection holds capacity
+        /// against (§8): it pins a conn slot, and its next body relay
+        /// claims a relay buffer. Drives only the idle-timeout division —
+        /// quiet connections reap sooner; serving ones are untouched.
         pub fn downstreamPressured(server: *const Self) bool {
             return server.relay_pressure or server.conn_pressure;
+        }
+
+        /// The §8 keep-alive suppression signal for the L7 render's
+        /// persistence decision: relay pressure only. Conn-slot occupancy
+        /// deliberately stays out — a conn pool held by *serving*
+        /// connections is the steady state of a keep-alive workload, not
+        /// imminent exhaustion, and closing them churns the population
+        /// into synchronized reconnect waves (#57). Slot scarcity is
+        /// answered by the idle-timeout division and the admit-time wall,
+        /// never by closing connections that are doing work.
+        pub fn keepAliveSuppressed(server: *const Self) bool {
+            return server.relay_pressure;
         }
 
         /// The §8 upstream-pool acquire/release pair: the pressure flag

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -40,11 +40,13 @@ pub const relay_buffers_max: u32 = conn_slots_max;
 pub const relay_buffer_bytes: u32 = 4 * 1024;
 
 /// §8 "watermarks before walls": each pool flips a pressure flag before
-/// it hits the wall so the proxy sheds *idle* capacity — shorter idle
-/// timeouts, keep-alive no longer honored, parked connections reaped
-/// sooner — before it must shed *work*. One rule for all three pools
-/// (relay buffers, conn slots, upstream slots). Hysteresis keeps a flag
-/// from flapping around a single threshold: engage at the high
+/// it hits the wall so the proxy sheds *idle* capacity before it must
+/// shed *work*: relay or conn pressure shortens idle timeouts, relay
+/// pressure alone stops honoring keep-alive (conn-pool occupancy is the
+/// steady state of a keep-alive workload, not a crisis — #57), upstream
+/// pressure reaps parked connections sooner. One rule for all three
+/// pools (relay buffers, conn slots, upstream slots). Hysteresis keeps
+/// a flag from flapping around a single threshold: engage at the high
 /// watermark, release only after draining back to the low one. Both are
 /// fractions of the *live* pool capacity, so an injected test pool and
 /// the production pool obey one rule. `On` uses ceil so a full pool

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -850,16 +850,20 @@ pub fn Proxy(comptime IoType: type) type {
 
             // The §8 persistence decision, made once and honored: honor
             // the client's ask unless pipelining, pressure, or drain says
-            // otherwise — then announce whatever was decided (§2).
-            // Downstream pressure — relay buffers or conn slots near their
-            // walls — stops honoring keep-alive so idle capacity returns
-            // (§8 watermarks). An until-close body forces the close
+            // otherwise — then announce whatever was decided (§2). Only
+            // relay pressure suppresses keep-alive: the next request on
+            // this connection would claim a relay buffer the pool is
+            // running out of. Conn-slot pressure deliberately does not
+            // reach here (`keepAliveSuppressed`, #57) — under slot
+            // scarcity this serving connection *is* the population, and
+            // closing it trades one briefly-free slot for a reconnect
+            // wave. An until-close body forces the close
             // unconditionally: the FIN is the only thing delimiting the
             // relayed body for the client, exactly as it delimited it
             // for us.
             const keep_downstream = conn.l7.client_keep_alive and
                 !conn.l7.client_pipelined and !server.draining and
-                !server.downstreamPressured() and response.framing != .until_close;
+                !server.keepAliveSuppressed() and response.framing != .until_close;
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const rendered = render.renderResponseHead(

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1465,7 +1465,7 @@ test "l7: a pipelining client gets its first response, then the close" {
     try bed.expectDrained();
 }
 
-test "l7: keep-alive is not honored under conn-slot pressure" {
+test "l7: keep-alive is honored under conn-slot pressure" {
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
@@ -1475,21 +1475,85 @@ test "l7: keep-alive is not honored under conn-slot pressure" {
     });
     defer bed.tearDown();
 
-    // Two concurrent clients fill both conn slots — the §8 watermark
-    // engages — so a keep-alive ask is answered with an announced close:
-    // idle downstream connections are exactly the capacity under
-    // pressure.
+    // The first client exchanges, then idles holding a conn slot but no
+    // relay buffer; a timer starts the second client mid-idle, filling
+    // both slots — the §8 conn watermark engages with the relay pool
+    // never above one of two. Yet both keep-alive asks are honored: a
+    // slot-holding connection that serves requests is the capacity
+    // doing its job, and closing it would churn the population into
+    // reconnect waves (#57). The conn-slot remedy is the shortened idle
+    // timeout, which reaps the connections once they go quiet and
+    // returns their slots.
+    const starter = struct {
+        fn onTimer(started: *Http1Bed, result: Io.TimerError!void) void {
+            result catch unreachable; // Nothing cancels the start timer.
+            started.client2.start(
+                &started.sim_io,
+                &started.server,
+                Http1Bed.bindAddress(),
+            );
+        }
+    };
+    var start_completion: SimIo.Completion = .{};
     bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\n\r\n";
-    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    bed.sim_io.timerStart(
+        &start_completion,
+        100 * std.time.ns_per_ms,
+        Http1Bed,
+        &bed,
+        starter.onTimer,
+    );
     try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expect(bed.server.counters.get("conn_pressure_engaged") >= 1);
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("relay_pressure_engaged"),
+    );
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        bed.client.response(),
+        "Connection: close",
+    ) == null);
     try std.testing.expect(std.mem.indexOf(
         u8,
         bed.client2.response(),
         "Connection: close",
-    ) != null);
+    ) == null);
+    // The divided idle deadline — not a keep-alive kill — returned the
+    // slots.
+    try std.testing.expect(bed.server.counters.get("deadline_expired") >= 1);
     try std.testing.expect(!bed.server.conn_pressure); // Cleared on drain.
+    try bed.expectDrained();
+}
+
+test "l7: keep-alive is not honored under relay pressure" {
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 92,
+        .origin_response = response,
+        .relay_buffers = 1,
+    });
+    defer bed.tearDown();
+
+    // A single relay buffer: the exchange's own claim crosses the §8
+    // high watermark, so the render sees relay pressure and answers the
+    // keep-alive ask with an announced close — the next request on this
+    // connection would claim a buffer the pool is out of.
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expect(bed.server.counters.get("relay_pressure_engaged") >= 1);
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("conn_pressure_engaged"),
+    );
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        bed.client.response(),
+        "Connection: close",
+    ) != null);
+    try std.testing.expect(!bed.server.relay_pressure); // Cleared on drain.
     try bed.expectDrained();
 }
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -563,7 +563,8 @@ test "server: conn-slot pressure engages before the wall and drains clean" {
 test "server: idle timeout shortens under pressure, is full otherwise" {
     // The pure selection rules the pressure flags drive: full timeouts
     // when relaxed; the idle timeout divides under either downstream
-    // pressure (relay or conn); the parked deadline divides again under
+    // pressure (relay or conn); keep-alive suppression follows relay
+    // pressure only (#57); the parked deadline divides again under
     // upstream pressure — each floored at 1 ms.
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{
@@ -573,13 +574,19 @@ test "server: idle timeout shortens under pressure, is full otherwise" {
     defer bed.tearDown();
 
     try std.testing.expect(!bed.server.downstreamPressured());
+    try std.testing.expect(!bed.server.keepAliveSuppressed());
     try std.testing.expectEqual(@as(u32, 1000), bed.server.idleTimeoutMs());
     try std.testing.expectEqual(@as(u32, 1000), bed.server.parkedTimeoutMs());
     bed.server.relay_pressure = true;
+    try std.testing.expect(bed.server.keepAliveSuppressed());
     try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.idleTimeoutMs());
     bed.server.relay_pressure = false;
     bed.server.conn_pressure = true;
     try std.testing.expect(bed.server.downstreamPressured());
+    // Conn pressure divides the idle timeout but never suppresses
+    // keep-alive: slot scarcity reaps quiet connections, not serving
+    // ones (#57).
+    try std.testing.expect(!bed.server.keepAliveSuppressed());
     try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.idleTimeoutMs());
     bed.server.conn_pressure = false;
     // Upstream pressure biases only the parked deadline, not the idle


### PR DESCRIPTION
Closes #57.

## Problem

The v0.0.0 watermark design (#54) stopped honoring downstream keep-alive under **conn-slot** pressure as well as relay pressure. On the cloud bench (`CONNECTIONS=1024` against `conn_slots_max` 1020) the conn flag limit-cycled between the ¾ engage mark (765) and the ½ release floor (510), announcing `Connection: close` on ~30% of responses — synchronized close/reconnect waves at ~1400 accepts/s against a ~38/s baseline and a seconds-long coordinated-omission latency tail with zero errors. The same rig at `CONNECTIONS=500` was clean, isolating the flag.

## Fix

Conn-pool occupancy cannot distinguish a healthy keep-alive population from imminent exhaustion: for a keep-alive workload, high occupancy *is* the steady state, and closing serving connections converts pressure into churn.

- The persistence decision now reads a new `Server.keepAliveSuppressed()` — **relay pressure only** (the next request on a kept-alive connection claims a relay buffer, so that coupling stays).
- `downstreamPressured()` (relay or conn) is unchanged and keeps driving only the idle-timeout division; together with the accept-time RST wall, that is the whole conn-slot remedy — the nginx/haproxy norm of never closing an established keep-alive connection to admit a newcomer.

## Tests & docs

- The #54 test flips to "keep-alive **is** honored under conn-slot pressure": a sim timer staggers the second client so one idle keep-alive conn (slot held, no buffer) plus one exchanging conn engage the conn watermark while the relay pool provably stays clear.
- New "keep-alive is not honored under relay pressure" test pins the surviving kill path (`relay_buffers = 1`, the exchange's own claim crosses the watermark).
- The pure-selection-rule test asserts conn pressure divides the idle timeout but never suppresses keep-alive.
- DESIGN.md §8 re-attributes each remedy to its pool; IMPLEMENTATION_NOTES.md gains an "Occupancy is not overload" entry recording the measured verdict.

Gates: `zig build ci` (182 tests, 64 sim seeds), `zig fmt --check`, tiger-style review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)