### PR TITLE
refactor(net): extract shared recv→send body pump (§6, §7)

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -34,6 +34,7 @@ const std = @import("std");
 const Balancer = @import("../balancer.zig").Balancer;
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
+const pump = @import("../net/pump.zig");
 const Io = @import("../io/io.zig");
 const parser = @import("parser.zig");
 const render = @import("render.zig");
@@ -598,7 +599,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // keep pumping into a connection that is already closing (§7).
                 if (conn.state != .l7_exchanging) return;
             }
-            if (framingDone(&conn.l7.request_framing)) {
+            if (framingDoneOf(&conn.l7.request_framing)) {
                 conn.l7.request_leg = .done;
             } else {
                 conn.l7.request_leg = .pumping_body;
@@ -609,118 +610,93 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
-        fn armRequestBodyRecv(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .pumping_body);
-            // A recv on the CLIENT socket: an expiry cannot force it, so
-            // the deadline verdict is unanswerable while this op is armed.
-            conn.l7.request_op_on_client = true;
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            server.io.recv(
-                conn.client_socket,
-                &conn.relay_buffer.?.client_to_upstream,
-                &conn.op_data_client_to_upstream.completion,
-                ConnType,
-                conn,
-                onRequestBodyRecv,
-            );
-        }
-
-        fn onRequestBodyRecv(conn: *ConnType, result: Io.RecvError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
+        /// The request leg's body pump (client → origin, §7). Framed by the
+        /// request's own framing; a client-side recv cannot be forced, so a
+        /// pending verdict makes the arm illegal and a settled verdict on a
+        /// send diverts. A short body tail past the framing is a pipelined
+        /// next request (§2 note). Failures doom the exchange: a recv EOF is
+        /// a truncated request (teardown), a send failure is the origin
+        /// giving out (`upstreamFailed`).
+        const RequestBodyPolicy = struct {
+            pub fn beforeRecv(conn: *ConnType) void {
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.request_leg == .pumping_body);
+                // A client-side recv is never armed under a pending verdict:
+                // expiry is unanswerable then, and a verdict arms nothing.
+                assert(conn.l7.pending_verdict == .none);
+                // A recv on the CLIENT socket: an expiry cannot force it, so
+                // the deadline verdict is unanswerable while this op is armed.
+                conn.l7.request_op_on_client = true;
             }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .pumping_body);
-            // A client-side recv is never armed under a pending verdict:
-            // expiry is unanswerable then, and a verdict arms nothing.
-            assert(conn.l7.pending_verdict == .none);
-            const received = result catch |err| {
+
+            pub fn beforeSend(conn: *ConnType) void {
+                assert(conn.state == .l7_exchanging);
+                conn.l7.request_op_on_client = false; // A send on the upstream socket.
+            }
+
+            /// Completion-time re-checks (post-await): a client-side body
+            /// recv is never armed under a pending verdict — expiry is
+            /// unanswerable then — so none can have arrived during the await.
+            pub fn onRecvEntry(conn: *ConnType) void {
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.request_leg == .pumping_body);
+                assert(conn.l7.pending_verdict == .none);
+            }
+
+            pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
+                return feedFraming(&conn.l7.request_framing, chunk);
+            }
+
+            pub fn afterFeed(conn: *ConnType, received: u32, fr: pump.FeedResult) void {
+                if (fr.consumed < received) {
+                    // Bytes past the body are a pipelined next request; the
+                    // connection will close after this exchange (§2 note).
+                    conn.l7.client_pipelined = true;
+                }
+            }
+
+            pub fn framingDone(conn: *ConnType) bool {
+                return framingDoneOf(&conn.l7.request_framing);
+            }
+
+            pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
                 // EOF mid-body is a truncated request; any failure here
                 // dooms the exchange in the client's own direction.
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
-                return;
-            };
-            assert(received >= 1);
-            const chunk = conn.relay_buffer.?.client_to_upstream[0..received];
-            const feed = feedFraming(&conn.l7.request_framing, chunk);
-            if (feed.malformed) {
-                server.beginTeardown(conn);
-                return;
             }
-            if (feed.consumed < received) {
-                // Bytes past the body are a pipelined next request; the
-                // connection will close after this exchange (§2 note).
-                conn.l7.client_pipelined = true;
+
+            pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
+                server.witnessKernelPressure(err);
+                upstreamFailed(server, conn);
             }
-            const direction = &conn.directions[0];
-            direction.transfer_len = feed.consumed;
-            direction.sent_len = 0;
-            if (feed.consumed >= 1) {
-                armRequestBodySend(server, conn);
-            } else {
-                assert(feed.done);
+
+            pub fn onDrained(server: *ServerType, conn: *ConnType) void {
+                _ = server;
                 conn.l7.request_leg = .done;
                 // The delivered recv was the flag's referent; keep the
                 // flag self-descriptive now that no request op is armed.
                 conn.l7.request_op_on_client = false;
             }
-        }
 
-        fn armRequestBodySend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            const direction = &conn.directions[0];
-            assert(direction.sent_len < direction.transfer_len);
-            conn.l7.request_op_on_client = false; // A send on the upstream socket.
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            server.io.send(
-                conn.upstream_socket.?,
-                conn.relay_buffer.?.client_to_upstream[direction.sent_len..direction.transfer_len],
-                &conn.op_data_client_to_upstream.completion,
-                ConnType,
-                conn,
-                onRequestBodySent,
-            );
-        }
-
-        fn onRequestBodySent(conn: *ConnType, result: Io.SendError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .pumping_body);
-            if (conn.l7.pending_verdict != .none) {
-                settlePendingVerdict(server, conn);
-                return;
-            }
-            const sent = result catch |err| {
-                server.witnessKernelPressure(err);
-                upstreamFailed(server, conn);
-                return;
-            };
-            assert(sent >= 1);
-            const direction = &conn.directions[0];
-            direction.sent_len += sent;
-            assert(direction.sent_len <= direction.transfer_len);
-            if (direction.sent_len < direction.transfer_len) {
-                armRequestBodySend(server, conn);
-                return;
-            }
-            // A full chunk moved: activity refreshes the deadline (§6).
-            server.storeDeadline(conn, server.idleTimeoutMs());
-            if (framingDone(&conn.l7.request_framing)) {
+            pub fn onComplete(server: *ServerType, conn: *ConnType) void {
+                _ = server;
                 conn.l7.request_leg = .done;
-            } else {
-                armRequestBodyRecv(server, conn);
             }
-        }
+
+            pub fn onSendEntry(server: *ServerType, conn: *ConnType) bool {
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.request_leg == .pumping_body);
+                if (conn.l7.pending_verdict != .none) {
+                    settlePendingVerdict(server, conn);
+                    return true;
+                }
+                return false;
+            }
+        };
+
+        const RequestBodyPump = pump.Pump(IoType, .client_to_upstream, RequestBodyPolicy);
+        const armRequestBodyRecv = RequestBodyPump.armRecv;
 
         fn startResponseLeg(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
@@ -1010,38 +986,44 @@ pub fn Proxy(comptime IoType: type) type {
         fn afterResponseExcess(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             conn.l7.response_leg = .pumping_body;
-            if (framingDone(&conn.l7.response_framing)) {
+            if (framingDoneOf(&conn.l7.response_framing)) {
                 finishExchange(server, conn);
             } else {
                 armResponseBodyRecv(server, conn);
             }
         }
 
-        fn armResponseBodyRecv(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .pumping_body);
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            server.io.recv(
-                conn.upstream_socket.?,
-                &conn.relay_buffer.?.upstream_to_client,
-                &conn.op_data_upstream_to_client.completion,
-                ConnType,
-                conn,
-                onResponseBodyRecv,
-            );
-        }
-
-        fn onResponseBodyRecv(conn: *ConnType, result: Io.RecvError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
+        /// The response leg's body pump (origin → client, §7). Framed by the
+        /// origin's response framing; the first response byte already
+        /// reached the client, so no verdict can be pending (a 504/replay is
+        /// off the table once bytes flow). An `until_close` body ends on the
+        /// origin's EOF; any other framing's EOF is a truncation the client
+        /// must see, and every failure tears down.
+        const ResponseBodyPolicy = struct {
+            pub fn beforeRecv(conn: *ConnType) void {
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.response_leg == .pumping_body);
+                assert(conn.l7.pending_verdict == .none); // response_started.
             }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .pumping_body);
-            assert(conn.l7.pending_verdict == .none); // response_started.
-            const received = result catch |err| {
+
+            /// Completion-time re-checks (post-await): once a response byte
+            /// has reached the client no verdict can be pending, so the
+            /// invariant must still hold after the await.
+            pub fn onRecvEntry(conn: *ConnType) void {
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.response_leg == .pumping_body);
+                assert(conn.l7.pending_verdict == .none); // response_started.
+            }
+
+            pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
+                return feedFraming(&conn.l7.response_framing, chunk);
+            }
+
+            pub fn framingDone(conn: *ConnType) bool {
+                return framingDoneOf(&conn.l7.response_framing);
+            }
+
+            pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
                 if (err == error.EndOfStream) {
                     if (conn.l7.response_framing == .until_close) {
                         // The origin's EOF is this framing's terminator.
@@ -1053,71 +1035,32 @@ pub fn Proxy(comptime IoType: type) type {
                 }
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
-                return;
-            };
-            assert(received >= 1);
-            const chunk = conn.relay_buffer.?.upstream_to_client[0..received];
-            const feed = feedFraming(&conn.l7.response_framing, chunk);
-            if (feed.malformed) {
-                server.beginTeardown(conn);
-                return;
             }
-            const direction = &conn.directions[1];
-            direction.transfer_len = feed.consumed;
-            direction.sent_len = 0;
-            if (feed.consumed >= 1) {
-                armResponseBodySend(server, conn);
-            } else {
-                assert(feed.done);
-                finishExchange(server, conn);
-            }
-        }
 
-        fn armResponseBodySend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            const direction = &conn.directions[1];
-            assert(direction.sent_len < direction.transfer_len);
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            server.io.send(
-                conn.client_socket,
-                conn.relay_buffer.?.upstream_to_client[direction.sent_len..direction.transfer_len],
-                &conn.op_data_upstream_to_client.completion,
-                ConnType,
-                conn,
-                onResponseBodySent,
-            );
-        }
-
-        fn onResponseBodySent(conn: *ConnType, result: Io.SendError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .pumping_body);
-            assert(conn.l7.pending_verdict == .none); // response_started.
-            const sent = result catch |err| {
+            pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
-                return;
-            };
-            assert(sent >= 1);
-            const direction = &conn.directions[1];
-            direction.sent_len += sent;
-            assert(direction.sent_len <= direction.transfer_len);
-            if (direction.sent_len < direction.transfer_len) {
-                armResponseBodySend(server, conn);
-                return;
             }
-            server.storeDeadline(conn, server.idleTimeoutMs());
-            if (framingDone(&conn.l7.response_framing)) {
+
+            pub fn onDrained(server: *ServerType, conn: *ConnType) void {
                 finishExchange(server, conn);
-            } else {
-                armResponseBodyRecv(server, conn);
             }
-        }
+
+            pub fn onComplete(server: *ServerType, conn: *ConnType) void {
+                finishExchange(server, conn);
+            }
+
+            pub fn onSendEntry(server: *ServerType, conn: *ConnType) bool {
+                _ = server;
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.response_leg == .pumping_body);
+                assert(conn.l7.pending_verdict == .none); // response_started.
+                return false;
+            }
+        };
+
+        const ResponseBodyPump = pump.Pump(IoType, .upstream_to_client, ResponseBodyPolicy);
+        const armResponseBodyRecv = ResponseBodyPump.armRecv;
 
         /// The response reached the client in full: settle both sides.
         /// The upstream connection parks for reuse when the origin allowed
@@ -1507,11 +1450,7 @@ pub fn Proxy(comptime IoType: type) type {
             armDrainRecv(server, conn);
         }
 
-        const FeedResult = struct {
-            consumed: u32,
-            done: bool,
-            malformed: bool,
-        };
+        const FeedResult = pump.FeedResult;
 
         /// Advance a framing tracker over `bytes`, reporting how many of
         /// them belong to the message. Consumed < bytes.len means the
@@ -1551,7 +1490,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
-        fn framingDone(framing: *const Framing) bool {
+        fn framingDoneOf(framing: *const Framing) bool {
             return switch (framing.*) {
                 .none => true,
                 .content_length => |remaining| remaining == 0,

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -1,0 +1,182 @@
+//! The shared recv → send → recv body pump, factored out of `relay.zig`
+//! (L4) and the two L7 body legs in `http/proxy.zig` (DESIGN.md §6, §7).
+//! Every one of those sites ran the identical loop — arm a recv into a
+//! fixed buffer, forward the chunk fully (short sends resume from the
+//! offset), only then arm the next recv — differing solely in *policy*:
+//! how a message ends (framing), what EOF and errors mean, and what "the
+//! body finished" does next.
+//!
+//! The mechanical plumbing is keyed entirely off the direction tag, so it
+//! is 100% shared: for a given `direction` the source/target sockets, the
+//! `relay_buffer` field, the embedded `Op`, the armed bit, and the
+//! `DirectionState` cursor all derive from `@tagName(direction)` — exactly
+//! the naming convention `relay.zig` already exploited. What is left is the
+//! `Policy`: a comptime struct of hooks the caller supplies.
+//!
+//! Required Policy decls:
+//!   feed(conn, chunk) FeedResult      how many bytes belong to the message
+//!   framingDone(conn) bool            is the message fully forwarded
+//!   onRecvError(server, conn, err)    terminal: EOF/reset handling
+//!   onSendError(server, conn, err)    terminal: send failure
+//!   onDrained(server, conn)           a recv yielded 0 forwardable bytes, done
+//!   onComplete(server, conn)          the whole body reached the far side
+//! Optional Policy decls (skipped when absent):
+//!   beforeRecv(conn) / beforeSend(conn)   pre-arm bookkeeping (flags, phase)
+//!   onRecvEntry(conn)                     post-await recv invariant re-checks
+//!   afterFeed(conn, received, fr)         e.g. pipelined-tail detection
+//!   onSendEntry(server, conn) bool        divert a settled verdict; true = handled
+//!
+//! The `on*Entry` hooks fire at completion time — after `delivered`, before
+//! the I/O result is unwrapped — so a Policy can re-assert the invariants
+//! that must have held across the in-flight await (the pre-arm `before*`
+//! hooks only see the state at submit time, not after the await). `onSend`'s
+//! variant additionally returns whether it handled the completion (a §7
+//! verdict divert); `onRecv` has no divert — a client-side recv cannot be
+//! forced (§8) — so `onRecvEntry` is assertion-only.
+
+const std = @import("std");
+
+const conn_module = @import("Conn.zig");
+const Io = @import("../io/io.zig");
+
+const assert = std.debug.assert;
+
+/// How many of a received chunk belong to the current message. `consumed`
+/// < chunk.len means the message ended mid-buffer (the rest is a pipelined
+/// tail); `done` means no more body follows; `malformed` fails the framing.
+pub const FeedResult = struct {
+    consumed: u32,
+    done: bool,
+    malformed: bool,
+};
+
+pub fn Pump(
+    comptime IoType: type,
+    comptime direction: conn_module.Conn(IoType).Direction,
+    comptime Policy: type,
+) type {
+    const ConnType = conn_module.Conn(IoType);
+    const ServerType = @import("../Server.zig").Server(IoType);
+    const direction_tag = @tagName(direction);
+
+    return struct {
+        const bit = "data_" ++ direction_tag;
+
+        fn op(conn: *ConnType) *ConnType.Op {
+            return &@field(conn, "op_data_" ++ direction_tag);
+        }
+
+        fn directionState(conn: *ConnType) *ConnType.DirectionState {
+            return &conn.directions[@intFromEnum(direction)];
+        }
+
+        fn buffer(conn: *ConnType) []u8 {
+            return &@field(conn.relay_buffer.?, direction_tag);
+        }
+
+        fn source(conn: *const ConnType) IoType.Socket {
+            return switch (direction) {
+                .client_to_upstream => conn.client_socket,
+                .upstream_to_client => conn.upstream_socket.?,
+            };
+        }
+
+        fn target(conn: *const ConnType) IoType.Socket {
+            return switch (direction) {
+                .client_to_upstream => conn.upstream_socket.?,
+                .upstream_to_client => conn.client_socket,
+            };
+        }
+
+        pub fn armRecv(server: *ServerType, conn: *ConnType) void {
+            // A direction-agnostic precondition the pump enforces itself, so
+            // the shared mechanism never relies solely on the optional
+            // `beforeRecv` hook: every pump reads and writes the relay buffer.
+            assert(conn.relay_buffer != null);
+            if (@hasDecl(Policy, "beforeRecv")) Policy.beforeRecv(conn);
+            conn.arm(op(conn), bit);
+            server.io.recv(
+                source(conn),
+                buffer(conn),
+                &op(conn).completion,
+                ConnType,
+                conn,
+                onRecv,
+            );
+        }
+
+        fn onRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(op(conn), bit);
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            if (@hasDecl(Policy, "onRecvEntry")) Policy.onRecvEntry(conn);
+            const received = result catch |err| return Policy.onRecvError(server, conn, err);
+            assert(received >= 1);
+            assert(received <= buffer(conn).len);
+            const chunk = buffer(conn)[0..received];
+            const fr = Policy.feed(conn, chunk);
+            if (fr.malformed) {
+                server.beginTeardown(conn);
+                return;
+            }
+            if (@hasDecl(Policy, "afterFeed")) Policy.afterFeed(conn, received, fr);
+            const state = directionState(conn);
+            state.transfer_len = fr.consumed;
+            state.sent_len = 0;
+            if (fr.consumed >= 1) {
+                armSend(server, conn);
+            } else {
+                assert(fr.done);
+                Policy.onDrained(server, conn);
+            }
+        }
+
+        pub fn armSend(server: *ServerType, conn: *ConnType) void {
+            assert(conn.relay_buffer != null);
+            if (@hasDecl(Policy, "beforeSend")) Policy.beforeSend(conn);
+            const state = directionState(conn);
+            assert(state.sent_len < state.transfer_len);
+            conn.arm(op(conn), bit);
+            server.io.send(
+                target(conn),
+                buffer(conn)[state.sent_len..state.transfer_len],
+                &op(conn).completion,
+                ConnType,
+                conn,
+                onSend,
+            );
+        }
+
+        fn onSend(conn: *ConnType, result: Io.SendError!u32) void {
+            const server = conn.server;
+            conn.delivered(op(conn), bit);
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            if (@hasDecl(Policy, "onSendEntry")) {
+                if (Policy.onSendEntry(server, conn)) return;
+            }
+            const sent = result catch |err| return Policy.onSendError(server, conn, err);
+            assert(sent >= 1);
+            const state = directionState(conn);
+            state.sent_len += sent;
+            assert(state.sent_len <= state.transfer_len);
+            if (state.sent_len < state.transfer_len) {
+                armSend(server, conn);
+                return;
+            }
+            // A full chunk moved: this is activity — push the idle deadline
+            // out (§6); the armed timer op is not touched.
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            if (Policy.framingDone(conn)) {
+                Policy.onComplete(server, conn);
+            } else {
+                armRecv(server, conn);
+            }
+        }
+    };
+}

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -5,11 +5,17 @@
 //! and held for the connection's life: a recv must always have a buffer
 //! posted, so `relay_buffers_max`, not conn slots, bounds concurrent L4
 //! connections.
+//!
+//! The recv → send loop itself lives in `pump.zig`; this file supplies only
+//! the L4 *policy* — no framing (relay runs until FIN both ways), EOF becomes
+//! a half-close, and the connection tears down when both directions have
+//! finished.
 
 const std = @import("std");
 
 const constants = @import("../constants.zig");
 const conn_module = @import("Conn.zig");
+const pump = @import("pump.zig");
 const Io = @import("../io/io.zig");
 
 const assert = std.debug.assert;
@@ -38,115 +44,111 @@ pub fn Relay(comptime IoType: type) type {
     const Direction = ConnType.Direction;
 
     return struct {
+        /// The L4 relay policy for one direction: no framing, EOF is a
+        /// half-close, teardown once both directions finish. Instantiated
+        /// once per direction so the terminal handlers know which side
+        /// FIN'd.
+        fn Policy(comptime direction: Direction) type {
+            return struct {
+                fn targetSocket(conn: *const ConnType) IoType.Socket {
+                    return switch (direction) {
+                        .client_to_upstream => conn.upstream_socket.?,
+                        .upstream_to_client => conn.client_socket,
+                    };
+                }
+
+                fn state(conn: *ConnType) *ConnType.DirectionState {
+                    return &conn.directions[@intFromEnum(direction)];
+                }
+
+                pub fn beforeRecv(conn: *ConnType) void {
+                    assert(conn.state == .relaying);
+                    const direction_state = state(conn);
+                    assert(direction_state.phase == .idle or direction_state.phase == .sending);
+                    direction_state.phase = .receiving;
+                }
+
+                pub fn beforeSend(conn: *ConnType) void {
+                    assert(conn.state == .relaying);
+                    const direction_state = state(conn);
+                    assert(direction_state.phase == .receiving or direction_state.phase == .sending);
+                    direction_state.phase = .sending;
+                }
+
+                /// Completion-time re-checks: the invariants must still hold
+                /// after the in-flight await, not only when the op was armed.
+                pub fn onRecvEntry(conn: *ConnType) void {
+                    assert(conn.state == .relaying);
+                    assert(state(conn).phase == .receiving);
+                }
+
+                pub fn onSendEntry(server: *ServerType, conn: *ConnType) bool {
+                    _ = server;
+                    assert(conn.state == .relaying);
+                    assert(state(conn).phase == .sending);
+                    return false; // Relay never diverts: it has no verdict.
+                }
+
+                /// No framing: every received byte is relayed and the
+                /// message never ends short of a FIN, so `done` stays false.
+                pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
+                    _ = conn;
+                    return .{ .consumed = @intCast(chunk.len), .done = false, .malformed = false };
+                }
+
+                /// A FIN never arrives through here (relay has no length to
+                /// count down); the loop only leaves on EOF or teardown.
+                pub fn framingDone(conn: *ConnType) bool {
+                    _ = conn;
+                    return false;
+                }
+
+                pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
+                    if (err == error.EndOfStream) {
+                        // Half-close (§6): propagate the FIN, keep the other
+                        // direction relaying under the deadline.
+                        state(conn).phase = .finished;
+                        server.io.shutdown(targetSocket(conn), .write);
+                        server.storeDeadline(conn, server.idleTimeoutMs());
+                        maybeFinish(server, conn);
+                        return;
+                    }
+                    server.witnessKernelPressure(err);
+                    server.beginTeardown(conn);
+                }
+
+                pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
+                    server.witnessKernelPressure(err);
+                    server.beginTeardown(conn);
+                }
+
+                /// Unreachable for L4: `feed` never yields 0 consumed bytes
+                /// and never reports `done`.
+                pub fn onDrained(server: *ServerType, conn: *ConnType) void {
+                    _ = server;
+                    _ = conn;
+                    unreachable;
+                }
+
+                /// Unreachable for L4: `framingDone` is always false.
+                pub fn onComplete(server: *ServerType, conn: *ConnType) void {
+                    _ = server;
+                    _ = conn;
+                    unreachable;
+                }
+            };
+        }
+
+        const PumpClientToUpstream = pump.Pump(IoType, .client_to_upstream, Policy(.client_to_upstream));
+        const PumpUpstreamToClient = pump.Pump(IoType, .upstream_to_client, Policy(.upstream_to_client));
+
         pub fn start(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .relaying);
             assert(conn.upstream_socket != null);
             assert(conn.directions[0].phase == .idle);
             assert(conn.directions[1].phase == .idle);
-            armRecv(server, conn, .client_to_upstream);
-            armRecv(server, conn, .upstream_to_client);
-        }
-
-        fn armRecv(server: *ServerType, conn: *ConnType, comptime direction: Direction) void {
-            assert(conn.state == .relaying);
-            const state = directionState(conn, direction);
-            assert(state.phase == .idle or state.phase == .sending);
-            state.phase = .receiving;
-            const op = dataOp(conn, direction);
-            conn.arm(op, armedBitName(direction));
-            server.io.recv(
-                sourceSocket(conn, direction),
-                buffer(conn, direction),
-                &op.completion,
-                ConnType,
-                conn,
-                onRecvFor(direction),
-            );
-        }
-
-        fn armSend(server: *ServerType, conn: *ConnType, comptime direction: Direction) void {
-            assert(conn.state == .relaying);
-            const state = directionState(conn, direction);
-            assert(state.phase == .receiving or state.phase == .sending);
-            assert(state.sent_len < state.transfer_len);
-            state.phase = .sending;
-            const op = dataOp(conn, direction);
-            conn.arm(op, armedBitName(direction));
-            server.io.send(
-                targetSocket(conn, direction),
-                buffer(conn, direction)[state.sent_len..state.transfer_len],
-                &op.completion,
-                ConnType,
-                conn,
-                onSendFor(direction),
-            );
-        }
-
-        fn onRecv(
-            comptime direction: Direction,
-            conn: *ConnType,
-            result: Io.RecvError!u32,
-        ) void {
-            const server = conn.server;
-            conn.delivered(dataOp(conn, direction), armedBitName(direction));
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .relaying);
-            const state = directionState(conn, direction);
-            assert(state.phase == .receiving);
-            const received = result catch |err| {
-                if (err == error.EndOfStream) {
-                    // Half-close (§6): propagate the FIN, keep the other
-                    // direction relaying under the deadline.
-                    state.phase = .finished;
-                    server.io.shutdown(targetSocket(conn, direction), .write);
-                    server.storeDeadline(conn, server.idleTimeoutMs());
-                    maybeFinish(server, conn);
-                    return;
-                }
-                server.witnessKernelPressure(err);
-                server.beginTeardown(conn);
-                return;
-            };
-            assert(received >= 1);
-            assert(received <= buffer(conn, direction).len);
-            state.transfer_len = received;
-            state.sent_len = 0;
-            armSend(server, conn, direction);
-        }
-
-        fn onSend(
-            comptime direction: Direction,
-            conn: *ConnType,
-            result: Io.SendError!u32,
-        ) void {
-            const server = conn.server;
-            conn.delivered(dataOp(conn, direction), armedBitName(direction));
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .relaying);
-            const state = directionState(conn, direction);
-            assert(state.phase == .sending);
-            const sent = result catch |err| {
-                server.witnessKernelPressure(err);
-                server.beginTeardown(conn);
-                return;
-            };
-            assert(sent >= 1);
-            state.sent_len += sent;
-            assert(state.sent_len <= state.transfer_len);
-            if (state.sent_len < state.transfer_len) {
-                armSend(server, conn, direction);
-            } else {
-                // A full exchange moved: this is activity — push the idle
-                // deadline out (§6); the armed timer op is not touched.
-                server.storeDeadline(conn, server.idleTimeoutMs());
-                armRecv(server, conn, direction);
-            }
+            PumpClientToUpstream.armRecv(server, conn);
+            PumpUpstreamToClient.armRecv(server, conn);
         }
 
         /// Both directions drained: the orderly end of an L4 connection.
@@ -157,66 +159,6 @@ pub fn Relay(comptime IoType: type) type {
                     server.beginTeardown(conn);
                 }
             }
-        }
-
-        // The per-direction plumbing derives from one naming convention:
-        // the DirectionState index, the RelayBuffer field, the op field
-        // (`op_data_` + tag), and the armed bit (`data_` + tag) are all
-        // keyed off the direction's tag name, so the only real branch is
-        // which socket is the source (its target is the source of the
-        // opposite direction).
-
-        fn directionState(conn: *ConnType, comptime direction: Direction) *ConnType.DirectionState {
-            return &conn.directions[@intFromEnum(direction)];
-        }
-
-        fn dataOp(conn: *ConnType, comptime direction: Direction) *ConnType.Op {
-            return &@field(conn, "op_data_" ++ @tagName(direction));
-        }
-
-        fn armedBitName(comptime direction: Direction) []const u8 {
-            return "data_" ++ @tagName(direction);
-        }
-
-        fn buffer(conn: *ConnType, comptime direction: Direction) []u8 {
-            // The L4 relay always holds its buffer for the connection's
-            // life (§6); it is only ever null on an idle L7 connection.
-            return &@field(conn.relay_buffer.?, @tagName(direction));
-        }
-
-        fn opposite(comptime direction: Direction) Direction {
-            return switch (direction) {
-                .client_to_upstream => .upstream_to_client,
-                .upstream_to_client => .client_to_upstream,
-            };
-        }
-
-        fn sourceSocket(conn: *const ConnType, comptime direction: Direction) IoType.Socket {
-            // The relay only runs in .relaying, where the upstream is set.
-            return switch (direction) {
-                .client_to_upstream => conn.client_socket,
-                .upstream_to_client => conn.upstream_socket.?,
-            };
-        }
-
-        fn targetSocket(conn: *const ConnType, comptime direction: Direction) IoType.Socket {
-            return sourceSocket(conn, opposite(direction));
-        }
-
-        fn onRecvFor(comptime direction: Direction) fn (*ConnType, Io.RecvError!u32) void {
-            return (struct {
-                fn callback(conn: *ConnType, result: Io.RecvError!u32) void {
-                    onRecv(direction, conn, result);
-                }
-            }).callback;
-        }
-
-        fn onSendFor(comptime direction: Direction) fn (*ConnType, Io.SendError!u32) void {
-            return (struct {
-                fn callback(conn: *ConnType, result: Io.SendError!u32) void {
-                    onSend(direction, conn, result);
-                }
-            }).callback;
         }
     };
 }


### PR DESCRIPTION
## What

The L4 relay (`net/relay.zig`, both directions) and the two L7 body legs (`http/proxy.zig`: request body client→origin, response body origin→client) each hand-rolled the **identical** recv → send → recv loop. This extracts that loop into a new `src/net/pump.zig` generic; each call site now supplies a comptime `Policy` of hooks.

The mechanical plumbing keys entirely off the direction tag — source/target sockets, the `relay_buffer` field, the embedded `Op`, the armed bit, and the `DirectionState` cursor all derive from `@tagName(direction)` (the naming convention `relay.zig` already exploited) — so it is 100% shared. Only the *policy* differs:

| | framing | EOF | terminal |
|---|---|---|---|
| L4 relay | none (until FIN) | half-close | teardown when both dirs finish |
| L7 request body | request framing | truncation → teardown | leg `.done` |
| L7 response body | response framing | `until_close` → finish, else teardown | `finishExchange` |

## Why

This is a **single-sourcing** win, not a LOC win (roughly flat): the correctness-critical plumbing that was triplicated — the generation-at-submit check, armed-bit set/clear, short-send resume, teardown re-entry guard, post-send deadline refresh — now lives in exactly one place.

## Assertion coverage

Invariants are re-checked at **both** submit time (pre-arm `before*` hooks) and completion time (post-await `on*Entry` hooks), matching the old handlers' two-point checking. `armRecv`/`armSend` also assert the direction-agnostic `relay_buffer != null` precondition directly, so the shared mechanism never depends solely on the optional hooks.

## Scope / follow-ups

- Five other **send-only** short-send loops in `proxy.zig` (head-send, excess-send ×2, static-response-send) still hand-roll the resume idiom. They have no interleaved recv, so they don't fit `Pump`'s recv→send→recv shape without further generic-splitting — deliberately left for a follow-up.

## Verification

- `zig build ci` — unit tests + fuzz corpus + boundary lint + 64/64 deterministic sim seeds ✅
- `zig fmt --check` ✅
- `tiger-style-reviewer` agent run on the diff; all flagged violations fixed (compound-condition nesting, abbreviations, doc comments, pump-layer precondition assert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)