### PR TITLE
Admin/metrics listener: Prometheus scrape endpoint (§8, PLANS.md Phase 2.5)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -141,6 +141,45 @@ behind all four gates of §9.
     `upstream_replayed ≤ upstream_reused`), asserted by the sim under
     every seed; the sim's adversary gained blackholed dials and a
     `stale_reuse` origin mode.
+- **Phase 2.5 — admin/metrics listener. Implemented 2026-07-21 (branch
+  `prototype/admin-listener`).** The metrics-exposure half of the §8 admin
+  plane, behind all four §9 gates. One dedicated listener off the three
+  shared pools — a single reserved scrape slot, budgeted separately in
+  `constants.zig` (`admin_listeners`, `admin_conns`, `admin_conn_ops_max`)
+  — that answers any request on the admin port with the Prometheus
+  exposition rendering of the counters. Reserving the admin ops derives
+  `conn_slots_max` 1020 → 1019 (the ¾-CQ budget was exactly saturated);
+  `fds_max` is unchanged (one fewer conn slot frees exactly the two fds the
+  admin listener + client claim).
+  - **Renderer** — `Counters.render`, zero-alloc into a caller-owned buffer
+    sized by a comptime-exact `render_bytes_max`; the SIGUSR1 dump (§8)
+    reuses it, so the dump and the scrape endpoint share one wire format.
+    Body framed by `Connection: close` (no Content-Length needed).
+  - **Scrape lifecycle** — accept → send → lingering close (half-close the
+    write side, drain client input to EOF so the close never RSTs the
+    response away, §2) → re-arm; one scrape at a time. A per-scrape
+    deadline (`admin_scrape_deadline_ms`) reaps a stalled/slowloris client
+    so it cannot pin the slot; accept/send/recv witness kernel pressure and
+    a failed accept backs off (`accept_retry_delay_ms`) like the data path.
+    The request is never parsed — the same counters regardless of method or
+    path, so no routing and no new attack surface.
+  - **Drain** — the server drain (§8) closes the admin listener and tears
+    down any in-flight scrape; `maybeStopAfterDrain` and `isIdle` gate on
+    the admin conn's quiescence.
+  - **Enablement** — `ZOXY_ADMIN_BIND` (e.g. `127.0.0.1:9100`), threaded as
+    `setAdminBind` before `start`; off when unset.
+  - **Observability** — `admin_served` / `admin_reaped` counters, pure
+    observability outside `reconcile`'s accounting.
+  - **Gates** — SimIo scrape scenarios (byte-exact across partial_io seeds,
+    reset-prefix robustness, a drain racing an in-flight scrape via the
+    raced-accept holder idiom, the deadline reaper), plus the render bound
+    proven tight at `maxInt(u64)`.
+  - **Deferred** — promote the bind to the JSON config (an `admin` block +
+    JSON Schema, clearing the config-schema metadata gate); the env var is
+    the prototype's deliberate shortcut so a bad value fails loudly rather
+    than silently starting with metrics off. Single-scrape-at-a-time is by
+    design (a localhost round trip); lift only on evidence. Richer admin
+    surface (push/OTLP export, per-route stats, a control plane) stays out.
 - **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
   activates). The stack is an **open decision under the Zig-first policy**
   (§4). Leading candidate (surveyed 2026-07-12): **picotls** (h2o/picotls)
@@ -240,8 +279,9 @@ queue, in rough value order:
   active health checks (§7).
 - Hot restart + drain-to-successor (§1).
 - Config DSL (§1 keeps config parse-once immutable).
-- Metrics/admin plane beyond loop-written counters + the SIGUSR1 dump
-  (§8).
+- Metrics/admin plane beyond the Prometheus scrape endpoint + SIGUSR1 dump
+  (Phase 2.5): push/OTLP export, per-route stats, a control surface, and
+  promoting the admin bind from `ZOXY_ADMIN_BIND` to the JSON config (§8).
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
 - Config JSON Schema — the generator ships (`zig build schema`, reflected

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -181,8 +181,8 @@ behind all four gates of §9.
     block (absent → off, valid literal → resolved, hostname/empty/extra →
     the matching loader error).
   - **Deferred** — single-scrape-at-a-time is by design (a localhost round
-    trip); lift only on evidence. Richer admin surface (push/OTLP export,
-    per-route stats, a control plane) stays out.
+    trip); lift only on evidence. Richer admin surface (push/OTLP export, a
+    control plane) stays out.
 - **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
   activates). The stack is an **open decision under the Zig-first policy**
   (§4). Leading candidate (surveyed 2026-07-12): **picotls** (h2o/picotls)
@@ -283,7 +283,7 @@ queue, in rough value order:
 - Hot restart + drain-to-successor (§1).
 - Config DSL (§1 keeps config parse-once immutable).
 - Metrics/admin plane beyond the Prometheus scrape endpoint + SIGUSR1 dump
-  (Phase 2.5): push/OTLP export, per-route stats, a control surface (§8).
+  (Phase 2.5): push/OTLP export, a control surface (§8).
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
 - Config JSON Schema — the generator ships (`zig build schema`, reflected

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -166,20 +166,23 @@ behind all four gates of §9.
   - **Drain** — the server drain (§8) closes the admin listener and tears
     down any in-flight scrape; `maybeStopAfterDrain` and `isIdle` gate on
     the admin conn's quiescence.
-  - **Enablement** — `ZOXY_ADMIN_BIND` (e.g. `127.0.0.1:9100`), threaded as
-    `setAdminBind` before `start`; off when unset.
+  - **Enablement** — an optional `"admin": { "bind": "127.0.0.1:9100" }`
+    config block resolves to `Config.admin_bind` (a static IP:port literal,
+    hostnames rejected like every bind); absent leaves the plane off. It
+    carries schema metadata (`AdminJson` in `dto_types`), so `zig build
+    schema` emits it and the metadata gate covers it. The simulator and
+    tests override via `setAdminBind` before `start`.
   - **Observability** — `admin_served` / `admin_reaped` counters, pure
     observability outside `reconcile`'s accounting.
   - **Gates** — SimIo scrape scenarios (byte-exact across partial_io seeds,
     reset-prefix robustness, a drain racing an in-flight scrape via the
     raced-accept holder idiom, the deadline reaper), plus the render bound
-    proven tight at `maxInt(u64)`.
-  - **Deferred** — promote the bind to the JSON config (an `admin` block +
-    JSON Schema, clearing the config-schema metadata gate); the env var is
-    the prototype's deliberate shortcut so a bad value fails loudly rather
-    than silently starting with metrics off. Single-scrape-at-a-time is by
-    design (a localhost round trip); lift only on evidence. Richer admin
-    surface (push/OTLP export, per-route stats, a control plane) stays out.
+    proven tight at `maxInt(u64)`, and config parse tests for the `admin`
+    block (absent → off, valid literal → resolved, hostname/empty/extra →
+    the matching loader error).
+  - **Deferred** — single-scrape-at-a-time is by design (a localhost round
+    trip); lift only on evidence. Richer admin surface (push/OTLP export,
+    per-route stats, a control plane) stays out.
 - **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
   activates). The stack is an **open decision under the Zig-first policy**
   (§4). Leading candidate (surveyed 2026-07-12): **picotls** (h2o/picotls)
@@ -280,8 +283,7 @@ queue, in rough value order:
 - Hot restart + drain-to-successor (§1).
 - Config DSL (§1 keeps config parse-once immutable).
 - Metrics/admin plane beyond the Prometheus scrape endpoint + SIGUSR1 dump
-  (Phase 2.5): push/OTLP export, per-route stats, a control surface, and
-  promoting the admin bind from `ZOXY_ADMIN_BIND` to the JSON config (§8).
+  (Phase 2.5): push/OTLP export, per-route stats, a control surface (§8).
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
 - Config JSON Schema — the generator ships (`zig build schema`, reflected

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -181,8 +181,11 @@ behind all four gates of §9.
     block (absent → off, valid literal → resolved, hostname/empty/extra →
     the matching loader error).
   - **Deferred** — single-scrape-at-a-time is by design (a localhost round
-    trip); lift only on evidence. Richer admin surface (push/OTLP export, a
-    control plane) stays out.
+    trip); lift only on evidence. A richer admin surface (a control plane)
+    stays out, and metrics stay **pull-only**: a push exporter (OTLP /
+    remote-write) would drag in a protobuf dependency, an outbound socket
+    with export buffering + retry (against §8's no-unbounded-queue rule),
+    and collector DNS (a §1 non-goal) — all the wrong grain for this proxy.
 - **Phase 3 — TLS.** CPU worker pool + job queues for handshakes (§3 seam
   activates). The stack is an **open decision under the Zig-first policy**
   (§4). Leading candidate (surveyed 2026-07-12): **picotls** (h2o/picotls)
@@ -282,8 +285,10 @@ queue, in rough value order:
   active health checks (§7).
 - Hot restart + drain-to-successor (§1).
 - Config DSL (§1 keeps config parse-once immutable).
-- Metrics/admin plane beyond the Prometheus scrape endpoint + SIGUSR1 dump
-  (Phase 2.5): push/OTLP export, a control surface (§8).
+- Metrics/admin plane beyond the pull-only Prometheus scrape endpoint +
+  SIGUSR1 dump (Phase 2.5): a control surface (§8). Push export (OTLP /
+  remote-write) is ruled out, not deferred — it wants a protobuf dep,
+  outbound export buffering, and collector DNS, all against the grain.
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
 - Config JSON Schema — the generator ships (`zig build schema`, reflected

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -12,6 +12,7 @@
 
 const std = @import("std");
 
+const admin_module = @import("admin.zig");
 const Balancer = @import("balancer.zig").Balancer;
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
@@ -69,6 +70,10 @@ pub fn Server(comptime IoType: type) type {
         /// timer.
         upstream_sweep_completion: IoType.Completion,
         upstream_sweep_armed: bool,
+        /// The dedicated admin/metrics listener (§8, PLANS.md §243): one
+        /// reserved scrape slot off the shared pools, budgeted separately
+        /// (`constants.admin_*`). Off unless a bind is set before `start`.
+        admin: admin_module.Admin(IoType),
 
         const Self = @This();
 
@@ -129,6 +134,14 @@ pub fn Server(comptime IoType: type) type {
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
+            server.admin.init(server, null);
+        }
+
+        /// Enable the admin/metrics listener on `bind_address` (main.zig
+        /// from `ZOXY_ADMIN_BIND`; the simulator sets it directly). Must be
+        /// called before `start`; with no call the admin plane stays off.
+        pub fn setAdminBind(server: *Self, bind_address: std.Io.net.IpAddress) void {
+            server.admin.setBind(bind_address);
         }
 
         pub fn start(server: *Self) Io.ListenError!void {
@@ -152,6 +165,7 @@ pub fn Server(comptime IoType: type) type {
                 };
                 server.armAccept(state);
             }
+            try server.admin.start();
             server.io.signalWait(Self, server, onSignal);
         }
 
@@ -167,6 +181,9 @@ pub fn Server(comptime IoType: type) type {
             for (server.listeners[0..server.listeners_count]) |*state| {
                 server.io.listenClose(state.listener);
             }
+            // The admin listener stops accepting and any in-flight scrape
+            // is torn down under the same drain (§8).
+            server.admin.beginDrain();
             // Parked upstreams are idle capacity; the drain sheds them
             // first (§8). Synchronous closes: no armed op to wait for.
             server.reapParked(true);
@@ -201,9 +218,12 @@ pub fn Server(comptime IoType: type) type {
             }
         }
 
-        fn maybeStopAfterDrain(server: *Self) void {
+        pub fn maybeStopAfterDrain(server: *Self) void {
             if (!server.draining) return;
             if (!server.conns.isFullyReleased()) return;
+            // An in-flight scrape holds no pool slot but does hold an armed
+            // op and the admin fd; the loop must not stop until it drains.
+            if (!server.admin.isQuiescent()) return;
             assert(server.relay_buffers.isFullyReleased());
             // beginDrain reaped every parked slot synchronously and no
             // conn is left to lease one, so the pool must be empty.
@@ -258,11 +278,14 @@ pub fn Server(comptime IoType: type) type {
             server.ensureUpstreamSweep();
         }
 
-        /// The simulator's leak invariant (§9).
+        /// The simulator's leak invariant (§9). The admin conn holds no
+        /// pool slot, but a leaked armed op or an open admin fd is a leak
+        /// all the same, so its quiescence is part of "idle".
         pub fn isIdle(server: *const Self) bool {
             return server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
-                server.upstreams.isFullyReleased();
+                server.upstreams.isFullyReleased() and
+                server.admin.isQuiescent();
         }
 
         pub fn activeCount(server: *const Self) u32 {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -134,12 +134,12 @@ pub fn Server(comptime IoType: type) type {
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
-            server.admin.init(server, null);
+            server.admin.init(server, config.admin_bind);
         }
 
-        /// Enable the admin/metrics listener on `bind_address` (main.zig
-        /// from `ZOXY_ADMIN_BIND`; the simulator sets it directly). Must be
-        /// called before `start`; with no call the admin plane stays off.
+        /// Override the admin/metrics bind before `start` — the simulator
+        /// and tests set it directly; production seeds it from the config's
+        /// `admin` block in `init`. Must be called before `start`.
         pub fn setAdminBind(server: *Self, bind_address: std.Io.net.IpAddress) void {
             server.admin.setBind(bind_address);
         }

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -38,10 +38,6 @@ const response_head =
 /// A full response is the fixed head plus one rendering of every counter.
 const response_bytes_max = response_head.len + counters_module.Counters.render_bytes_max;
 
-/// Fixed throwaway buffer for the lingering-close drain — the request is
-/// discarded, so this is never inspected and one small buffer suffices.
-const drain_scratch_bytes = 512;
-
 pub fn Admin(comptime IoType: type) type {
     const ServerType = @import("Server.zig").Server(IoType);
 
@@ -64,9 +60,13 @@ pub fn Admin(comptime IoType: type) type {
         response: [response_bytes_max]u8,
         response_len: u32,
         sent: u32,
-        drain_scratch: [drain_scratch_bytes]u8,
+        drain_scratch: [constants.admin_drain_scratch_bytes]u8,
         armed: Armed,
         op_accept: IoType.Completion,
+        /// Backoff timer re-arming an accept that failed with kernel
+        /// pressure; never armed while `accept` is (§8 tight-spin guard),
+        /// so it reuses the listener's two-op ring budget.
+        op_accept_retry: IoType.Completion,
         op_send: IoType.Completion,
         op_recv: IoType.Completion,
         op_deadline: IoType.Completion,
@@ -96,12 +96,13 @@ pub fn Admin(comptime IoType: type) type {
         /// One bit per embedded op; the slot is quiescent only when clear.
         pub const Armed = packed struct(u8) {
             accept: bool = false,
+            accept_retry: bool = false,
             send: bool = false,
             recv: bool = false,
             deadline: bool = false,
             deadline_cancel: bool = false,
             close: bool = false,
-            _pad: u2 = 0,
+            _pad: u1 = 0,
         };
 
         pub fn init(
@@ -117,6 +118,13 @@ pub fn Admin(comptime IoType: type) type {
             admin.response_len = 0;
             admin.sent = 0;
             admin.armed = .{};
+            admin.op_accept = .{};
+            admin.op_accept_retry = .{};
+            admin.op_send = .{};
+            admin.op_recv = .{};
+            admin.op_deadline = .{};
+            admin.op_deadline_cancel = .{};
+            admin.op_close = .{};
             assert(admin.armedCount() == 0);
             assert(admin.state == .off);
         }
@@ -150,13 +158,17 @@ pub fn Admin(comptime IoType: type) type {
         }
 
         fn onAccept(admin: *Self, result: Io.AcceptError!IoType.Socket) void {
+            assert(admin.state == .accepting);
             admin.disarm("accept");
             if (admin.server.draining) {
                 // The drain reached the listener: a Canceled accept
                 // (`listenClose`), or a scrape that slipped in as the drain
-                // began — shed that socket, do not serve (§8). Either way the
-                // admin plane is done accepting and now quiescent, so the
-                // drain-stop gate must be re-checked.
+                // began — shed that socket, do not serve (§8). No shed
+                // counter: admin accepts are outside `reconcile`'s
+                // accepted/admitted/shed accounting entirely (they never
+                // increment `accepted`), so counting one here would break the
+                // gate identity. Either way the admin plane is done accepting
+                // and now quiescent, so the drain-stop gate is re-checked.
                 if (result) |socket| {
                     shed.closeQuietly(IoType, admin.server.io, socket);
                 } else |_| {}
@@ -165,10 +177,15 @@ pub fn Admin(comptime IoType: type) type {
                 admin.server.maybeStopAfterDrain();
                 return;
             }
-            const socket = result catch {
-                // A transient accept error on a localhost listener (Canceled
-                // cannot occur outside a drain): re-arm, no socket to shed.
-                admin.armAccept();
+            const socket = result catch |err| {
+                // A kernel-pressure accept failure (ENFILE/ENOMEM-class,
+                // process-wide, so reachable even on a localhost listener)
+                // would re-fire instantly on an immediate re-arm — a tight
+                // spin starving the loop (§8). Witness it and back off through
+                // the shared retry delay, exactly as `Server.onAccept` does;
+                // Canceled cannot occur outside a drain, handled above.
+                admin.server.witnessKernelPressure(err);
+                admin.armAcceptRetry();
                 return;
             };
             admin.socket = socket;
@@ -176,6 +193,37 @@ pub fn Admin(comptime IoType: type) type {
             admin.armDeadline();
             admin.renderResponse();
             admin.armSend();
+            assert(admin.state == .sending);
+        }
+
+        fn armAcceptRetry(admin: *Self) void {
+            assert(admin.listening);
+            assert(!admin.server.draining);
+            assert(admin.armedCount() == 0);
+            admin.state = .accepting;
+            admin.arm("accept_retry");
+            admin.server.io.timerStart(
+                &admin.op_accept_retry,
+                @as(u64, constants.accept_retry_delay_ms) * std.time.ns_per_ms,
+                Self,
+                admin,
+                onAcceptRetry,
+            );
+        }
+
+        fn onAcceptRetry(admin: *Self, result: Io.TimerError!void) void {
+            assert(admin.state == .accepting);
+            admin.disarm("accept_retry");
+            // Nothing ever cancels the retry timer; a drain begun while it
+            // was pending is handled by cleaning up instead of re-arming.
+            result catch unreachable;
+            if (admin.server.draining) {
+                admin.listening = false;
+                admin.state = .off;
+                admin.server.maybeStopAfterDrain();
+                return;
+            }
+            admin.armAccept();
         }
 
         /// Build the full response once, into the fixed buffer: the static
@@ -210,9 +258,11 @@ pub fn Admin(comptime IoType: type) type {
                 admin.continueTeardown();
                 return;
             }
-            const n = result catch {
+            const n = result catch |err| {
                 // A reset or unexpected error mid-response: nothing left to
-                // deliver, tear down.
+                // deliver, tear down. Witness kernel pressure (§8) like every
+                // other data-op site.
+                admin.server.witnessKernelPressure(err);
                 admin.beginTeardown();
                 return;
             };
@@ -253,16 +303,18 @@ pub fn Admin(comptime IoType: type) type {
                 // More client input arrived; keep discarding until EOF. The
                 // scrape deadline bounds a client that never closes.
                 admin.armRecv();
-            } else |err| {
-                // EndOfStream (the client closed after reading the response)
-                // and Reset both mean input is done — close cleanly. A live
-                // Canceled cannot happen here (recv is never canceled outside
-                // teardown), but route it through teardown defensively.
-                if (err == error.Canceled) {
+            } else |err| switch (err) {
+                // The client closed after reading the response (EndOfStream)
+                // or reset — input is done, close cleanly.
+                error.EndOfStream, error.Reset => admin.beginClose(),
+                // Canceled cannot occur outside teardown; route through it
+                // defensively.
+                error.Canceled => admin.beginTeardown(),
+                // Kernel pressure on the drain read (§8): witness and tear down.
+                error.Unexpected => {
+                    admin.server.witnessKernelPressure(err);
                     admin.beginTeardown();
-                    return;
-                }
-                admin.beginClose();
+                },
             }
         }
 

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -1,0 +1,413 @@
+//! The admin/metrics listener (DESIGN.md §8, PLANS.md §243): one dedicated
+//! listener, off the three shared pools, that answers any request on the
+//! admin port with the Prometheus rendering of the counters
+//! (`counters.zig`). Exactly one scrape at a time — the "reserved slot" —
+//! so a scrape and the data path can never shed one another; the fd and
+//! ring budgets reserve for it unconditionally (`constants.admin_*`).
+//!
+//! Lifecycle of one scrape: accept → send the rendered response → lingering
+//! close (half-close the write side, drain client input to EOF so the close
+//! never RSTs the response away, §2) → re-arm accept. A per-scrape deadline
+//! (`admin_scrape_deadline_ms`) reaps a stalled or slowloris client so it
+//! cannot pin the single slot, exactly as every data-path socket is reaped
+//! (§8). Drain (§8) closes the listener and tears down any in-flight scrape,
+//! then the loop may stop.
+//!
+//! The request is never parsed: the endpoint serves the same counters
+//! regardless of method or path, so there is no routing, no head buffer,
+//! and no attack surface beyond a fixed-size drain. Generic over the Io
+//! backend like the rest of the data path, so the simulator drives it too.
+
+const std = @import("std");
+
+const constants = @import("constants.zig");
+const counters_module = @import("counters.zig");
+const Io = @import("io/io.zig");
+const shed = @import("shed.zig");
+
+const assert = std.debug.assert;
+
+/// Response head sent before the rendered body. `Connection: close` frames
+/// the body by connection close (RFC 9112 §6.3), so no Content-Length is
+/// needed — the renderer's length never has to be known before the head.
+const response_head =
+    "HTTP/1.1 200 OK\r\n" ++
+    "Content-Type: text/plain; version=0.0.4\r\n" ++
+    "Connection: close\r\n\r\n";
+
+/// A full response is the fixed head plus one rendering of every counter.
+const response_bytes_max = response_head.len + counters_module.Counters.render_bytes_max;
+
+/// Fixed throwaway buffer for the lingering-close drain — the request is
+/// discarded, so this is never inspected and one small buffer suffices.
+const drain_scratch_bytes = 512;
+
+pub fn Admin(comptime IoType: type) type {
+    const ServerType = @import("Server.zig").Server(IoType);
+
+    return struct {
+        server: *ServerType,
+        /// Null when no admin bind is configured — the whole plane is off
+        /// and `start` opens no listener.
+        bind_address: ?std.Io.net.IpAddress,
+        /// Valid only while `listening`; the single dedicated listener.
+        listener: IoType.Listener,
+        listening: bool,
+        state: State,
+        /// Valid in `.sending`/`.draining`/`.closing` — the scrape client.
+        socket: IoType.Socket,
+        /// Absolute scrape deadline; a lazy tick-and-compare re-arms until
+        /// it is due, then reaps (the §4 single-timer discipline).
+        deadline_ns: u64,
+        /// The rendered response and the send cursor over it (short sends
+        /// resume from `sent`).
+        response: [response_bytes_max]u8,
+        response_len: u32,
+        sent: u32,
+        drain_scratch: [drain_scratch_bytes]u8,
+        armed: Armed,
+        op_accept: IoType.Completion,
+        op_send: IoType.Completion,
+        op_recv: IoType.Completion,
+        op_deadline: IoType.Completion,
+        op_deadline_cancel: IoType.Completion,
+        op_close: IoType.Completion,
+
+        const Self = @This();
+
+        pub const State = enum(u8) {
+            /// No admin bind configured.
+            off,
+            /// Listener armed, waiting for the next scrape.
+            accepting,
+            /// Writing the rendered response to the client.
+            sending,
+            /// Write side half-closed; discarding client input to EOF so
+            /// the close does not RST the response away (§2).
+            draining,
+            /// Teardown: sockets shut down, data op draining, close not yet
+            /// submitted (the abnormal path — deadline, error, server drain).
+            tearing_down,
+            /// Close submitted; the slot frees (accept re-arms) once the
+            /// armed set empties (§5 release rule, single-socket form).
+            closing,
+        };
+
+        /// One bit per embedded op; the slot is quiescent only when clear.
+        pub const Armed = packed struct(u8) {
+            accept: bool = false,
+            send: bool = false,
+            recv: bool = false,
+            deadline: bool = false,
+            deadline_cancel: bool = false,
+            close: bool = false,
+            _pad: u2 = 0,
+        };
+
+        pub fn init(
+            admin: *Self,
+            server: *ServerType,
+            bind_address: ?std.Io.net.IpAddress,
+        ) void {
+            admin.server = server;
+            admin.bind_address = bind_address;
+            admin.listening = false;
+            admin.state = .off;
+            admin.deadline_ns = 0;
+            admin.response_len = 0;
+            admin.sent = 0;
+            admin.armed = .{};
+            assert(admin.armedCount() == 0);
+            assert(admin.state == .off);
+        }
+
+        /// Set the bind address before `start` (main.zig, from the env var;
+        /// the simulator sets it directly). A no-op default leaves admin off.
+        pub fn setBind(admin: *Self, bind_address: std.Io.net.IpAddress) void {
+            assert(admin.state == .off);
+            assert(!admin.listening);
+            admin.bind_address = bind_address;
+        }
+
+        /// Open the listener and arm the first accept, or stay off when no
+        /// bind is configured. Called from `Server.start`.
+        pub fn start(admin: *Self) Io.ListenError!void {
+            assert(admin.state == .off);
+            assert(!admin.listening);
+            const bind = admin.bind_address orelse return;
+            admin.listener = try admin.server.io.listen(bind);
+            admin.listening = true;
+            admin.armAccept();
+        }
+
+        fn armAccept(admin: *Self) void {
+            assert(admin.listening);
+            assert(!admin.server.draining);
+            assert(admin.armedCount() == 0);
+            admin.state = .accepting;
+            admin.arm("accept");
+            admin.server.io.accept(admin.listener, &admin.op_accept, Self, admin, onAccept);
+        }
+
+        fn onAccept(admin: *Self, result: Io.AcceptError!IoType.Socket) void {
+            admin.disarm("accept");
+            if (admin.server.draining) {
+                // The drain reached the listener: a Canceled accept
+                // (`listenClose`), or a scrape that slipped in as the drain
+                // began — shed that socket, do not serve (§8). Either way the
+                // admin plane is done accepting and now quiescent, so the
+                // drain-stop gate must be re-checked.
+                if (result) |socket| {
+                    shed.closeQuietly(IoType, admin.server.io, socket);
+                } else |_| {}
+                admin.listening = false;
+                admin.state = .off;
+                admin.server.maybeStopAfterDrain();
+                return;
+            }
+            const socket = result catch {
+                // A transient accept error on a localhost listener (Canceled
+                // cannot occur outside a drain): re-arm, no socket to shed.
+                admin.armAccept();
+                return;
+            };
+            admin.socket = socket;
+            admin.storeDeadline();
+            admin.armDeadline();
+            admin.renderResponse();
+            admin.armSend();
+        }
+
+        /// Build the full response once, into the fixed buffer: the static
+        /// head then the counters rendering (zero-alloc, §5).
+        fn renderResponse(admin: *Self) void {
+            @memcpy(admin.response[0..response_head.len], response_head);
+            const body = admin.server.counters.render(admin.response[response_head.len..]);
+            admin.response_len = @intCast(response_head.len + body.len);
+            admin.sent = 0;
+            assert(admin.response_len >= response_head.len);
+            assert(admin.response_len <= admin.response.len);
+        }
+
+        fn armSend(admin: *Self) void {
+            assert(admin.state == .accepting or admin.state == .sending);
+            assert(admin.sent < admin.response_len);
+            admin.state = .sending;
+            admin.arm("send");
+            admin.server.io.send(
+                admin.socket,
+                admin.response[admin.sent..admin.response_len],
+                &admin.op_send,
+                Self,
+                admin,
+                onSend,
+            );
+        }
+
+        fn onSend(admin: *Self, result: Io.SendError!u32) void {
+            admin.disarm("send");
+            if (admin.state == .tearing_down) {
+                admin.continueTeardown();
+                return;
+            }
+            const n = result catch {
+                // A reset or unexpected error mid-response: nothing left to
+                // deliver, tear down.
+                admin.beginTeardown();
+                return;
+            };
+            admin.sent += n;
+            assert(admin.sent <= admin.response_len);
+            if (admin.sent < admin.response_len) {
+                admin.armSend();
+                return;
+            }
+            // Response fully sent: half-close the write side and drain the
+            // client's input to EOF so the close does not RST it away (§2).
+            admin.state = .draining;
+            admin.server.io.shutdown(admin.socket, .write);
+            admin.armRecv();
+        }
+
+        fn armRecv(admin: *Self) void {
+            assert(admin.state == .draining);
+            admin.arm("recv");
+            admin.server.io.recv(
+                admin.socket,
+                &admin.drain_scratch,
+                &admin.op_recv,
+                Self,
+                admin,
+                onRecv,
+            );
+        }
+
+        fn onRecv(admin: *Self, result: Io.RecvError!u32) void {
+            admin.disarm("recv");
+            if (admin.state == .tearing_down) {
+                admin.continueTeardown();
+                return;
+            }
+            assert(admin.state == .draining);
+            if (result) |_| {
+                // More client input arrived; keep discarding until EOF. The
+                // scrape deadline bounds a client that never closes.
+                admin.armRecv();
+            } else |err| {
+                // EndOfStream (the client closed after reading the response)
+                // and Reset both mean input is done — close cleanly. A live
+                // Canceled cannot happen here (recv is never canceled outside
+                // teardown), but route it through teardown defensively.
+                if (err == error.Canceled) {
+                    admin.beginTeardown();
+                    return;
+                }
+                admin.beginClose();
+            }
+        }
+
+        /// The clean-completion close: no data op is armed, the write side
+        /// is already half-closed, so shut the read side and close.
+        fn beginClose(admin: *Self) void {
+            assert(admin.state == .draining);
+            assert(!admin.armed.send and !admin.armed.recv);
+            admin.state = .closing;
+            admin.server.io.shutdown(admin.socket, .both);
+            admin.cancelDeadline();
+            admin.submitClose();
+        }
+
+        /// Abnormal teardown (§5, single-socket form): deadline expiry, a
+        /// send/recv error, or the server drain. Shut both sides, cancel the
+        /// deadline, then close once the data op drains.
+        fn beginTeardown(admin: *Self) void {
+            if (admin.state == .tearing_down or admin.state == .closing) return;
+            assert(admin.state == .sending or admin.state == .draining);
+            admin.state = .tearing_down;
+            admin.server.io.shutdown(admin.socket, .both);
+            admin.cancelDeadline();
+            admin.continueTeardown();
+        }
+
+        /// Drain of a torn-down scrape: submit the close once no data op is
+        /// armed, then free the slot when the armed set empties.
+        fn continueTeardown(admin: *Self) void {
+            assert(admin.state == .tearing_down or admin.state == .closing);
+            if (admin.state == .tearing_down and !admin.armed.send and !admin.armed.recv) {
+                admin.state = .closing;
+                admin.submitClose();
+            }
+            admin.maybeFinish();
+        }
+
+        fn cancelDeadline(admin: *Self) void {
+            if (!admin.armed.deadline or admin.armed.deadline_cancel) return;
+            admin.arm("deadline_cancel");
+            admin.server.io.timerCancel(
+                &admin.op_deadline,
+                &admin.op_deadline_cancel,
+                Self,
+                admin,
+                onDeadlineCancel,
+            );
+        }
+
+        fn submitClose(admin: *Self) void {
+            assert(admin.state == .closing);
+            assert(!admin.armed.close);
+            assert(!admin.armed.send and !admin.armed.recv);
+            admin.arm("close");
+            admin.server.io.close(admin.socket, &admin.op_close, Self, admin, onClose);
+        }
+
+        fn onClose(admin: *Self) void {
+            admin.disarm("close");
+            admin.maybeFinish();
+        }
+
+        fn onDeadlineCancel(admin: *Self) void {
+            admin.disarm("deadline_cancel");
+            admin.maybeFinish();
+        }
+
+        fn storeDeadline(admin: *Self) void {
+            admin.deadline_ns = admin.server.io.nowNs() +
+                @as(u64, constants.admin_scrape_deadline_ms) * std.time.ns_per_ms;
+        }
+
+        fn armDeadline(admin: *Self) void {
+            const delay_ns = admin.deadline_ns -| admin.server.io.nowNs();
+            admin.arm("deadline");
+            admin.server.io.timerStart(&admin.op_deadline, delay_ns, Self, admin, onDeadline);
+        }
+
+        /// Lazy tick-and-compare (§4): a fire before the stored deadline is
+        /// due re-arms for the remainder; a fire that is due reaps the scrape.
+        fn onDeadline(admin: *Self, result: Io.TimerError!void) void {
+            admin.disarm("deadline");
+            if (result) |_| {
+                if (admin.state == .tearing_down or admin.state == .closing) {
+                    admin.continueTeardown();
+                    return;
+                }
+                if (admin.server.io.nowNs() >= admin.deadline_ns) {
+                    admin.beginTeardown();
+                } else {
+                    admin.armDeadline();
+                }
+            } else |err| {
+                // The only cancel is teardown's; its drain runs here.
+                assert(err == error.Canceled);
+                if (admin.state == .tearing_down or admin.state == .closing) {
+                    admin.continueTeardown();
+                }
+            }
+        }
+
+        /// The scrape is over once every op has drained. Re-arm the next
+        /// accept, or — during drain — let the server check for quiescence.
+        fn maybeFinish(admin: *Self) void {
+            if (admin.state != .closing) return;
+            if (admin.armedCount() != 0) return;
+            if (admin.server.draining) {
+                admin.listening = false;
+                admin.state = .off;
+                admin.server.maybeStopAfterDrain();
+                return;
+            }
+            admin.armAccept();
+        }
+
+        /// Server drain (§8): close the listener (its armed accept cancels)
+        /// and tear down any in-flight scrape. A scrape already past its
+        /// send races the drain and finishes through `maybeFinish`.
+        pub fn beginDrain(admin: *Self) void {
+            if (admin.state == .off) return;
+            if (admin.listening) admin.server.io.listenClose(admin.listener);
+            switch (admin.state) {
+                .accepting => {}, // The listenClose cancels the armed accept.
+                .sending, .draining => admin.beginTeardown(),
+                .tearing_down, .closing, .off => {},
+            }
+        }
+
+        /// Quiescent for the drain-stop gate: no armed op and not listening.
+        pub fn isQuiescent(admin: *const Self) bool {
+            return admin.armedCount() == 0 and !admin.listening;
+        }
+
+        fn arm(admin: *Self, comptime bit: []const u8) void {
+            assert(!@field(admin.armed, bit));
+            @field(admin.armed, bit) = true;
+        }
+
+        fn disarm(admin: *Self, comptime bit: []const u8) void {
+            assert(@field(admin.armed, bit));
+            @field(admin.armed, bit) = false;
+        }
+
+        pub fn armedCount(admin: *const Self) u8 {
+            return @popCount(@as(u8, @bitCast(admin.armed)));
+        }
+    };
+}

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -30,13 +30,13 @@ const assert = std.debug.assert;
 /// Response head sent before the rendered body. `Connection: close` frames
 /// the body by connection close (RFC 9112 §6.3), so no Content-Length is
 /// needed — the renderer's length never has to be known before the head.
-const response_head =
+pub const response_head =
     "HTTP/1.1 200 OK\r\n" ++
     "Content-Type: text/plain; version=0.0.4\r\n" ++
     "Connection: close\r\n\r\n";
 
 /// A full response is the fixed head plus one rendering of every counter.
-const response_bytes_max = response_head.len + counters_module.Counters.render_bytes_max;
+pub const response_bytes_max = response_head.len + counters_module.Counters.render_bytes_max;
 
 pub fn Admin(comptime IoType: type) type {
     const ServerType = @import("Server.zig").Server(IoType);
@@ -274,6 +274,7 @@ pub fn Admin(comptime IoType: type) type {
             }
             // Response fully sent: half-close the write side and drain the
             // client's input to EOF so the close does not RST it away (§2).
+            admin.server.counters.increment("admin_served");
             admin.state = .draining;
             admin.server.io.shutdown(admin.socket, .write);
             admin.armRecv();
@@ -403,6 +404,9 @@ pub fn Admin(comptime IoType: type) type {
                     return;
                 }
                 if (admin.server.io.nowNs() >= admin.deadline_ns) {
+                    // The scrape overran its deadline: reap the client so it
+                    // cannot pin the single reserved slot (§8).
+                    admin.server.counters.increment("admin_reaped");
                     admin.beginTeardown();
                 } else {
                     admin.armDeadline();

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -376,3 +376,22 @@ test "admin: the scrape deadline reaps a client that never finishes" {
     try testing.expectEqual(@as(u64, 1), harness.server.counters.get("admin_reaped"));
     try harness.expectDrained();
 }
+
+test "admin: draining an idle-and-accepting listener releases cleanly" {
+    // A direct, timing-independent reproduction of the once-fixed drain bug:
+    // a Canceled accept during drain must clear `listening` so the loop can
+    // reach quiescence. The admin listener is armed and accepting with zero
+    // scrapes ever served when the drain begins, so `beginDrain` closes the
+    // listener, `listenClose` cancels the armed accept, and onAccept's
+    // draining branch must return the admin to quiescent. A regression that
+    // left `listening` set would strand `isQuiescent`, and the run would
+    // deadlock instead of draining.
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, .{ .seed = 1, .adversary = .{ .partial_io = false } });
+    defer harness.tearDown();
+
+    harness.server.beginDrain();
+    try harness.sim_io.run();
+
+    try harness.expectDrained();
+}

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -1,0 +1,378 @@
+//! Directed admin-listener scenarios over SimIo (§9). The scrape path is a
+//! data-path state machine — accept → send → lingering close → re-arm, with
+//! its own deadline reaper and drain teardown — so it earns the same
+//! deterministic gate as the relay: a virtual scrape client drives it, the
+//! response is asserted byte-exact against the counters' own rendering, and
+//! every run ends with the server idle, sockets released, and counters
+//! reconciled. Adversarial seeds split every send and recv down to one byte
+//! and inject resets, exercising the short-send resume and the error/
+//! teardown paths; a stalled client proves the deadline reaper frees the
+//! single reserved slot.
+
+const std = @import("std");
+
+const admin = @import("admin.zig");
+const config_module = @import("config.zig");
+const constants = @import("constants.zig");
+const counters_module = @import("counters.zig");
+const router = @import("http/router.zig");
+const Io = @import("io/io.zig");
+const Server = @import("Server.zig").Server;
+const SimIo = @import("io/SimIo.zig");
+
+const assert = std.debug.assert;
+const testing = std.testing;
+
+const ServerSim = Server(SimIo);
+
+const request = "GET /metrics HTTP/1.1\r\nHost: admin\r\n\r\n";
+
+fn adminAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9100") catch unreachable;
+}
+fn bindAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8080") catch unreachable;
+}
+fn originAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
+}
+
+const Harness = struct {
+    arena_state: std.heap.ArenaAllocator,
+    sim_io: SimIo,
+    endpoints: [1]std.Io.net.IpAddress,
+    clusters: [1]config_module.Config.Cluster,
+    routes: [1]router.Route,
+    listeners: [1]config_module.Config.Listener,
+    config: config_module.Config,
+    server: ServerSim,
+    scrape: Scrape,
+    holder: Holder,
+
+    fn setUp(harness: *Harness, gpa: std.mem.Allocator, sim: SimIo.Options) !void {
+        harness.arena_state = std.heap.ArenaAllocator.init(gpa);
+        errdefer harness.arena_state.deinit();
+        const arena = harness.arena_state.allocator();
+
+        try harness.sim_io.init(arena, sim);
+        harness.endpoints = .{originAddress()};
+        harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
+        harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        harness.listeners = .{.{
+            .bind_address = bindAddress(),
+            .routes = &harness.routes,
+            .protocol = .l4,
+        }};
+        harness.config = .{
+            .listeners = &harness.listeners,
+            .clusters = &harness.clusters,
+            .connect_timeout_ms = 50,
+            .idle_timeout_ms = 1000,
+            .drain_deadline_ms = 1000,
+            .max_lifetime_ms = 0,
+        };
+        try harness.server.init(arena, &harness.sim_io, &harness.config, .{
+            .conn_slots = 4,
+            .relay_buffers = 2,
+        });
+        harness.server.setAdminBind(adminAddress());
+        try harness.server.start();
+        harness.scrape = .{ .server = &harness.server, .io = &harness.sim_io };
+        harness.holder = .{};
+    }
+
+    fn tearDown(harness: *Harness) void {
+        harness.arena_state.deinit();
+    }
+
+    fn expectDrained(harness: *Harness) !void {
+        try testing.expect(harness.server.isIdle());
+        try testing.expect(harness.server.reconcile());
+        try testing.expect(harness.sim_io.sockets.isFullyReleased());
+    }
+};
+
+/// The response an undisturbed scrape must receive: the fixed head then a
+/// rendering of *all-zero* counters. The server renders the body at accept
+/// time, before `admin_served` (or any counter this scenario touches) moves,
+/// so the on-the-wire snapshot is always the zero state — checkable
+/// byte-for-byte regardless of what the counters read after the run.
+fn expectedResponse(buffer: []u8) []const u8 {
+    assert(buffer.len >= admin.response_bytes_max);
+    var zero: counters_module.Counters = .{};
+    @memcpy(buffer[0..admin.response_head.len], admin.response_head);
+    const body = zero.render(buffer[admin.response_head.len..]);
+    return buffer[0 .. admin.response_head.len + body.len];
+}
+
+/// A scripted scrape client. `.normal` sends the request and reads the
+/// response to EOF; `.drain_mid_scrape` begins the server drain the instant
+/// the first response byte arrives, so the drain tears down an established,
+/// mid-flight scrape while the client is still reading (the client's live
+/// recv observes the teardown, so nothing is orphaned); `.stall` never reads
+/// or closes and arms a far-future timer so the run outlives the scrape
+/// deadline — the reaper must free the slot before the timer closes.
+const Scrape = struct {
+    server: *ServerSim = undefined,
+    io: *SimIo = undefined,
+    connect_completion: SimIo.Completion = .{},
+    send_completion: SimIo.Completion = .{},
+    recv_completion: SimIo.Completion = .{},
+    timer_completion: SimIo.Completion = .{},
+    socket: SimIo.Socket = undefined,
+    recv_buffer: [admin.response_bytes_max]u8 = undefined,
+    received_len: u32 = 0,
+    sent_len: u32 = 0,
+    send_pending: bool = false,
+    mode: Mode = .normal,
+    outcome: Outcome = .pending,
+    drained: bool = false,
+
+    const Mode = enum { normal, drain_mid_scrape, stall };
+    const Outcome = enum { pending, refused, eof, reset };
+
+    fn start(scrape: *Scrape) void {
+        scrape.io.connect(adminAddress(), &scrape.connect_completion, Scrape, scrape, onConnect);
+    }
+
+    fn onConnect(scrape: *Scrape, result: Io.ConnectError!SimIo.Socket) void {
+        scrape.socket = result catch {
+            scrape.outcome = .refused;
+            scrape.beginDrainOnce();
+            return;
+        };
+        if (scrape.mode == .stall) {
+            // Neither read nor close: sit until the scrape deadline reaps the
+            // slot. A far-future timer keeps the run progressing past the
+            // deadline, then closes so the run can drain to idle.
+            scrape.io.timerStart(
+                &scrape.timer_completion,
+                @as(u64, constants.admin_scrape_deadline_ms + 1000) * std.time.ns_per_ms,
+                Scrape,
+                scrape,
+                onStallTimer,
+            );
+            return;
+        }
+        scrape.armRecv();
+        scrape.armSend();
+    }
+
+    fn armSend(scrape: *Scrape) void {
+        assert(scrape.sent_len < request.len);
+        assert(!scrape.send_pending);
+        scrape.send_pending = true;
+        scrape.io.send(
+            scrape.socket,
+            request[scrape.sent_len..],
+            &scrape.send_completion,
+            Scrape,
+            scrape,
+            onSend,
+        );
+    }
+
+    fn onSend(scrape: *Scrape, result: Io.SendError!u32) void {
+        assert(scrape.send_pending);
+        scrape.send_pending = false;
+        const sent = result catch {
+            // A send error mid-scrape is legal (the server reset or tore
+            // down); the recv path settles the outcome.
+            scrape.settleIfTerminal();
+            return;
+        };
+        scrape.sent_len += sent;
+        assert(scrape.sent_len <= request.len);
+        if (scrape.outcome != .pending) {
+            scrape.settleIfTerminal();
+        } else if (scrape.sent_len < request.len) {
+            scrape.armSend();
+        }
+    }
+
+    fn armRecv(scrape: *Scrape) void {
+        assert(scrape.received_len < scrape.recv_buffer.len);
+        scrape.io.recv(
+            scrape.socket,
+            scrape.recv_buffer[scrape.received_len..],
+            &scrape.recv_completion,
+            Scrape,
+            scrape,
+            onRecv,
+        );
+    }
+
+    fn onRecv(scrape: *Scrape, result: Io.RecvError!u32) void {
+        const received = result catch |err| {
+            scrape.outcome = switch (err) {
+                error.Reset => .reset,
+                else => .eof,
+            };
+            scrape.settleIfTerminal();
+            return;
+        };
+        scrape.received_len += received;
+        assert(scrape.received_len <= scrape.recv_buffer.len);
+        // Race the drain against the established scrape: the first response
+        // byte proves the admin is mid-send (or draining), so beginning the
+        // drain now forces its in-flight teardown while this recv stays live
+        // to witness it.
+        if (scrape.mode == .drain_mid_scrape) scrape.beginDrainOnce();
+        scrape.armRecv();
+    }
+
+    fn onStallTimer(scrape: *Scrape, result: Io.TimerError!void) void {
+        result catch unreachable;
+        assert(scrape.mode == .stall);
+        // The deadline has long since reaped the scrape; close and drain so
+        // the run reaches idle.
+        scrape.io.closeNow(scrape.socket);
+        scrape.beginDrainOnce();
+    }
+
+    fn settleIfTerminal(scrape: *Scrape) void {
+        if (scrape.outcome == .pending) return;
+        if (scrape.send_pending) return;
+        scrape.io.closeNow(scrape.socket);
+        scrape.beginDrainOnce();
+    }
+
+    /// The scrape is over: begin the server drain (closing the admin
+    /// listener) so the loop can quiesce, exactly once.
+    fn beginDrainOnce(scrape: *Scrape) void {
+        if (scrape.drained) return;
+        scrape.drained = true;
+        scrape.server.beginDrain();
+    }
+};
+
+/// A data-path holder for the drain-race scenario: it connects to the L4
+/// listener whose origin is blackholed, so the proxy's upstream dial hangs
+/// and the conn slot stays occupied until the connect deadline. That keeps
+/// the pools non-empty — and the loop running — long enough for the raced
+/// admin scrape to finish tearing down and the scrape client to observe it,
+/// instead of the server stopping the instant its only work (the scrape)
+/// drains. It settles when its own conn is reaped. (The established sim idiom
+/// for this race — see server_test's "accept that raced the drain".)
+const Holder = struct {
+    io: *SimIo = undefined,
+    connect_completion: SimIo.Completion = .{},
+    recv_completion: SimIo.Completion = .{},
+    socket: SimIo.Socket = undefined,
+    scratch: [64]u8 = undefined,
+    settled: bool = false,
+
+    fn start(holder: *Holder, io: *SimIo) void {
+        holder.io = io;
+        io.connect(bindAddress(), &holder.connect_completion, Holder, holder, onConnect);
+    }
+
+    fn onConnect(holder: *Holder, result: Io.ConnectError!SimIo.Socket) void {
+        holder.socket = result catch {
+            holder.settled = true;
+            return;
+        };
+        holder.io.recv(holder.socket, &holder.scratch, &holder.recv_completion, Holder, holder, onRecv);
+    }
+
+    fn onRecv(holder: *Holder, result: Io.RecvError!u32) void {
+        // The proxy never relays (origin blackholed), so the only recv
+        // completion is the teardown reset/FIN when the conn is reaped —
+        // close and settle.
+        _ = result catch {};
+        holder.io.closeNow(holder.socket);
+        holder.settled = true;
+    }
+};
+
+test "admin: a scrape returns the counters as byte-exact Prometheus text" {
+    var seed: u64 = 1;
+    while (seed <= 20) : (seed += 1) {
+        var harness: Harness = undefined;
+        // partial_io splits every send and recv, exercising the short-send
+        // resume and fragmented drain without severing the exchange.
+        try harness.setUp(testing.allocator, .{
+            .seed = seed,
+            .adversary = .{ .partial_io = true },
+        });
+        defer harness.tearDown();
+
+        harness.scrape.start();
+        try harness.sim_io.run();
+
+        try testing.expectEqual(Scrape.Outcome.eof, harness.scrape.outcome);
+        var expected_buffer: [admin.response_bytes_max]u8 = undefined;
+        const expected = expectedResponse(&expected_buffer);
+        try testing.expectEqualStrings(
+            expected,
+            harness.scrape.recv_buffer[0..harness.scrape.received_len],
+        );
+        try testing.expectEqual(@as(u64, 1), harness.server.counters.get("admin_served"));
+        try harness.expectDrained();
+    }
+}
+
+test "admin: a scrape stays intact and drains under resets" {
+    // reset_percent severs connections mid-exchange: the scrape may see a
+    // truncated response, but every byte it did receive must be a prefix of
+    // the true response, and the server must still drain to idle.
+    var seed: u64 = 1;
+    while (seed <= 20) : (seed += 1) {
+        var harness: Harness = undefined;
+        try harness.setUp(testing.allocator, .{
+            .seed = seed,
+            .adversary = .{ .partial_io = true, .reset_percent = 25 },
+        });
+        defer harness.tearDown();
+
+        harness.scrape.start();
+        try harness.sim_io.run();
+
+        var expected_buffer: [admin.response_bytes_max]u8 = undefined;
+        const expected = expectedResponse(&expected_buffer);
+        const got = harness.scrape.recv_buffer[0..harness.scrape.received_len];
+        try testing.expect(std.mem.startsWith(u8, expected, got));
+        try harness.expectDrained();
+    }
+}
+
+test "admin: a drain racing an in-flight scrape tears down cleanly" {
+    var seed: u64 = 1;
+    while (seed <= 20) : (seed += 1) {
+        var harness: Harness = undefined;
+        try harness.setUp(testing.allocator, .{
+            .seed = seed,
+            .adversary = .{ .partial_io = true },
+        });
+        defer harness.tearDown();
+
+        // Blackhole the origin so the holder's dial hangs, pinning a conn
+        // slot until the connect deadline — that keeps the loop alive while
+        // the raced admin scrape tears down and the scrape client observes it.
+        harness.sim_io.blackholeAddress(originAddress());
+        harness.holder.start(&harness.sim_io);
+        harness.scrape.mode = .drain_mid_scrape;
+        harness.scrape.start();
+        try harness.sim_io.run();
+
+        // The scrape may complete or be torn down by the drain; either way no
+        // op or socket leaks, and counters reconcile.
+        try testing.expect(harness.holder.settled);
+        try harness.expectDrained();
+    }
+}
+
+test "admin: the scrape deadline reaps a client that never finishes" {
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, .{ .seed = 7, .adversary = .{ .partial_io = false } });
+    defer harness.tearDown();
+
+    harness.scrape.mode = .stall;
+    harness.scrape.start();
+    try harness.sim_io.run();
+
+    // The reaper freed the slot before the client ever finished — witnessed
+    // by its counter — and the run still drained clean.
+    try testing.expectEqual(@as(u64, 1), harness.server.counters.get("admin_reaped"));
+    try harness.expectDrained();
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -37,6 +37,10 @@ pub const Config = struct {
     /// the real shed rungs at loopback-feasible load. Defaulted so the
     /// test beds' literal configs keep the full pools.
     limits: Limits = .{},
+    /// The admin/metrics listener's bind address (§8, PLANS.md Phase 2.5),
+    /// or null when no `admin` block is configured — the plane stays off.
+    /// A static IP:port literal like every other bind (hostnames rejected).
+    admin_bind: ?std.Io.net.IpAddress = null,
 
     pub const Limits = struct {
         conn_slots: u32 = constants.conn_slots_max,
@@ -129,6 +133,7 @@ pub const ValidationError = error{
     LimitRelayBuffersOutOfRange,
     LimitRelayBuffersOverConnSlots,
     LimitUpstreamSlotsOutOfRange,
+    AdminBindInvalid,
 };
 
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
@@ -147,6 +152,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     try validateTimeouts(&parsed.timeouts);
     const limits = try resolveLimits(&parsed.limits);
+    const admin_bind = try resolveAdminBind(parsed.admin);
 
     assert(listeners.len >= 1);
     assert(clusters.len >= 1);
@@ -158,7 +164,16 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
         .limits = limits,
+        .admin_bind = admin_bind,
     };
+}
+
+/// Resolve the optional admin/metrics listener (§8, PLANS.md Phase 2.5):
+/// absent means the plane is off; a present `bind` must be a static IP:port
+/// literal (hostnames rejected, like every other bind — DNS is a non-goal).
+fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddress {
+    const admin = admin_json orelse return null;
+    return std.Io.net.IpAddress.parseLiteral(admin.bind) catch error.AdminBindInvalid;
 }
 
 /// Resolve the effective pool sizes (§5, §8): the comptime constants are
@@ -207,6 +222,9 @@ pub const ConfigJson = struct {
     /// Optional pool shrinks (§5, §8); absent fields keep the comptime
     /// ceilings.
     limits: LimitsJson = .{},
+    /// Optional admin/metrics listener (§8, PLANS.md Phase 2.5); absent
+    /// leaves the plane off.
+    admin: ?AdminJson = null,
 
     pub const schema_doc =
         "Startup config for the zoxy L4/L7 proxy. Encodes structure, enums, " ++
@@ -222,6 +240,18 @@ pub const ConfigJson = struct {
         .clusters = .{ .desc = "Named upstream clusters, keyed by cluster name." },
         .timeouts = .{ .desc = "Connection lifecycle deadlines (milliseconds)." },
         .limits = .{ .desc = "Optional pool shrinks; absent keeps the compiled ceilings." },
+        .admin = .{ .desc = "Optional admin/metrics listener; absent leaves it off." },
+    };
+};
+
+pub const AdminJson = struct {
+    bind: []const u8,
+
+    pub const schema_doc =
+        "Optional admin/metrics listener. When present, exposes the process " ++
+        "counters as Prometheus exposition text on `bind`; absent leaves it off.";
+    pub const schema_fields = .{
+        .bind = .{ .desc = "IP:port literal to bind the admin/metrics listener (hostnames are rejected)." },
     };
 };
 
@@ -578,6 +608,7 @@ pub const dto_types = .{
     ConfigJson,  ListenerJson,    RouteJson,    FilterJson,
     MatchJson,   HeaderMatchJson, ActionJson,   HeaderEditJson,
     RewriteJson, ClusterJson,     TimeoutsJson, LimitsJson,
+    AdminJson,
 };
 
 comptime {
@@ -1471,6 +1502,38 @@ test "config: limits shrink pools below the ceilings, never past them" {
     // contradiction, not a derivable default.
     try expectParseError(error.LimitRelayBuffersOverConnSlots, head ++ tail ++
         "\"limits\":{\"conn_slots\":4,\"relay_buffers\":8}}");
+}
+
+test "config: admin block resolves a bind literal, absent leaves it off" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}],";
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}
+    ;
+    // Absent: the admin plane stays off.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(), head ++ tail ++ "}");
+        try std.testing.expect(parsed.admin_bind == null);
+    }
+    // Present: the bind resolves to the given IP:port.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ tail ++ ",\"admin\":{\"bind\":\"127.0.0.1:9100\"}}",
+        );
+        try std.testing.expect(parsed.admin_bind != null);
+        try std.testing.expectEqual(@as(u16, 9100), parsed.admin_bind.?.getPort());
+    }
+    // A hostname (or any non-literal) is rejected — DNS is a non-goal, like
+    // every other bind.
+    try expectParseError(error.AdminBindInvalid, head ++ tail ++ ",\"admin\":{\"bind\":\"localhost:9100\"}}");
+    // The admin object is strict: `bind` is required and extras are rejected.
+    try expectParseError(error.MissingField, head ++ tail ++ ",\"admin\":{}}");
+    try expectParseError(error.UnknownField, head ++ tail ++ ",\"admin\":{\"bind\":\"127.0.0.1:9100\",\"x\":1}}");
 }
 
 test "config: unknown listener protocol fails loudly" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -37,6 +37,12 @@ pub const admin_conns: u32 = 1;
 /// two-per-listener term.
 pub const admin_conn_ops_max: u32 = 3;
 
+/// Deadline for one admin scrape, from accept to close (§8): the reaper
+/// that keeps a stalled or slowloris scrape client from pinning the single
+/// reserved admin slot forever. Short — a metrics scrape is a localhost
+/// round trip — and independent of the data path's `idle_timeout_ms`.
+pub const admin_scrape_deadline_ms: u32 = 5_000;
+
 /// Connection slots (`Pool(Conn)`). The binding constraint is the
 /// io_uring completion queue, not fds or memory (§8): every admitted
 /// connection — L4 relaying or L7 in any phase — can hold up to
@@ -275,6 +281,7 @@ comptime {
     assert(admin_listeners >= 1);
     assert(admin_conns >= 1);
     assert(admin_conn_ops_max >= 1);
+    assert(admin_scrape_deadline_ms >= 1);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -43,6 +43,11 @@ pub const admin_conn_ops_max: u32 = 3;
 /// round trip — and independent of the data path's `idle_timeout_ms`.
 pub const admin_scrape_deadline_ms: u32 = 5_000;
 
+/// Throwaway buffer for the admin lingering-close drain (§2): the scrape's
+/// request is discarded, never inspected, so one small fixed buffer read
+/// in a loop to EOF suffices — sized only to keep the read count modest.
+pub const admin_drain_scratch_bytes: u32 = 512;
+
 /// Connection slots (`Pool(Conn)`). The binding constraint is the
 /// io_uring completion queue, not fds or memory (§8): every admitted
 /// connection — L4 relaying or L7 in any phase — can hold up to
@@ -282,6 +287,7 @@ comptime {
     assert(admin_conns >= 1);
     assert(admin_conn_ops_max >= 1);
     assert(admin_scrape_deadline_ms >= 1);
+    assert(admin_drain_scratch_bytes >= 1);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -10,6 +10,33 @@ const assert = std.debug.assert;
 /// Upper bound on configured listeners.
 pub const listeners_max: u16 = 8;
 
+/// The single dedicated admin/metrics listener (DESIGN.md §8, PLANS.md
+/// §243): separate from the configured `listeners_max` so a scrape can
+/// never consume a data-path listener slot, and reserved in the fd and
+/// ring budgets below unconditionally — the ceiling is a comptime
+/// constant, so it must cover the worst case (admin enabled) even when a
+/// given config leaves it unbound.
+pub const admin_listeners: u32 = 1;
+
+/// Concurrent admin client connections — one scrape served at a time (the
+/// "reserved slot", §8). It lives outside the three shared pools, so a
+/// metrics scrape and the data path can never shed one another. It counts
+/// once in the fd budget (its socket) and `admin_conn_ops_max` times in
+/// the ring budget.
+pub const admin_conns: u32 = 1;
+
+/// Worst-case simultaneously armed ring ops for one admin client: three.
+/// The admin conn carries its own idle/scrape deadline — like every other
+/// network-facing socket it must not let a peer that connects and never
+/// completes park the reserved slot forever (§8) — so a drain-initiated
+/// teardown that races an in-flight send holds the send, the deadline,
+/// and the deadline-cancel co-armed (the same lazy-timer force pattern as
+/// the data path's `conn_ops_max`); a data op and the `close` never
+/// coexist (close is submitted only after the data op drains), so the peak
+/// is three, not four. The accept op is the listener's, budgeted in the
+/// two-per-listener term.
+pub const admin_conn_ops_max: u32 = 3;
+
 /// Connection slots (`Pool(Conn)`). The binding constraint is the
 /// io_uring completion queue, not fds or memory (§8): every admitted
 /// connection — L4 relaying or L7 in any phase — can hold up to
@@ -17,12 +44,14 @@ pub const listeners_max: u16 = 8;
 /// (an L7 head read is a data op like any other), so every slot claims
 /// its worst-case share of the pre-budgeted ring. With the ring at its
 /// usable maximum (`ring_entries = 4096`, CQ = 8192, ¾ headroom = 6144)
-/// and the parked-upstream reservation carved out first, that caps this
-/// at `(6144 - 18 - upstream_slots_max) / conn_ops_max = 1020` —
-/// comptime-derived below. Keep-alive surplus beyond this ceiling waits
-/// for the deeper-CQ fork lever (`IORING_SETUP_CQSIZE`, docs/PLANS.md),
-/// the same prerequisite as c10k.
-pub const conn_slots_max: u32 = 1020;
+/// and the parked-upstream and admin reservations carved out first, that
+/// caps this at `(6144 - 23 - upstream_slots_max) / conn_ops_max = 1019` —
+/// comptime-derived below (the 23 is the fixed ops: two per config and
+/// admin listener [18], the admin client's op budget [3], the signal wake
+/// [1], and the drain timer [1]). Keep-alive surplus beyond this ceiling
+/// waits for the deeper-CQ fork lever (`IORING_SETUP_CQSIZE`,
+/// docs/PLANS.md), the same prerequisite as c10k.
+pub const conn_slots_max: u32 = 1019;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -173,24 +202,28 @@ pub const timeout_ms_max: u32 = 3_600_000;
 /// every connection slot at its op peak (L7 slots hold armed ops with or
 /// without a relay buffer, so the term is per slot, not per buffer), one
 /// idle-timer op per parked upstream (§5/§8 — reserved ahead of the
-/// keep-alive slice), two ops per listener (a draining listener holds
-/// its armed accept — or the accept-retry backoff timer — plus the async
-/// cancel that reaps it), the single async wakeup op for signals, and
-/// the server's one drain-deadline timer.
+/// keep-alive slice), two ops per listener — configured *and* admin — (a
+/// draining listener holds its armed accept — or the accept-retry backoff
+/// timer — plus the async cancel that reaps it), `admin_conn_ops_max` ops
+/// per admin client (its send/deadline/teardown peak), the single async
+/// wakeup op for signals, and the server's one drain-deadline timer.
 pub const in_flight_ops_max: u32 =
     conn_slots_max * conn_ops_max + upstream_slots_max +
-    2 * @as(u32, listeners_max) + 1 + 1;
+    2 * (@as(u32, listeners_max) + admin_listeners) +
+    admin_conns * admin_conn_ops_max + 1 + 1;
 
 /// Kernel completion queue capacity (io_uring fixes CQ at 2 × SQ).
 pub const completion_queue_entries: u32 = 2 * @as(u32, ring_entries);
 
 /// Worst-case fd count (§8: fds are pre-budgeted, not shed): stdio + ring
-/// + async eventfd + listeners + two sockets per admitted connection
-/// (client plus the exchange's upstream) + the one transient
-/// just-accepted fd an admission decision is pending on + one socket per
-/// parked upstream, which belongs to no connection.
+/// + async eventfd + listeners (configured + admin) + two sockets per
+/// admitted connection (client plus the exchange's upstream) + the one
+/// transient just-accepted fd an admission decision is pending on + one
+/// socket per in-flight admin scrape + one socket per parked upstream,
+/// which belongs to no connection.
 pub const fds_max: u32 =
-    3 + 1 + 1 + listeners_max + 2 * conn_slots_max + 1 + upstream_slots_max;
+    3 + 1 + 1 + (listeners_max + admin_listeners) +
+    2 * conn_slots_max + 1 + admin_conns + upstream_slots_max;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -231,12 +264,17 @@ comptime {
     assert(poolPressureOn(relay_buffers_max) <= relay_buffers_max);
     // The conn-slot ceiling is derived, not chosen: the largest slot
     // count whose worst-case ops fit the ¾-CQ budget after the fixed
-    // ops and the parked-upstream reservation are carved out (§8).
+    // ops — the parked-upstream reservation and the admin listener plus
+    // its one client op — are carved out (§8).
     assert(conn_slots_max == @divFloor(
-        completion_queue_entries * 3 / 4 - 2 * @as(u32, listeners_max) - 1 - 1 -
-            upstream_slots_max,
+        completion_queue_entries * 3 / 4 -
+            2 * (@as(u32, listeners_max) + admin_listeners) -
+            admin_conns * admin_conn_ops_max - 1 - 1 - upstream_slots_max,
         conn_ops_max,
     ));
+    assert(admin_listeners >= 1);
+    assert(admin_conns >= 1);
+    assert(admin_conn_ops_max >= 1);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool
@@ -326,6 +364,7 @@ test "budgets: conn slots sit at the completion-queue ceiling" {
     // slot would break the budget.
     try std.testing.expect(in_flight_ops_max <= completion_queue_entries * 3 / 4);
     const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
-        2 * @as(u32, listeners_max) + 1 + 1;
+        2 * (@as(u32, listeners_max) + admin_listeners) +
+        admin_conns * admin_conn_ops_max + 1 + 1;
     try std.testing.expect(one_more > completion_queue_entries * 3 / 4);
 }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -75,6 +75,14 @@ pub const Counters = struct {
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path).
     kernel_pressure_errors: Value = Value.init(0),
+    /// Admin/metrics scrapes whose full response was written (§8, PLANS.md
+    /// §243). Pure observability: the admin plane sits entirely outside
+    /// `reconcile`'s accepted/admitted/shed accounting, so these never enter
+    /// the gate identity.
+    admin_served: Value = Value.init(0),
+    /// Admin scrapes reaped by the scrape deadline before completing — a
+    /// stalled or slowloris client freed from the single reserved slot (§8).
+    admin_reaped: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -92,16 +92,62 @@ pub const Counters = struct {
         return @field(counters, name).load(.monotonic);
     }
 
-    /// Phase 0 exposure (§8): SIGUSR1 dumps to stderr through the signal
-    /// seam; the admin plane stays deferred (docs/PLANS.md).
-    pub fn dump(counters: *const Counters) void {
-        std.debug.print("zoxy counters:", .{});
-        inline for (@typeInfo(Counters).@"struct".fields) |field| {
-            if (field.type == Value) {
-                std.debug.print(" {s}={d}", .{ field.name, counters.get(field.name) });
-            }
+    /// The metric-name prefix for the Prometheus exposition rendering
+    /// (`render`). Every counter is exposed as `zoxy_<field>`.
+    pub const metric_prefix = "zoxy_";
+
+    /// Exact byte bound on a full `render` (§5: the caller sizes a fixed
+    /// buffer to it, so rendering never allocates and never truncates).
+    /// Per counter: a `# TYPE …` line plus a sample line whose value is at
+    /// most `maxInt(u64)` — 20 digits. Comptime-summed over the real field
+    /// set, so it tracks the counters as they are added or removed.
+    pub const render_bytes_max: usize = blk: {
+        const u64_digits_max = 20; // len("18446744073709551615")
+        var total: usize = 0;
+        for (@typeInfo(Counters).@"struct".fields) |field| {
+            if (field.type != Value) continue;
+            const name_len = metric_prefix.len + field.name.len;
+            total += "# TYPE ".len + name_len + " counter\n".len;
+            total += name_len + " ".len + u64_digits_max + "\n".len;
         }
-        std.debug.print("\n", .{});
+        break :blk total;
+    };
+
+    /// Render every counter as Prometheus exposition text into a
+    /// caller-owned buffer (zero-alloc, §5) — the single renderer shared by
+    /// the SIGUSR1 `dump` and any future admin endpoint. The buffer must be
+    /// at least `render_bytes_max`; that bound is exact, so a correctly
+    /// sized caller can never truncate. Returns the filled prefix.
+    pub fn render(counters: *const Counters, buffer: []u8) []const u8 {
+        assert(buffer.len >= render_bytes_max);
+        var cursor: usize = 0;
+        inline for (@typeInfo(Counters).@"struct".fields) |field| {
+            if (field.type != Value) continue;
+            // The format string is fully comptime (only the value is
+            // runtime), so bufPrint cannot fail for a value that fits u64
+            // in a buffer sized to render_bytes_max.
+            const written = std.fmt.bufPrint(
+                buffer[cursor..],
+                "# TYPE " ++ metric_prefix ++ field.name ++ " counter\n" ++
+                    metric_prefix ++ field.name ++ " {d}\n",
+                .{counters.get(field.name)},
+            ) catch unreachable;
+            cursor += written.len;
+        }
+        assert(cursor >= 1);
+        assert(cursor <= render_bytes_max);
+        return buffer[0..cursor];
+    }
+
+    /// Phase 0 exposure (§8): SIGUSR1 dumps the Prometheus rendering to
+    /// stderr through the signal seam; the admin plane stays deferred
+    /// (docs/PLANS.md). Shares `render` so the dump and a future scrape
+    /// endpoint never disagree on the wire format.
+    pub fn dump(counters: *const Counters) void {
+        var buffer: [render_bytes_max]u8 = undefined;
+        const text = counters.render(&buffer);
+        assert(text.len <= buffer.len);
+        std.debug.print("{s}", .{text});
     }
 
     /// The §9 invariant: admitted work is completed or still active, and
@@ -143,4 +189,54 @@ test "counters: reconcile holds across a lifecycle" {
     counters.increment("shed_conn_slots");
     try std.testing.expect(counters.reconcile(0));
     try std.testing.expectEqual(@as(u64, 1), counters.get("shed_conn_slots"));
+}
+
+test "counters: render emits Prometheus exposition for every field" {
+    var counters: Counters = .{};
+    counters.increment("accepted");
+    counters.increment("accepted");
+    counters.increment("l7_responses");
+
+    var buffer: [Counters.render_bytes_max]u8 = undefined;
+    const text = counters.render(&buffer);
+
+    // Every counter appears exactly once as a TYPE line and a sample line,
+    // and the sample carries the live value.
+    try std.testing.expect(std.mem.indexOf(u8, text, "# TYPE zoxy_accepted counter\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_accepted 2\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_l7_responses 1\n") != null);
+    // Untouched counters still render at zero — a scrape sees the whole set.
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_completed 0\n") != null);
+
+    // One TYPE line per counter field: the rendering is complete.
+    var type_lines: usize = 0;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, text, search, "# TYPE ")) |at| {
+        type_lines += 1;
+        search = at + "# TYPE ".len;
+    }
+    var field_count: usize = 0;
+    inline for (@typeInfo(Counters).@"struct".fields) |field| {
+        if (field.type == Counters.Value) field_count += 1;
+    }
+    try std.testing.expectEqual(field_count, type_lines);
+}
+
+test "counters: render bound holds at the maximum value" {
+    // The render_bytes_max bound must survive every counter at maxInt(u64)
+    // — the widest possible sample line — so a saturated proxy never
+    // truncates or overruns the buffer.
+    var counters: Counters = .{};
+    inline for (@typeInfo(Counters).@"struct".fields) |field| {
+        if (field.type == Counters.Value) {
+            @field(counters, field.name).store(std.math.maxInt(u64), .monotonic);
+        }
+    }
+    var buffer: [Counters.render_bytes_max]u8 = undefined;
+    const text = counters.render(&buffer);
+    // With every value at its 20-digit maximum, the render fills the buffer
+    // exactly — proving render_bytes_max is a tight bound, not just an upper
+    // one (the "exact" claim in its doc comment).
+    try std.testing.expectEqual(Counters.render_bytes_max, text.len);
+    try std.testing.expect(std.mem.indexOf(u8, text, "18446744073709551615\n") != null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,6 +47,7 @@ pub fn main(init: std.process.Init) !void {
     try global_io.init(arena);
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
+    try enableAdminIfConfigured(&server, init.environ_map);
     try server.start();
     installSignalHandlers();
 
@@ -59,6 +60,25 @@ pub fn main(init: std.process.Init) !void {
 
 /// fds are pre-budgeted, not shed (§8): raise the soft limit up to the
 /// hard limit, and refuse to start if even that cannot cover the budget.
+/// Opt-in admin/metrics listener (§8, PLANS.md §243): `ZOXY_ADMIN_BIND`
+/// (e.g. `127.0.0.1:9100`) turns it on. Kept out of the JSON config for
+/// now — a bad value fails loudly rather than starting a proxy with a
+/// silently-off metrics endpoint.
+fn enableAdminIfConfigured(
+    server: *ServerXev,
+    environ_map: *const std.process.Environ.Map,
+) !void {
+    const literal = environ_map.get("ZOXY_ADMIN_BIND") orelse return;
+    const bind = std.Io.net.IpAddress.parseLiteral(literal) catch {
+        std.debug.print(
+            "zoxy: ZOXY_ADMIN_BIND '{s}' is not a host:port literal\n",
+            .{literal},
+        );
+        return error.AdminBindInvalid;
+    };
+    server.setAdminBind(bind);
+}
+
 fn ensureFdBudget() !void {
     const fds_max: u64 = zoxy.constants.fds_max;
     var limits = try std.posix.getrlimit(.NOFILE);

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,7 +47,6 @@ pub fn main(init: std.process.Init) !void {
     try global_io.init(arena);
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
-    try enableAdminIfConfigured(&server, init.environ_map);
     try server.start();
     installSignalHandlers();
 
@@ -60,25 +59,6 @@ pub fn main(init: std.process.Init) !void {
 
 /// fds are pre-budgeted, not shed (§8): raise the soft limit up to the
 /// hard limit, and refuse to start if even that cannot cover the budget.
-/// Opt-in admin/metrics listener (§8, PLANS.md §243): `ZOXY_ADMIN_BIND`
-/// (e.g. `127.0.0.1:9100`) turns it on. Kept out of the JSON config for
-/// now — a bad value fails loudly rather than starting a proxy with a
-/// silently-off metrics endpoint.
-fn enableAdminIfConfigured(
-    server: *ServerXev,
-    environ_map: *const std.process.Environ.Map,
-) !void {
-    const literal = environ_map.get("ZOXY_ADMIN_BIND") orelse return;
-    const bind = std.Io.net.IpAddress.parseLiteral(literal) catch {
-        std.debug.print(
-            "zoxy: ZOXY_ADMIN_BIND '{s}' is not a host:port literal\n",
-            .{literal},
-        );
-        return error.AdminBindInvalid;
-    };
-    server.setAdminBind(bind);
-}
-
 fn ensureFdBudget() !void {
     const fds_max: u64 = zoxy.constants.fds_max;
     var limits = try std.posix.getrlimit(.NOFILE);

--- a/src/root.zig
+++ b/src/root.zig
@@ -55,5 +55,6 @@ test {
     _ = @import("io/xev_smoke_test.zig");
     _ = @import("server_test.zig");
     _ = @import("http_proxy_test.zig");
+    _ = @import("admin_test.zig");
     _ = @import("zero_alloc_test.zig");
 }


### PR DESCRIPTION
## What

An in-loop admin/metrics listener that exposes the process counters (`counters.zig`) as Prometheus exposition text over a dedicated localhost port — the metrics-exposure half of the §8 admin plane, previously deferred (PLANS.md §243).

Enable with an optional config block, then scrape with any HTTP client:

```json
{ "admin": { "bind": "127.0.0.1:9100" } }
```

```
$ curl -s http://127.0.0.1:9100/metrics
HTTP/1.1 200 OK
Content-Type: text/plain; version=0.0.4
Connection: close

# TYPE zoxy_accepted counter
zoxy_accepted 2
# TYPE zoxy_admitted counter
zoxy_admitted 2
...
```

The `admin` block is optional (absent → plane off), carries JSON Schema metadata (`zig build schema` emits it, `bind` required, `additionalProperties:false`), and rejects hostnames like every other bind.

## Design

Follows the settled invariants — one loop owns all I/O (§3), zero allocation after startup (§5), closed-form comptime budgets (§8), and the deterministic-sim seam (§9):

- **Single reserved slot, off the shared pools.** One dedicated listener with one scrape served at a time, budgeted separately (`admin_listeners`, `admin_conns`, `admin_conn_ops_max`) so a scrape and the data path can never shed one another. Reserving the admin ops derives `conn_slots_max` 1020 → 1019 (the ¾-CQ budget was exactly saturated); `fds_max` is unchanged.
- **Zero-alloc renderer.** `Counters.render` writes into a caller-owned buffer sized by a comptime-exact `render_bytes_max`; the SIGUSR1 dump reuses it, so the dump and the scrape endpoint share one wire format.
- **Bullet-proof scrape lifecycle.** accept → send → lingering close (half-close write, drain client input to EOF so the close never RSTs the response away, §2) → re-arm. A per-scrape deadline reaps a stalled/slowloris client so it cannot pin the slot; accept/send/recv witness kernel pressure and a failed accept backs off like the data path. The request is never parsed (same counters regardless of method/path — no new attack surface).
- **Drain integration.** The server drain (§8) closes the admin listener and tears down any in-flight scrape; `maybeStopAfterDrain`/`isIdle` gate on the admin conn's quiescence.
- Generic over the `Io` backend, so the simulator drives it too.

## Testing

- **SimIo gate (`src/admin_test.zig`)** — byte-exact response across 20 partial_io seeds, reset-prefix robustness across 20 seeds, a drain racing an in-flight scrape (raced-accept holder idiom), the deadline reaper, and an explicit idle-listener drain test. Every run asserts server-idle + counters-reconcile + no socket leak.
- **Config** — parse tests for the `admin` block (absent → off, valid literal → resolved, hostname/empty/extra field → the matching loader error), plus the comptime schema-metadata gate.
- **`zig build ci`** green (unit + fuzz + boundary lint + 64 sim seeds + zero-alloc gate).
- **Verified end-to-end** on the real binary: scrape returns valid exposition, sequential re-arm, clean `Connection: close` (no RST truncation), clean SIGTERM drain to `isIdle` in ~0.25s.

Each slice was reviewed against `docs/TIGER_STYLE.md`; the review rounds caught the missing scrape-deadline reaper (at the budget stage), a kernel-pressure/backoff gap, a coverage gap, and a stale-doc gap — all fixed.

## Deferred (follow-ups)

- Single-scrape-at-a-time is by design (a localhost round trip); lift only on evidence.
- Richer admin surface (push/OTLP export, per-route stats, a control plane) stays out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)