### PR TITLE
Make the ⅞ CQ fill an operator-tunable default (§8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -383,10 +383,10 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 9622 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 9622 | 2 × 4 KiB |
+| conn slots | 1386 | 11259 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 11259 | 2 × 4 KiB |
 | upstream slots | 1024 | 1024 | ~40 B state + 8 KiB head |
-| **pool memory** | **~32 MiB** | **~174 MiB** | |
+| **pool memory** | **~32 MiB** | **~203 MiB** | |
 
 Rules:
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -264,6 +264,10 @@ unmerged behind it, so the pin moves only after re-audit.
   in-flight completions — which live in pool slots — so the
   no-unbounded-queue rule holds by construction. The in-flight op budget
   that keeps CQ overflow unreachable is part of the startup printout (§8).
+  How much of that CQ the in-flight ops may fill is ⅞ by default
+  (`cq_fill_eighths_default` — the fill the c10k ceiling is derived at);
+  `limits.cq_fill_eighths` lowers it per deployment toward ⅛ to reserve
+  more burst headroom, at a lower feasible connection ceiling (§5).
 - **Ring setup flags.** The ring is created with `SINGLE_ISSUER`,
   `COOP_TASKRUN`, and `DEFER_TASKRUN`: completion task-work stays on
   the loop thread and is batched at the reap point instead of
@@ -396,6 +400,15 @@ Rules:
   `worker_jobs_max ≤ conn_slots`. Note that `relay_buffers` — not conn
   slots — is the true bound on concurrent L4 connections plus active L7
   relays (§6).
+- **The CQ fill is a headroom knob, not a pool shrink.**
+  `limits.cq_fill_eighths` sets how many eighths of the completion queue
+  the worst-case in-flight ops may fill: ⅞ (the default, the fill the c10k
+  ceiling is derived at) packs the ring tightest, and lowering it toward ⅛
+  reserves more burst headroom at the cost of a lower feasible conn-slot
+  ceiling. Unlike the pool sizes it is the one `limits` field that does not
+  shrink a pool; a fill whose ring would exceed the compiled one
+  (`cqFillFits` false for the chosen conn/upstream slots and listeners) is
+  rejected at load, not clamped (§4/§8).
 - **The config arena is the only allocating region** — parse-once,
   immutable, shared read-only. (Carried verbatim; it worked.)
 - **The config surface has a generated JSON Schema.** `zig build schema`

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -242,40 +242,44 @@ Verdicts, so they are not re-litigated:
   with c10k below; TLS and chunked L7 bodies fall back to copy
   regardless.
 
-## c10k — lifting the 1225-connection ceiling
+## c10k — the CQSIZE ceiling (lever #1 landed)
 
-Concurrent L4 connections are CQ-bound, not memory- or fd-bound:
-`relay_buffers_max = (6144 − 18) / 5 = 1225` (derivation in
-`constants.zig`). Two levers, both fork work:
+Concurrent L4 connections were CQ-bound, not memory- or fd-bound: before
+the CQSIZE lever the CQ was fixed at 2 × SQ, capping `relay_buffers_max`
+at `(6144 − 18) / 5 = 1225`. Two levers were on the table:
 
-1. **Deeper CQ** — `IORING_SETUP_CQSIZE`; libxev fixes the CQ at 2 × SQ
-   today, and exposing it needs `IoUring.init_params` plumbing in the
-   fork, not just a flag OR. This directly lifts the ceiling. Past it,
-   fds bind next: `fds_max = 14 + 2·relay_buffers`, so true c10k (~10 k
-   buffers → ~20 k fds) also raises the documented `RLIMIT_NOFILE`
-   assumption.
-2. **`splice`** (above) — an independent win at saturation, same
-   fork/re-audit cost.
+1. **Deeper CQ** — `IORING_SETUP_CQSIZE`. **Landed (#61):** the audited
+   fork exposes `Options.cq_entries`, XevIo requests the kernel maximum
+   (65536) at the ceiling, and `conn_slots_max` / `relay_buffers_max`
+   rose to 11259 on a single ring. How full the in-flight ops may pack
+   that CQ is a configurable ⅞ default (`limits.cq_fill_eighths`);
+   lowering it toward ⅛ trades the ceiling back down for burst headroom,
+   and a fill that cannot fit the compiled ring is rejected at load, not
+   clamped (§4/§5). Past the ceiling, fds bind next: `fds_max` scales with
+   `2·relay_buffers`, so a deployment configured toward c10k raises the
+   documented `RLIMIT_NOFILE` assumption (handled at startup, §8).
+2. **`splice`** (above) — an independent win at saturation, still fork
+   work; same re-audit cost.
 
-Entry gate: demonstrate a workload that actually hits the 1225 wall
-before spending a fork re-audit on it.
+Entry gate for further ceiling work: demonstrate a workload that actually
+saturates the 11259 ceiling before spending another fork re-audit on it.
 
 ## libxev fork queue
 
 The §4 pin policy (audited commit, moves only after re-audit) makes fork
 changes deliberate, batched work. Landed so far: `Options.io_uring_flags`
-(branch `zoxy-ring-flags`, c369817 — the §4 ring setup flags). Known
-queue, in rough value order:
+(branch `zoxy-ring-flags`, c369817 — the §4 ring setup flags) and
+`Options.cq_entries` (branch `zoxy-cqsize`, pin 6bd950d — the
+`IORING_SETUP_CQSIZE` c10k lever, #61). Known queue, in rough value order:
 
-1. `IORING_SETUP_CQSIZE` exposure (c10k lever #1).
-2. Per-errno surfacing on data ops: the backend collapses ENOBUFS/ENOMEM
+1. Per-errno surfacing on data ops: the backend collapses ENOBUFS/ENOMEM
    — and every uncommon errno — into `error.Unexpected`
    (IMPLEMENTATION_NOTES.md), so zoxy ships a categorical
    kernel-pressure witness instead. Fork change: map
    `.NOBUFS`/`.NOMEM => error.SystemResources` and widen
    ReadError/WriteError.
-3. `IORING_OP_SPLICE` (the op union is closed today).
-4. Multishot accept/recv ops — only behind the workloads in the verdict
+2. `IORING_OP_SPLICE` (the op union is closed today).
+3. Multishot accept/recv ops — only behind the workloads in the verdict
    table above.
 
 ## Deferred, revisit on evidence

--- a/src/config.zig
+++ b/src/config.zig
@@ -46,6 +46,13 @@ pub const Config = struct {
         conn_slots: u32 = constants.conn_slots_default,
         relay_buffers: u32 = constants.relay_buffers_default,
         upstream_slots: u32 = constants.upstream_slots_default,
+        /// How many eighths of the io_uring completion queue the worst-case
+        /// in-flight ops may fill (§8). Unlike the pool sizes this is not a
+        /// shrink: ⅞ (the compiled default, the fill the ceiling is derived
+        /// at) packs the ring tightest, and lowering it reserves more burst
+        /// headroom at the cost of a lower feasible conn-slot count. A value
+        /// whose ring would exceed the compiled one is rejected at load.
+        cq_fill_eighths: u32 = constants.cq_fill_eighths_default,
     };
 
     pub const Listener = struct {
@@ -133,6 +140,8 @@ pub const ValidationError = error{
     LimitRelayBuffersOutOfRange,
     LimitRelayBuffersOverConnSlots,
     LimitUpstreamSlotsOutOfRange,
+    LimitCqFillOutOfRange,
+    LimitConnSlotsOverCqFill,
     AdminBindInvalid,
 };
 
@@ -151,7 +160,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     const clusters = try resolveClusters(arena, &parsed.clusters);
     const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     try validateTimeouts(&parsed.timeouts);
-    const limits = try resolveLimits(&parsed.limits);
+    const limits = try resolveLimits(&parsed.limits, @intCast(listeners.len));
     const admin_bind = try resolveAdminBind(parsed.admin);
 
     assert(listeners.len >= 1);
@@ -182,7 +191,8 @@ fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddres
 /// relay-buffer count derives from the effective conn slots (a buffer
 /// beyond the slot count could never be acquired); a *specified* count
 /// above them is a contradiction and fails loudly.
-fn resolveLimits(limits_json: *const LimitsJson) ValidationError!Config.Limits {
+fn resolveLimits(limits_json: *const LimitsJson, listeners_count: u32) ValidationError!Config.Limits {
+    assert(listeners_count >= 1);
     // Omitted limits default to the lean out-of-box sizes, not the
     // compiled ceilings (§5): a small footprint unless the operator opts
     // up. relay buffers still follow conn slots when omitted (one buffer
@@ -203,11 +213,24 @@ fn resolveLimits(limits_json: *const LimitsJson) ValidationError!Config.Limits {
     if (upstream_slots < 1 or upstream_slots > constants.upstream_slots_max) {
         return error.LimitUpstreamSlotsOutOfRange;
     }
+    // The CQ fill is the one limit an operator tightens for headroom, not a
+    // pool shrink (§8): a smaller fill demands a deeper ring for the same
+    // conn slots. Range-check first, then reject a fill that — with these
+    // conn/upstream slots and listeners — would need a completion queue past
+    // the compiled ring, so main.zig's completionQueueDepthFor never clamps.
+    const cq_fill_eighths = limits_json.cq_fill_eighths orelse constants.cq_fill_eighths_default;
+    if (cq_fill_eighths < constants.cq_fill_eighths_min or cq_fill_eighths > constants.cq_fill_eighths_max) {
+        return error.LimitCqFillOutOfRange;
+    }
+    if (!constants.cqFillFits(conn_slots, upstream_slots, listeners_count, cq_fill_eighths)) {
+        return error.LimitConnSlotsOverCqFill;
+    }
     assert(relay_buffers <= conn_slots);
     return .{
         .conn_slots = conn_slots,
         .relay_buffers = relay_buffers,
         .upstream_slots = upstream_slots,
+        .cq_fill_eighths = cq_fill_eighths,
     };
 }
 
@@ -223,8 +246,8 @@ pub const ConfigJson = struct {
     listeners: []const ListenerJson,
     clusters: ClustersJson,
     timeouts: TimeoutsJson,
-    /// Optional pool shrinks (§5, §8); absent fields keep the comptime
-    /// ceilings.
+    /// Optional pool sizes and the CQ-fill headroom knob (§5, §8); absent
+    /// fields take the lean defaults, not the compiled ceilings.
     limits: LimitsJson = .{},
     /// Optional admin/metrics listener (§8, PLANS.md Phase 2.5); absent
     /// leaves the plane off.
@@ -243,7 +266,7 @@ pub const ConfigJson = struct {
         },
         .clusters = .{ .desc = "Named upstream clusters, keyed by cluster name." },
         .timeouts = .{ .desc = "Connection lifecycle deadlines (milliseconds)." },
-        .limits = .{ .desc = "Optional pool shrinks; absent keeps the compiled ceilings." },
+        .limits = .{ .desc = "Optional pool sizes and the CQ-fill headroom knob; absent fields take the lean defaults." },
         .admin = .{ .desc = "Optional admin/metrics listener; absent leaves it off." },
     };
 };
@@ -263,10 +286,12 @@ pub const LimitsJson = struct {
     conn_slots: ?u32 = null,
     relay_buffers: ?u32 = null,
     upstream_slots: ?u32 = null,
+    cq_fill_eighths: ?u32 = null,
 
     pub const schema_doc =
-        "Optional pool shrinks; absent keeps the compiled ceilings. Config " ++
-        "may only shrink a pool below its ceiling, never grow it.";
+        "Optional pool sizes and the CQ-fill headroom knob; absent fields " ++
+        "take the lean defaults. Pools may only shrink below their ceilings; " ++
+        "cq_fill_eighths trades ceiling for burst headroom, never a pool size.";
     pub const schema_fields = .{
         .conn_slots = .{
             .desc = "Concurrent connection slots.",
@@ -282,6 +307,13 @@ pub const LimitsJson = struct {
             .desc = "Shared upstream connection slots.",
             .minimum = 1,
             .maximum = constants.upstream_slots_max,
+        },
+        .cq_fill_eighths = .{
+            .desc = "Eighths of the io_uring completion queue the worst-case " ++
+                "in-flight ops may fill; lower reserves more burst headroom " ++
+                "but lowers the feasible connection-slot ceiling.",
+            .minimum = constants.cq_fill_eighths_min,
+            .maximum = constants.cq_fill_eighths_max,
         },
     };
 };
@@ -1461,6 +1493,8 @@ test "config: limits shrink pools below the ceilings, never past them" {
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.relay_buffers);
         try std.testing.expectEqual(constants.upstream_slots_max, parsed.limits.upstream_slots);
+        // The CQ fill defaults to ⅞ when the block omits it.
+        try std.testing.expectEqual(constants.cq_fill_eighths_default, parsed.limits.cq_fill_eighths);
     }
     // Full limits resolve verbatim; absent block keeps the ceilings.
     {
@@ -1470,11 +1504,13 @@ test "config: limits shrink pools below the ceilings, never past them" {
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1},
-            \\ "limits":{"conn_slots":64,"relay_buffers":8,"upstream_slots":8}}
+            \\ "limits":{"conn_slots":64,"relay_buffers":8,"upstream_slots":8,"cq_fill_eighths":4}}
         );
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
         try std.testing.expectEqual(@as(u32, 8), parsed.limits.relay_buffers);
         try std.testing.expectEqual(@as(u32, 8), parsed.limits.upstream_slots);
+        // A tighter fill resolves verbatim when the pools leave room for it.
+        try std.testing.expectEqual(@as(u32, 4), parsed.limits.cq_fill_eighths);
     }
     {
         var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -1489,6 +1525,7 @@ test "config: limits shrink pools below the ceilings, never past them" {
         try std.testing.expectEqual(constants.conn_slots_default, parsed.limits.conn_slots);
         try std.testing.expectEqual(constants.relay_buffers_default, parsed.limits.relay_buffers);
         try std.testing.expectEqual(constants.upstream_slots_default, parsed.limits.upstream_slots);
+        try std.testing.expectEqual(constants.cq_fill_eighths_default, parsed.limits.cq_fill_eighths);
     }
     const tail =
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
@@ -1508,6 +1545,23 @@ test "config: limits shrink pools below the ceilings, never past them" {
     // contradiction, not a derivable default.
     try expectParseError(error.LimitRelayBuffersOverConnSlots, head ++ tail ++
         "\"limits\":{\"conn_slots\":4,\"relay_buffers\":8}}");
+    // The CQ fill has its own range [min, max] in eighths; below or above
+    // fails loudly, each distinct from the pool-size errors.
+    try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":0}}");
+    try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":8}}");
+    // A fill tighter than the ceiling was derived at cannot serve the full
+    // conn-slot ceiling — the completion queue it would need exceeds the
+    // compiled ring, so the combination is rejected (§8).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const json = try std.fmt.allocPrint(
+            arena_state.allocator(),
+            "{s}{s}\"limits\":{{\"conn_slots\":{d},\"cq_fill_eighths\":{d}}}}}",
+            .{ head, tail, constants.conn_slots_max, constants.cq_fill_eighths_max - 1 },
+        );
+        try std.testing.expectError(error.LimitConnSlotsOverCqFill, parse(arena_state.allocator(), json));
+    }
 }
 
 test "config: admin block resolves a bind literal, absent leaves it off" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -53,17 +53,18 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// connection — L4 relaying or L7 in any phase — can hold up to
 /// `conn_ops_max` armed ops whether or not it holds a relay buffer
 /// (an L7 head read is a data op like any other), so every slot claims
-/// its worst-case share of the pre-budgeted ring. The ring now requests
-/// the deepest CQ the kernel allows (`completion_queue_entries`,
-/// IORING_SETUP_CQSIZE) against the 4096 SQ, so with the ¾ headroom
-/// (49152) and the parked-upstream and admin reservations carved out
-/// first, this caps at `(49152 - 23 - upstream_slots_max) / conn_ops_max
-/// = 9621` — comptime-derived below (the 23 is the fixed ops: two per
-/// config and admin listener [18], the admin client's op budget [3], the
-/// signal wake [1], and the drain timer [1]). That is the c10k ceiling on
-/// a single ring; the last stretch to a round 10k needs `conn_ops_max`
-/// cut from 5 to 4 (the teardown-race peak, docs/PLANS.md).
-pub const conn_slots_max: u32 = 9621;
+/// its worst-case share of the pre-budgeted ring. The ring requests the
+/// deepest CQ the kernel allows (`completion_queue_entries`,
+/// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
+/// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
+/// parked-upstream and admin reservations carved out first, this caps at
+/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 11259` —
+/// comptime-derived below (the 23 is the fixed ops: two per config and
+/// admin listener [18], the admin client's op budget [3], the signal
+/// wake [1], and the drain timer [1]). That clears a round 10k on a
+/// single ring; a deployment trades the ceiling back down for more burst
+/// headroom via `limits.cq_fill_eighths` (§8).
+pub const conn_slots_max: u32 = 11259;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -242,27 +243,75 @@ pub const in_flight_ops_max: u32 =
 /// clamp) keep it out of reach.
 pub const completion_queue_entries_max: u32 = 65536;
 
-/// The CQ depth a deployment needs: its worst-case in-flight ops with the
-/// same ¾ headroom the ceiling reserves (invert `in_flight <= cq × 3/4`),
-/// rounded up to a power of two and clamped to the kernel range. XevIo
-/// requests this via IORING_SETUP_CQSIZE, so a small deployment gets a
-/// shallow ring and only a c10k one asks for the full 65536.
-pub fn completionQueueDepthFor(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
+/// §8 CQ fill: in-flight ring ops may occupy at most this many eighths of
+/// the completion queue; the rest stays free to absorb completion bursts.
+/// ⅞ is both the default and the largest fill a config may request — it is
+/// the fill the `conn_slots_max` ceiling is derived at, so no deployment
+/// can demand a CQ deeper than the pools were sized for. An operator
+/// trades the ceiling down for more burst headroom by lowering
+/// `limits.cq_fill_eighths` toward `cq_fill_eighths_min`. ⅞ replaced the
+/// original ¾ (= 6/8) once the CQSIZE lever (#61) made the CQ a real
+/// kernel argument.
+pub const cq_fill_eighths_default: u32 = 7;
+/// The largest fill (least burst headroom) any config may request: equal to
+/// the default, because the compiled ceiling reserves exactly this much —
+/// asking for more would demand a ring past the c10k budget.
+pub const cq_fill_eighths_max: u32 = cq_fill_eighths_default;
+/// The smallest fill (most burst headroom) any config may request. At the
+/// floor in-flight ops fill only ⅛ of the CQ — the most burst slack a
+/// deployment can reserve, at the cost of the lowest connection ceiling.
+pub const cq_fill_eighths_min: u32 = 1;
+
+/// The CQ depth a deployment needs: its worst-case in-flight ops fit
+/// within `cq_fill_eighths`/8 of the ring (invert `in_flight <= cq ×
+/// eighths/8`), rounded up to a power of two and clamped to the kernel
+/// range. XevIo requests this via IORING_SETUP_CQSIZE, so a small
+/// deployment gets a shallow ring and only a c10k one asks for the full
+/// 65536. The caller must have validated feasibility (`cqFillFits`): at
+/// the max fill an in-domain conn count always fits, and a tighter fill
+/// only ever asks for a *deeper* ring, so the fill postcondition holds.
+pub fn completionQueueDepthFor(
+    conn_slots: u32,
+    upstream_slots: u32,
+    listeners: u32,
+    cq_fill_eighths: u32,
+) u32 {
+    assert(cq_fill_eighths >= cq_fill_eighths_min);
+    assert(cq_fill_eighths <= cq_fill_eighths_max);
     const in_flight = inFlightOps(conn_slots, upstream_slots, listeners);
-    const with_headroom = (in_flight * 4 + 2) / 3; // ceil(in_flight × 4/3)
+    // The shallowest ring whose fill budget covers every in-flight op;
+    // eighths >= 1 is asserted above, so the divide never faults.
+    const with_headroom = std.math.divCeil(u32, in_flight * 8, cq_fill_eighths) catch unreachable;
     const depth = std.math.ceilPowerOfTwo(u32, @max(with_headroom, ring_entries)) catch
         completion_queue_entries_max;
     // Explicit u32: `@min` with a comptime bound would otherwise narrow the
-    // type to u17, overflowing the `* 3` in the headroom check below.
+    // type to u17, overflowing the fill check below.
     const clamped: u32 = @min(depth, completion_queue_entries_max);
-    // In-domain (inFlightOps asserts the args), `with_headroom` never
-    // exceeds the cap, so the clamp cannot truncate below the requirement:
-    // the ring holds every in-flight op with the ¾ headroom, is a power of
-    // two, and is at least the SQ depth.
-    assert(in_flight <= clamped * 3 / 4);
+    // A power-of-two ring is a multiple of 8 (>= ring_entries), so the fill
+    // budget is exact — `@divExact` pins that structurally. A feasible
+    // in-domain caller keeps in_flight within it; the ring is >= the SQ.
+    assert(in_flight <= @divExact(clamped, 8) * cq_fill_eighths);
     assert(std.math.isPowerOfTwo(clamped));
     assert(clamped >= ring_entries);
     return clamped;
+}
+
+/// Whether a deployment's worst-case in-flight ops fit the deepest kernel
+/// CQ at the requested fill (§8) — the loader's guard before it accepts a
+/// `limits.cq_fill_eighths` that asks for more headroom than the conn-slot
+/// count leaves room for. The kernel CQ is a power of two, so the fill
+/// budget `completion_queue_entries_max / 8 * eighths` is exact.
+pub fn cqFillFits(
+    conn_slots: u32,
+    upstream_slots: u32,
+    listeners: u32,
+    cq_fill_eighths: u32,
+) bool {
+    assert(cq_fill_eighths >= cq_fill_eighths_min);
+    assert(cq_fill_eighths <= cq_fill_eighths_max);
+    const in_flight = inFlightOps(conn_slots, upstream_slots, listeners);
+    // The kernel CQ max is a power of two, so its fill budget is exact.
+    return in_flight <= @divExact(completion_queue_entries_max, 8) * cq_fill_eighths;
 }
 
 /// The CQ capacity the §8 ceiling budgets are derived against: the depth a
@@ -270,7 +319,7 @@ pub fn completionQueueDepthFor(conn_slots: u32, upstream_slots: u32, listeners: 
 /// maximum (65536), which is exactly what makes `conn_slots_max` the c10k
 /// ceiling — as deep as one ring allows, independent of `ring_entries`.
 pub const completion_queue_entries: u32 =
-    completionQueueDepthFor(conn_slots_max, upstream_slots_max, listeners_max);
+    completionQueueDepthFor(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_default);
 
 /// The fds a deployment needs (§8: fds are pre-budgeted, not shed): stdio
 /// + ring + async eventfd + listeners (configured + admin) + two sockets
@@ -317,6 +366,14 @@ comptime {
     assert(std.math.isPowerOfTwo(completion_queue_entries));
     assert(completion_queue_entries >= ring_entries);
     assert(completion_queue_entries <= completion_queue_entries_max);
+    // The CQ fill bounds: at least one eighth of the ring always stays free
+    // for completion bursts (max <= 7), the floor packs at least one eighth
+    // (min >= 1), and the default is a value in that range. The ceiling is
+    // derived at the default, so the default must equal the max.
+    assert(cq_fill_eighths_min >= 1);
+    assert(cq_fill_eighths_max <= 7);
+    assert(cq_fill_eighths_min <= cq_fill_eighths_default);
+    assert(cq_fill_eighths_default == cq_fill_eighths_max);
     // The defaults are a lean, valid subset of the ceilings.
     assert(conn_slots_default >= 1 and conn_slots_default <= conn_slots_max);
     assert(relay_buffers_default >= 1 and relay_buffers_default <= relay_buffers_max);
@@ -357,11 +414,11 @@ comptime {
     assert(poolPressureOn(relay_buffers_max) > poolPressureOff(relay_buffers_max));
     assert(poolPressureOn(relay_buffers_max) <= relay_buffers_max);
     // The conn-slot ceiling is derived, not chosen: the largest slot
-    // count whose worst-case ops fit the ¾-CQ budget after the fixed
-    // ops — the parked-upstream reservation and the admin listener plus
-    // its one client op — are carved out (§8).
+    // count whose worst-case ops fit the ⅞-CQ budget (at the default =
+    // loosest fill) after the fixed ops — the parked-upstream reservation
+    // and the admin listener plus its one client op — are carved out (§8).
     assert(conn_slots_max == @divFloor(
-        completion_queue_entries * 3 / 4 -
+        @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * (@as(u32, listeners_max) + admin_listeners) -
             admin_conns * admin_conn_ops_max - 1 - 1 - upstream_slots_max,
         conn_ops_max,
@@ -404,9 +461,10 @@ pub fn memoryBytesTotal(
 
 test "budgets: in-flight ops fit the completion queue with headroom" {
     try std.testing.expect(in_flight_ops_max <= completion_queue_entries);
-    // Headroom is deliberate: at least a quarter of the CQ stays free for
-    // completion bursts even at the worst-case armed-op count.
-    try std.testing.expect(in_flight_ops_max <= completion_queue_entries * 3 / 4);
+    // Headroom is deliberate: at least an eighth of the CQ stays free for
+    // completion bursts even at the worst-case armed-op count (the default
+    // = loosest fill the ceiling is derived at).
+    try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
 }
 
 test "pressure: relay watermarks have a hysteresis gap at every capacity" {
@@ -446,12 +504,12 @@ test "budgets: memory total matches the closed form" {
 }
 
 test "budgets: c10k ceiling fd count needs a raised NOFILE" {
-    // At the c10k ceiling the fd budget is ~20k — well past the common
+    // At the c10k ceiling the fd budget is ~24k — well past the common
     // 4096 unprivileged hard limit, so a deployment that configures up to
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 20282), fds_max);
+    try std.testing.expectEqual(@as(u32, 23558), fds_max);
     try std.testing.expect(fds_max <= 65536);
 }
 
@@ -461,22 +519,40 @@ test "budgets: the default deployment is lean" {
     // ceiling — operators opt up through `limits` (§5). One listener.
     try std.testing.expect(fdsRequired(conn_slots_default, upstream_slots_default, 1) < 4096);
     try std.testing.expect(
-        completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1) < completion_queue_entries,
+        completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_default) <
+            completion_queue_entries,
     );
     // The effective CQ still covers the default's in-flight ops with the
-    // ¾ headroom, exactly as the ceiling does for its own.
-    const depth = completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1);
-    try std.testing.expect(inFlightOps(conn_slots_default, upstream_slots_default, 1) <= depth * 3 / 4);
+    // ⅞ headroom, exactly as the ceiling does for its own.
+    const depth = completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_default);
+    try std.testing.expect(inFlightOps(conn_slots_default, upstream_slots_default, 1) <= @divExact(depth, 8) * cq_fill_eighths_default);
 }
 
 test "budgets: conn slots sit at the completion-queue ceiling" {
-    // The ¾-CQ headroom rule is what actually caps concurrent
-    // connections; conn_slots_max is the largest value that still
-    // satisfies it after the parked-upstream reservation, so one more
-    // slot would break the budget.
-    try std.testing.expect(in_flight_ops_max <= completion_queue_entries * 3 / 4);
+    // The ⅞-CQ fill rule (at the default = loosest fill) is what actually
+    // caps concurrent connections; conn_slots_max is the largest value
+    // that still satisfies it after the parked-upstream reservation, so
+    // one more slot would break the budget.
+    try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
     const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
         2 * (@as(u32, listeners_max) + admin_listeners) +
         admin_conns * admin_conn_ops_max + 1 + 1;
-    try std.testing.expect(one_more > completion_queue_entries * 3 / 4);
+    try std.testing.expect(one_more > @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
+}
+
+test "budgets: a tighter cq fill trades ceiling for burst headroom" {
+    // More headroom (fewer eighths) never asks for a shallower ring: at a
+    // fixed conn count the requested CQ is monotonic in the fill.
+    const loose = completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_max);
+    const tight = completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_min);
+    try std.testing.expect(tight >= loose);
+    // The conn-slot ceiling fits only at the max fill; one eighth tighter
+    // overflows even the deepest kernel CQ — the loader must reject that
+    // pairing (`cqFillFits` is the guard).
+    try std.testing.expect(cqFillFits(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_max));
+    try std.testing.expect(!cqFillFits(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_max - 1));
+    // The lean default still fits with plenty of room to spare, even at the
+    // old ¾ (= 6/8) fill and at the tightest floor.
+    try std.testing.expect(cqFillFits(conn_slots_default, upstream_slots_default, 1, 6));
+    try std.testing.expect(cqFillFits(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_min));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,6 +54,7 @@ pub fn main(init: std.process.Init) !void {
         config.limits.conn_slots,
         config.limits.upstream_slots,
         listeners_count,
+        zoxy.constants.cq_fill_eighths_default,
     );
     // The effective config never exceeds the compiled ceilings (§8): the
     // pools, the ring, and the fd demand all fit what the constants proved.

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,7 +54,7 @@ pub fn main(init: std.process.Init) !void {
         config.limits.conn_slots,
         config.limits.upstream_slots,
         listeners_count,
-        zoxy.constants.cq_fill_eighths_default,
+        config.limits.cq_fill_eighths,
     );
     // The effective config never exceeds the compiled ceilings (§8): the
     // pools, the ring, and the fd demand all fit what the constants proved.


### PR DESCRIPTION
Follow-on to #61 (the `IORING_SETUP_CQSIZE` c10k lever): that PR landed the deeper completion queue but left the fill watermark at ¾. This raises the compiled default to ⅞ and exposes it as an operator-tunable `limits` field.

## Slice 1 — raise the default, lift the ceiling (`50bfc5e`)
- CQ fill watermark **¾ → ⅞** as the compiled default: the worst-case in-flight budget rises 49152 → 57344, lifting `conn_slots_max` **9621 → 11259** (a round 10k+ on a single ring).
- New constants `cq_fill_eighths_{default,max,min}` (⅞ default = max, ⅛ floor, comptime-asserted); `completionQueueDepthFor` takes the fill; new `cqFillFits` predicate.
- §5 pool-budget table tracks the raised ceiling (~174 → **~203 MiB** at c10k).

## Slice 2 — expose it to operators (`4ef2038`)
- `Config.Limits.cq_fill_eighths` + `LimitsJson` field with JSON-Schema bounds reflected from the constants (1–7); `assert_meta_matches` enforces the field↔metadata pairing at comptime.
- `resolveLimits` range-checks the field (`LimitCqFillOutOfRange`) and feasibility-checks it via `cqFillFits` (`LimitConnSlotsOverCqFill`) for the chosen conn/upstream slots and listeners — so `main.zig`'s `completionQueueDepthFor` can never clamp a resolved config. The listener count is threaded from `parse()`; the ring is sized at the effective fill.
- Unlike the pool sizes, this is **not a shrink** — it is the one `limits` field that trades ceiling for burst headroom (lower eighths → more headroom, lower feasible conn-slot ceiling).
- **Drive-by fix:** the limits-object schema descriptions said "pool shrinks; absent keeps the compiled ceilings" — the second half contradicted the tested behavior (absent → lean defaults). Corrected all three strings.
- DESIGN.md §4/§5 document the knob; PLANS.md records the #61 CQSIZE lever as landed and the fill as now configurable.

## Gates
- `zig build ci` — unit + fuzz + 64/64 deterministic sim seeds ✅
- `zig fmt --check src scripts build.zig build.zig.zon` ✅
- `zig build schema` — emits `cq_fill_eighths` with bounds 1–7 ✅
- `tiger-style-reviewer` on each slice's diff — **ready to commit** (no violations) ✅

## Tests
`config: limits shrink pools below the ceilings, never past them` extended with: default fill resolution, verbatim resolution of a tighter fill, out-of-range rejection (0 and 8), and an infeasible ceiling + tight-fill combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)