### PR TITLE
Add --help and --version flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,48 @@ zoxy is built on the [TigerBeetle](https://tigerbeetle.com) I/O model — comple
 with caller-owned completions — and follows [TigerStyle](docs/TIGER_STYLE.md):
 **all memory is reserved at startup, and the request-serving path allocates nothing.**
 
-## Requirements
+## Usage
+
+The built binary takes exactly one argument — the path to a JSON config:
+
+```sh
+zoxy <config.json>   # start the proxy
+zoxy --help          # usage summary (-h)
+zoxy --version       # print the version (-V)
+```
+
+Signals: `SIGTERM`/`SIGINT` drain in-flight connections and exit 0;
+`SIGUSR1` dumps counters to stdout.
+
+A minimal config — an L4 listener forwarding to one origin
+([`config/example.json`](config/example.json)):
+
+```json
+{
+    "listeners": [
+        { "bind": "127.0.0.1:8080", "cluster": "origin", "protocol": "l4" }
+    ],
+    "clusters": {
+        "origin": { "endpoints": ["127.0.0.1:9000"] }
+    },
+    "timeouts": {
+        "connect_ms": 5000,
+        "idle_ms": 60000,
+        "drain_deadline_ms": 10000,
+        "max_lifetime_ms": 0
+    }
+}
+```
+
+The full config format — every field, enum, and numeric bound — is
+described by the JSON Schema shipped as a release asset (also emitted
+locally by `zig build schema`).
+
+## Development
+
+### Requirements
 
 - **Zig 0.16** (pinned by [devenv](devenv.nix): `zig_0_16` + `zls`).
-
-## Build & run
 
 With [devenv](https://devenv.sh) `.envrc` activates the same shell automatically on `cd`):
 

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,13 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // The version string is single-sourced from build.zig.zon and handed to
+    // the binary through a build-options module, so `zoxy --version` and the
+    // package metadata can never drift apart.
+    const zoxy_version = @import("build.zig.zon").version;
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", zoxy_version);
+
     // libxev is pinned by content hash to the zoxy-io fork's
     // zoxy-ring-flags branch: the audited upstream snapshot plus the
     // setup-flags commit (DESIGN.md §4); see build.zig.zon. The pin moves
@@ -50,6 +57,9 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // src/main.zig reads its version from this module (also added to the
+    // ReleaseFast `release_zoxy` below, the other build of that same source).
+    exe.root_module.addOptions("build_options", build_options);
     b.installArtifact(exe);
 
     const run_command = b.addRunArtifact(exe);
@@ -156,6 +166,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    release_zoxy.root_module.addOptions("build_options", build_options);
     const bench_exe = b.addExecutable(.{
         .name = "zoxy-bench",
         .root_module = b.createModule(.{

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,16 +3,26 @@
 //! RLIMIT_NOFILE, print the closed-form budgets, install signal handlers
 //! (the only raw syscall surface outside src/io/, held to the rlimit and
 //! sigaction allowlist by lint), then hand the process to the event loop
-//! until a drain completes.
+//! until a drain completes. `--help` and `--version` are answered before any
+//! of that and exit immediately.
 
 const std = @import("std");
 
 const zoxy = @import("zoxy");
+const build_options = @import("build_options");
 
 const XevIo = zoxy.Io.XevIo;
 const ServerXev = zoxy.Server(XevIo);
 
 const assert = std.debug.assert;
+
+// The version is single-sourced from build.zig.zon and reaches the binary
+// through the build_options module (see build.zig). Guard its one invariant —
+// that it is actually present — once at comptime, rather than re-asserting a
+// comptime-known truth on every --version/--help print.
+comptime {
+    assert(build_options.version.len > 0);
+}
 
 /// The sigaction handler needs a stable address before main returns;
 /// the loop lives for the whole process (§3).
@@ -22,18 +32,29 @@ pub fn main(init: std.process.Init) !void {
     const arena = init.arena.allocator();
 
     const args = try init.minimal.args.toSlice(arena);
-    if (args.len != 2) {
-        std.debug.print("usage: zoxy <config.json>\n", .{});
-        return error.InvalidArguments;
-    }
+    const config_path = switch (classifyArgs(args)) {
+        .run => |path| path,
+        .help => {
+            try printHelp(init.io);
+            return;
+        },
+        .version => {
+            try printVersion(init.io);
+            return;
+        },
+        .usage => |reason| {
+            printUsageError(reason);
+            return error.InvalidArguments;
+        },
+    };
 
     const config_bytes = std.Io.Dir.cwd().readFileAlloc(
         init.io,
-        args[1],
+        config_path,
         arena,
         .limited(zoxy.constants.config_bytes_max),
     ) catch |err| {
-        std.debug.print("zoxy: cannot read config '{s}': {t}\n", .{ args[1], err });
+        std.debug.print("zoxy: cannot read config '{s}': {t}\n", .{ config_path, err });
         return err;
     };
     const config = zoxy.config.parse(arena, config_bytes) catch |err| {
@@ -74,6 +95,99 @@ pub fn main(init: std.process.Init) !void {
     // The loop only stops after a completed drain (§8).
     assert(server.isIdle());
     server.counters.dump();
+}
+
+/// What the command line asked for: run against a config, or one of the
+/// two informational modes, or a usage mistake (with the reason so the
+/// message can be specific).
+const Cli = union(enum) {
+    run: []const u8,
+    help,
+    version,
+    usage: UsageError,
+};
+
+const UsageError = enum { missing_config, extra_arguments, unknown_option };
+
+/// Classify argv without touching the world, so it is unit-testable. zoxy
+/// takes exactly one positional argument — the config path; a `--help` or
+/// `--version` anywhere on the line wins so it still works appended to a
+/// half-typed command.
+fn classifyArgs(args: []const []const u8) Cli {
+    assert(args.len >= 1); // argv always carries the program name at [0].
+    for (args[1..]) |arg| {
+        if (flagMatches(arg, "-h", "--help")) return .help;
+    }
+    for (args[1..]) |arg| {
+        if (flagMatches(arg, "-V", "--version")) return .version;
+    }
+    if (args.len < 2) return .{ .usage = .missing_config };
+    if (args.len > 2) return .{ .usage = .extra_arguments };
+    const only = args[1];
+    // A lone unrecognized -flag is a typo, not a file named "-x".
+    if (only.len > 0 and only[0] == '-') return .{ .usage = .unknown_option };
+    assert(only.len == 0 or only[0] != '-');
+    return .{ .run = only };
+}
+
+fn flagMatches(arg: []const u8, short: []const u8, long: []const u8) bool {
+    assert(short.len >= 2); // "-x"
+    assert(long.len >= 3); // "--x"
+    return std.mem.eql(u8, arg, short) or std.mem.eql(u8, arg, long);
+}
+
+const help_text =
+    \\zoxy {s} — a zero-allocation L4/L7 edge proxy.
+    \\
+    \\Usage:
+    \\  zoxy <config.json>   Start the proxy with the given JSON config.
+    \\  zoxy --help, -h      Show this message and exit.
+    \\  zoxy --version, -V   Print the version and exit.
+    \\
+    \\zoxy reads the whole config once at startup, sizes every pool and the
+    \\io_uring ring from it, then serves without allocating again. The config
+    \\format is documented by the JSON Schema shipped with each release and by
+    \\docs/DESIGN.md.
+    \\
+    \\Signals:
+    \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0.
+    \\  SIGUSR1           Dump counters to stdout.
+    \\
+;
+
+/// `--help`: the full usage text, to stdout (so `zoxy --help | less` works).
+fn printHelp(io: std.Io) !void {
+    // The writer drains to stdout whenever this staging buffer fills, so its
+    // size is a batching choice, not a cap on the help text length.
+    var buffer: [1024]u8 = undefined;
+    var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
+    const writer = &file_writer.interface;
+    try writer.print(help_text, .{build_options.version});
+    try writer.flush();
+}
+
+/// `--version`: the bare version line, to stdout.
+fn printVersion(io: std.Io) !void {
+    var buffer: [64]u8 = undefined;
+    var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
+    const writer = &file_writer.interface;
+    try writer.print("zoxy {s}\n", .{build_options.version});
+    try writer.flush();
+}
+
+/// A usage mistake: the specific reason plus a one-line reminder, to stderr.
+fn printUsageError(reason: UsageError) void {
+    // The switch is exhaustive over UsageError, so every reason has a message
+    // and a missing arm is a compile error — no runtime guard adds anything.
+    const detail = switch (reason) {
+        .missing_config => "missing the required <config.json> argument",
+        .extra_arguments => "too many arguments; expected exactly one <config.json>",
+        .unknown_option => "unknown option; run `zoxy --help` for usage",
+    };
+    std.debug.print(
+        "zoxy: {s}\nusage: zoxy <config.json>  (or --help, --version)\n",
+        .{detail},
+    );
 }
 
 /// fds are pre-budgeted, not shed (§8): raise the soft limit up to the
@@ -167,4 +281,42 @@ fn onRawSignal(signal_number: std.posix.SIG) callconv(.c) void {
         else => return,
     };
     global_io.notifySignalFromHandler(signal);
+}
+
+const testing = std.testing;
+
+test "classifyArgs: a single positional is the config path" {
+    const args = [_][]const u8{ "zoxy", "config.json" };
+    const cli = classifyArgs(&args);
+    try testing.expect(cli == .run);
+    try testing.expectEqualStrings("config.json", cli.run);
+}
+
+test "classifyArgs: --help and -h request help" {
+    try testing.expect(classifyArgs(&.{ "zoxy", "--help" }) == .help);
+    try testing.expect(classifyArgs(&.{ "zoxy", "-h" }) == .help);
+}
+
+test "classifyArgs: --version and -V request the version" {
+    try testing.expect(classifyArgs(&.{ "zoxy", "--version" }) == .version);
+    try testing.expect(classifyArgs(&.{ "zoxy", "-V" }) == .version);
+}
+
+test "classifyArgs: help wins over version, and both win appended to a config" {
+    // A flag anywhere on the line is honored; help outranks version.
+    try testing.expect(classifyArgs(&.{ "zoxy", "--version", "--help" }) == .help);
+    try testing.expect(classifyArgs(&.{ "zoxy", "config.json", "--help" }) == .help);
+    try testing.expect(classifyArgs(&.{ "zoxy", "config.json", "--version" }) == .version);
+}
+
+test "classifyArgs: usage mistakes carry their reason" {
+    try testing.expectEqual(Cli{ .usage = .missing_config }, classifyArgs(&.{"zoxy"}));
+    try testing.expectEqual(
+        Cli{ .usage = .extra_arguments },
+        classifyArgs(&.{ "zoxy", "a.json", "b.json" }),
+    );
+    try testing.expectEqual(
+        Cli{ .usage = .unknown_option },
+        classifyArgs(&.{ "zoxy", "--nope" }),
+    );
 }


### PR DESCRIPTION
## What

The `zoxy` binary previously answered a wrong argument count with one terse `usage:` line — no way to discover the flags or check the running version. This adds:

- **`--help` / `-h`** — full usage text (the config argument, both flags, and the drain/dump signals), to stdout so it pipes cleanly.
- **`--version` / `-V`** — the bare version line, to stdout.

```
$ zoxy --version
zoxy 0.0.2

$ zoxy --help
zoxy 0.0.2 — a zero-allocation L4/L7 edge proxy.

Usage:
  zoxy <config.json>   Start the proxy with the given JSON config.
  zoxy --help, -h      Show this message and exit.
  zoxy --version, -V   Print the version and exit.
  ...
```

## How

- **Version is single-sourced** from `build.zig.zon` (`@import("build.zig.zon").version`) and reaches the binary through a `build_options` module wired into both builds of `src/main.zig` (the installed `exe` and the ReleaseFast `release_zoxy`). `zoxy --version` can never drift from the package metadata.
- Argv is classified by a pure, unit-tested `classifyArgs(args) Cli` → `run` / `help` / `version` / `usage`. `main` dispatches on it. A `--help`/`--version` anywhere on the line wins (help outranks version); help/version exit 0; a usage mistake prints a specific reason to stderr and exits non-zero — the same `error.InvalidArguments` contract as before.
- README: new **Usage** section (flags + the minimal `config/example.json`); the old "Build & run" is renamed **Development** with **Requirements** folded in.

## Testing

- `zig build ci` green (unit tests incl. the new `classifyArgs` cases + lint + 64/64 sim seeds).
- `zig fmt --check` clean.
- tiger-style-reviewer: **ready to commit** (no violations).
- Manually exercised `--version`, `-V`, `--help`, no-args, unknown-option, and extra-args paths (exit codes 0/0/0/1/1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)