### PR TITLE
Cut conn_ops_max 5 → 4: lift the c10k ceiling to 14074 (§8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -368,10 +368,10 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 11259 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 11259 | 2 × 4 KiB |
+| conn slots | 1386 | 14074 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 14074 | 2 × 4 KiB |
 | upstream slots | 1024 | 1024 | ~40 B state + 8 KiB head |
-| **pool memory** | **~32 MiB** | **~203 MiB** | |
+| **pool memory** | **~32 MiB** | **~251 MiB** | |
 
 Rules:
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -91,20 +91,23 @@ not re-propose.
 ## The concurrency ceiling is CQ-bound (95d1f8f)
 
 Concurrent L4 connections are bound by the io_uring completion queue,
-not fds or memory: each admitted connection holds up to
-`conn_ops_max = 5` armed ops, the ring is pre-budgeted and never shed
-(§8), and in-flight ops must stay within the configured CQ fill
-(`cq_fill_eighths`, ⅞ by default). First measured before the CQSIZE
-lever, when libxev fixed the CQ at 2 × SQ = 8192 and it capped
-`relay_buffers_max` at `(6144 − 18) / 5 = 1225`. The finding held and
-drove the fork work: `IORING_SETUP_CQSIZE` (#61) lets XevIo request the
-kernel maximum (65536), lifting `conn_slots_max` / `relay_buffers_max` to
-`(57344 − 23 − upstream_slots_max) / 5 = 11259` at ⅞. fds bind next now,
-not memory (`fds_max = 23558` at the ceiling, so a c10k deployment raises
+not fds or memory: each admitted connection holds up to `conn_ops_max`
+armed ops, the ring is pre-budgeted and never shed (§8), and in-flight
+ops must stay within the configured CQ fill (`cq_fill_eighths`, ⅞ by
+default). First measured before the CQSIZE lever, when libxev fixed the
+CQ at 2 × SQ = 8192 and it capped `relay_buffers_max` at
+`(6144 − 18) / 5 = 1225`. The finding held and drove the fork work:
+`IORING_SETUP_CQSIZE` (#61) lets XevIo request the kernel maximum
+(65536), lifting the ceiling to `(57344 − 23 − upstream_slots_max) / 5 =
+11259` at ⅞. Serializing teardown closes behind the full armed-set
+drain then cut `conn_ops_max` to 4 (the five-op teardown-vs-dial race
+became structurally unreachable, proven by a pinned-seed sim test), so
+`conn_slots_max` / `relay_buffers_max` now ceiling at
+`(57344 − 23 − upstream_slots_max) / 4 = 14074`. fds bind next, not
+memory (`fds_max = 29188` at the ceiling, so a c10k deployment raises
 `RLIMIT_NOFILE` at startup, §8). `constants.zig` owns the arithmetic and
-comptime-asserts it. The remaining ceiling levers — `splice` (fork) and
-cutting `conn_ops_max` 5 → 4 (in-tree teardown work) — are in PLANS.md,
-"c10k".
+comptime-asserts it. The remaining ceiling lever — `splice` — is fork
+work, in PLANS.md "c10k".
 
 ## libxev error surfacing is lossy
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -71,40 +71,35 @@ Verdicts, so they are not re-litigated:
   with c10k below; TLS and chunked L7 bodies fall back to copy
   regardless.
 
-## c10k — the CQSIZE ceiling (lever #1 landed)
+## c10k — the CQSIZE ceiling (levers #1 and #3 landed)
 
 Concurrent L4 connections were CQ-bound, not memory- or fd-bound: before
 the CQSIZE lever the CQ was fixed at 2 × SQ, capping `relay_buffers_max`
-at `(6144 − 18) / 5 = 1225`. Two levers were on the table:
+at `(6144 − 18) / 5 = 1225`. Three levers were on the table:
 
-1. **Deeper CQ** — `IORING_SETUP_CQSIZE`. **Landed (#61):**
-   `conn_slots_max` / `relay_buffers_max` now ceiling at 11259 on a single
-   ring, with the in-flight fill configurable via `limits.cq_fill_eighths`
-   (⅞ default; lowering it toward ⅛ trades the ceiling back down for burst
-   headroom, and a fill that cannot fit the compiled ring is rejected at
-   load, not clamped, §4/§5). `fds_max` scales with `2·relay_buffers`, so a
-   deployment configured toward c10k raises the documented `RLIMIT_NOFILE`
-   assumption (handled at startup, §8).
+1. **Deeper CQ** — `IORING_SETUP_CQSIZE`. **Landed (#61):** the in-flight
+   fill is configurable via `limits.cq_fill_eighths` (⅞ default; lowering
+   it toward ⅛ trades the ceiling back down for burst headroom, and a fill
+   that cannot fit the compiled ring is rejected at load, not clamped,
+   §4/§5). `fds_max` scales with `2·relay_buffers`, so a deployment
+   configured toward c10k raises the documented `RLIMIT_NOFILE` assumption
+   (handled at startup, §8).
 2. **`splice`** (above) — an independent win at saturation, still fork
    work; same re-audit cost.
-3. **Cut `conn_ops_max` 5 → 4** — the one ceiling lever that is *not*
-   fork work. The per-connection ring-op budget is 5 only to cover the
-   teardown-race worst case (a teardown racing its own upstream dial:
-   both closes + the deadline + `connect_cancel` + `deadline_cancel`
-   armed at once); steady-state relay peaks at 4. The ceiling is
-   `(cq_fill_budget − fixed − upstream_slots) / conn_ops_max`, so dropping
-   the divisor to 4 lifts `conn_slots_max` ~25% (11259 → 14074 at ⅞) at
-   the same ring depth and per-slot memory. The cost is in-tree: rework
-   the connect-teardown path so those five ops can never be armed together
-   (serialize cancel-then-close, or drop the deadline during teardown),
-   with a §9 sim case proving the four-op ceiling holds under the race.
-   Lowering the constant without that proof trips the CQ-overcommit
-   assert (§4/§8), not a shed.
+3. **Cut `conn_ops_max` 5 → 4** — the one ceiling lever that was *not*
+   fork work. **Landed:** teardown closes are serialized behind the full
+   armed-set drain (`continueTeardown`), so the five-op teardown-vs-dial
+   race is structurally unreachable and the worst case is two tying
+   four-op sets. The budget is enforced at every arm (`Conn.arm`
+   asserts it under every test and sim seed), and a drain-vs-dial sim
+   test pins seeds that co-armed five ops under the old code and now
+   peak at exactly four — the §9 proof the cut required.
+   `conn_slots_max` / `relay_buffers_max` ceiling at 14074 at ⅞ fill
+   (`fds_max` 29188).
 
 Entry gate for further ceiling work: demonstrate a workload that actually
-saturates the 11259 ceiling first — the fork levers cost a re-audit and
-the `conn_ops_max` cut costs a teardown-path proof, neither worth
-spending blind.
+saturates the 14074 ceiling first — the remaining fork levers cost a
+re-audit, not worth spending blind.
 
 ## libxev fork queue
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -61,6 +61,11 @@ pub fn Server(comptime IoType: type) type {
         relay_pressure: bool,
         conn_pressure: bool,
         upstream_pressure: bool,
+        /// Highest armed-op count any one connection has reached (§8):
+        /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and
+        /// records the peak here, so a test can claim a race co-armed
+        /// exactly the budgeted worst case, not merely stayed under it.
+        armed_ops_peak: u8,
         drain_deadline_completion: IoType.Completion,
         /// The one timer covering every parked upstream (§5): a parked
         /// connection holds no armed op, so this sweep compares stored
@@ -131,6 +136,7 @@ pub fn Server(comptime IoType: type) type {
             server.relay_pressure = false;
             server.conn_pressure = false;
             server.upstream_pressure = false;
+            server.armed_ops_peak = 0;
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -62,9 +62,11 @@ pub fn Server(comptime IoType: type) type {
         conn_pressure: bool,
         upstream_pressure: bool,
         /// Highest armed-op count any one connection has reached (§8):
-        /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and
-        /// records the peak here, so a test can claim a race co-armed
-        /// exactly the budgeted worst case, not merely stayed under it.
+        /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
+        /// under runtime safety only (never in the shipped ReleaseFast
+        /// build), records the peak here, so a test can claim a race
+        /// co-armed exactly the budgeted worst case, not merely stayed
+        /// under it.
         armed_ops_peak: u8,
         drain_deadline_completion: IoType.Completion,
         /// The one timer covering every parked upstream (§5): a parked

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -525,8 +525,8 @@ pub fn Server(comptime IoType: type) type {
 
         /// Teardown is a state, not an event (§5): shutdown both fds,
         /// cancel pending connect/timer (the only legal cancels, §4),
-        /// then closes once data ops drain; the last terminal completion
-        /// releases the slot.
+        /// then closes once every armed op drains; the last terminal
+        /// completion releases the slot.
         pub fn beginTeardown(server: *Self, conn: *ConnType) void {
             if (conn.isTearingDown()) return;
             assert(conn.isLive());
@@ -557,37 +557,40 @@ pub fn Server(comptime IoType: type) type {
             server.continueTeardown(conn);
         }
 
-        /// Public for the relay: a data completion delivered during
-        /// teardown re-enters here (§5 — ops drain, then closes).
+        /// Public for the relay: a non-close completion delivered during
+        /// teardown re-enters here (§5). Closes are serialized behind the
+        /// full drain — submitted only once every other op (data,
+        /// connect, deadline, both cancels) has delivered — so a dial
+        /// completing against its own teardown peaks at four armed ops,
+        /// never five: the `conn_ops_max` budget the CQ is sized by (§8).
         pub fn continueTeardown(server: *Self, conn: *ConnType) void {
-            assert(conn.isTearingDown());
-            if (conn.state == .tearing_down) {
-                const blocking_ops = conn.armed.connect or
-                    conn.armed.data_client_to_upstream or
-                    conn.armed.data_upstream_to_client;
-                if (!blocking_ops) {
-                    conn.state = .closing;
-                    conn.arm(&conn.op_close_client, "close_client");
-                    server.io.close(
-                        conn.client_socket,
-                        &conn.op_close_client.completion,
-                        ConnType,
-                        conn,
-                        onCloseClient,
-                    );
-                    if (conn.upstream_socket) |socket| {
-                        conn.arm(&conn.op_close_upstream, "close_upstream");
-                        server.io.close(
-                            socket,
-                            &conn.op_close_upstream.completion,
-                            ConnType,
-                            conn,
-                            onCloseUpstream,
-                        );
-                    }
-                }
+            // Only non-close deliveries route here, and a non-close op can
+            // be armed only before .closing; closes deliver into
+            // maybeRelease instead.
+            assert(conn.state == .tearing_down);
+            if (conn.armedCount() != 0) return;
+            conn.state = .closing;
+            conn.arm(&conn.op_close_client, "close_client");
+            server.io.close(
+                conn.client_socket,
+                &conn.op_close_client.completion,
+                ConnType,
+                conn,
+                onCloseClient,
+            );
+            if (conn.upstream_socket) |socket| {
+                conn.arm(&conn.op_close_upstream, "close_upstream");
+                server.io.close(
+                    socket,
+                    &conn.op_close_upstream.completion,
+                    ConnType,
+                    conn,
+                    onCloseUpstream,
+                );
             }
-            server.maybeRelease(conn);
+            // Postcondition: .closing holds the closes and nothing else.
+            assert(conn.armed.close_client);
+            assert(conn.armedCount() <= 2);
         }
 
         /// §5 release rule: closes submitted and the armed-op set empty —
@@ -849,9 +852,9 @@ pub fn Server(comptime IoType: type) type {
             } else |err| {
                 assert(err == error.Canceled);
                 if (conn.isTearingDown()) {
-                    // The deadline is not a blocking op, so its Canceled
-                    // delivery can arrive after closes were submitted
-                    // (.closing).
+                    // Closes wait for this delivery (and every other
+                    // armed op) before they are submitted, so the state
+                    // here is always .tearing_down, never .closing.
                     server.continueTeardown(conn);
                     return;
                 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -31,10 +31,10 @@ pub const admin_conns: u32 = 1;
 /// completes park the reserved slot forever (§8) — so a drain-initiated
 /// teardown that races an in-flight send holds the send, the deadline,
 /// and the deadline-cancel co-armed (the same lazy-timer force pattern as
-/// the data path's `conn_ops_max`); a data op and the `close` never
-/// coexist (close is submitted only after the data op drains), so the peak
-/// is three, not four. The accept op is the listener's, budgeted in the
-/// two-per-listener term.
+/// the data path's `conn_ops_max`); the `close` never joins the set —
+/// the same close-after-full-drain discipline the data path's
+/// `continueTeardown` follows — so the peak is three, not four. The
+/// accept op is the listener's, budgeted in the two-per-listener term.
 pub const admin_conn_ops_max: u32 = 3;
 
 /// Deadline for one admin scrape, from accept to close (§8): the reaper
@@ -58,13 +58,13 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
 /// parked-upstream and admin reservations carved out first, this caps at
-/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 11259` —
+/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 14074` —
 /// comptime-derived below (the 23 is the fixed ops: two per config and
 /// admin listener [18], the admin client's op budget [3], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
-pub const conn_slots_max: u32 = 11259;
+pub const conn_slots_max: u32 = 14074;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -159,15 +159,17 @@ pub const accept_retry_delay_ms: u32 = 10;
 /// fixes the completion queue at twice this (§4).
 pub const ring_entries: u16 = 4096;
 
-/// Worst-case simultaneously armed ring ops for one connection: five.
-/// The peak is a teardown racing its own upstream dial — a connecting
-/// conn holds connect + deadline, teardown arms connect_cancel +
-/// deadline_cancel, then the dial completes while its cancel is still in
-/// flight: the connect bit clears and both closes are submitted with the
-/// deadline, connect_cancel, and deadline_cancel completions all still
-/// outstanding. In steady relay the peak is only four (two data ops +
-/// timer + cancel), but the budget must cover the teardown race (§8).
-pub const conn_ops_max: u32 = 5;
+/// Worst-case simultaneously armed ring ops for one connection: four.
+/// Two peaks tie: a teardown racing its own upstream dial holds
+/// {connect, deadline, connect_cancel, deadline_cancel}, and a relay
+/// teardown holds {both data ops, deadline, deadline_cancel}. Closes
+/// never join either set — `continueTeardown` submits them only once
+/// every other op has drained (serialize cancel-then-close), which is
+/// what cut this budget from five: before that, a dial completing
+/// against its own cancel co-armed the closes with the deadline and
+/// both cancels. `Conn.arm` asserts the budget on every arm, and the
+/// drain-vs-dial sim test pins seeds that reach exactly four (§8, §9).
+pub const conn_ops_max: u32 = 4;
 
 /// Completions drained per loop tick before control returns to the kernel;
 /// bounds both callback batches and `Io.now_ns` staleness (§4).
@@ -504,12 +506,12 @@ test "budgets: memory total matches the closed form" {
 }
 
 test "budgets: c10k ceiling fd count needs a raised NOFILE" {
-    // At the c10k ceiling the fd budget is ~24k — well past the common
+    // At the c10k ceiling the fd budget is ~29k — well past the common
     // 4096 unprivileged hard limit, so a deployment that configures up to
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 23558), fds_max);
+    try std.testing.expectEqual(@as(u32, 29188), fds_max);
     try std.testing.expect(fds_max <= 65536);
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -337,7 +337,14 @@ pub fn Conn(comptime IoType: type) type {
             op.generation_at_submit = conn.generation;
             @field(conn.armed, bit) = true;
             assert(conn.armedCount() <= constants.conn_ops_max);
-            conn.server.armed_ops_peak = @max(conn.server.armed_ops_peak, conn.armedCount());
+            // Test-only watermark: tracked wherever the budget assert
+            // above is live (Debug, ReleaseSafe), never in the shipped
+            // ReleaseFast build, so the hot path pays nothing in
+            // production for what only a test reads.
+            if (std.debug.runtime_safety) {
+                conn.server.armed_ops_peak =
+                    @max(conn.server.armed_ops_peak, conn.armedCount());
+            }
         }
 
         /// Every delivery passes through here first: the generation

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -328,11 +328,16 @@ pub fn Conn(comptime IoType: type) type {
         }
 
         /// Records the arm in the op and the armed set; call immediately
-        /// before submitting through the seam.
+        /// before submitting through the seam. Enforces the §8
+        /// per-connection ring-op budget at the arm site — the CQ is
+        /// sized as `conn_ops_max` per slot, so exceeding it here is the
+        /// invariant violation the ring budget makes unreachable.
         pub fn arm(conn: *Self, op: *Op, comptime bit: []const u8) void {
             assert(!@field(conn.armed, bit));
             op.generation_at_submit = conn.generation;
             @field(conn.armed, bit) = true;
+            assert(conn.armedCount() <= constants.conn_ops_max);
+            conn.server.armed_ops_peak = @max(conn.server.armed_ops_peak, conn.armedCount());
         }
 
         /// Every delivery passes through here first: the generation

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -202,6 +202,8 @@ pub const TestBed = struct {
         origin_listens: bool = true,
         idle_timeout_ms: u32 = 1000,
         max_lifetime_ms: u32 = 0,
+        connect_timeout_ms: u32 = 50,
+        drain_deadline_ms: u32 = 1000,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -225,9 +227,9 @@ pub const TestBed = struct {
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
-            .connect_timeout_ms = 50,
+            .connect_timeout_ms = options.connect_timeout_ms,
             .idle_timeout_ms = options.idle_timeout_ms,
-            .drain_deadline_ms = 1000,
+            .drain_deadline_ms = options.drain_deadline_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, options.server);
@@ -617,4 +619,42 @@ test "server: refused upstream tears the connection down and is counted" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try std.testing.expectEqual(@as(u8, 1), bed.scenario.outcomeCount(.eof));
     try bed.expectDrained();
+}
+
+test "teardown: a drain racing its own upstream dial peaks at four armed ops" {
+    // The §8 worst case the ring budget must cover: the drain deadline
+    // reaps a connection whose upstream dial is still in flight, teardown
+    // arms both cancels on top of {connect, deadline}, and the delayed
+    // dial then completes against its own cancel. Closes serialize
+    // behind the full drain (continueTeardown), so the peak stays at
+    // conn_ops_max = 4 — before the serialization these exact seeds
+    // co-armed five ops ({deadline, both cancels, both closes}), found
+    // by sweeping 1..400 against the old code and pinned here so the
+    // race, not just some teardown, is what every run witnesses.
+    const race_seeds = [_]u64{ 40, 109, 116, 163, 211, 334 };
+    for (race_seeds) |seed| {
+        var bed: TestBed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .sim = .{
+                .seed = seed,
+                .adversary = .{ .partial_io = true, .connect_delay_ns_max = 5_000_000 },
+            },
+            // Connect and idle stay far out so the drain deadline — not a
+            // request deadline — is what tears the dialing conn down.
+            .idle_timeout_ms = 60_000,
+            .connect_timeout_ms = 60_000,
+            .drain_deadline_ms = 1,
+        });
+        defer bed.tearDown();
+
+        bed.startClients(1, false);
+        bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 2_000_000);
+        try bed.sim_io.run();
+
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("admitted"));
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("drained_at_deadline"));
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+        try std.testing.expectEqual(@as(u8, 4), bed.server.armed_ops_peak);
+        try bed.expectDrained();
+    }
 }


### PR DESCRIPTION
## What

Cuts the per-connection ring-op budget `conn_ops_max` from 5 to 4, the one c10k ceiling lever (PLANS.md §"c10k", lever #3) that isn't libxev-fork work. This lifts `conn_slots_max` / `relay_buffers_max` **11259 → 14074** (~25% more concurrent connections) on the same ring depth and per-slot memory.

The 5th op existed solely for one teardown race: a connection tearing down while its own upstream dial is still in flight, where the dial completes against its own cancel and both closes get submitted while `{deadline, connect_cancel, deadline_cancel}` are still outstanding. This PR makes that race unreachable by serializing closes, then drops the constant.

## How (four slices)

1. **`net: enforce the per-connection ring-op budget at arm time`** — `Conn.arm()` asserts `armedCount() <= conn_ops_max` on every arm, turning the budget from accounting into a runtime-enforced invariant across every unit test and sim seed. Records the peak in `Server.armed_ops_peak`.
2. **`net: serialize teardown cancels before closes; prove the 4-op peak`** — `continueTeardown` submits closes only once the entire armed set has drained (one extra loop round-trip, µs), so the race peaks at `{connect, deadline, connect_cancel, deadline_cancel}` = 4 and a relay teardown at `{data×2, deadline, deadline_cancel}` = 4. Directed test pins six seeds (found by sweeping 1..400 against the old code, where they co-armed 5 ops) and asserts the peak now lands on exactly 4 — the §9 proof.
3. **`budgets: cut conn_ops_max 5 → 4, lifting the c10k ceiling to 14074`** — the constants flip; `fds_max` follows to 29188 (still < 65536). The comptime ceiling assert ties the two edits together.
4. **`docs: mark the conn_ops_max c10k lever landed`** + **`net: gate the armed-op watermark behind runtime safety`** — DESIGN/PLANS/IMPLEMENTATION_NOTES refresh; the watermark write is gated on `std.debug.runtime_safety` so the shipped ReleaseFast binary pays nothing for test-only observability.

## Verification

- `zig build ci` (unit + fuzz corpus + 64-seed sim + fd-boundary lint) green on every slice.
- `zig fmt --check` clean.
- Extra `zig build sim -- 1 512` — 512 seeds clean under the new 4-op assert.
- `zig build -Doptimize=ReleaseFast` compiles clean with the watermark elided.
- **Not run:** `zig build bench` (merge-time gate) — worth one Tier-1 band comparison at merge, since teardown now waits one extra loop round-trip before closes.

## Notes / follow-ups (out of scope)

- The ~251 MiB in the DESIGN §5 table is the *ceiling* footprint (a deployment configured all the way up), not a default — the default deployment is unchanged at ~32 MiB.
- Pre-existing wrinkle found during enumeration: `expireDeadline`'s dial-504 branch re-arms the grace deadline without checking `armed.deadline_cancel`. It self-heals and stays within budget, but deserves a comment/assert later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
