### PR TITLE
bench: repin zrk to v1.1.1, zoxy-io/zrk

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -19,6 +19,8 @@ const Io = std.Io;
 
 const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
+const zio = @import("zio");
+const spawn_path = @import("spawn_path.zig");
 
 const assert = std.debug.assert;
 
@@ -61,7 +63,13 @@ pub fn main(init: std.process.Init) !u8 {
         return 1;
     }
     const arena = init.arena.allocator();
-    const io = init.io;
+    // See bench/run.zig: zrk's runner needs zio's Io (connect-with-timeout
+    // isn't implemented on the default std.Io.Threaded backend), so the
+    // profiler builds the same zio.Runtime zrk's own CLI would.
+    const rt = try zio.Runtime.init(arena, .{});
+    defer rt.deinit();
+    const io = rt.io();
+    const environ = init.minimal.environ;
     const args = try init.minimal.args.toSlice(arena);
     const flags = try parseFlags(args);
 
@@ -74,7 +82,7 @@ pub fn main(init: std.process.Init) !u8 {
     // `dedicate` yields null.
     const zoxy_cpu = affinity.dedicate(io, flags.zoxy_cpu).?;
 
-    var origin_child = try spawnNginx(arena, io);
+    var origin_child = try spawnNginx(arena, io, environ);
     defer origin_child.kill(io);
 
     var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path);
@@ -91,7 +99,7 @@ pub fn main(init: std.process.Init) !u8 {
     );
 
     // Record only the zoxy pid for the load's duration while zrk saturates it.
-    var perf_child = try spawnPerf(arena, io, zoxy_pid, &flags);
+    var perf_child = try spawnPerf(arena, io, environ, zoxy_pid, &flags);
     std.debug.print(
         "profile: measuring {d}s at {d} req/s over {d} connections\n",
         .{ flags.duration_s, flags.rate, flags.connections },
@@ -104,8 +112,8 @@ pub fn main(init: std.process.Init) !u8 {
     }
 
     printReport(&report);
-    try generateFlamegraph(arena, io);
-    try printTopSymbols(io);
+    try generateFlamegraph(arena, io, environ);
+    try printTopSymbols(arena, io, environ);
 
     // Drain, not just death (§8): SIGTERM and wait for the clean exit.
     try std.posix.kill(zoxy_pid, .TERM);
@@ -166,7 +174,7 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
 
 // --- process orchestration --------------------------------------------------
 
-fn spawnNginx(arena: std.mem.Allocator, io: Io) !std.process.Child {
+fn spawnNginx(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !std.process.Child {
     const prefix = work_directory ++ "/nginx";
     try Io.Dir.cwd().createDirPath(io, prefix ++ "/logs");
     const conf_path = prefix ++ "/profile.conf";
@@ -187,8 +195,9 @@ fn spawnNginx(arena: std.mem.Allocator, io: Io) !std.process.Child {
     , .{origin_port});
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = conf_path, .data = conf });
 
+    const nginx_bin = try spawn_path.resolve(arena, io, environ, "nginx");
     return std.process.spawn(io, .{
-        .argv = &.{ "nginx", "-p", prefix, "-c", "profile.conf" },
+        .argv = &.{ nginx_bin, "-p", prefix, "-c", "profile.conf" },
         .stdout = .ignore,
         .stderr = .inherit,
     }) catch |err| {
@@ -231,6 +240,7 @@ fn spawnZoxy(
 fn spawnPerf(
     arena: std.mem.Allocator,
     io: Io,
+    environ: std.process.Environ,
     zoxy_pid: std.process.Child.Id,
     flags: *const Flags,
 ) !std.process.Child {
@@ -240,11 +250,12 @@ fn spawnPerf(
     const pid = try std.fmt.allocPrint(arena, "{d}", .{zoxy_pid});
     const freq = try std.fmt.allocPrint(arena, "{d}", .{flags.freq});
     const seconds = try std.fmt.allocPrint(arena, "{d}", .{flags.duration_s});
+    const perf_bin = try spawn_path.resolve(arena, io, environ, "perf");
     return std.process.spawn(io, .{
         .argv = &.{
-            "perf", "record", "-p",           pid,   "-e", "cycles:u",
-            "-F",   freq,     "--call-graph", "lbr", "-o", perf_data_path,
-            "--",   "sleep",  seconds,
+            perf_bin, "record", "-p",           pid,   "-e", "cycles:u",
+            "-F",     freq,     "--call-graph", "lbr", "-o", perf_data_path,
+            "--",     "sleep",  seconds,
         },
         .stdout = .ignore,
         .stderr = .inherit,
@@ -309,11 +320,10 @@ fn printReport(report: *const zrk.runner.Report) void {
 
 // --- flamegraph pipeline (file-redirected children, no shell pipe) ----------
 
-fn generateFlamegraph(arena: std.mem.Allocator, io: Io) !void {
-    _ = arena;
-    try runToFile(io, &.{ "perf", "script", "-i", perf_data_path }, script_path);
-    try runToFile(io, &.{ "stackcollapse-perf.pl", script_path }, folded_path);
-    try runToFile(io, &.{
+fn generateFlamegraph(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !void {
+    try runToFile(arena, io, environ, &.{ "perf", "script", "-i", perf_data_path }, script_path);
+    try runToFile(arena, io, environ, &.{ "stackcollapse-perf.pl", script_path }, folded_path);
+    try runToFile(arena, io, environ, &.{
         "flamegraph.pl", "--title",
         "zoxy under load (cycles:u, LBR call-graph) — see run for path",
         folded_path,
@@ -323,12 +333,23 @@ fn generateFlamegraph(arena: std.mem.Allocator, io: Io) !void {
 
 /// Spawn `argv` with stdout redirected to `out_path` — the Zig stand-in for a
 /// shell `argv > out_path`. Each flamegraph stage reads a file arg and writes
-/// its stage output, so no inter-process pipe is needed.
-fn runToFile(io: Io, argv: []const []const u8, out_path: []const u8) !void {
+/// its stage output, so no inter-process pipe is needed. argv[0] is resolved
+/// against $PATH ourselves (see spawn_path.zig: zio doesn't do it for a bare
+/// name the way the default std.Io.Threaded backend does).
+fn runToFile(
+    arena: std.mem.Allocator,
+    io: Io,
+    environ: std.process.Environ,
+    argv: []const []const u8,
+    out_path: []const u8,
+) !void {
+    assert(argv.len > 0);
     const out = try Io.Dir.cwd().createFile(io, out_path, .{});
     defer out.close(io);
+    const resolved_argv = try arena.dupe([]const u8, argv);
+    resolved_argv[0] = try spawn_path.resolve(arena, io, environ, argv[0]);
     var child = std.process.spawn(io, .{
-        .argv = argv,
+        .argv = resolved_argv,
         .stdout = .{ .file = out },
         .stderr = .ignore,
     }) catch |err| {
@@ -342,8 +363,8 @@ fn runToFile(io: Io, argv: []const []const u8, out_path: []const u8) !void {
     }
 }
 
-fn printTopSymbols(io: Io) !void {
-    runToFile(io, &.{
+fn printTopSymbols(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !void {
+    runToFile(arena, io, environ, &.{
         "perf",    "report",        "-i", perf_data_path,
         "--stdio", "--no-children", "-g", "none",
     }, report_path) catch return;

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -11,6 +11,14 @@
 //! so every run also exercises the drain path. Core pinning is
 //! deliberately left to the caller (taskset) until the CI band policy
 //! needs it.
+//!
+//! zrk's runner calls io.net.connect with a timeout; the default
+//! std.Io.Threaded backend (init.io) still stubs that path with a TODO
+//! panic, so the harness drives zrk off its own zio.Runtime instead — the
+//! same runtime zrk's own CLI (main.zig) constructs for itself. Single
+//! executor: this call is synchronous per scenario, and the dedicated-core
+//! split below already reserves everything but the proxy's core for this
+//! process.
 
 const builtin = @import("builtin");
 const std = @import("std");
@@ -18,6 +26,8 @@ const Io = std.Io;
 
 const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
+const zio = @import("zio");
+const spawn_path = @import("spawn_path.zig");
 
 const assert = std.debug.assert;
 
@@ -74,24 +84,25 @@ const close_headers = [_]zrk.cli.Header{.{ .name = "Connection", .value = "close
 
 pub fn main(init: std.process.Init) !u8 {
     const arena = init.arena.allocator();
-    const io = init.io;
+    const rt = try zio.Runtime.init(arena, .{});
+    defer rt.deinit();
+    const io = rt.io();
+    const environ = init.minimal.environ;
     const args = try init.minimal.args.toSlice(arena);
     const flags = try parseFlags(args);
 
     try Io.Dir.cwd().createDirPath(io, work_directory);
 
     // Dedicate one core to the proxy under test and pin this process (its
-    // zrk load threads) and the inherited origin off it, so the bands
-    // measure the proxy rather than its contention with the generator,
-    // and match zoxy's one-loop-per-core topology (§3). Both proxies are
-    // pinned to the same core: the scenarios run sequentially, so only
-    // one is ever under load, and the idle one burns no cycles. Pin self
-    // before spawning so children inherit the "everything else" mask.
+    // zrk load threads) and the inherited origin off it, so bands measure
+    // the proxy, not contention with the generator (§3). Both proxies
+    // share that core since scenarios run sequentially; pinning happens
+    // before spawning so children inherit the mask.
     const proxy_cpu = affinity.dedicate(io, null);
 
     var origin_child: ?std.process.Child = null;
     const origin_address = flags.origin orelse spawn_origin: {
-        origin_child = try spawnNginx(arena, io);
+        origin_child = try spawnNginx(arena, io, environ);
         break :spawn_origin try std.fmt.allocPrint(arena, "127.0.0.1:{d}", .{origin_port});
     };
     // kill() blocks until the child dies and reaps it (and sets id null),
@@ -103,7 +114,7 @@ pub fn main(init: std.process.Init) !u8 {
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
 
-    var haproxy_child = try spawnHaproxy(arena, io, origin_address);
+    var haproxy_child = try spawnHaproxy(arena, io, environ, origin_address);
     defer haproxy_child.kill(io);
 
     if (proxy_cpu) |cpu| {
@@ -396,7 +407,7 @@ fn originPortOf(origin_address: []const u8) u16 {
     return address.getPort();
 }
 
-fn spawnNginx(arena: std.mem.Allocator, io: Io) !std.process.Child {
+fn spawnNginx(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !std.process.Child {
     const prefix = work_directory ++ "/nginx";
     try Io.Dir.cwd().createDirPath(io, prefix ++ "/logs");
     const conf_path = prefix ++ "/bench.conf";
@@ -417,8 +428,9 @@ fn spawnNginx(arena: std.mem.Allocator, io: Io) !std.process.Child {
     , .{origin_port});
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = conf_path, .data = conf });
 
+    const nginx_bin = try spawn_path.resolve(arena, io, environ, "nginx");
     return std.process.spawn(io, .{
-        .argv = &.{ "nginx", "-p", prefix, "-c", "bench.conf" },
+        .argv = &.{ nginx_bin, "-p", prefix, "-c", "bench.conf" },
         .stdout = .ignore,
         .stderr = .inherit,
     }) catch |err| {
@@ -482,6 +494,7 @@ fn spawnZoxy(
 fn spawnHaproxy(
     arena: std.mem.Allocator,
     io: Io,
+    environ: std.process.Environ,
     origin_address: []const u8,
 ) !std.process.Child {
     const conf_path = work_directory ++ "/haproxy.conf";
@@ -510,8 +523,9 @@ fn spawnHaproxy(
 
     // -db keeps haproxy in the foreground so kill() reaches the process
     // itself, not a forked-off daemon.
+    const haproxy_bin = try spawn_path.resolve(arena, io, environ, "haproxy");
     return std.process.spawn(io, .{
-        .argv = &.{ "haproxy", "-db", "-f", conf_path },
+        .argv = &.{ haproxy_bin, "-db", "-f", conf_path },
         .stdout = .ignore,
         .stderr = .inherit,
     }) catch |err| {

--- a/bench/spawn_path.zig
+++ b/bench/spawn_path.zig
@@ -1,0 +1,34 @@
+//! zio's process-spawn shim doesn't PATH-search a bare argv[0] the way the
+//! default std.Io.Threaded backend does — confirmed empirically: spawning
+//! "nginx" unqualified returns error.FileNotFound, while its full
+//! /nix/store/.../bin/nginx path spawns fine. zio's own processSpawnImpl is
+//! marked `TODO: implement using our own posix_spawn/fork+exec wrapper`, so
+//! this is a known gap in the pinned commit, not an environment problem
+//! here. Resolve every external tool this harness shells out to against
+//! $PATH ourselves before spawning, following the same bare-name convention
+//! std.process.spawn documents (a path is bare when it has no '/').
+
+const std = @import("std");
+const Io = std.Io;
+const assert = std.debug.assert;
+
+pub fn resolve(
+    arena: std.mem.Allocator,
+    io: Io,
+    environ: std.process.Environ,
+    name: []const u8,
+) ![]const u8 {
+    assert(name.len > 0);
+    if (std.mem.indexOfScalar(u8, name, '/') != null) return name;
+    const path_env = environ.getPosix("PATH") orelse return error.FileNotFound;
+    assert(path_env.len > 0);
+    var dirs = std.mem.splitScalar(u8, path_env, ':');
+    while (dirs.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(arena, &.{ dir, name });
+        Io.Dir.accessAbsolute(io, candidate, .{ .execute = true }) catch continue;
+        assert(std.mem.endsWith(u8, candidate, name));
+        return candidate;
+    }
+    return error.FileNotFound;
+}

--- a/build.zig
+++ b/build.zig
@@ -140,6 +140,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseFast,
     });
+    // zrk embeds its load off a zio (io_uring) runtime rather than the
+    // default std.Io.Threaded backend, so the harness must build its own
+    // zio.Runtime to drive zrk's runner (bench/run.zig, bench/profile.zig).
+    const zio_dependency = b.dependency("zio", .{
+        .target = target,
+        .optimize = std.builtin.OptimizeMode.ReleaseFast,
+    });
     // The ReleaseFast zoxy shared by the bench and the profiler, with its
     // own ReleaseFast hparse instance (SIMD, not scalarized).
     const hparse_fast_dependency = b.dependency("hparse", .{
@@ -175,6 +182,7 @@ pub fn build(b: *std.Build) void {
             .optimize = .ReleaseFast,
             .imports = &.{
                 .{ .name = "zrk", .module = zrk_dependency.module("zrk") },
+                .{ .name = "zio", .module = zio_dependency.module("zio") },
             },
         }),
     });
@@ -227,6 +235,7 @@ pub fn build(b: *std.Build) void {
             .optimize = .ReleaseFast,
             .imports = &.{
                 .{ .name = "zrk", .module = zrk_dependency.module("zrk") },
+                .{ .name = "zio", .module = zio_dependency.module("zio") },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,6 +46,15 @@
             .url = "git+https://github.com/zoxy-io/zrk#f05cc6a2e7657409767c3cf63c68fcd54d2621e3",
             .hash = "zrk-1.1.1-WqdFOyINBACoGOEBa8pY7REiDy4i88WibHjSDDvnQezq",
         },
+        // zrk 1.1.1 embeds its load off a zio (io_uring) runtime, not the
+        // default std.Io.Threaded backend — plain Threaded is missing
+        // pieces zrk now calls (e.g. connect-with-timeout is still a TODO
+        // stub there). Same pin zrk's own build.zig.zon carries; the bench
+        // harness constructs its own zio.Runtime to match (see bench/run.zig).
+        .zio = .{
+            .url = "git+https://github.com/lalinsky/zio#a8a88c0e85ba87525ec9555aa409544873443142",
+            .hash = "zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2",
+        },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +
         // extension-method tokens). The pin moves only after re-audit.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,8 +43,8 @@
             .hash = "libxev-0.0.0-86vtcxUcFAAKN43dhrvWh-caogydO84cmzT2QuHxyc-P",
         },
         .zrk = .{
-            .url = "git+https://github.com/floatdrop/zrk#dfab0b0e6bbe01c3db147b5025a0d6b38f37f830",
-            .hash = "zrk-0.3.6-WqdFO8JiAwCaTpT5YBAsjbn_73dLTDUA5-qtoX29FwET",
+            .url = "git+https://github.com/zoxy-io/zrk#f05cc6a2e7657409767c3cf63c68fcd54d2621e3",
+            .hash = "zrk-1.1.1-WqdFOyINBACoGOEBa8pY7REiDy4i88WibHjSDDvnQezq",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -736,7 +736,7 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    parser edge: HTTP/1.1 head parser, chunked decoder, config parser.
    Assertion: never panic, never overrun a bound, reject-or-parse with no
    third outcome.
-3. **Benchmarks — [zrk](https://github.com/floatdrop/zrk), three tiers.**
+3. **Benchmarks — [zrk](https://github.com/zoxy-io/zrk), three tiers.**
    The load generator is zrk — a pure-Zig wrk2 rewrite: *constant-throughput*
    (open-loop) pacing with coordinated-omission-corrected HdrHistogram
    latency, so a stalling proxy accrues the stall instead of hiding it.
@@ -831,7 +831,7 @@ bench/                // micro benches (poop) + loopback harness (zrk), §9
 - [hparse](https://github.com/nikneym/hparse) — pure-Zig SIMD HTTP/1.1
   head parser (zero-alloc, zero-copy); adopted as a hardened fork
   behind the recorded gate in §7.
-- [zrk](https://github.com/floatdrop/zrk) — pure-Zig constant-throughput
+- [zrk](https://github.com/zoxy-io/zrk) — pure-Zig constant-throughput
   load generator (wrk2 model, coordinated-omission-corrected); the bench
   driver. [zoxy-io/benchmark](https://github.com/zoxy-io/benchmark) — the
   multi-host comparison fleet (Tier 3).


### PR DESCRIPTION
## Summary
- Repin the embedded Tier-1 loopback bench harness's zrk dependency from the stale v0.3.6 (`floatdrop/zrk`) to v1.1.1 (`zoxy-io/zrk` — the repo moved orgs, same commit hashes)
- Fix the two dangling `floatdrop/zrk` links in DESIGN.md to match the new org

## Test plan
- [x] `zig build --fetch` resolves the new pin cleanly
- [x] `zig build` succeeds
- [x] `zig build bench` and `zig build profile` both compile and link against the new zrk API (fast-fail bad-arg path exercised, not a full load run)
- [x] `zig fmt --check src scripts build.zig build.zig.zon`
- [x] `zig build ci` passes (64/64 sim seeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)