### PR TITLE
Guard the deadline expiry behind the rebase cancel (#65)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -194,6 +194,35 @@ the orderly failures (EOF, RST) are peeled off first. SimIo grew a
 one-shot `kernel_pressure` fault and a `kernel_pressure_percent`
 adversary knob to exercise the rung.
 
+## The deadline rebase cancel reaches the expiry path (#65)
+
+Every deadline re-arm guards on `!armed.deadline_cancel` so the in-flight
+rebase cancel (the one deadline cancel outside teardown, §8) cannot match
+a freshly armed timer — every site except `expireDeadline`'s two verdict
+branches, which `onDeadline`'s success path reached unguarded.
+
+Reachable, and by exactly one route: `storeDeadline` writes
+`min(now + timeout, birth + max_lifetime)` and every timeout is ≥ 1 ms,
+so a stored target can only be in the past when the §6 lifetime cap
+already is. Past the cap the dial's re-base stores an already-expired
+target, and the head-read timer delivering *success* in that same batch
+then finds the deadline due with the cancel still in flight. SimIo will
+not stumble into it: its clock never advances inside a batch, and never
+at all while any op is ready — a pending cancel always is — so the head
+and the cap have to wake at the same instant by construction. 2000
+undirected seeds missed it; the directed case (`http_proxy_test.zig`,
+client head held back to exactly the cap) hits it at seeds 88 and 93
+of 200.
+
+Fixed by hoisting the guard over the whole success path: a due deadline
+defers to `onDeadlineRebase`, which re-arms at the stored target once the
+cancel drains, expiring one round-trip later. `expireDeadline` asserts
+`!armed.deadline_cancel` — the directed case's oracle, and it panics
+there if the guard is dropped. Nothing changes at the boundary: past the
+cap the verdict's own grace clamps into the past too, so the connection
+is condemned either way. What changed is that the invariant is uniform
+and now asserted rather than assumed.
+
 ## Occupancy is not overload — conn-pressure keep-alive kill reverted (#57)
 
 The v0.0.0 watermark design (#54) suppressed downstream keep-alive under

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -842,15 +842,19 @@ pub fn Server(comptime IoType: type) type {
                     server.continueTeardown(conn);
                     return;
                 }
+                // A rebase cancel (§8) in flight owns the re-arm — it is
+                // still matching against this very completion, so no path
+                // here may arm a fresh timer for it to find; onDeadline-
+                // Rebase re-arms at the stored target once it drains.
+                // Expiry is not exempt: the §6 lifetime clamp can store a
+                // target already in the past, so the dial's own re-base
+                // leaves the deadline due the moment this delivery lands.
+                if (conn.armed.deadline_cancel) return;
                 if (server.io.nowNs() >= conn.deadline_ns) {
                     server.expireDeadline(conn);
-                } else if (!conn.armed.deadline_cancel) {
+                } else {
                     server.armDeadline(conn);
                 }
-                // else: a rebase cancel (§8) is in flight (an idle timer that
-                // fired as the dial re-based it under pressure); onDeadline-
-                // Rebase re-arms once it drains, so no fresh timer is left for
-                // the cancel to match.
             } else |err| {
                 assert(err == error.Canceled);
                 if (conn.isTearingDown()) {
@@ -903,6 +907,9 @@ pub fn Server(comptime IoType: type) type {
         fn expireDeadline(server: *Self, conn: *ConnType) void {
             assert(!conn.isTearingDown());
             assert(!conn.armed.deadline); // Delivered; re-armed only below.
+            // Both verdict branches re-arm: the caller must have drained the
+            // rebase cancel first, or it could match the fresh timer (§8).
+            assert(!conn.armed.deadline_cancel);
             server.counters.increment("deadline_expired");
             if (conn.state == .l7_exchanging and
                 conn.l7.pending_verdict == .none and

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -30,9 +30,14 @@ const HttpClient = struct {
     connect_completion: SimIo.Completion = .{},
     send_completion: SimIo.Completion = .{},
     recv_completion: SimIo.Completion = .{},
+    delay_completion: SimIo.Completion = .{},
     socket: SimIo.Socket = undefined,
     address: std.Io.net.IpAddress = undefined,
     request: []const u8 = undefined,
+    /// Hold the head back this long after connecting. The scenario that
+    /// needs the head to land at a chosen instant (not at once, under the
+    /// frozen intra-batch clock) sets it; 0 sends immediately.
+    send_delay_ms: u32 = 0,
     /// Sent on the same connection once the first response is complete —
     /// sequential keep-alive, never pipelining.
     second_request: ?[]const u8 = null,
@@ -43,6 +48,7 @@ const HttpClient = struct {
     /// the idle sweep instead arms a drain timer and clears this.
     drain_on_finish: bool = true,
     sent_len: u32 = 0,
+    send_in_flight: bool = false,
     receive_buffer: [4096]u8 = undefined,
     received_len: u32 = 0,
     outcome: Outcome = .pending,
@@ -59,11 +65,31 @@ const HttpClient = struct {
     fn onConnect(client: *HttpClient, result: Io.ConnectError!SimIo.Socket) void {
         client.socket = result catch unreachable;
         client.armRecv();
+        if (client.send_delay_ms == 0) {
+            client.armSend();
+            return;
+        }
+        client.io.timerStart(
+            &client.delay_completion,
+            @as(u64, client.send_delay_ms) * std.time.ns_per_ms,
+            HttpClient,
+            client,
+            onSendDelay,
+        );
+    }
+
+    fn onSendDelay(client: *HttpClient, result: Io.TimerError!void) void {
+        result catch unreachable; // Nothing cancels the client's send delay.
+        // The server may have reaped the silent connection while the delay
+        // ran; its socket is already closed, so there is nothing to send.
+        if (client.outcome != .pending) return;
         client.armSend();
     }
 
     fn armSend(client: *HttpClient) void {
         assert(client.sent_len < client.request.len);
+        assert(!client.send_in_flight);
+        client.send_in_flight = true;
         client.io.send(
             client.socket,
             client.request[client.sent_len..],
@@ -75,14 +101,20 @@ const HttpClient = struct {
     }
 
     fn onSend(client: *HttpClient, result: Io.SendError!u32) void {
+        client.send_in_flight = false;
         // A reject may close the connection before the whole request is
         // sent; a send failure then is expected, not an error.
-        const sent = result catch return;
+        const sent = result catch {
+            client.finish();
+            return;
+        };
         client.sent_len += sent;
         assert(client.sent_len <= client.request.len);
         if (client.sent_len < client.request.len) {
             client.armSend();
+            return;
         }
+        client.finish();
     }
 
     fn armRecv(client: *HttpClient) void {
@@ -96,20 +128,30 @@ const HttpClient = struct {
         );
     }
 
+    /// The peer's close ends this client — but not before its own send has
+    /// drained: closing under a pending send would leave the simulator a
+    /// stale handle (a §5 violation it asserts on), so whichever of the
+    /// close and the send lands second finishes.
+    fn finish(client: *HttpClient) void {
+        if (client.outcome == .pending) return;
+        if (client.send_in_flight) return;
+        client.io.closeNow(client.socket);
+        if (client.next) |successor| {
+            client.next = null;
+            successor.start(client.io, client.server, client.address);
+            return;
+        }
+        if (client.drain_on_finish) {
+            // Begin the drain so the run winds down instead of idling
+            // on the armed accept — the L4 harness does the same.
+            client.server.beginDrain();
+        }
+    }
+
     fn onRecv(client: *HttpClient, result: Io.RecvError!u32) void {
         const received = result catch |err| {
             client.outcome = if (err == error.Reset) .reset else .fin;
-            client.io.closeNow(client.socket);
-            if (client.next) |successor| {
-                client.next = null;
-                successor.start(client.io, client.server, client.address);
-                return;
-            }
-            if (client.drain_on_finish) {
-                // Begin the drain so the run winds down instead of idling
-                // on the armed accept — the L4 harness does the same.
-                client.server.beginDrain();
-            }
+            client.finish();
             return;
         };
         assert(received >= 1);
@@ -389,6 +431,13 @@ const Http1Bed = struct {
         conn_slots: u32 = 4,
         relay_buffers: u32 = 2,
         upstream_slots: u32 = 2,
+        /// The §6 absolute age cap; 0 (the default) disables it. A cap the
+        /// exchange outlives clamps every stored deadline to it, so a
+        /// re-based target can already be in the past.
+        max_lifetime_ms: u32 = 0,
+        /// Hold the client's head back this long after it connects, so it
+        /// lands at a chosen instant rather than at once.
+        send_delay_ms: u32 = 0,
         /// The single route's prefix; "/" is the catch-all. A narrower
         /// prefix lets a test drive the no-route 404 path (§7).
         route_prefix: []const u8 = "/",
@@ -425,7 +474,7 @@ const Http1Bed = struct {
             .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
             .drain_deadline_ms = 1000,
-            .max_lifetime_ms = 0,
+            .max_lifetime_ms = options.max_lifetime_ms,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -442,7 +491,7 @@ const Http1Bed = struct {
         if (options.origin_listens) {
             try bed.origin.start(&bed.sim_io, originAddress());
         }
-        bed.client = .{};
+        bed.client = .{ .send_delay_ms = options.send_delay_ms };
         bed.client2 = .{};
         bed.drain_timer_completion = .{};
     }
@@ -1261,6 +1310,54 @@ test "l7: a response already started forfeits the 504 — teardown only" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_gateway_timeout"));
     try bed.expectDrained();
+}
+
+test "l7: a dial re-basing an already-expired deadline defers past the cancel" {
+    // Issue #65 (§8): the dial's re-base cancel is matching against
+    // op_deadline's own completion, so no path may arm a fresh timer on
+    // it until that cancel drains — the expiry included. The §6 lifetime
+    // cap is what puts expiry on that path: the head lands exactly at the
+    // cap, so the dial's storeDeadline clamps to an already-past target
+    // and the head-read timer — delivered success in the same batch as
+    // the re-base, before the cancel — finds the deadline due with the
+    // cancel still in flight. The oracle is expireDeadline's
+    // `assert(!conn.armed.deadline_cancel)`: with onDeadline's guard
+    // dropped, this seed panics there.
+    //
+    // The client's head is held back to exactly the cap so the two wake
+    // at the same instant (the clock never advances mid-batch, and never
+    // at all while a cancel is pending, so a re-based target can only be
+    // in the past if the cap already is). Only a minority of schedules
+    // then order the batch the way the race needs — seeds 88 and 93
+    // today — so the sweep is the coverage: pinning one seed would let an
+    // unrelated shift in the PRNG draws silently stop reaching the path.
+    const cap_ms: u32 = 25;
+    var seed: u64 = 1;
+    while (seed <= 100) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .max_lifetime_ms = cap_ms,
+            .send_delay_ms = cap_ms,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /capped HTTP/1.1\r\nHost: o\r\n\r\n");
+
+        // Past the cap every stored deadline clamps into the past, so the
+        // deferred expiry lands the moment the cancel drains and the
+        // verdict's own grace expires with it: the cap reaps the
+        // connection either way. What this pins is the discipline on the
+        // way there, not a response — the exchange is condemned before it
+        // can be answered, so the close is a FIN or (with the client's
+        // head still unread) an RST, and §2 constrains neither: no
+        // response byte was ever delivered.
+        try std.testing.expect(bed.client.outcome != .pending);
+        try std.testing.expect(bed.server.counters.get("deadline_expired") >= 1);
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+        try bed.expectDrained();
+    }
 }
 
 test "l7: the 504 verdict path allocates nothing after init" {


### PR DESCRIPTION
Fixes #65.

## The verdict: reachable

So resolution 2 from the issue, not the assert-only 1 — but reachable by exactly one route.

`storeDeadline` writes `min(now + timeout, birth + max_lifetime)` and every timeout is >= 1 ms, so a freshly stored target sits in the past only once the §6 lifetime cap already does. Past the cap, the dial's own re-base stores an already-expired target; the head-read timer then delivering **success** in that same batch finds `nowNs() >= deadline_ns` with the rebase cancel still in flight → `expireDeadline` → unguarded re-arm on the very completion the cancel is matching.

## The fix

Hoist the guard over the whole success path in `onDeadline` rather than adding it to each of `expireDeadline`'s two verdict branches: a due deadline now defers to `onDeadlineRebase`, which re-arms at the stored target once the cancel drains, expiring one round-trip later. `expireDeadline` asserts `!armed.deadline_cancel`, pinning what both of its re-arms assume.

## Settling it in the sim

SimIo will not stumble into this: its clock never advances inside a batch, and never at all while any op is ready — a pending cancel always is. The head arrival and the cap therefore have to wake at the same instant *by construction*. Confirmed the hard way first: a probe assert with no guard passed 2000 undirected seeds, even though the sim fuzz already arms `max_lifetime` on a third of them.

The directed case holds the client's head back to exactly the cap; seeds 88 and 93 of 1..100 then order the batch the way the race needs. The sweep is the coverage rather than a pinned seed — the oracle is an assert, so silent loss of coverage is the failure mode and an unrelated shift in PRNG draws could move which seed hits. Verified as a real oracle: with the guard disabled, the test panics at `expireDeadline`'s new assert, entered from `onDeadline`.

## Worth flagging

- **No boundary-observable symptom, by construction.** Any execution reaching this race has already passed the cap, so the verdict's own grace clamps into the past too and the connection is condemned either way. That rules out an outcome-based regression test — the assert is the only oracle available. The severity assessment in the issue holds.
- **Test-harness change beyond the fix**: the scripted client now lets an in-flight send drain before closing. The cap can reap it mid-head, and closing under a pending send left SimIo a stale handle (a §5 violation it asserts on). Pre-existing latent fragility that no prior scenario reached.
- `IMPLEMENTATION_NOTES.md` records the frozen-clock reasoning so the reachability argument doesn't have to be re-derived.

## Gates

`zig build ci` clean, `zig fmt --check` clean, plus 2500 extra sim seeds (1..1500, 2000..2999). `tiger-style-reviewer`: ready to commit — its seed-brittleness note is what prompted the sweep over a pinned seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)