### PR TITLE
docs: retire the CPU worker seam — TLS runs on the loop (§1, §3, §5, §8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -89,15 +89,17 @@ excluded by policy (ECDSA only) and measurement retired the seam
 (settled 2026-07-25, IMPLEMENTATION_NOTES.md): a full ECDSA handshake is
 ~100–400 µs of asymmetric crypto, and a terminated L7-over-TLS hop
 measured at HAProxy parity on steady-state keep-alive load — ~20k req/s,
-p50 110 µs against its 101 µs, one core each, same fixture certificate
-and origin. Handshake-heavy load is bounded by the asymmetric crypto
-itself (~47% of the handshake profile), so its levers are session
-resumption (µs-class for returning clients) and, past that, more cores —
-which this design buys as **N independent processes behind SO_REUSEPORT**,
-never as threads sharing pool memory. Single-threaded is a property of
-the design, not a phase of it; should a workload ever demand in-process
-parallelism, the re-entry gate in [PLANS.md](PLANS.md) treats it as a
-from-scratch decision.
+p50 110–122 µs against its 101–105 µs, one core each, same fixture
+certificate and origin. Handshake-heavy load has a lower ceiling that is
+measurably *not* a CPU wall: it scales with connection count, so what
+binds is a per-connection stall under investigation, which no amount of
+threading would remove. Where handshake CPU does eventually bind, the
+levers are session resumption (µs-class for returning clients) and then
+more cores — which this design buys as **N independent processes behind
+SO_REUSEPORT**, never as threads sharing pool memory. Single-threaded is
+a property of the design, not a phase of it; should a workload ever
+demand in-process parallelism, the re-entry gate in
+[PLANS.md](PLANS.md) treats it as a from-scratch decision.
 
 <details>
   <summary><b>Why this is the simplest topology that satisfies the goals</b></summary>
@@ -132,11 +134,13 @@ traffic against tens of GB/s of per-core bandwidth. At 100 k req/s a
 request costs ~4–6 ring ops → ~500 k SQE/s, well inside a single ring's
 capability, batched one submit per loop tick. The previous iteration
 measured itself latency-bound with CPU headroom on the data path; the
-only CPU-heavy work is the TLS handshake, measured at ~100–400 µs with
-ECDSA certs and at HAProxy parity through the whole terminated hop in
-steady state (IMPLEMENTATION_NOTES.md). The loop absorbs it in steps
-between completions, and the worst single uninterruptible step — ~275 µs
-of P-256 sign — is what bounds tick inflation. **Horizontal
+only CPU-heavy work is the TLS handshake, measured at ~100–400 µs of
+crypto with ECDSA certs and at HAProxy parity through the whole
+terminated hop in steady state (IMPLEMENTATION_NOTES.md, which also
+records the per-connection handshake stall that is *not* CPU and is
+still open). The loop absorbs it in steps between completions, and the
+worst single uninterruptible step — ~275 µs of P-256 sign — is what
+bounds tick inflation. **Horizontal
 scaling is N independent zoxy processes behind SO_REUSEPORT** —
 share-nothing at the process boundary, where the kernel actually
 isolates — not N loops, and not N worker threads, in one process.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -33,8 +33,9 @@ Goals, in priority order:
 3. **Minimal memory consumption.** Pools are *shared*, sized for concurrent
    *activity*, not for open-connection worst cases multiplied by core count
    (§5). Total memory is a closed-form function of `src/constants.zig`.
-4. **Simplicity.** One event loop, one ring, one writer for every pool.
-   Fewer moving parts than the previous iteration, not more.
+4. **Simplicity.** One thread, one event loop, one ring, one writer for
+   every pool — no worker threads, no cross-thread queues (§3). Fewer
+   moving parts than the previous iteration, not more.
 5. **L4 (TCP relay) and L7 (HTTP/1.1 reverse proxy)** serving, with
    keep-alive and shared upstream connection reuse.
 
@@ -49,6 +50,12 @@ Non-goals (deliberate, recorded so they are decisions rather than drift):
 - Multi-process orchestration, xDS, hot restart — until operability demands
   them (the previous iteration's Phase-4 machinery is a known-good recipe
   when they do).
+- **In-process worker threads and cross-thread job queues.** The design
+  reserved a CPU-worker seam for TLS handshakes; measurement retired it
+  (§3, settled 2026-07-25) and it is deleted, not dormant. The binary is
+  single-threaded and CPU scale-out is process-per-core behind
+  SO_REUSEPORT. Re-adding threads is a from-scratch decision behind a
+  measured gate ([PLANS.md](PLANS.md)), not un-commenting a seam.
 - Config reload. Config is parse-once immutable (§5); a change is a
   process restart — consistent with process-per-port scale-out (§3). Hot
   restart / drain-to-successor stays deferred ([PLANS.md](PLANS.md)).
@@ -56,42 +63,41 @@ Non-goals (deliberate, recorded so they are decisions rather than drift):
   addresses resolved once at config load (§7); re-resolution waits for a
   demonstrated need.
 
-## 3. Topology — one loop, one ring, shared pools
+## 3. Topology — one thread, one loop, one ring, shared pools
 
-The user-visible promise: *one io_uring serves everything; workers exist
-only for CPU-heavy jobs; every pool is shared.*
+The user-visible promise: *one thread owns one io_uring and every pool;
+nothing else runs.*
 
 ```mermaid
 flowchart LR
-    subgraph loop_thread [event-loop thread - owns all I/O and all pools]
+    subgraph loop_thread [the only thread - owns all I/O and all pools]
         A[accept gate] --> L[libxev loop on one io_uring]
         L <--> P[shared pools: conn slots, relay buffers, upstream conns]
         L <--> T[per-connection deadline timers - absolute]
     end
     C[clients] --> A
-    subgraph cpu_workers [cpu worker threads - no sockets, no pools]
-        W1[worker 1]
-        WN[worker n]
-    end
-    L -- push --> J[bounded SPMC job queue]
-    J -- CAS pop --> W1
-    J -- CAS pop --> WN
-    W1 -- SPSC completion ring + xev.Async --> L
-    WN -- SPSC completion ring + xev.Async --> L
     L --> O[origin servers]
 ```
 
 **The decision.** One event-loop thread owns the single `io_uring` (via
-libxev) and performs *all* socket I/O: accepts, recvs, sends, connects,
-timers. A small, fixed set of CPU worker threads exists only for jobs
-that burn milliseconds of CPU; they never touch a socket, a pool, or the
-ring. The seam is designed here but activates only on evidence
-([PLANS.md](PLANS.md) Phase 3c): TLS handshakes — its original
-motivation — measured at ~100–400 µs in pure std.crypto with
-ECDSA/Ed25519 certs (IMPLEMENTATION_NOTES.md), cheap enough to run on
-the loop under a per-tick budget, so TLS lands single-threaded and the
-worker set stays empty until a workload outgrows that budget. Until
-then the binary is single-threaded.
+libxev) and performs *all* socket I/O — accepts, recvs, sends, connects,
+timers — and *all* CPU work, TLS handshakes included. There are no other
+threads: no worker pool, no job queue, no cross-thread completion rings.
+The design reserved that seam for TLS handshakes on a ~1–2 ms
+per-handshake estimate; that was an RSA number, so RSA server certs are
+excluded by policy (ECDSA only) and measurement retired the seam
+(settled 2026-07-25, IMPLEMENTATION_NOTES.md): a full ECDSA handshake is
+~100–400 µs of asymmetric crypto, and a terminated L7-over-TLS hop
+measured at HAProxy parity on steady-state keep-alive load — ~20k req/s,
+p50 110 µs against its 101 µs, one core each, same fixture certificate
+and origin. Handshake-heavy load is bounded by the asymmetric crypto
+itself (~47% of the handshake profile), so its levers are session
+resumption (µs-class for returning clients) and, past that, more cores —
+which this design buys as **N independent processes behind SO_REUSEPORT**,
+never as threads sharing pool memory. Single-threaded is a property of
+the design, not a phase of it; should a workload ever demand in-process
+parallelism, the re-entry gate in [PLANS.md](PLANS.md) treats it as a
+from-scratch decision.
 
 <details>
   <summary><b>Why this is the simplest topology that satisfies the goals</b></summary>
@@ -100,7 +106,7 @@ then the binary is single-threaded.
   acquires and releases pool slots, so pools need no locks, no atomics, no
   cache-line padding on the data path — plain code. The previous iteration
   spent a hardware-counter investigation earning this property; here it
-  holds by construction.
+  holds by construction — there is no second thread that could violate it.
 - **Minimal memory.** One shared pool sized for the global limit replaces
   N per-core pools each sized for a local worst case. Idle keep-alive
   connections hold a slot and a head buffer, not relay buffers (§5) —
@@ -126,13 +132,14 @@ traffic against tens of GB/s of per-core bandwidth. At 100 k req/s a
 request costs ~4–6 ring ops → ~500 k SQE/s, well inside a single ring's
 capability, batched one submit per loop tick. The previous iteration
 measured itself latency-bound with CPU headroom on the data path; the
-only CPU-heavy work is the TLS handshake — once estimated at ~1–2 ms
-(the RSA number that motivated the worker seam), since measured at
-~100–400 µs with ECDSA/Ed25519 certs (IMPLEMENTATION_NOTES.md), cheap
-enough for the loop itself under a per-tick budget. **Horizontal
+only CPU-heavy work is the TLS handshake, measured at ~100–400 µs with
+ECDSA certs and at HAProxy parity through the whole terminated hop in
+steady state (IMPLEMENTATION_NOTES.md). The loop absorbs it in steps
+between completions, and the worst single uninterruptible step — ~275 µs
+of P-256 sign — is what bounds tick inflation. **Horizontal
 scaling is N independent zoxy processes behind SO_REUSEPORT** —
 share-nothing at the process boundary, where the kernel actually
-isolates — not N loops in one process.
+isolates — not N loops, and not N worker threads, in one process.
 
 **Why not one ring per worker.** Ring-per-worker with *shared* pools is the
 hybrid to avoid: the moment several ring-owning threads acquire/release pool
@@ -160,47 +167,23 @@ honest cost: upstream connection reuse becomes per-process rather than
 global. It stays maximal within each process, and single-node deployments —
 the common case — keep the fully global reuse win.
 
-**Worker seam — one shared job queue, not per-worker queues.** Loop →
-workers: the **job queue**, one bounded SPMC ring (single producer: the
-loop; consumers: workers CAS-pop) of job descriptors — pointers into
-the requesting connection's slot, whose scratch memory is part of the slot,
-so enqueue allocates nothing. Workers futex-wait on the queue when empty.
-Worker → loop: a per-worker SPSC **completion ring** plus one `xev.Async`
-to wake the loop (completions stay single-producer/single-consumer, so
-that direction needs no CAS). A full job queue is an exhaustion signal
-like any other: the job is shed (§8), never blocked on.
-
-The trade study, since Pingora offers both shapes (per-worker queues with
-work stealing — the Go/Tokio runtime model — or one shared queue):
-
-- **Work stealing solves a problem we don't have.** Stealing pays off when
-  tasks *spawn tasks* on the worker they run on, creating local imbalance
-  that must be re-spread. Here every job originates from exactly one
-  producer (the loop) and spawns nothing; there is no locality to preserve
-  (a handshake job's cache lines live in the connection slot, foreign to
-  every worker equally) and nothing to steal back. Stealing would add the
-  hardest concurrency artifact in the design (Chase–Lev deques + the
-  victim-selection loop) for zero expected benefit.
-- **Per-worker SPSC without stealing is simpler but strands work:** the
-  loop must pick a worker at enqueue time, and a job pinned behind a slow
-  neighbour waits while other workers idle — head-of-line blocking that
-  turns into spurious sheds under the very burst (handshake storm) the
-  workers exist for. It also splits the exhaustion signal into N queue-full
-  conditions, muddying the shed ladder's single-choke-point property.
-- **One shared queue is the fit:** jobs are few and coarse (~ms-scale TLS
-  handshakes, not µs-scale tasks), so one CAS per pop is noise against the
-  job body; idle workers self-balance by construction (exactly the
-  behaviour the previous iteration had to *build* as `accept_mode=shared`
-  for accepts); and one queue = one depth = one shed rung. The known cost —
-  producer/consumer contention on the queue's cache lines — matters at
-  millions of tiny ops/s, two orders of magnitude past the handshake rate.
-  Determinism (§9) is untouched either way: workers are off the data path
-  and virtualized in the simulator.
-
-If profiling ever shows queue contention (it should not at handshake
-rates), the escape hatch is per-worker queues *fed round-robin by the
-loop* — still no stealing — traded knowingly for the head-of-line cost
-above.
+**Why no CPU worker threads.** This section used to specify a worker
+seam: one bounded SPMC job queue, per-worker SPSC completion rings, an
+`xev.Async` wake, and the parked-slot ownership rules that went with it
+in §5. It existed for exactly one workload — TLS handshakes — and the
+Phase-3a measurements took that workload away (above), so the seam is
+**deleted, not kept dormant.** A dormant design is not free: it leaves
+ownership rules in §5, a rung in §8, and a module in §10 that no code
+exercises and no gate proves, and every later change has to stay
+compatible with a mechanism that may never exist. What replaces it is
+policy: the binary has one thread, and CPU scale-out is process-per-core
+(above). The honest cost is that a sustained handshake storm cannot
+borrow an idle core in-process — the answers there are resumption first,
+more processes second, and neither needs a shared-memory concurrency
+model. The retired trade study (one shared queue vs per-worker queues vs
+work stealing, and why stealing solves a problem this design does not
+have) is in git history; re-adding threads means re-deriving it against
+the measurement that retired it ([PLANS.md](PLANS.md)).
 
 </details>
 
@@ -385,10 +368,9 @@ Rules:
 
 - **Pools never grow.** Exhaustion is a shed signal (§8), never a realloc.
 - **Limit relationships are comptime-asserted** in `src/constants.zig`
-  (TIGER_STYLE): e.g. `relay_buffers ≤ conn_slots`,
-  `worker_jobs_max ≤ conn_slots`. Note that `relay_buffers` — not conn
-  slots — is the true bound on concurrent L4 connections plus active L7
-  relays (§6).
+  (TIGER_STYLE): e.g. `relay_buffers_max ≤ conn_slots_max`, and the same
+  for the defaults. Note that `relay_buffers` — not conn slots — is the
+  true bound on concurrent L4 connections plus active L7 relays (§6).
 - **The CQ fill is a headroom knob, not a pool shrink.**
   `limits.cq_fill_eighths` sets how many eighths of the completion queue
   the worst-case in-flight ops may fill: ⅞ (the default, the fill the c10k
@@ -427,15 +409,13 @@ Rules:
   memory corruption — so slots carry a generation counter asserted on every
   completion delivery, and the simulator asserts no completion is ever
   delivered to a freed or reused slot (§9).
-- **No cross-thread sharing of pool memory.** Workers receive pointers
-  into a slot that is *parked* (no data I/O in flight) for the duration
-  of the job; ownership transfers through the job queue (loop → worker)
-  and that worker's completion ring (worker → loop), one owner at a time.
-  **A completion arriving for a parked slot never touches slot memory:**
-  the deadline timer stays armed on the loop, and its firing (or any
-  straggler completion) only sets a flag in the loop-owned slot header —
-  the state machine acts on flags when the job's completion returns
-  ownership. Teardown of a parked slot is deferred, never concurrent.
+- **Pool memory has exactly one owner, always.** With one thread in the
+  binary (§3) there is no cross-thread handoff to get right: no parked
+  slots, no ownership transfer, no flag protocol for completions that
+  arrive while another thread holds a slot. Single-writer pools are a
+  state the design cannot represent violating, not a rule the code has to
+  remember — which is why the worker seam was deleted rather than left
+  dormant (§3).
 
 ## 6. L4 data path — TCP relay
 
@@ -624,7 +604,6 @@ the loop thread.
 | relay buffers (L4) | accept admission | close immediately |
 | relay buffers (L7) | request admission on a kept-alive conn | static `503` from the head buffer, then keep or close per pressure |
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7) / close (L4) |
-| worker job queue | job enqueue | shed the job's connection (TLS handshake → close) |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
@@ -661,12 +640,14 @@ the loop thread.
   *work*; each engage crossing has a counter.
 - **Metrics witness every shed.** Every rung has a counter, written only
   by the loop thread as a relaxed atomic — one writer, any number of
-  readers, so a metrics/admin thread can read without a data race and
-  single-writer stays intact. The simulator asserts counters reconcile
-  (admitted = completed + shed + in-flight) under every seed. Counters
-  live in `counters.zig` (§10); Phase 0 exposure is a SIGUSR1-triggered
-  dump (through the seam's `signal` primitive, §4) — the admin plane
-  stays deferred ([PLANS.md](PLANS.md)).
+  readers. The admin plane reads them on the loop itself (§3: there is no
+  second thread); the relaxed atomic costs nothing on the write side and
+  keeps any out-of-loop reader race-free by construction. The simulator
+  asserts counters reconcile (admitted = completed + shed + in-flight)
+  under every seed. Counters live in `counters.zig` (§10); exposure is
+  the admin/metrics listener's Prometheus rendering (`admin.zig`, one
+  reserved scrape slot off the shared pools) plus a SIGUSR1 dump through
+  the seam's `signal` primitive (§4).
 - **File descriptors are pre-budgeted, not shed.** The fd count is
   closed-form — listeners + connection slots + upstream slots + ring,
   async and signal fds — evaluated on the *effective* config
@@ -727,10 +708,8 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    leaks (all pools drain to
    zero), no deadlock, counters reconcile, every shed is witnessed, no
    completion is delivered to a freed or reused slot (slot generations
-   checked on every delivery, §5), and no loop-side write ever lands in
-   a parked slot's scratch (the scheduler deliberately fires deadlines
-   while worker jobs are in flight, §5). A failure prints its seed; the same seed replays the
-   exact schedule.
+   checked on every delivery, §5). A failure prints its seed; the same
+   seed replays the exact schedule.
    `zig build sim -- fuzz` runs forever on entropy-derived seeds.
 2. **Fuzzing — `zig build test --fuzz`.** `std.testing.fuzz` on every
    parser edge: HTTP/1.1 head parser, chunked decoder, config parser.
@@ -813,7 +792,7 @@ src/
   balancer.zig        // upstream endpoint pick: per-cluster rr | p2c (§7)
   shed.zig            // exhaustion ladder: decisions + static responses
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
-  worker.zig          // SPMC job queue + SPSC completion rings (Phase 3c, evidence-gated)
+  admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
 sim/                  // simulator harness + invariants
 bench/                // micro benches (poop) + loopback harness (zrk), §9
 ```

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -165,55 +165,82 @@ in front of the same plaintext origin, so the added pair isolates
 termination cost). This is the evidence DESIGN §3 rests on when it
 deletes the CPU-worker seam rather than deferring it.
 
-Steady state — keep-alive, the shape a real HTTPS front end runs in:
+Steady state — keep-alive, the shape a real HTTPS front end runs in
+(three runs at branch tip `ab547a2`, bands not single numbers):
 
 | | req/s | p50 | p90 | p99 |
 |---|---|---|---|---|
-| zoxy L7 + TLS | 19970 | 110 µs | 174 µs | 1374 µs |
-| haproxy https | 19960 | 101 µs | 151 µs | 1043 µs |
+| zoxy L7 + TLS | 19961–19970 | 110–122 µs | 137–174 µs | 784–1374 µs |
+| haproxy https | 19960–19965 | 101–105 µs | 131–151 µs | 223–1043 µs |
 
-Parity. A terminated hop on one thread is not the bottleneck at 20k
-req/s, and nothing about that number wants another thread.
+Parity on rate and p50. A terminated hop on one thread is not the
+bottleneck at 20k req/s, and nothing about that number wants another
+thread. zoxy's tail is the worse half of the band (p99 up to ~1.4 ms
+against haproxy's ~0.3 ms, and a `max` that lands on ~41.8 ms in *every*
+run — see the stall below, which happens once per connection and so
+amortizes away here).
 
 Handshake-bound — `Connection: close`, one full handshake per request,
-neither side resuming (zrk has no session resumption yet):
+neither side resuming (zrk has no session resumption yet). Three runs,
+and the third one is what explains the first two:
 
-| | req/s | p50 |
-|---|---|---|
-| zoxy L7 + TLS | 712 | 3240 ms |
-| haproxy https | 1897 (of 2000 offered — never saturated) | 724 µs |
+| offered | connections | zoxy L7 + TLS | haproxy https |
+|---|---|---|---|
+| 2000/s | 32 | 704 req/s | 1996 req/s |
+| 2000/s | 64 | 1427 req/s | 1996 req/s |
+| 500/s | 32 | 499 req/s, p50 212 µs | 499 req/s, p50 309 µs |
 
-Recorded honestly: this gap is **unexplained**, and it is the one number
-that argues the other way. The handshake profile (`zig build profile
---protocol https`, sampling zoxy alone) accounts for ~13% of zoxy-side
-overhead, not a 2.7× deficit — X25519 ~25%, P-256 ECDSA ~12%, ML-KEM
-~10% (zoxy and haproxy negotiate the same X25519MLKEM768 group against
-this client, so both pay it), `memset` 11.2% (ztls `secureZero`; bounding
-it moved the share to 10.1% and throughput not at all — see below),
-SHA-256 in Zig 2.4%. So ~712 handshakes/s is ~1.4 ms of wall time each
-against ~100–400 µs of crypto, and the rest is unaccounted.
+**The ceiling is per-connection, not per-core.** Doubling the connections
+doubled the throughput, and the implied per-connection handshake cycle is
+the same either way — 32 / 704 = 45.5 ms, 64 / 1427 = 44.8 ms. Below that
+floor (the 500/s run, 64 ms per connection cycle) zoxy keeps up
+completely, and its post-handshake exchange is *faster* than haproxy's.
+So the shape is a fixed ~45 ms serialized stall per handshake connection,
+load-independent, capping each connection at ~22 handshakes/s — not a
+CPU wall, and not the "~1.4 ms of wall time per handshake" the first
+profile's arithmetic suggested. ~40 ms is the signature magnitude of a
+Nagle/delayed-ACK interaction (§4 records the same 40 ms lesson from
+pooled upstream connections), and the recurring ~41.8 ms `max` in the
+keep-alive runs points the same way, but **the mechanism is not yet
+identified**; zoxy sets `TCP_NODELAY` on its own sockets, so it is not
+the obvious half of that classic.
 
-What it does *not* argue for is threads. The work is asymmetric crypto,
-which a worker thread does not make cheaper per handshake; it only adds
-cores, and process-per-core behind SO_REUSEPORT (§3) adds the same cores
-without a shared-memory concurrency model. The in-tree levers are
-session resumption (stateless tickets, landed on the branch — µs-class
-for returning clients) and finding whatever the unaccounted wall time is.
+Two readings to retire, both of them mine:
 
-Two caveats on the close-mode number specifically, both worth clearing
-before treating it as a ceiling:
+- **It is not the TLS-engine ceiling.** These runs have 1024 engines (the
+  default now follows conn slots) and `shed_tls_engines` is **0** in
+  every one of them, alongside 0 socket errors and 0 status errors. The
+  earlier "13× slower than haproxy" reading *was* that bug — 261,322 of
+  261,579 accepts shed at the engine rung against a 256-engine default —
+  but that bug is fixed and the close-mode gap survives it unchanged
+  (712 req/s before, 704 after, at the same 32 connections).
+- **p50 3.2 s was not service time.** It is zrk's
+  coordinated-omission-corrected wait against the offered schedule: at
+  2000/s offered into a ~704/s ceiling the backlog is the measurement.
+  Per-request service latency is the 500/s row.
 
-- It was taken **before** the TLS-engine default followed conn slots. A
-  later, higher-concurrency run read as "13× slower than haproxy" and
-  was not slower at all: 261,322 of 261,579 accepts were shed at the
-  engine rung (default 256 engines against 1386 advertised conn slots),
-  so the load generator ran with most of its connections dead. The
-  712 req/s run passed the sub-1% socket-error gate, so it was not
-  shedding — but the close-mode band is owed a re-measure on the fixed
-  default regardless.
+What none of it argues for is threads. A serialized per-connection stall
+is not CPU work, so a worker pool would buy exactly nothing; and where
+real handshake CPU eventually binds, more cores come from
+process-per-core behind SO_REUSEPORT (§3), not from threads sharing pool
+memory. The in-tree levers are the stall (find it), session resumption
+(stateless tickets, landed on the branch — µs-class for returning
+clients), and only then anything about parallelism.
+
+Measurement caveats worth carrying forward:
+
+- The handshake profile shares (`zig build profile --protocol https`:
+  X25519 ~25%, P-256 ECDSA ~12%, ML-KEM ~10% — zoxy and haproxy negotiate
+  the same X25519MLKEM768 group against this client, so both pay it —
+  `memset` 11.2%, SHA-256 in Zig 2.4%) are **user-space shares only**:
+  `perf_event_paranoid` is 2 on this box, so kernel samples never enter
+  the profile. They cannot be turned into a wall-time budget, which is
+  how "47% crypto" turned into an arithmetic that the 64-connection run
+  then falsified.
 - The §9 health gates check socket and status errors, not achieved rate
-  against offered, so a run delivering 712 of 2000 req/s *passed* them.
-  Rate-versus-offered is not yet a gate.
+  against offered, so a run delivering 704 of 2000 req/s *passed* them.
+  Rate-versus-offered is not yet a gate — and it would have caught this
+  on the first run.
 
 ## Profile share is not throughput headroom — bounding a wipe (2026-07-25)
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -157,6 +157,95 @@ unshipped. No other production-credible pure-Zig TLS 1.3 server
 exists as of the scan; Geun-Oh/zigtls is aimed the right way but
 0.1.0-dev — watch-list only.
 
+## TLS on the loop — the band that retired the worker pool (2026-07-25)
+
+Measured on the `phase-3a-ztls` branch (ztls engine, ECDSA P-256 fixture
+cert, one core each side, both proxies terminating the *same* certificate
+in front of the same plaintext origin, so the added pair isolates
+termination cost). This is the evidence DESIGN §3 rests on when it
+deletes the CPU-worker seam rather than deferring it.
+
+Steady state — keep-alive, the shape a real HTTPS front end runs in:
+
+| | req/s | p50 | p90 | p99 |
+|---|---|---|---|---|
+| zoxy L7 + TLS | 19970 | 110 µs | 174 µs | 1374 µs |
+| haproxy https | 19960 | 101 µs | 151 µs | 1043 µs |
+
+Parity. A terminated hop on one thread is not the bottleneck at 20k
+req/s, and nothing about that number wants another thread.
+
+Handshake-bound — `Connection: close`, one full handshake per request,
+neither side resuming (zrk has no session resumption yet):
+
+| | req/s | p50 |
+|---|---|---|
+| zoxy L7 + TLS | 712 | 3240 ms |
+| haproxy https | 1897 (of 2000 offered — never saturated) | 724 µs |
+
+Recorded honestly: this gap is **unexplained**, and it is the one number
+that argues the other way. The handshake profile (`zig build profile
+--protocol https`, sampling zoxy alone) accounts for ~13% of zoxy-side
+overhead, not a 2.7× deficit — X25519 ~25%, P-256 ECDSA ~12%, ML-KEM
+~10% (zoxy and haproxy negotiate the same X25519MLKEM768 group against
+this client, so both pay it), `memset` 11.2% (ztls `secureZero`; bounding
+it moved the share to 10.1% and throughput not at all — see below),
+SHA-256 in Zig 2.4%. So ~712 handshakes/s is ~1.4 ms of wall time each
+against ~100–400 µs of crypto, and the rest is unaccounted.
+
+What it does *not* argue for is threads. The work is asymmetric crypto,
+which a worker thread does not make cheaper per handshake; it only adds
+cores, and process-per-core behind SO_REUSEPORT (§3) adds the same cores
+without a shared-memory concurrency model. The in-tree levers are
+session resumption (stateless tickets, landed on the branch — µs-class
+for returning clients) and finding whatever the unaccounted wall time is.
+
+Two caveats on the close-mode number specifically, both worth clearing
+before treating it as a ceiling:
+
+- It was taken **before** the TLS-engine default followed conn slots. A
+  later, higher-concurrency run read as "13× slower than haproxy" and
+  was not slower at all: 261,322 of 261,579 accepts were shed at the
+  engine rung (default 256 engines against 1386 advertised conn slots),
+  so the load generator ran with most of its connections dead. The
+  712 req/s run passed the sub-1% socket-error gate, so it was not
+  shedding — but the close-mode band is owed a re-measure on the fixed
+  default regardless.
+- The §9 health gates check socket and status errors, not achieved rate
+  against offered, so a run delivering 712 of 2000 req/s *passed* them.
+  Rate-versus-offered is not yet a gate.
+
+## Profile share is not throughput headroom — bounding a wipe (2026-07-25)
+
+Same profile: `compiler_rt.memset` at 11.2% of zoxy's CPU, ~84% of it
+traced to ztls's `secureZero` on teardown — dominated by `fin_frag`, a
+16 KiB buffer reserved against a client-auth flight we never request and
+wiped in full on every handshake (16386 of the 18269 bytes `deinit`
+zeroed). Bounding the wipe to a high-water mark **did not change
+handshake throughput**, three runs each on saturated close-mode load:
+
+- before: 710 / 712 / 712 req/s, memset 11.2%
+- after: 709 / 709 / 710 req/s, memset 10.1%
+
+The share moves as predicted; the throughput does not, because the
+handshake is bounded by asymmetric crypto (~47% of the profile), not by
+the zeroing. **A symbol's share of samples is what it costs while
+running, not what removing it buys** — the same number only when that
+symbol is the bottleneck. The change was kept (it is correct and does
+strictly less work), but it is not a lever.
+
+Two process notes, both paid for:
+
+- An intermediate measurement through a `.path` dependency override read
+  733 / 733 req/s for code that measures 709 / 709 / 710 through the
+  pinned `.url`. The build mechanism, not the code. Trust numbers from
+  the shipped configuration.
+- A first attempt put the high-water mark inside `ArrayBuffer` itself,
+  taxing every append to benefit one buffer: 633 req/s, an 11%
+  regression — caught only because the baseline had been measured three
+  times and was stable to ±2 req/s. Measure the baseline's variance
+  before believing a delta.
+
 ## The concurrency ceiling is CQ-bound (95d1f8f)
 
 Concurrent L4 connections are bound by the io_uring completion queue,

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -69,21 +69,26 @@ under [Deferred, revisit on evidence](#deferred-revisit-on-evidence).
 - **Phase 3c — CPU worker pool: retired, not deferred** (2026-07-25).
   The §3 worker seam (SPMC job queue, per-worker completion rings, the
   §5 parked-slot ownership rules) is **removed from the design**, and
-  in-process threads are now a §1 non-goal. The 3a band settled it: a
+  in-process threads are now a §1 non-goal. The 3a bands settled it: a
   terminated L7-over-TLS hop runs at HAProxy parity in steady state on
-  one thread, and handshake-bound load is bounded by asymmetric crypto
-  that a second thread does not make cheaper per handshake — it only
-  adds cores, which process-per-core behind SO_REUSEPORT already does
-  without a shared-memory concurrency model
-  ([IMPLEMENTATION_NOTES.md](IMPLEMENTATION_NOTES.md)). Re-entry is a
+  one thread, and the handshake-bound ceiling is not a CPU wall at all —
+  it doubles when the connection count doubles, so a fixed ~45 ms
+  per-connection stall binds it, which no thread removes
+  ([IMPLEMENTATION_NOTES.md](IMPLEMENTATION_NOTES.md)). Where handshake
+  CPU does eventually bind, threads only add cores, and process-per-core
+  behind SO_REUSEPORT already does that without a shared-memory
+  concurrency model. Re-entry is a
   from-scratch design decision, not un-commenting a seam, and needs both
   halves of a gate: a measured workload where handshake demand exceeds
   one loop within a single process *and* process-per-core scale-out is
   not an acceptable answer. The retired trade study (shared queue vs
   per-worker queues vs work stealing) is in git history. The open
-  handshake-throughput work is not threads: the unexplained close-mode
-  gap to haproxy, session resumption, and a re-measure on the fixed
-  TLS-engine default (all recorded in the notes).
+  handshake-throughput work is not threads: find the ~45 ms
+  per-connection stall (the engine-ceiling and CPU-saturation readings
+  are both measured out — see the notes), then session resumption. Worth
+  adding while there: a Tier-1 gate on achieved rate against offered,
+  which the §9 error gates do not cover and which would have caught the
+  stall on its first run.
 
 ## io_uring op upgrades — evaluated, all deferred (2026-07-16)
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -66,15 +66,24 @@ under [Deferred, revisit on evidence](#deferred-revisit-on-evidence).
   (macOS dev box, kernels without the TLS ULP). Known fiddly parts:
   KeyUpdate and post-handshake control messages arrive via CMSG, and
   session tickets must be sent before the switchover.
-- **Phase 3c — CPU worker pool, behind an evidence gate.** The §3
-  worker seam (SPMC job queue, per-worker completion rings, the §5
-  parked-slot ownership rules) stays designed but inactive — it is the
-  hardest remaining concurrency work in the plan, and the 3a numbers
-  say it buys nothing at realistic handshake rates. Entry gate: a
-  measured workload where handshake demand exceeds the on-loop budget
-  within one process (sustained cold full-handshake load past
-  ~4k/s/core) *and* process-per-core scale-out (§3) is not an
-  acceptable answer. Until then the binary stays single-threaded.
+- **Phase 3c — CPU worker pool: retired, not deferred** (2026-07-25).
+  The §3 worker seam (SPMC job queue, per-worker completion rings, the
+  §5 parked-slot ownership rules) is **removed from the design**, and
+  in-process threads are now a §1 non-goal. The 3a band settled it: a
+  terminated L7-over-TLS hop runs at HAProxy parity in steady state on
+  one thread, and handshake-bound load is bounded by asymmetric crypto
+  that a second thread does not make cheaper per handshake — it only
+  adds cores, which process-per-core behind SO_REUSEPORT already does
+  without a shared-memory concurrency model
+  ([IMPLEMENTATION_NOTES.md](IMPLEMENTATION_NOTES.md)). Re-entry is a
+  from-scratch design decision, not un-commenting a seam, and needs both
+  halves of a gate: a measured workload where handshake demand exceeds
+  one loop within a single process *and* process-per-core scale-out is
+  not an acceptable answer. The retired trade study (shared queue vs
+  per-worker queues vs work stealing) is in git history. The open
+  handshake-throughput work is not threads: the unexplained close-mode
+  gap to haproxy, session resumption, and a re-measure on the fixed
+  TLS-engine default (all recorded in the notes).
 
 ## io_uring op upgrades — evaluated, all deferred (2026-07-16)
 


### PR DESCRIPTION
The `phase-3a-ztls` band settled the question the worker pool existed to
answer, so §3's CPU-worker seam is deleted rather than left dormant.

## Steady state: parity on one thread

A terminated L7-over-TLS hop, one core each side, same fixture
certificate in front of the same plaintext origin. Three runs at branch
tip `ab547a2` — bands, not single numbers:

| | req/s | p50 | p90 | p99 |
|---|---|---|---|---|
| zoxy L7 + TLS | 19961–19970 | 110–122 µs | 137–174 µs | 784–1374 µs |
| haproxy https | 19960–19965 | 101–105 µs | 131–151 µs | 223–1043 µs |

Parity on rate and p50; zoxy owns the worse tail.

## Handshake-bound: re-measured, and it is not CPU

The first version of this PR left the close-mode gap to haproxy
unexplained and suspected a low `tls_engines` default. Both readings are
now measured out:

| offered | connections | zoxy L7 + TLS | haproxy https |
|---|---|---|---|
| 2000/s | 32 | 704 req/s | 1996 req/s |
| 2000/s | 64 | **1427 req/s** | 1996 req/s |
| 500/s | 32 | 499 req/s, p50 212 µs | 499 req/s, p50 309 µs |

Doubling the connections doubled the throughput, and the implied
per-connection handshake cycle is identical either way — 32/704 = 45.5 ms,
64/1427 = 44.8 ms. **The ceiling is a fixed ~45 ms serialized stall per
handshake connection**, load-independent, capping each connection at ~22
handshakes/s. Below that floor (the 500/s run) zoxy keeps up completely
and its post-handshake exchange is *faster* than haproxy's.

~40 ms is the signature magnitude of a Nagle/delayed-ACK interaction (§4
records the same lesson from pooled upstream connections), and the
recurring ~41.8 ms `max` in every keep-alive TLS run points the same way
— but the mechanism is **not identified**, and zoxy sets `TCP_NODELAY` on
its own sockets, so it is not the obvious half of that classic. It is
recorded as the open item it is.

Retired readings:

- **Not the engine ceiling.** These runs carry 1024 engines (the default
  now follows conn slots) and `shed_tls_engines` is **0** in every one,
  with 0 socket and 0 status errors. The earlier "13× slower than
  haproxy" reading *was* that bug — 261,322 of 261,579 accepts shed
  against a 256-engine default — but this gap survives the fix unchanged:
  712 req/s before, 704 after, same 32 connections.
- **p50 3.2 s was never service time.** It is zrk's CO-corrected wait
  against the offered schedule: 2000/s offered into a ~704/s ceiling.
- **"Bounded by asymmetric crypto (~47% of the profile)" cannot carry
  weight.** `perf_event_paranoid` is 2 on this box, so those shares are
  user-space samples only — kernel time never enters the profile. That
  arithmetic is what the 64-connection run falsified.

A serialized per-connection stall is not CPU work, so a worker pool would
buy exactly nothing here. Where handshake CPU does eventually bind, more
cores come from process-per-core behind SO_REUSEPORT — not from threads
sharing pool memory.

## What changes

- **§1** — goal 4 becomes "one thread, one event loop, one ring"; new
  non-goal: in-process worker threads and cross-thread job queues.
- **§3** — retitled; the mermaid loses the worker subgraph, job queue and
  completion rings; the decision paragraph cites the bands; the
  SPMC-vs-per-worker-queue trade study is replaced by **"Why no CPU
  worker threads"**, including the honest cost — a handshake storm cannot
  borrow an idle core in-process. The retired study stays in git history.
- **§5** — the parked-slot cross-thread ownership bullet becomes "pool
  memory has exactly one owner, always".
- **§8** — the `worker job queue` ladder rung is gone. **§9** — the
  parked-slot-scratch invariant with it. **§10** — `worker.zig` too.
- **PLANS** — Phase 3c goes from "designed but inactive" to *retired, not
  deferred*, behind a two-part re-entry gate. Open handshake work is the
  stall, then resumption — plus a Tier-1 gate on achieved rate against
  offered, which the §9 error gates do not cover and which would have
  caught the stall on its first run (704 of 2000 req/s *passed* them).
- **NOTES** — all three bands, the stall arithmetic, the retired
  readings, the `perf_event_paranoid` caveat, and the `secureZero` lesson
  that a symbol's share of samples is what it costs while running, not
  what removing it buys.

Two stale claims fixed in the neighbourhood: the §5 assertion example
named `worker_jobs_max`, a constant that does not exist, and §8 called
the admin plane deferred while justifying relaxed-atomic counters with a
metrics thread this binary does not have.

## Gates

`zig fmt --check` and `zig build ci` (64 sim seeds) pass on this docs-only
diff. The bands above are `zig build bench` on `phase-3a-ztls`, three
runs, nginx origin, proxy pinned to one core.

⚠️ Rebasing `phase-3a-ztls` onto this will conflict in the §8 ladder
table and the §10 module map, where its TLS additions sit in the same
hunks as these deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)