### PR TITLE
refactor: one protocol fork, callable twice (§6, §7 — PLANS A5)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -136,7 +136,22 @@ Sizes are estimates, in diff lines, for sequencing only.
 | A2 | `fillRandom` on the Io seam (`getrandom` in XevIo, scenario PRNG in SimIo), with the balancer's p2c seed routed through it | 60 | TLS needs key material through the seam; the side win is seed-replayable p2c in the simulator (§9) |
 | A3 | Lint boundaries as a data table `{import, allowed_prefix, message}` | 50 | the branch's 5th positional bool touched every test call; a new dependency boundary should be one row |
 | A4 | `abortAdmission(server, conn, socket, rung)` | 30 | collapses the release + pressure + counter + close quartet that `admitL4`/`admitHttp` already repeat and `admitTls` repeated twice more |
-| A5 | Split `prepare` from `startProtocol(server, conn)` | 40 | one protocol fork, callable from accept *or* from a later phase — deletes the branch's duplicated switch and the `tls_protocol` field outright |
+| A5 | Split `prepare` from `startProtocol(server, conn)` — *landed* | 40 | one protocol fork, callable from accept *or* from a later phase — deletes the branch's duplicated switch and the `tls_protocol` field outright |
+
+**What A5 leaves to the phase that hands a connection over.**
+`startProtocol` stores the entry state and the entry deadline even at
+admission, where the tail set exactly those values a moment earlier. The
+two writes are identical there because `admit` reaches it through one
+synchronous chain, so neither the per-tick clock nor the pressure flags
+`entryTimeoutMs` reads can move in between. A phase handing over a live
+connection arrives in a *different* tick, where those values legitimately
+differ — so no single assertion covers both callers, and the safety at
+admission is structural rather than asserted. **The hand-over caller owns
+re-establishing that invariant and is where to assert it**; it should also
+decide how a connection recalls its own protocol (a listener pointer on the
+slot would subsume `routes`, `filters` and `cluster_index` — which is how
+the `tls_protocol` field stays deleted). Recorded because two independent
+reviews of A5 landed on it, and neither could guard it from here.
 
 ### Tier B — the structural ones, in dependency order
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -373,13 +373,98 @@ pub fn Server(comptime IoType: type) type {
         }
 
         /// The admission fork (§6, §7): every protocol shares the accept
-        /// gate, the conn slot, the deadline, and teardown; they diverge
-        /// only in what a fresh connection does next.
+        /// gate, the conn slot, the deadline, and teardown. They diverge in
+        /// exactly two places, and this is the first — what a protocol must
+        /// already hold to be admitted at all. An L4 connection relays for
+        /// its whole life, so a missing relay buffer is an admission-time
+        /// shed (§8), counted before `admitted`; an idle L7 connection
+        /// holds a slot and head buffer only and acquires a buffer per body
+        /// leg (§5). The second divergence is `startProtocol`.
         fn admit(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
             assert(!server.draining);
-            switch (state.protocol) {
-                .l4 => server.admitL4(state, client_socket),
-                .http => server.admitHttp(state, client_socket),
+            const conn = server.admitConn(client_socket) orelse return;
+            const buffer: ?*relay.RelayBuffer = switch (state.protocol) {
+                .l4 => server.acquireRelayBuffer() orelse {
+                    server.conns.release(conn);
+                    server.updateConnPressure();
+                    server.counters.increment("shed_relay_buffers");
+                    shed.closeQuietly(IoType, server.io, client_socket);
+                    return;
+                },
+                .http => null,
+            };
+            server.finishAdmission(conn, client_socket, buffer, state);
+            server.startProtocol(conn, state.protocol);
+        }
+
+        /// The state a protocol's connection starts serving in, in one
+        /// place so nothing else carries the mapping.
+        fn entryState(protocol: config_module.Config.Listener.Protocol) ConnType.State {
+            return switch (protocol) {
+                .l4 => .connecting,
+                .http => .l7_reading_head,
+            };
+        }
+
+        /// The first deadline that connection runs under: an L4 connection
+        /// is dialing, so it gets the connect budget (§8); an L7 one is
+        /// reading a head, so a slowloris meets the clock or
+        /// `head_bytes_max`, whichever comes first (§7).
+        fn entryTimeoutMs(
+            server: *const Self,
+            protocol: config_module.Config.Listener.Protocol,
+        ) u32 {
+            return switch (protocol) {
+                .l4 => server.config.connect_timeout_ms,
+                .http => server.idleTimeoutMs(),
+            };
+        }
+
+        /// Start a protocol on an admitted connection: its serving state,
+        /// its first deadline, and its first op. Split from the admission
+        /// tail so it is callable from either side of the fork — at
+        /// admission for a fresh connection, and by any phase that runs
+        /// *ahead* of the protocol and hands a live connection over when it
+        /// finishes. TLS termination is the phase that will need it
+        /// (§4, PLANS.md): it is orthogonal to l4/http, so the protocol
+        /// fork happens after the handshake rather than at accept.
+        ///
+        /// It takes the protocol as an argument rather than reading it off
+        /// the slot deliberately: on this branch the second caller does not
+        /// exist, and a field with one writer and one reader would be state
+        /// kept for a caller that is not here (§1). The phase that needs to
+        /// recall a connection's protocol is the one that should decide how.
+        ///
+        /// The state and deadline stores are idempotent at admission — the
+        /// tail below set exactly these values from the same protocol, and
+        /// `admit` reaches here through one synchronous chain, so the clock
+        /// and the pressure flags `entryTimeoutMs` reads cannot have moved
+        /// between the two writes — and they are load-bearing for a
+        /// hand-over, which arrives in whatever state its phase ran in.
+        /// Keeping them here is what makes both callers a single call.
+        fn startProtocol(
+            server: *Self,
+            conn: *ConnType,
+            protocol: config_module.Config.Listener.Protocol,
+        ) void {
+            assert(!server.draining);
+            assert(!conn.isTearingDown());
+            // The one timer this connection ever arms is already armed
+            // (§4: a state transition only ever *stores* a new deadline).
+            assert(conn.armed.deadline);
+            conn.state = entryState(protocol);
+            server.storeDeadline(conn, server.entryTimeoutMs(protocol));
+            switch (protocol) {
+                .l4 => {
+                    // A recv must always have a buffer posted (§6).
+                    assert(conn.relay_buffer != null);
+                    server.armConnect(conn, conn.cluster_index);
+                },
+                .http => {
+                    // An idle L7 connection holds no relay buffer (§5).
+                    assert(conn.relay_buffer == null);
+                    Proxy.start(server, conn);
+                },
             }
         }
 
@@ -396,74 +481,42 @@ pub fn Server(comptime IoType: type) type {
             return conn;
         }
 
-        /// The shared admission tail (§8 single choke point): counting,
-        /// slot prepare, socket options, and the first deadline are
-        /// identical across protocols; only the entry state, buffer, and
-        /// timeout differ.
+        /// The shared admission tail (§8 single choke point): counting, slot
+        /// prepare, socket options, the routing tables, and the one deadline
+        /// timer this connection ever arms are identical across protocols —
+        /// the protocol only chooses which values go in, through
+        /// `entryState` and `entryTimeoutMs`.
         fn finishAdmission(
             server: *Self,
             conn: *ConnType,
             client_socket: IoType.Socket,
             buffer: ?*relay.RelayBuffer,
-            state: ConnType.State,
-            timeout_ms: u32,
-            cluster_index: u16,
+            listener: *const ListenerState,
         ) void {
             assert(!server.draining);
-            assert(state == .connecting or state == .l7_reading_head);
-            assert(timeout_ms >= 1);
             server.counters.increment("admitted");
-            conn.prepare(server, client_socket, buffer, state, cluster_index);
+            conn.prepare(
+                server,
+                client_socket,
+                buffer,
+                entryState(listener.protocol),
+                listener.cluster_index,
+            );
             server.io.setNodelay(client_socket) catch {
                 server.counters.increment("kernel_pressure_errors");
             };
-            server.storeDeadline(conn, timeout_ms);
+            // The L7 path routes and filters once the head parses (§7);
+            // every connection gets its listener's tables and the protocol
+            // decides whether it reads them — an l4 listener resolves to
+            // exactly one catch-all route and no filters, so this is one
+            // rule rather than a third fork.
+            conn.routes = listener.routes;
+            conn.filters = listener.filters;
+            assert(conn.routes.len >= 1);
+            server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));
             server.armDeadline(conn);
             assert(conn.deadline_ns > 0);
             assert(conn.armed.deadline);
-        }
-
-        fn admitL4(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
-            const conn = server.admitConn(client_socket) orelse return;
-            const buffer = server.relay_buffers.acquire() orelse {
-                server.conns.release(conn);
-                server.updateConnPressure();
-                server.counters.increment("shed_relay_buffers");
-                shed.closeQuietly(IoType, server.io, client_socket);
-                return;
-            };
-            server.updateRelayPressure();
-            server.finishAdmission(
-                conn,
-                client_socket,
-                buffer,
-                .connecting,
-                server.config.connect_timeout_ms,
-                state.cluster_index,
-            );
-            server.armConnect(conn, state.cluster_index);
-        }
-
-        /// L7 admission (§5, §7): a slot only — an idle L7 connection
-        /// holds no relay buffer, which is acquired when a body relay
-        /// starts. The head-read deadline is armed so a slowloris meets
-        /// the clock or `head_bytes_max` first (§7).
-        fn admitHttp(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
-            const conn = server.admitConn(client_socket) orelse return;
-            server.finishAdmission(
-                conn,
-                client_socket,
-                null,
-                .l7_reading_head,
-                server.idleTimeoutMs(),
-                state.cluster_index,
-            );
-            // The L7 path routes and filters once the head parses; hand it
-            // the listener's tables (§7).
-            conn.routes = state.routes;
-            conn.filters = state.filters;
-            assert(conn.routes.len >= 1);
-            Proxy.start(server, conn);
         }
 
         /// L7 body relays acquire their buffer mid-connection (§5), so

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -66,9 +66,10 @@ pub fn Conn(comptime IoType: type) type {
         /// the L7 path `routeRequest` overwrites it with the request
         /// path's cluster once the head parses (§7).
         cluster_index: u16,
-        /// The listener's §7 route table (empty on the L4 path, which has
-        /// no path to match). Set once at admission and constant for the
-        /// connection's life, so it survives keep-alive turnarounds.
+        /// The listener's §7 route table, never empty — an l4 listener
+        /// resolves to the one catch-all route it can never consult, since
+        /// it has no path to match. Set once at admission and constant for
+        /// the connection's life, so it survives keep-alive turnarounds.
         routes: []const router.Route,
         /// The listener's §7 filter rules, same lifetime as `routes`
         /// (empty on L4 and when no filters are configured).
@@ -305,8 +306,8 @@ pub fn Conn(comptime IoType: type) type {
             conn.head_len = 0;
             conn.response_pending = &.{};
             conn.cluster_index = cluster_index;
-            // L4 never routes or filters; admitHttp installs the real
-            // tables.
+            // Placeholders until the admission tail installs the
+            // listener's real tables (§7); L4 never reads them.
             conn.routes = &.{};
             conn.filters = &.{};
             conn.upstream = null;


### PR DESCRIPTION
First slice of the [prefactoring plan](docs/PLANS.md) (#70): **A5**.

## Why

Admission forked on the listener's protocol into `admitL4`/`admitHttp`, and
each branch encoded four separate things — which pool resource the protocol
must hold to be admitted, the connection's entry state, its first deadline,
and its first op. That is fine while the fork happens exactly once, at
accept. It stops being fine the moment a phase runs *ahead* of the protocol:
`phase-3a-ztls` had to insert TLS termination before the fork and then
repeat the entire fork after the handshake, carrying a `conn.tls_protocol`
field for no reason but to remember which way to go.

## What

The fork is now in one place and callable from either side of it:

- **`admit`** — the slot, plus whatever the protocol must hold to be
  admitted at all. An L4 connection relays for its whole life, so a missing
  relay buffer is an admission-time shed counted before `admitted` (§8);
  an idle L7 connection holds a slot and head buffer only (§5).
- **`finishAdmission`** — the shared tail: counters, slot prepare,
  `TCP_NODELAY`, the listener's tables, deadline store + timer arm.
- **`startProtocol(conn, protocol)`** — entry state, first deadline, first
  op, with `entryState`/`entryTimeoutMs` holding the protocol-to-value
  mappings that were previously spelled out per call site.

`startProtocol` takes the protocol as an **argument, not a field**,
deliberately: the second caller does not exist on `main`, and a field with
one writer and one reader would be state kept for a caller that is not here
(§1). The phase that eventually needs to recall a connection's protocol is
the one that should decide how — and it will have one fork to feed rather
than two to keep in sync.

## Two deliberate side effects

- **The repeated state/deadline store in `startProtocol`.** `admit` reaches
  it through one synchronous chain, so neither the per-tick clock nor the
  pressure flags `entryTimeoutMs` reads can move between the two writes —
  the values are identical, and keeping them there is what makes both
  callers a single call. What that leaves to the future hand-over caller is
  now written into PLANS beside the slice (second commit).
- **Every connection now gets its listener's route and filter tables**,
  where only the L7 path did. An l4 listener resolves to exactly one
  catch-all route and rejects a `filters` key at load, so this is one rule
  instead of a third fork — and `assert(routes.len >= 1)` now covers both
  protocols. `Conn.routes`'s "empty on the L4 path" comment was true before
  this change and is corrected.

The two asserts dropped from the old tail are not lost: `Conn.prepare` still
asserts the entry state and `storeDeadline` the timeout, and both values now
come from exhaustive switches over a closed enum.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass. Reviewed twice
before pushing:

- **`tiger-style-reviewer`** on the diff — one violation (a stale
  `Conn.routes` doc comment), fixed, gates re-run.
- **An independent review** — no severe findings; it verified the
  behavior-preservation claims against `git show main:src/Server.zig` rather
  than the gates: `admitted` counted exactly once and never for a shed
  connection, op submission order unchanged (`armDeadline` still precedes
  the first data op), and the double-store reasoning traced to
  `XevIo.nowNs`'s per-tick cache and `SimIo`'s static clock. It also
  confirmed `server_test.zig:493-513` still covers the relay-buffer shed
  rung this diff touches.

Both reviews independently flagged that the admission-side double-store is
structural rather than asserted, and that no single assertion can cover both
callers — hence the PLANS note rather than a guard that would be trivially
true today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)