### PR TITLE
refactor: pair conn-slot release with its pressure update (§5, §8 — PLANS A4)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -135,7 +135,7 @@ Sizes are estimates, in diff lines, for sequencing only.
 | A1 | Zero-slot `Pool`: relax `count >= 1`, sentinel `free_head`, one test | 20 | a pool the config never asked for reserves nothing and is permanently exhausted, so its acquire site needs no special case |
 | A2 | `fillRandom` on the Io seam (`getrandom` in XevIo, scenario PRNG in SimIo), with the balancer's p2c seed routed through it | 60 | TLS needs key material through the seam; the side win is seed-replayable p2c in the simulator (§9) |
 | A3 | Lint boundaries as a data table `{import, allowed_prefix, message}` | 50 | the branch's 5th positional bool touched every test call; a new dependency boundary should be one row |
-| A4 | `abortAdmission(server, conn, socket, rung)` | 30 | collapses the release + pressure + counter + close quartet that `admitL4`/`admitHttp` already repeat and `admitTls` repeated twice more |
+| A4 | `abortAdmission(server, conn, socket, rung)` — *landed*, with `releaseConn` as the pool pairing it was missing | 30 | collapses the release + pressure + counter + close quartet that `admitL4`/`admitHttp` already repeat and `admitTls` repeated twice more |
 | A5 | Split `prepare` from `startProtocol(server, conn)` — *landed* | 40 | one protocol fork, callable from accept *or* from a later phase — deletes the branch's duplicated switch and the `tls_protocol` field outright |
 
 **What A5 leaves to the phase that hands a connection over.**

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -385,10 +385,7 @@ pub fn Server(comptime IoType: type) type {
             const conn = server.admitConn(client_socket) orelse return;
             const buffer: ?*relay.RelayBuffer = switch (state.protocol) {
                 .l4 => server.acquireRelayBuffer() orelse {
-                    server.conns.release(conn);
-                    server.updateConnPressure();
-                    server.counters.increment("shed_relay_buffers");
-                    shed.closeQuietly(IoType, server.io, client_socket);
+                    server.abortAdmission(conn, client_socket, "shed_relay_buffers");
                     return;
                 },
                 .http => null,
@@ -481,6 +478,39 @@ pub fn Server(comptime IoType: type) type {
             return conn;
         }
 
+        /// Undo an admission that cannot proceed: a connection already
+        /// holding a conn slot whose protocol could not get the rest of what
+        /// it needs (§8). Every rung past the slot itself ends the same three
+        /// ways — return the slot with its pressure re-derived (§5), witness
+        /// the rung, close the socket — and none of them ever counted
+        /// `admitted`, which is what keeps the reconcile identity exact (§9).
+        ///
+        /// One call rather than three lines because of the pressure update:
+        /// only its engage crossing carries a counter (§8), so a release that
+        /// omits it leaves the flag engaged over a pool that just shrank with
+        /// nothing witnessing that — every idle timeout quietly divides
+        /// instead of anything failing.
+        ///
+        /// The close is a plain FIN, not the conn-slot rung's RST — §8's
+        /// table names the RST for the slot rung alone, and `shed.zig` owns
+        /// the split; every rung past the slot closes quietly.
+        fn abortAdmission(
+            server: *Self,
+            conn: *ConnType,
+            client_socket: IoType.Socket,
+            comptime rung: []const u8,
+        ) void {
+            // Naming, and only naming: what this witnesses is always a shed.
+            // `reconcile` sums an explicit list (§9), so a new rung has to be
+            // added there too — the simulator's reconcile invariant is what
+            // actually catches a miss, not this assert.
+            comptime assert(std.mem.startsWith(u8, rung, "shed_"));
+            assert(!server.draining);
+            server.releaseConn(conn);
+            server.counters.increment(rung);
+            shed.closeQuietly(IoType, server.io, client_socket);
+        }
+
         /// The shared admission tail (§8 single choke point): counting, slot
         /// prepare, socket options, the routing tables, and the one deadline
         /// timer this connection ever arms are identical across protocols —
@@ -533,6 +563,15 @@ pub fn Server(comptime IoType: type) type {
         pub fn releaseRelayBuffer(server: *Self, buffer: *relay.RelayBuffer) void {
             server.relay_buffers.release(buffer);
             server.updateRelayPressure();
+        }
+
+        /// The same pair for conn slots, with `admitConn` as its acquire
+        /// side: pressure follows occupancy in both directions (§5, §8), so
+        /// every slot return goes through here and the flag can never
+        /// outlive the occupancy that raised it.
+        fn releaseConn(server: *Self, conn: *ConnType) void {
+            server.conns.release(conn);
+            server.updateConnPressure();
         }
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
@@ -657,8 +696,7 @@ pub fn Server(comptime IoType: type) type {
             // An idle L7 connection holds no relay buffer (§5); only
             // release one that was actually acquired.
             if (conn.relay_buffer) |buffer| {
-                server.relay_buffers.release(buffer);
-                server.updateRelayPressure();
+                server.releaseRelayBuffer(buffer);
                 conn.relay_buffer = null;
             }
             // The leased upstream slot rides the same release rule: its
@@ -669,8 +707,7 @@ pub fn Server(comptime IoType: type) type {
                 server.releaseUpstream(leased);
                 conn.upstream = null;
             }
-            server.conns.release(conn);
-            server.updateConnPressure();
+            server.releaseConn(conn);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
         }


### PR DESCRIPTION
Second slice of the [prefactoring plan](docs/PLANS.md) (#70): **A4**, after
A5 in #71.

## Why — a different problem than the plan described

The plan said "extract the admission-rollback quartet." Reading the code, the
underlying issue is narrower and more mechanical: **relay buffers have both
halves of their pool pairing, conn slots had only the acquire half.**

`acquireRelayBuffer`/`releaseRelayBuffer` each keep the pressure flag derived
from occupancy. Conn slots had `admitConn` (acquire + pressure) and no
counterpart, so `conns.release` + `updateConnPressure` was spelled out at
both of its call sites — and `maybeRelease` had drifted into inlining the
*relay-buffer* release too, despite that helper existing. Same rot, already
spreading.

## What

- **`releaseConn`** — closes the conn-slot pair, mirroring
  `releaseRelayBuffer`.
- **`abortAdmission(conn, socket, rung)`** — names what an admission rollback
  is: return the slot with its pressure re-derived (§5), witness the rung
  (§8), close the socket.
- Three call sites route through the two helpers, and `conns.release` /
  `relay_buffers.release` now appear exactly once each in the file.

The pressure update is why this earns a name rather than three lines: only
its *engage* crossing carries a counter, so a release that forgets it leaves
the flag engaged over a pool that just shrank with nothing witnessing the
mistake — every idle timeout quietly divides instead of anything failing.
`phase-3a-ztls` added two more rollback sites of exactly this shape, which is
how the plan noticed the pattern at all.

## One thing to know when reviewing

`abortAdmission` comptime-asserts its rung is named `shed_*`. That pins
**naming and nothing more**: `counters.reconcile` sums an explicit list, so a
new rung still has to be added there, and the simulator's reconcile invariant
is the real backstop. The comment says exactly that rather than implying the
assert is sufficient — an earlier draft overclaimed and was corrected.

## Behavior preservation

Both release orders unchanged (relay buffer before conn slot in teardown;
release and pressure before the counter in the rollback), one pressure update
per release, no counter counted twice. Verified against `HEAD` site by site.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` on the diff: no violations, behavior preservation
confirmed per site — and it caught three comments of mine overstating their
claims (the reconcile guarantee above, a "no witness" phrasing that ignored
the engage counter, and treating §8's table as literally specifying FIN for
the relay-buffer rung when it names the RST for the slot rung alone and
`shed.zig` owns the split). All three corrected before pushing, gates re-run.

A4's row in PLANS is marked landed, renamed to name the pool pairing the
slice turned out to be about.

Next on the critical path: **B2**, splitting the framed cursor from the wire
cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)