### PR TITLE
refactor: name the forwarding debt on a direction (§6, §7 — PLANS B2)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -158,8 +158,8 @@ reviews of A5 landed on it, and neither could guard it from here.
 | # | slice | ~ | what it buys |
 |---|---|---|---|
 | B2 | Split the cursor: an explicit wire cursor distinct from the framed one, `assert(wire == framed)` while every policy is identity — *landed as vocabulary, not as a field; see below* | 60 | turns the silent-corruption hazard into a failed assertion. A pure refactor today |
-| B1 | Pump transform seam — `recvBuffer`, `transformIn`, `transformOut`, `sendSlice`, `creditSend`, identity by default — and the loop condition becomes *"anything left to write?"* rather than *"cursor reached length"* | 120 | TLS L4 becomes a policy; `tls_relay.zig` never gets written |
-| B5 | A toy transform in the simulator: deterministic and non-identity (XOR mask, or 4-byte length re-framing) on an L4 sim listener, verified byte-exact by the token oracle under the adversary | 150 | proves the seam *without crypto*, so TLS adds only crypto, not new mechanism risk. The de-risking slice for all of Tier B |
+| B1 | Pump transform seam — `recvBuffer`, `transformIn`, `transformOut`, `sendSlice`, `creditSend`, identity by default — and the loop condition becomes *"anything left to write?"* rather than *"cursor reached length"*. **Not done without B5** | 120 | TLS L4 becomes a policy; `tls_relay.zig` never gets written |
+| B5 | A toy transform in the simulator: deterministic and non-identity (XOR mask, or 4-byte length re-framing) on an L4 sim listener, verified byte-exact by the token oracle under the adversary. **Lands with B1, not after it** | 150 | proves the seam *without crypto*, so TLS adds only crypto, not new mechanism risk. The de-risking slice for all of Tier B |
 | B3 | One client-write channel over B2's cursor: `armClientWrite(conn, plaintext)` for all three client-directed sends | 150 | TLS changes one place, kTLS none; also settles what §8's "static responses straight from static memory" means once the bytes must be encrypted |
 | B4 | Head-fill source seam: read through a source (socket today), one "head complete? → parse / 431 / 413 / read again" decision | 100 | removes the parallel TLS completion path and the duplicated limit decision |
 
@@ -179,7 +179,10 @@ check the open-coded version never had.
 well as the transform's**, which is the risk this row was sequenced first
 to retire. What is retired is its *spread* — that shape now lands inside
 four methods rather than across the seven sites that used to open-code
-them.
+them. The rest of that cost is answered by fusing B5 into B1 (below): a
+toy transform cannot run *before* the seam it is a policy on, but it can
+land in the same slice, which is what keeps the mechanism from ever
+existing unverified.
 
 ### Tier C — budget and accounting hygiene
 
@@ -196,13 +199,19 @@ them.
 | D1 | Tier-1 gate on achieved rate against offered | 40 | the §9 gates check socket and status errors only, so a run delivering 704 of 2000 req/s passed them |
 | D2 | A large-body band in the harness | 80 | the record layer's per-byte cost is unmeasured, and the kTLS decision (Phase 3b) depends on that number |
 
-**Order.** Critical path to a small TLS slice: **A5 → A4 → B2 → B1 → B5
-→ B3 → B4**, with A1–A3 and Tier C as fill-in. B2 comes before B1
-because the cursor split is provable while every policy is still
-identity — introducing the seam first means building it over the
-ambiguity. B5 follows B1 immediately, so "the seam works" is a tested
-claim rather than an assertion about unexercised code; extend it to a
-toy-transformed `http` sim listener when B3 and B4 land.
+**Order.** Critical path to a small TLS slice: **A5 → A4 → B2 →
+(B1 + B5) → B3 → B4**, with A1–A3 and Tier C as fill-in.
+
+B1 and B5 are **one slice, not two**. The seam is what introduces a second,
+wire-side cursor, and under identity there is nothing to check it against —
+that is exactly what B2 could not stage (above). A toy transform cannot run
+before the seam, since it *is* a policy on it, but landing it in the same
+slice means the mechanism is never in the tree unverified: the identity
+transforms prove the existing L4 and L7 body tests still pass unchanged (the
+regression net), and the toy transform proves the wire cursor is actually
+independent of the framed one — byte-exact under the adversary, with no
+crypto involved. Only then do TLS transforms hook on. Extend the toy
+transform to a `http` sim listener when B3 and B4 land.
 
 **`tls_relay.zig` is not to be re-created.** Its own header records the
 parallel loop as provisional — "worth doing once TLS is proven, and

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -157,11 +157,29 @@ reviews of A5 landed on it, and neither could guard it from here.
 
 | # | slice | ~ | what it buys |
 |---|---|---|---|
-| B2 | Split the cursor: an explicit wire cursor distinct from the framed one, `assert(wire == framed)` while every policy is identity | 60 | turns the silent-corruption hazard into a failed assertion. A pure refactor today |
+| B2 | Split the cursor: an explicit wire cursor distinct from the framed one, `assert(wire == framed)` while every policy is identity — *landed as vocabulary, not as a field; see below* | 60 | turns the silent-corruption hazard into a failed assertion. A pure refactor today |
 | B1 | Pump transform seam — `recvBuffer`, `transformIn`, `transformOut`, `sendSlice`, `creditSend`, identity by default — and the loop condition becomes *"anything left to write?"* rather than *"cursor reached length"* | 120 | TLS L4 becomes a policy; `tls_relay.zig` never gets written |
 | B5 | A toy transform in the simulator: deterministic and non-identity (XOR mask, or 4-byte length re-framing) on an L4 sim listener, verified byte-exact by the token oracle under the adversary | 150 | proves the seam *without crypto*, so TLS adds only crypto, not new mechanism risk. The de-risking slice for all of Tier B |
 | B3 | One client-write channel over B2's cursor: `armClientWrite(conn, plaintext)` for all three client-directed sends | 150 | TLS changes one place, kTLS none; also settles what §8's "static responses straight from static memory" means once the bytes must be encrypted |
 | B4 | Head-fill source seam: read through a source (socket today), one "head complete? → parse / 431 / 413 / read again" decision | 100 | removes the parallel TLS completion path and the duplicated limit decision |
+
+**What B2 landed, and what it left to B1.** The row above asked for a wire
+cursor *field* asserted equal to the framed one. Written out, that field
+would be a byte-for-byte shadow of the credit cursor: under identity there
+is no second buffer for it to count against, so the equality would be
+tautological on every path rather than an independently derived check —
+a mechanism no code exercises and no gate proves, which is the same
+objection §1 makes to the retired worker seam. So B2 landed the
+*distinction* instead: `DirectionState` speaks `owe`/`credit`/`owed`/
+`pending`, the raw cursors are private to it (no call site outside
+`Conn.zig` touches them), `owe` asserts the previous debt was settled, and
+`pending` asserts the framed window fits the buffer it slices — a live
+check the open-coded version never had.
+**The honest cost: B1 now carries the wire cursor's mechanical shape as
+well as the transform's**, which is the risk this row was sequenced first
+to retire. What is retired is its *spread* — that shape now lands inside
+four methods rather than across the seven sites that used to open-code
+them.
 
 ### Tier C — budget and accounting hygiene
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -525,10 +525,9 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.l7.client_pipelined = true;
             }
             const direction = &conn.directions[0];
-            direction.transfer_len = feed.consumed;
-            direction.sent_len = 0;
+            direction.owe(feed.consumed);
             conn.l7.request_leg = .sending_body_excess;
-            if (feed.consumed >= 1) {
+            if (direction.owed() >= 1) {
                 armRequestExcessSend(server, conn);
             } else {
                 requestHeadVacated(server, conn);
@@ -539,13 +538,12 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_body_excess);
             const direction = &conn.directions[0];
-            assert(direction.sent_len < direction.transfer_len);
             const base = conn.l7.request_head_len;
             conn.l7.request_op_on_client = false; // A send on the upstream socket.
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
-                conn.head[base + direction.sent_len .. base + direction.transfer_len],
+                direction.pending(conn.head[base..]),
                 &conn.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -573,9 +571,8 @@ pub fn Proxy(comptime IoType: type) type {
             };
             assert(sent >= 1);
             const direction = &conn.directions[0];
-            direction.sent_len += sent;
-            assert(direction.sent_len <= direction.transfer_len);
-            if (direction.sent_len < direction.transfer_len) {
+            direction.credit(sent);
+            if (direction.owed() >= 1) {
                 armRequestExcessSend(server, conn);
                 return;
             }
@@ -864,7 +861,6 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             const direction = &conn.directions[1];
-            direction.sent_len = 0;
             // The common small response arrives from the origin in one
             // piece; forward it in one piece too. Appending the excess to
             // the rendered head trades a bounded memcpy for a whole ring
@@ -876,9 +872,10 @@ pub fn Proxy(comptime IoType: type) type {
                     excess[0..feed.consumed],
                 );
                 conn.l7.rendered_response_len = @intCast(rendered.len + feed.consumed);
-                direction.transfer_len = 0;
+                // The excess rides the head send: this leg owes nothing.
+                direction.owe(0);
             } else {
-                direction.transfer_len = feed.consumed;
+                direction.owe(feed.consumed);
             }
 
             conn.l7.response_leg = .sending_head;
@@ -930,7 +927,7 @@ pub fn Proxy(comptime IoType: type) type {
             // Head on the wire; forward the coalesced body excess straight
             // from upstream.head, then pump the rest from the socket.
             const direction = &conn.directions[1];
-            if (direction.transfer_len >= 1) {
+            if (direction.owed() >= 1) {
                 conn.l7.response_leg = .sending_body_excess;
                 armResponseExcessSend(server, conn);
             } else {
@@ -942,12 +939,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .sending_body_excess);
             const direction = &conn.directions[1];
-            assert(direction.sent_len < direction.transfer_len);
             const base = conn.l7.response_head_len_marker;
             conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.send(
                 conn.client_socket,
-                conn.upstream.?.head[base + direction.sent_len .. base + direction.transfer_len],
+                direction.pending(conn.upstream.?.head[base..]),
                 &conn.op_data_upstream_to_client.completion,
                 ConnType,
                 conn,
@@ -972,9 +968,8 @@ pub fn Proxy(comptime IoType: type) type {
             };
             assert(sent >= 1);
             const direction = &conn.directions[1];
-            direction.sent_len += sent;
-            assert(direction.sent_len <= direction.transfer_len);
-            if (direction.sent_len < direction.transfer_len) {
+            direction.credit(sent);
+            if (direction.owed() >= 1) {
                 armResponseExcessSend(server, conn);
                 return;
             }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -17,6 +17,75 @@ const upstream_module = @import("upstream.zig");
 
 const assert = std.debug.assert;
 
+/// Strict recv → send → recv per direction (§6): exactly one data op in
+/// flight per direction, phase says which; per-connection memory stays
+/// constant regardless of stream size. Nothing here depends on the Io
+/// backend, so it lives at file scope rather than being re-instantiated
+/// per `Conn(IoType)` — which is also what makes it unit-testable.
+///
+/// The two counts are one debt, kept in the units *framing* works in:
+/// `framed_len` is what framing assigned to this message out of the last
+/// recv, and `credited_len` is how much of that the target has accepted —
+/// a short send resumes from there. Today every send writes those same
+/// bytes, so the debt is settled in the units it was incurred and
+/// `pending` can slice one buffer with both cursors.
+///
+/// A *transforming* direction breaks that symmetry, and §4's TLS
+/// termination is the one coming: the wire would carry ciphertext, which is
+/// neither the same bytes nor the same count, so it has to keep its own
+/// wire cursor and credit this debt only once a whole framed chunk is out.
+/// Naming the debt apart from the wire is what keeps that a change to
+/// `credit` and `pending` rather than a change at every call site — and
+/// until then, that the two are the same bytes is what `pending` asserts.
+pub const DirectionState = struct {
+    phase: Phase = .idle,
+    /// Bytes framing assigned to this message from the last recv.
+    framed_len: u32 = 0,
+    /// How many of those the target has accepted.
+    credited_len: u32 = 0,
+
+    pub const Phase = enum(u8) { idle, receiving, sending, finished };
+
+    /// Framing chose `len` bytes of what the last recv delivered: a fresh
+    /// debt, nothing credited yet. Zero is legal — framing may end a
+    /// message without forwarding a byte.
+    ///
+    /// The previous debt must be settled first. That is the strict
+    /// recv → send → recv discipline (§6) stated as a precondition rather
+    /// than left to the call sites: overwriting an unsettled debt is
+    /// precisely how a direction would forget bytes it still owed the
+    /// target, and losing them silently is the failure mode this vocabulary
+    /// exists to make loud.
+    pub fn owe(state: *DirectionState, len: u32) void {
+        assert(state.owed() == 0);
+        state.framed_len = len;
+        state.credited_len = 0;
+    }
+
+    /// The target accepted `len` more of the debt.
+    pub fn credit(state: *DirectionState, len: u32) void {
+        assert(len >= 1);
+        state.credited_len += len;
+        assert(state.credited_len <= state.framed_len);
+    }
+
+    /// What the target has not accepted yet.
+    pub fn owed(state: *const DirectionState) u32 {
+        assert(state.credited_len <= state.framed_len);
+        return state.framed_len - state.credited_len;
+    }
+
+    /// The window of `buffer` still owed: what a send arms, and what a
+    /// short send resumes from. `buffer` starts where this direction's
+    /// framed bytes start — the relay buffer on a body leg, past the head
+    /// on an excess leg (§7).
+    pub fn pending(state: *const DirectionState, buffer: []const u8) []const u8 {
+        assert(state.owed() >= 1);
+        assert(state.framed_len <= buffer.len);
+        return buffer[state.credited_len..state.framed_len];
+    }
+};
+
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
@@ -250,19 +319,6 @@ pub fn Conn(comptime IoType: type) type {
             upstream_to_client,
         };
 
-        /// Strict recv → send → recv per direction (§6): exactly one data
-        /// op in flight per direction, phase says which; per-connection
-        /// memory stays constant regardless of stream size.
-        pub const DirectionState = struct {
-            phase: Phase = .idle,
-            /// Bytes filled by the last recv.
-            transfer_len: u32 = 0,
-            /// Bytes of the transfer already sent (short sends resume).
-            sent_len: u32 = 0,
-
-            pub const Phase = enum(u8) { idle, receiving, sending, finished };
-        };
-
         /// One bit per embedded op; release requires all clear (§5).
         pub const Armed = packed struct(u8) {
             data_client_to_upstream: bool = false,
@@ -361,4 +417,45 @@ pub fn Conn(comptime IoType: type) type {
             return @popCount(@as(u8, @bitCast(conn.armed)));
         }
     };
+}
+
+test "direction: a framed chunk is owed until credited, then settled" {
+    var state: DirectionState = .{};
+    const buffer = "0123456789";
+
+    state.owe(6);
+    try std.testing.expectEqual(@as(u32, 6), state.owed());
+    try std.testing.expectEqualStrings("012345", state.pending(buffer));
+
+    // A short send: what is left is the tail, resumed from the credit.
+    state.credit(2);
+    try std.testing.expectEqual(@as(u32, 4), state.owed());
+    try std.testing.expectEqualStrings("2345", state.pending(buffer));
+
+    state.credit(4);
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
+}
+
+test "direction: a settled debt is the precondition for the next one" {
+    var state: DirectionState = .{};
+    state.owe(4);
+    state.credit(4);
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
+
+    // Only now may the next chunk be owed, and it starts from zero rather
+    // than from where the last one ended — every framed chunk is its own
+    // debt over the same buffer. `owe` asserts that settlement, so the
+    // recv → send → recv discipline (§6) cannot be skipped quietly.
+    state.owe(3);
+    try std.testing.expectEqual(@as(u32, 3), state.owed());
+    try std.testing.expectEqualStrings("abc", state.pending("abcdef"));
+}
+
+test "direction: framing may end a message owing nothing" {
+    var state: DirectionState = .{};
+    state.owe(0);
+    // Nothing to forward, so nothing arms a send — `pending` asserts a
+    // non-empty debt precisely because a zero one must not reach a send
+    // (the seam's `bytes.len >= 1` contract, §4).
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
 }

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -66,7 +66,7 @@ pub fn Pump(
             return &@field(conn, "op_data_" ++ direction_tag);
         }
 
-        fn directionState(conn: *ConnType) *ConnType.DirectionState {
+        fn directionState(conn: *ConnType) *conn_module.DirectionState {
             return &conn.directions[@intFromEnum(direction)];
         }
 
@@ -124,9 +124,8 @@ pub fn Pump(
             }
             if (@hasDecl(Policy, "afterFeed")) Policy.afterFeed(conn, received, fr);
             const state = directionState(conn);
-            state.transfer_len = fr.consumed;
-            state.sent_len = 0;
-            if (fr.consumed >= 1) {
+            state.owe(fr.consumed);
+            if (state.owed() >= 1) {
                 armSend(server, conn);
             } else {
                 assert(fr.done);
@@ -138,11 +137,10 @@ pub fn Pump(
             assert(conn.relay_buffer != null);
             if (@hasDecl(Policy, "beforeSend")) Policy.beforeSend(conn);
             const state = directionState(conn);
-            assert(state.sent_len < state.transfer_len);
             conn.arm(op(conn), bit);
             server.io.send(
                 target(conn),
-                buffer(conn)[state.sent_len..state.transfer_len],
+                state.pending(buffer(conn)),
                 &op(conn).completion,
                 ConnType,
                 conn,
@@ -163,9 +161,8 @@ pub fn Pump(
             const sent = result catch |err| return Policy.onSendError(server, conn, err);
             assert(sent >= 1);
             const state = directionState(conn);
-            state.sent_len += sent;
-            assert(state.sent_len <= state.transfer_len);
-            if (state.sent_len < state.transfer_len) {
+            state.credit(sent);
+            if (state.owed() >= 1) {
                 armSend(server, conn);
                 return;
             }

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -57,7 +57,7 @@ pub fn Relay(comptime IoType: type) type {
                     };
                 }
 
-                fn state(conn: *ConnType) *ConnType.DirectionState {
+                fn state(conn: *ConnType) *conn_module.DirectionState {
                     return &conn.directions[@intFromEnum(direction)];
                 }
 


### PR DESCRIPTION
Third slice of the [prefactoring plan](docs/PLANS.md) (#70): **B2**, after A5
(#71) and A4 (#72). First of Tier B.

## Why

`DirectionState` held `transfer_len` and `sent_len`, and three production
sites open-coded the same dance over them — set both, `assert(sent <
transfer)`, slice `buffer[sent..transfer]`, add, assert, re-arm if short —
with the cursor indexing a different buffer at each site (the relay buffer in
the pump, `conn.head` past the request head, `upstream.head` past the
response head).

That arithmetic is exactly where a transform breaks. Under TLS the wire
carries ciphertext, which is neither the same bytes nor the same count as the
plaintext framing chose; `phase-3a-ztls` needed a `creditSend` hook for it
and recorded it as the one place a wrong move corrupts the byte stream
silently rather than failing loudly.

## What

`framed_len` is what framing assigned, `credited_len` is what the target
accepted, and the type speaks **`owe` / `credit` / `owed` / `pending`**. All
three sites go through that vocabulary — no code outside `Conn.zig` touches
the cursors at all (grep-verified).

Two assertions the open-coded version could not have:

- **`owe` asserts the previous debt is settled.** The strict recv → send →
  recv discipline (§6) as a precondition rather than a convention:
  overwriting an unsettled debt is exactly how a direction forgets bytes it
  still owed. It holds across all 64 sim seeds and the L7 suite, so it
  documents reality rather than hoping for it — and it makes `owe` honest
  about being a reset, since a reset is only reachable from a settled debt.
- **`pending` asserts the framed window fits the buffer it slices.** The old
  raw slicing had only Zig's implicit bounds check, which ReleaseFast does
  not carry.

`DirectionState` also moves to file scope: it never referenced `IoType`, so
it was re-instantiated per backend for nothing, and at file scope it is
unit-testable without a Server or an Io. Three tests cover the debt
lifecycle, the settled-debt precondition, and framing that ends a message
owing nothing — verified they actually execute by temporarily breaking one
(`202/203 tests passed`) and restoring it.

## The deviation, and what it costs — please weigh this

The B2 row asked for a wire-cursor **field** asserted equal to the framed
one. Written out, that field is a byte-for-byte shadow of the credit cursor:
under identity there is no second buffer for it to count against, so the
equality is tautological on every path rather than an independently derived
check — a mechanism no code exercises and no gate proves, which is §1's
objection to the retired worker seam applied to a smaller case. So this slice
lands the *distinction* (vocabulary, encapsulation, two live assertions)
instead of the field.

**The cost is real and is recorded against the row:** PLANS sequenced B2
first specifically to prove the wire cursor's mechanical shape under a no-op
transform. That property is not obtained — **B1 now carries that shape along
with the transform's**. What is retired is its *spread*: the shape lands
inside four methods rather than across the seven sites that used to
open-code it.

Which raises a sequencing question for after this merges: **B5 (the toy
transform in the simulator) may belong before B1 rather than after**, so the
wire cursor has a deterministic non-identity test to land against instead of
arriving with TLS.

## Behavior preservation

Every site reduces to the same slice arithmetic (`buffer[base + credited ..
base + framed]`); the response-excess path's reordered `owe` is inert because
nothing reads that direction in between; the guards that were `sent <
transfer` are now `owed() >= 1` on the same condition.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` on the diff: **one violation** — `owe` missing its
negative-space precondition, now the assert above — plus two test-style
notes, all fixed and gates re-run. It verified behavior preservation site by
site (including that the reordering is inert and the slices are
byte-identical) and confirmed the file-scope hoist changes nothing about the
slot layout or the §5 memory closed-form.

It also flagged, unrelated to this diff: `renderResponse` in `proxy.zig` now
sits at exactly the 70-line TIGER_STYLE limit — unchanged by this slice, but
it should shrink before it grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)