### PR TITLE
refactor: give the pump a transform seam, identity for every user (§4, §6 — PLANS B1)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -202,16 +202,23 @@ existing unverified.
 **Order.** Critical path to a small TLS slice: **A5 → A4 → B2 →
 (B1 + B5) → B3 → B4**, with A1–A3 and Tier C as fill-in.
 
-B1 and B5 are **one slice, not two**. The seam is what introduces a second,
-wire-side cursor, and under identity there is nothing to check it against —
-that is exactly what B2 could not stage (above). A toy transform cannot run
-before the seam, since it *is* a policy on it, but landing it in the same
-slice means the mechanism is never in the tree unverified: the identity
-transforms prove the existing L4 and L7 body tests still pass unchanged (the
-regression net), and the toy transform proves the wire cursor is actually
-independent of the framed one — byte-exact under the adversary, with no
-crypto involved. Only then do TLS transforms hook on. Extend the toy
-transform to a `http` sim listener when B3 and B4 land.
+B1 and B5 are **one unit of done, delivered as two PRs merged back to
+back** (settled 2026-07-25). The seam is what introduces a second, wire-side
+cursor, and under identity there is nothing to check it against — that is
+exactly what B2 could not stage (above). A toy transform cannot run *before*
+the seam, since it *is* a policy on it, so the order is fixed: seam, then
+proof.
+
+Two diffs rather than one because each is separately reviewable — a seam
+with identity defaults, where the existing L4 and L7 body tests passing
+unchanged is the regression net, then a toy transform proving the wire
+cursor is genuinely independent of the framed one, byte-exact under the
+adversary with no crypto involved. The honest cost of splitting: between the
+two merges the seam sits on `main` with its hooks unexercised and its
+failure branches unreachable. That is bounded by treating B1 as **not done
+until B5 lands** — B5 opens immediately, and no TLS transform hooks on until
+both are in. Extend the toy transform to a `http` sim listener when B3 and
+B4 land.
 
 **`tls_relay.zig` is not to be re-created.** Its own header records the
 parallel loop as provisional — "worth doing once TLS is proven, and

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -6,12 +6,16 @@
 //! how a message ends (framing), what EOF and errors mean, and what "the
 //! body finished" does next.
 //!
-//! The mechanical plumbing is keyed entirely off the direction tag, so it
-//! is 100% shared: for a given `direction` the source/target sockets, the
-//! `relay_buffer` field, the embedded `Op`, the armed bit, and the
-//! `DirectionState` cursor all derive from `@tagName(direction)` — exactly
-//! the naming convention `relay.zig` already exploited. What is left is the
-//! `Policy`: a comptime struct of hooks the caller supplies.
+//! The mechanical plumbing is keyed off the direction tag: for a given
+//! `direction` the source/target sockets, the `relay_buffer` field, the
+//! embedded `Op`, the armed bit, and the `DirectionState` debt all derive
+//! from `@tagName(direction)` — exactly the naming convention `relay.zig`
+//! already exploited. What is left is the `Policy`: a comptime struct of
+//! hooks the caller supplies. Two of those hooks (`recvBuffer`, `sendSlice`)
+//! can override *which buffer* a half of the direction uses, because a
+//! transforming direction does not read and write the same one — see the
+//! transform seam below; a policy that declares neither keeps the derived
+//! relay buffer for both halves.
 //!
 //! Required Policy decls:
 //!   feed(conn, chunk) FeedResult      how many bytes belong to the message
@@ -25,6 +29,35 @@
 //!   onRecvEntry(conn)                     post-await recv invariant re-checks
 //!   afterFeed(conn, received, fr)         e.g. pipelined-tail detection
 //!   onSendEntry(server, conn) bool        divert a settled verdict; true = handled
+//!   recvBuffer(conn) []u8                 where a read lands
+//!   transformIn(conn, chunk) ?[]const u8  read bytes → framed bytes
+//!   transformOut(conn, consumed) bool     framed bytes → wire bytes
+//!   sendSlice(conn) []const u8            what a send writes; empty = drained
+//!   creditSend(conn, sent)                credit whichever cursor tracks the wire
+//!
+//! **The transform seam** (the last five). A plain relay recvs and sends the
+//! same bytes, so one buffer per direction serves both halves and the framed
+//! debt (`DirectionState`) is settled in the units it was incurred. A
+//! *transforming* direction is neither: its halves live in different buffers,
+//! and the bytes on the wire are not the bytes that arrived nor the same
+//! count of them — §4's TLS termination decrypts what it reads and encrypts
+//! what it writes. These five hooks are the only places that difference is
+//! encoded, and a policy declaring none of them gets exactly the plain
+//! behaviour, so the L4 and L7 body paths are unaffected by construction.
+//!
+//! Two contracts beyond the signatures:
+//!
+//! 1. **`creditSend` must settle the framed debt by the time `sendSlice`
+//!    runs empty.** A transform may carry its own wire cursor and ignore the
+//!    framed one while a chunk is going out, but when the wire is drained the
+//!    chunk it framed is delivered, and `onSend` asserts exactly that — which
+//!    is what lets the next chunk's `owe` demand a clean slate (§6).
+//! 2. **`sendSlice` must be stable across `beforeSend`.** The pump calls it
+//!    twice per completion: once to decide whether anything is left to arm,
+//!    and again inside `armSend` to arm it, with `beforeSend` in between. A
+//!    `beforeSend` that stages wire bytes would make those two answers
+//!    disagree — stage in `transformOut`, which runs exactly once per chunk,
+//!    and leave `beforeSend` to the bookkeeping it exists for.
 //!
 //! The `on*Entry` hooks fire at completion time — after `delivered`, before
 //! the I/O result is unwrapped — so a Policy can re-assert the invariants
@@ -74,6 +107,58 @@ pub fn Pump(
             return &@field(conn.relay_buffer.?, direction_tag);
         }
 
+        // -- the transform seam (§4, §6; see the module header) --
+
+        /// Where a read lands. Plain: the direction's relay buffer.
+        /// Transforming: wherever the *untransformed* bytes belong, since
+        /// the relay buffer is then the transform's destination and cannot
+        /// also be the read target.
+        fn recvBuffer(conn: *ConnType) []u8 {
+            if (@hasDecl(Policy, "recvBuffer")) return Policy.recvBuffer(conn);
+            return buffer(conn);
+        }
+
+        /// Turn what was read into the bytes framing should see, so framing
+        /// never learns a transform happened. Null is a failed transform,
+        /// which is this connection's alone — a peer chooses what it sends
+        /// (§8) — so the caller tears it down instead of asserting.
+        fn transformIn(conn: *ConnType, chunk: []u8) ?[]const u8 {
+            if (@hasDecl(Policy, "transformIn")) return Policy.transformIn(conn, chunk);
+            return chunk;
+        }
+
+        /// Stage the framed chunk for the wire, exactly once per chunk:
+        /// before the first send, never on a resume, or a short write would
+        /// re-transform bytes already gone. False fails the connection for
+        /// the same reason `transformIn` may.
+        fn transformOut(conn: *ConnType, consumed: u32) bool {
+            assert(consumed >= 1);
+            if (@hasDecl(Policy, "transformOut")) return Policy.transformOut(conn, consumed);
+            return true;
+        }
+
+        /// What a send writes, and what a short write resumes from. Plain:
+        /// the framed window still owed, empty once the debt is settled —
+        /// which is how `onSend` asks "anything left to write?" without
+        /// knowing whether a transform is in play. Transforming: the staged
+        /// wire bytes, which carry their own cursor.
+        fn sendSlice(conn: *ConnType) []const u8 {
+            if (@hasDecl(Policy, "sendSlice")) return Policy.sendSlice(conn);
+            const state = directionState(conn);
+            if (state.owed() == 0) return &.{};
+            return state.pending(buffer(conn));
+        }
+
+        /// Credit whichever cursor tracks the wire. Plain: the framed debt
+        /// itself, since the wire carries exactly those bytes. Transforming:
+        /// the transform's own cursor — ciphertext does not count against a
+        /// debt framing measured in plaintext — but the framed debt must
+        /// still be settled by the time `sendSlice` empties (module header).
+        fn creditSend(conn: *ConnType, sent: u32) void {
+            if (@hasDecl(Policy, "creditSend")) return Policy.creditSend(conn, sent);
+            directionState(conn).credit(sent);
+        }
+
         fn source(conn: *const ConnType) IoType.Socket {
             return switch (direction) {
                 .client_to_upstream => conn.client_socket,
@@ -97,7 +182,7 @@ pub fn Pump(
             conn.arm(op(conn), bit);
             server.io.recv(
                 source(conn),
-                buffer(conn),
+                recvBuffer(conn),
                 &op(conn).completion,
                 ConnType,
                 conn,
@@ -115,8 +200,11 @@ pub fn Pump(
             if (@hasDecl(Policy, "onRecvEntry")) Policy.onRecvEntry(conn);
             const received = result catch |err| return Policy.onRecvError(server, conn, err);
             assert(received >= 1);
-            assert(received <= buffer(conn).len);
-            const chunk = buffer(conn)[0..received];
+            assert(received <= recvBuffer(conn).len);
+            const chunk = transformIn(conn, recvBuffer(conn)[0..received]) orelse {
+                server.beginTeardown(conn);
+                return;
+            };
             const fr = Policy.feed(conn, chunk);
             if (fr.malformed) {
                 server.beginTeardown(conn);
@@ -126,6 +214,12 @@ pub fn Pump(
             const state = directionState(conn);
             state.owe(fr.consumed);
             if (state.owed() >= 1) {
+                // Stage the wire bytes once, here: a short write resumes
+                // through `sendSlice`, never back through the transform.
+                if (!transformOut(conn, fr.consumed)) {
+                    server.beginTeardown(conn);
+                    return;
+                }
                 armSend(server, conn);
             } else {
                 assert(fr.done);
@@ -136,11 +230,15 @@ pub fn Pump(
         pub fn armSend(server: *ServerType, conn: *ConnType) void {
             assert(conn.relay_buffer != null);
             if (@hasDecl(Policy, "beforeSend")) Policy.beforeSend(conn);
-            const state = directionState(conn);
+            const wire = sendSlice(conn);
+            // Nothing arms an empty send: the seam's contract is
+            // `bytes.len >= 1` (§4), and an empty slice here would mean a
+            // caller asked to write with nothing staged.
+            assert(wire.len >= 1);
             conn.arm(op(conn), bit);
             server.io.send(
                 target(conn),
-                state.pending(buffer(conn)),
+                wire,
                 &op(conn).completion,
                 ConnType,
                 conn,
@@ -160,12 +258,21 @@ pub fn Pump(
             }
             const sent = result catch |err| return Policy.onSendError(server, conn, err);
             assert(sent >= 1);
-            const state = directionState(conn);
-            state.credit(sent);
-            if (state.owed() >= 1) {
+            creditSend(conn, sent);
+            // "Anything left to write?" rather than "is the framed debt
+            // settled?" — the same question for a plain policy, whose
+            // `sendSlice` empties exactly when the debt does, and the only
+            // form that still holds when the wire carries a different number
+            // of bytes than framing counted.
+            if (sendSlice(conn).len > 0) {
                 armSend(server, conn);
                 return;
             }
+            // The wire is drained, so the chunk framing chose is delivered:
+            // the seam's contract (module header) is that a transform has
+            // settled the framed debt by now, which is what lets the next
+            // chunk's `owe` demand a clean slate.
+            assert(directionState(conn).owed() == 0);
             // A full chunk moved: this is activity — push the idle deadline
             // out (§6); the armed timer op is not touched.
             server.storeDeadline(conn, server.idleTimeoutMs());


### PR DESCRIPTION
Fourth slice of the [prefactoring plan](docs/PLANS.md) (#70): **B1**, after
A5 (#71), A4 (#72), B2 (#73). **B5 follows immediately — this is not done
without it** (see the last section).

## Why

The pump assumed a direction reads and writes the *same* buffer. True of a
plain relay; false of a transforming one — under TLS termination the client
side carries ciphertext while framing works in plaintext, so each half of the
direction lives in a different buffer and the wire byte count is not the
framed one. On `phase-3a-ztls` that assumption cost a **357-line parallel
relay** beside this 164-line one, and then a transform seam was added anyway
for the L7 body legs: two mechanisms for one job.

## What

Five optional hooks are now the only places that difference is encoded —
`recvBuffer`, `transformIn`, `transformOut`, `sendSlice`, `creditSend` — and
the send loop asks **"is anything left to write?"** instead of "is the framed
debt settled?". Identical under identity; the only form that survives a wire
carrying a different number of bytes than framing counted.

No policy declares a hook, so the L4 relay and both L7 body legs get exactly
today's behaviour. `zig build ci` passing unchanged — 64 sim seeds plus the
L7 suite — is the regression net that says so.

## Two contracts, one of them asserted

- **`creditSend` must settle the framed debt by the time `sendSlice` runs
  empty.** A transform may keep its own wire cursor while a chunk goes out,
  but a drained wire means the framed chunk is delivered, and `onSend` now
  asserts it. This is not hypothetical: the branch's TLS `creditSend`
  credited only the engine outbox and left the direction cursor untouched,
  which would trip B2's `owe` precondition on the very next chunk. Better to
  fail at the seam than lose bytes quietly.
- **`sendSlice` must be stable across `beforeSend`** — the pump calls it once
  to decide whether to arm and again to arm, with `beforeSend` in between.
  Stage in `transformOut`, which runs exactly once per chunk. (Caught by
  review; documented rather than restructured, since every current
  `beforeSend` only touches phase flags.)

## The split, and what it costs

PLANS said B1 and B5 were one slice. They are one unit of *done*, delivered
as **two PRs merged back to back**, because each diff is separately
reviewable. The cost is written into PLANS rather than glossed: between the
merges the seam sits on `main` with its hooks unexercised and its two failure
branches (`transformIn` null, `transformOut` false) unreachable. Bounded by:
B1 is not done until B5 lands, B5 opens immediately, and no TLS transform
hooks on until both are in.

B5's toy transform is deliberately **length-prefix re-framing rather than an
XOR mask** — an XOR is byte-for-byte, so it would exercise the hooks without
ever testing the thing that matters, a wire count that differs from the framed
one. Re-framing differs by 4 bytes per chunk and is genuinely fallible, so it
also reaches those two failure branches.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` verified identity is bit-for-bit preserved hook by
hook, that the new drained-wire assertion is unreachable on every error,
divert and short-send path, and that the `bytes.len >= 1` citation matches
both Io backends. Its one violation was this split contradicting PLANS —
resolved by recording the decision; its two judgement calls (an unasserted
`consumed`, a one-off discard idiom) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)