### PR TITLE
test: prove the transform seam with a non-identity transform (§4, §6, §9 — PLANS B5)

### DIFF
--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -58,6 +58,10 @@
 //!    `beforeSend` that stages wire bytes would make those two answers
 //!    disagree — stage in `transformOut`, which runs exactly once per chunk,
 //!    and leave `beforeSend` to the bookkeeping it exists for.
+//! 3. **A policy whose `transformIn` can yield nothing must tolerate
+//!    `beforeRecv` twice with no send between**, because that is how the pump
+//!    reads on for the rest of a fragment (see `onRecv`). Identity never can:
+//!    a recv delivers at least one byte and identity forwards all of them.
 //!
 //! The `on*Entry` hooks fire at completion time — after `delivered`, before
 //! the I/O result is unwrapped — so a Policy can re-assert the invariants
@@ -205,6 +209,22 @@ pub fn Pump(
                 server.beginTeardown(conn);
                 return;
             };
+            // A transform may legally yield nothing from a read: what
+            // arrived is a fragment of a unit it can only decode whole — a
+            // TLS record, a length-prefixed frame. Framing must never see an
+            // empty chunk, because `feed` reporting `consumed == 0` means
+            // *end of message*, so the read is re-armed and the transform
+            // keeps the fragment until the rest lands. A policy whose
+            // transform can do this must therefore tolerate `beforeRecv`
+            // twice with no send between (identity never can: a recv
+            // delivers at least one byte and identity forwards all of them).
+            if (chunk.len == 0) {
+                // Nothing was framed, so nothing is owed: a fragment must
+                // never leave a debt deferred across the next read.
+                assert(directionState(conn).owed() == 0);
+                armRecv(server, conn);
+                return;
+            }
             const fr = Policy.feed(conn, chunk);
             if (fr.malformed) {
                 server.beginTeardown(conn);

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -1,0 +1,684 @@
+//! The transform seam under a real, non-identity transform (§4, §6, §9).
+//!
+//! `pump.zig`'s transform hooks are identity for every production policy,
+//! and identity proves nothing about the property they exist for: that the
+//! bytes on the wire can be a different count, in a different buffer, from
+//! the bytes framing measured. This file is the seam's first real user —
+//! deterministic and crypto-free — so those mechanics are exercised before
+//! TLS depends on them (PLANS.md, B1 + B5).
+//!
+//! The toy mirrors TLS's shape: the *client* side of the connection speaks
+//! frames (`[u16 big-endian length][payload]`) while framing and the upstream
+//! side see plain payload bytes.
+//!
+//!   client → upstream: read frames into a scratch, un-frame into the relay
+//!                      buffer, forward the payload
+//!   upstream → client: read payload into the relay buffer, frame it into a
+//!                      scratch, write that frame in capped windows
+//!
+//! Three properties identity cannot pin, and this does:
+//!
+//!   1. the read lands somewhere other than the relay buffer (`recvBuffer`),
+//!      so the buffer framing reads is not the buffer the socket filled;
+//!   2. the wire carries two bytes per frame that the framed count never
+//!      sees, so `sendSlice`/`creditSend` must keep their own cursor and the
+//!      framed debt is settled only when that cursor drains — the contract
+//!      `onSend` asserts;
+//!   3. a transform may yield *nothing* from a read (a frame split across
+//!      deliveries) without that meaning end of message.
+//!
+//! The oracle is byte-exactness in both directions under the adversary's
+//! 1-byte deliveries across a spread of seeds: the payload must reach the
+//! origin whole, and the origin's echo must come back framed and whole. The
+//! scratch lives here rather than on `Conn` — a slot does not grow a field
+//! for a test, and issue #75 is about the one it already has.
+
+const std = @import("std");
+
+const config_module = @import("../config.zig");
+const conn_module = @import("Conn.zig");
+const pump = @import("pump.zig");
+const router = @import("../http/router.zig");
+const server_module = @import("../Server.zig");
+const Io = @import("../io/io.zig");
+const SimIo = @import("../io/SimIo.zig");
+
+const assert = std.debug.assert;
+
+const ServerSim = server_module.Server(SimIo);
+const ConnSim = conn_module.Conn(SimIo);
+const Direction = ConnSim.Direction;
+
+/// `[u16 big-endian length][payload]` — the smallest framing with a real
+/// header, so every frame puts two bytes on the wire that framing never
+/// counts.
+const header_bytes: u32 = 2;
+/// Cap on what one send may write, so a frame always needs several sends and
+/// the transform's cursor has to survive the resumes.
+const wire_window_max: u32 = 7;
+/// Largest payload one frame may carry, and so the bound on both scratch
+/// buffers. Past it is a transform *failure*, not an assertion.
+const payload_max: u32 = 64;
+
+/// Exactly `payload_max` bytes, so the origin's echo — framed in one chunk
+/// whenever a read delivers it whole — drives the outbound scratch to its
+/// exact bound rather than staying comfortably inside it.
+const payload = "toy-transform-payload-0123456789abcdefghijklmnopqrstuvwxyz012345";
+/// The client sends the payload as three frames, so the un-framer meets a
+/// stream of them rather than one message.
+const client_frames = [_]u32{ 10, 10, payload.len - 20 };
+
+comptime {
+    assert(payload.len == payload_max);
+    // A frame must outgrow one send window, or the wire cursor is never
+    // exercised across a resume.
+    assert(header_bytes + payload.len > wire_window_max);
+}
+
+/// The transform's buffers. One connection per scenario, so one instance;
+/// `setUp` resets it and `armPumps` asserts it is clean.
+var scratch: Scratch = .{};
+
+const Scratch = struct {
+    /// Frame bytes read from the client, kept across reads until a frame is
+    /// whole — the fragment case that makes `transformIn` yield nothing.
+    inbound: [payload_max + header_bytes]u8 = undefined,
+    inbound_len: u32 = 0,
+    /// The frame staged for the client, under the wire cursor the framed
+    /// debt is not allowed to share.
+    outbound: [payload_max + header_bytes]u8 = undefined,
+    outbound_len: u32 = 0,
+    outbound_sent: u32 = 0,
+
+    fn isClean(self: *const Scratch) bool {
+        return self.inbound_len == 0 and self.outbound_len == 0 and self.outbound_sent == 0;
+    }
+};
+
+/// Everything both directions share: the L4 shape — no framing of its own,
+/// EOF is a half-close, teardown once both directions finish.
+fn Base(comptime direction: Direction) type {
+    return struct {
+        fn state(conn: *ConnSim) *conn_module.DirectionState {
+            return &conn.directions[@intFromEnum(direction)];
+        }
+
+        fn targetSocket(conn: *const ConnSim) SimIo.Socket {
+            return switch (direction) {
+                .client_to_upstream => conn.upstream_socket.?,
+                .upstream_to_client => conn.client_socket,
+            };
+        }
+
+        /// Unlike the production L4 policy this admits `.receiving` twice in
+        /// a row: a transform that yielded no whole frame re-arms the read
+        /// with no send in between (pump.zig).
+        pub fn beforeRecv(conn: *ConnSim) void {
+            assert(conn.state == .relaying);
+            state(conn).phase = .receiving;
+        }
+
+        pub fn beforeSend(conn: *ConnSim) void {
+            assert(conn.state == .relaying);
+            const direction_state = state(conn);
+            assert(direction_state.phase == .receiving or direction_state.phase == .sending);
+            direction_state.phase = .sending;
+        }
+
+        /// Framing sees payload bytes and relays all of them, exactly as the
+        /// L4 policy does: the transform is invisible here, which is the
+        /// seam's whole point.
+        pub fn feed(conn: *ConnSim, chunk: []const u8) pump.FeedResult {
+            _ = conn;
+            assert(chunk.len >= 1);
+            return .{ .consumed = @intCast(chunk.len), .done = false, .malformed = false };
+        }
+
+        pub fn framingDone(conn: *ConnSim) bool {
+            _ = conn;
+            return false;
+        }
+
+        pub fn onRecvError(server: *ServerSim, conn: *ConnSim, err: Io.RecvError) void {
+            if (err == error.EndOfStream) {
+                state(conn).phase = .finished;
+                server.io.shutdown(targetSocket(conn), .write);
+                if (conn.directions[0].phase == .finished and
+                    conn.directions[1].phase == .finished)
+                {
+                    server.beginTeardown(conn);
+                }
+                return;
+            }
+            server.beginTeardown(conn);
+        }
+
+        pub fn onSendError(server: *ServerSim, conn: *ConnSim, err: Io.SendError) void {
+            server.witnessKernelPressure(err);
+            server.beginTeardown(conn);
+        }
+
+        pub fn onDrained(server: *ServerSim, conn: *ConnSim) void {
+            _ = server;
+            _ = conn;
+            unreachable; // `feed` consumes every byte it is given.
+        }
+
+        pub fn onComplete(server: *ServerSim, conn: *ConnSim) void {
+            _ = server;
+            _ = conn;
+            unreachable; // `framingDone` is always false.
+        }
+    };
+}
+
+/// Client → upstream: the *read* side transforms. Frames land in the
+/// scratch; the relay buffer receives the un-framed payload, so the read
+/// cannot land there.
+const ToUpstreamPolicy = struct {
+    const base = Base(.client_to_upstream);
+
+    pub const beforeRecv = base.beforeRecv;
+    pub const beforeSend = base.beforeSend;
+    pub const feed = base.feed;
+    pub const framingDone = base.framingDone;
+    pub const onRecvError = base.onRecvError;
+    pub const onSendError = base.onSendError;
+    pub const onDrained = base.onDrained;
+    pub const onComplete = base.onComplete;
+
+    /// After whatever fragment the last read left, never the relay buffer.
+    pub fn recvBuffer(conn: *ConnSim) []u8 {
+        _ = conn;
+        // A whole frame always fits, so the scratch cannot fill without a
+        // frame completing and freeing it.
+        assert(scratch.inbound_len < scratch.inbound.len);
+        return scratch.inbound[scratch.inbound_len..];
+    }
+
+    /// Un-frame every whole frame that has arrived, into the relay buffer.
+    /// An empty result means "no whole frame yet"; null means the peer
+    /// framed something illegal, which is this connection's failure and not
+    /// an invariant violation (§8).
+    pub fn transformIn(conn: *ConnSim, chunk: []u8) ?[]const u8 {
+        assert(chunk.len >= 1);
+        scratch.inbound_len += @intCast(chunk.len);
+        assert(scratch.inbound_len <= scratch.inbound.len);
+        const out = &conn.relay_buffer.?.client_to_upstream;
+        var out_len: u32 = 0;
+        // Bounded by the scratch: each turn either consumes a whole frame or
+        // breaks out.
+        while (scratch.inbound_len >= header_bytes) {
+            const need = std.mem.readInt(u16, scratch.inbound[0..2], .big);
+            if (need == 0 or need > payload_max) return null;
+            const frame_len = header_bytes + @as(u32, need);
+            if (scratch.inbound_len < frame_len) break; // a fragment; read on
+            if (out_len + need > out.len) return null;
+            @memcpy(out[out_len..][0..need], scratch.inbound[header_bytes..frame_len]);
+            out_len += need;
+            const rest = scratch.inbound_len - frame_len;
+            std.mem.copyForwards(
+                u8,
+                scratch.inbound[0..rest],
+                scratch.inbound[frame_len..scratch.inbound_len],
+            );
+            scratch.inbound_len = rest;
+        }
+        return out[0..out_len];
+    }
+};
+
+/// Upstream → client: the *write* side transforms. Framing measures payload
+/// bytes in the relay buffer; the wire carries a header on top, under its
+/// own cursor.
+const ToClientPolicy = struct {
+    const base = Base(.upstream_to_client);
+
+    pub const beforeRecv = base.beforeRecv;
+    pub const beforeSend = base.beforeSend;
+    pub const feed = base.feed;
+    pub const framingDone = base.framingDone;
+    pub const onRecvError = base.onRecvError;
+    pub const onSendError = base.onSendError;
+    pub const onDrained = base.onDrained;
+    pub const onComplete = base.onComplete;
+
+    /// Frame the chunk once, before the first send. A payload the frame
+    /// cannot carry fails the connection — the seam's fallible path, and the
+    /// reason `transformOut` returns a bool rather than asserting.
+    pub fn transformOut(conn: *ConnSim, consumed: u32) bool {
+        assert(consumed >= 1);
+        // The previous frame left the wire before this one is staged: this
+        // runs exactly once per framed chunk.
+        assert(scratch.outbound_len == scratch.outbound_sent);
+        if (consumed > payload_max) return false;
+        const body = conn.relay_buffer.?.upstream_to_client[0..consumed];
+        std.mem.writeInt(u16, scratch.outbound[0..2], @intCast(consumed), .big);
+        @memcpy(scratch.outbound[header_bytes..][0..consumed], body);
+        scratch.outbound_len = header_bytes + consumed;
+        scratch.outbound_sent = 0;
+        return true;
+    }
+
+    /// The staged frame under its own cursor, capped so a frame takes several
+    /// sends. Empty once drained, which is how the pump asks "anything left
+    /// to write?".
+    pub fn sendSlice(conn: *ConnSim) []const u8 {
+        _ = conn;
+        const left = scratch.outbound_len - scratch.outbound_sent;
+        if (left == 0) return &.{};
+        return scratch.outbound[scratch.outbound_sent..][0..@min(left, wire_window_max)];
+    }
+
+    /// Credit the wire cursor; settle the framed debt only when the whole
+    /// frame is out, because a partly written frame has delivered no payload
+    /// the caller may account for.
+    pub fn creditSend(conn: *ConnSim, sent: u32) void {
+        assert(sent >= 1);
+        scratch.outbound_sent += sent;
+        assert(scratch.outbound_sent <= scratch.outbound_len);
+        if (scratch.outbound_sent < scratch.outbound_len) return;
+        const direction_state = &conn.directions[@intFromEnum(Direction.upstream_to_client)];
+        direction_state.credit(direction_state.owed());
+    }
+};
+
+const PumpToUpstream = pump.Pump(SimIo, .client_to_upstream, ToUpstreamPolicy);
+const PumpToClient = pump.Pump(SimIo, .upstream_to_client, ToClientPolicy);
+
+/// The client peer: writes pre-framed bytes, expects framed bytes back, then
+/// FINs and waits for the proxied FIN.
+const Client = struct {
+    harness: *Harness = undefined,
+    socket: SimIo.Socket = undefined,
+    connect_completion: SimIo.Completion = .{},
+    send_completion: SimIo.Completion = .{},
+    recv_completion: SimIo.Completion = .{},
+    wire: [payload.len + client_frames.len * header_bytes]u8 = undefined,
+    wire_len: u32 = 0,
+    sent_len: u32 = 0,
+    /// Sized for the worst framing the adversary can provoke: one frame per
+    /// delivered byte, so a header per payload byte.
+    received: [payload.len * (1 + header_bytes)]u8 = undefined,
+    received_len: u32 = 0,
+    unframed: [payload.len]u8 = undefined,
+    unframed_len: u32 = 0,
+    /// Overrides the framed payload with raw bytes, for the illegal-frame
+    /// case; empty means send `wire`.
+    raw: []const u8 = &.{},
+    fin_sent: bool = false,
+    eof: bool = false,
+    reset: bool = false,
+
+    fn frameUp(client: *Client) void {
+        var offset: u32 = 0;
+        var written: u32 = 0;
+        for (client_frames) |chunk| {
+            std.mem.writeInt(u16, client.wire[written..][0..2], @intCast(chunk), .big);
+            @memcpy(client.wire[written + header_bytes ..][0..chunk], payload[offset..][0..chunk]);
+            written += header_bytes + chunk;
+            offset += chunk;
+        }
+        assert(offset == payload.len);
+        client.wire_len = written;
+    }
+
+    fn outgoing(client: *const Client) []const u8 {
+        if (client.raw.len > 0) return client.raw;
+        return client.wire[0..client.wire_len];
+    }
+
+    fn armSend(client: *Client) void {
+        const bytes = client.outgoing();
+        assert(client.sent_len < bytes.len);
+        client.harness.io.send(
+            client.socket,
+            bytes[client.sent_len..],
+            &client.send_completion,
+            Client,
+            client,
+            onSend,
+        );
+    }
+
+    fn armRecv(client: *Client) void {
+        client.harness.io.recv(
+            client.socket,
+            client.received[client.received_len..],
+            &client.recv_completion,
+            Client,
+            client,
+            onRecv,
+        );
+    }
+
+    fn onSend(client: *Client, result: Io.SendError!u32) void {
+        const sent = result catch {
+            client.reset = true;
+            return;
+        };
+        client.sent_len += sent;
+        assert(client.sent_len <= client.outgoing().len);
+        if (client.sent_len < client.outgoing().len) client.armSend();
+    }
+
+    fn onRecv(client: *Client, result: Io.RecvError!u32) void {
+        const received = result catch |err| {
+            if (err == error.EndOfStream) client.eof = true else client.reset = true;
+            return;
+        };
+        client.received_len += received;
+        client.unframe();
+        if (client.unframed_len >= payload.len and !client.fin_sent) {
+            // The whole payload came back framed: FIN, then wait for the
+            // proxied FIN so teardown is observed rather than assumed.
+            client.fin_sent = true;
+            client.harness.io.shutdown(client.socket, .write);
+        }
+        if (client.received_len < client.received.len) client.armRecv();
+    }
+
+    /// Strip whatever whole frames have arrived; the leftover stays in place
+    /// because `received_len` only grows.
+    fn unframe(client: *Client) void {
+        var offset: u32 = 0;
+        client.unframed_len = 0;
+        while (offset + header_bytes <= client.received_len) {
+            const need = std.mem.readInt(u16, client.received[offset..][0..2], .big);
+            const end = offset + header_bytes + need;
+            if (end > client.received_len) break;
+            @memcpy(client.unframed[client.unframed_len..][0..need], client.received[offset + header_bytes .. end]);
+            client.unframed_len += need;
+            offset = end;
+        }
+    }
+};
+
+/// The origin peer: a plain echo, or a canned answer for the oversize case.
+const Origin = struct {
+    harness: *Harness = undefined,
+    socket: SimIo.Socket = undefined,
+    accept_completion: SimIo.Completion = .{},
+    send_completion: SimIo.Completion = .{},
+    recv_completion: SimIo.Completion = .{},
+    buffer: [payload_max * 8]u8 = undefined,
+    received_len: u32 = 0,
+    echoed_len: u32 = 0,
+    /// Sent unprompted on accept instead of echoing; empty means echo.
+    canned: []const u8 = &.{},
+    canned_sent: u32 = 0,
+    eof: bool = false,
+
+    fn armRecv(origin: *Origin) void {
+        origin.harness.io.recv(
+            origin.socket,
+            origin.buffer[origin.received_len..],
+            &origin.recv_completion,
+            Origin,
+            origin,
+            onRecv,
+        );
+    }
+
+    fn armEcho(origin: *Origin) void {
+        assert(origin.echoed_len < origin.received_len);
+        origin.harness.io.send(
+            origin.socket,
+            origin.buffer[origin.echoed_len..origin.received_len],
+            &origin.send_completion,
+            Origin,
+            origin,
+            onSent,
+        );
+    }
+
+    fn armCanned(origin: *Origin) void {
+        assert(origin.canned_sent < origin.canned.len);
+        origin.harness.io.send(
+            origin.socket,
+            origin.canned[origin.canned_sent..],
+            &origin.send_completion,
+            Origin,
+            origin,
+            onCannedSent,
+        );
+    }
+
+    fn onRecv(origin: *Origin, result: Io.RecvError!u32) void {
+        const received = result catch |err| {
+            if (err == error.EndOfStream) {
+                origin.eof = true;
+                origin.harness.io.shutdown(origin.socket, .write);
+            }
+            return;
+        };
+        origin.received_len += received;
+        if (origin.canned.len > 0) {
+            origin.armRecv();
+            return;
+        }
+        origin.armEcho();
+    }
+
+    fn onSent(origin: *Origin, result: Io.SendError!u32) void {
+        const sent = result catch return;
+        origin.echoed_len += sent;
+        if (origin.echoed_len < origin.received_len) {
+            origin.armEcho();
+            return;
+        }
+        origin.armRecv();
+    }
+
+    fn onCannedSent(origin: *Origin, result: Io.SendError!u32) void {
+        const sent = result catch return;
+        origin.canned_sent += sent;
+        if (origin.canned_sent < origin.canned.len) origin.armCanned();
+    }
+};
+
+const Harness = struct {
+    arena_state: std.heap.ArenaAllocator = undefined,
+    io: SimIo = undefined,
+    server: ServerSim = undefined,
+    routes: [1]router.Route = undefined,
+    listeners: [1]config_module.Config.Listener = undefined,
+    clusters: [1]config_module.Config.Cluster = undefined,
+    endpoints: [1]std.Io.net.IpAddress = undefined,
+    config: config_module.Config = undefined,
+
+    client_listener: SimIo.Listener = undefined,
+    origin_listener: SimIo.Listener = undefined,
+    accept_completion: SimIo.Completion = .{},
+    connect_completion: SimIo.Completion = .{},
+    /// The proxy's two ends: accepted from the client, dialed to the origin.
+    proxy_client_socket: SimIo.Socket = undefined,
+    proxy_upstream_socket: SimIo.Socket = undefined,
+
+    conn: ?*ConnSim = null,
+    client: Client = .{},
+    origin: Origin = .{},
+
+    const Options = struct {
+        sim: SimIo.Options,
+        /// Raw client bytes instead of the framed payload.
+        client_raw: []const u8 = &.{},
+        /// Origin answers with this, unprompted, instead of echoing.
+        origin_canned: []const u8 = &.{},
+    };
+
+    fn clientAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:19300") catch unreachable;
+    }
+
+    fn originAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:19301") catch unreachable;
+    }
+
+    fn setUp(bed: *Harness, gpa: std.mem.Allocator, options: Options) !void {
+        scratch = .{};
+        bed.* = .{};
+        bed.arena_state = std.heap.ArenaAllocator.init(gpa);
+        errdefer bed.arena_state.deinit();
+        const arena = bed.arena_state.allocator();
+
+        try bed.io.init(arena, options.sim);
+        bed.endpoints = .{originAddress()};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
+        bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        bed.listeners = .{.{
+            .bind_address = clientAddress(),
+            .routes = &bed.routes,
+            .protocol = .l4,
+        }};
+        bed.config = .{
+            .listeners = &bed.listeners,
+            .clusters = &bed.clusters,
+            .connect_timeout_ms = 1000,
+            .idle_timeout_ms = 5000,
+            .drain_deadline_ms = 1000,
+            .max_lifetime_ms = 0,
+        };
+        // The Server owns the pools, the clock and teardown. Its own
+        // listeners stay unbound: this scenario drives the pump directly, so
+        // the sockets are the harness's own rather than admission's.
+        try bed.server.init(arena, &bed.io, &bed.config, .{ .conn_slots = 2, .relay_buffers = 1 });
+
+        bed.client.harness = bed;
+        bed.client.raw = options.client_raw;
+        bed.client.frameUp();
+        bed.origin.harness = bed;
+        bed.origin.canned = options.origin_canned;
+
+        bed.client_listener = try bed.io.listen(clientAddress());
+        bed.origin_listener = try bed.io.listen(originAddress());
+        bed.io.accept(bed.client_listener, &bed.accept_completion, Harness, bed, onProxyAccepted);
+        bed.io.accept(bed.origin_listener, &bed.origin.accept_completion, Origin, &bed.origin, onOriginAccepted);
+        bed.io.connect(clientAddress(), &bed.client.connect_completion, Client, &bed.client, onClientConnected);
+    }
+
+    fn tearDown(bed: *Harness) void {
+        bed.io.listenClose(bed.client_listener);
+        bed.io.listenClose(bed.origin_listener);
+        bed.arena_state.deinit();
+    }
+
+    fn onProxyAccepted(bed: *Harness, result: Io.AcceptError!SimIo.Socket) void {
+        bed.proxy_client_socket = result catch unreachable;
+        bed.io.connect(originAddress(), &bed.connect_completion, Harness, bed, onProxyDialed);
+    }
+
+    fn onProxyDialed(bed: *Harness, result: Io.ConnectError!SimIo.Socket) void {
+        bed.proxy_upstream_socket = result catch unreachable;
+        bed.armPumps();
+    }
+
+    fn onClientConnected(client: *Client, result: Io.ConnectError!SimIo.Socket) void {
+        client.socket = result catch unreachable;
+        client.armRecv();
+        client.armSend();
+    }
+
+    fn onOriginAccepted(origin: *Origin, result: Io.AcceptError!SimIo.Socket) void {
+        origin.socket = result catch unreachable;
+        if (origin.canned.len > 0) {
+            origin.armCanned();
+            origin.armRecv();
+            return;
+        }
+        origin.armRecv();
+    }
+
+    /// A conn from the real pool, prepared as admission would minus what this
+    /// scenario does not exercise (no accept gate, no dial, no deadline
+    /// timer — so teardown's deadline-cancel interleaving is not covered
+    /// here). Both `accepted` and `admitted` are counted by hand, since the
+    /// reconcile identity (§9) reads them together.
+    fn armPumps(bed: *Harness) void {
+        assert(bed.conn == null);
+        assert(scratch.isClean());
+        const conn = bed.server.conns.acquire().?;
+        const buffer = bed.server.relay_buffers.acquire().?;
+        // The accept gate and the admission tail are not exercised here, so
+        // their counters are set by hand: `reconcile` (§9) checks
+        // completed <= admitted <= accepted, and this connection did pass
+        // through both in spirit.
+        bed.server.counters.increment("accepted");
+        bed.server.counters.increment("admitted");
+        conn.prepare(&bed.server, bed.proxy_client_socket, buffer, .connecting, 0);
+        conn.upstream_socket = bed.proxy_upstream_socket;
+        conn.state = .relaying;
+        bed.conn = conn;
+        bed.server.storeDeadline(conn, 5_000);
+        PumpToUpstream.armRecv(&bed.server, conn);
+        PumpToClient.armRecv(&bed.server, conn);
+    }
+
+    /// Every scenario ends the same way: the connection is gone, both pools
+    /// are back, and the books balance.
+    fn expectSettled(bed: *Harness) !void {
+        try std.testing.expect(bed.server.conns.isFullyReleased());
+        try std.testing.expect(bed.server.relay_buffers.isFullyReleased());
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+        try std.testing.expect(bed.server.reconcile());
+    }
+};
+
+test "transform: framed client bytes relay byte-exact in both directions" {
+    for (1..16) |seed| {
+        var bed: Harness = undefined;
+        try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = seed } });
+        defer bed.tearDown();
+
+        try bed.io.run();
+
+        // The origin saw payload bytes only: the framing never reached it.
+        try std.testing.expectEqualStrings(payload, bed.origin.buffer[0..bed.origin.received_len]);
+        // The client got them back framed, and un-framing returns the
+        // payload byte-for-byte.
+        try std.testing.expectEqualStrings(payload, bed.client.unframed[0..bed.client.unframed_len]);
+        // The wire carried more bytes than framing ever counted — the
+        // property an identity transform cannot exhibit.
+        try std.testing.expect(bed.client.received_len > bed.client.unframed_len);
+        try std.testing.expect(bed.client.eof);
+        try bed.expectSettled();
+    }
+}
+
+test "transform: a frame the peer framed illegally sheds the connection" {
+    // A length past what the transform can carry: `transformIn` answers null
+    // and the pump tears the connection down (§8) instead of asserting.
+    var illegal: [header_bytes + 4]u8 = undefined;
+    std.mem.writeInt(u16, illegal[0..2], @intCast(payload_max + 1), .big);
+    @memset(illegal[header_bytes..], 'x');
+
+    var bed: Harness = undefined;
+    try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 7 }, .client_raw = &illegal });
+    defer bed.tearDown();
+
+    try bed.io.run();
+
+    // Nothing was forwarded, and the client's connection is gone.
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.received_len);
+    try std.testing.expect(bed.client.eof or bed.client.reset);
+    try bed.expectSettled();
+}
+
+test "transform: a chunk too large to stage sheds the connection" {
+    // Whole deliveries, so the origin's answer arrives in one chunk and the
+    // framed length really does exceed what one frame can carry.
+    const oversize = "z" ** (payload_max + 1);
+
+    var bed: Harness = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 11, .adversary = .{ .partial_io = false } },
+        .origin_canned = oversize,
+    });
+    defer bed.tearDown();
+
+    try bed.io.run();
+
+    // `transformOut` refused to stage it, so no frame reached the client.
+    try std.testing.expectEqual(@as(u32, 0), bed.client.unframed_len);
+    try bed.expectSettled();
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("net/relay.zig");
     _ = @import("net/upstream.zig");
     _ = @import("testing/origin.zig");
+    _ = @import("net/pump_transform_test.zig");
     _ = @import("io/contract_test.zig");
     _ = @import("io/sim_io_test.zig");
     _ = @import("io/xev_smoke_test.zig");


### PR DESCRIPTION
Fifth slice of the [prefactoring plan](docs/PLANS.md) (#70): **B5**, the other
half of B1 (#74). With this, the seam is no longer in the tree unexercised —
the condition #74 said bounded its own split.

## Why identity wasn't enough

B1 landed five hooks with identity defaults. Identity proves nothing about the
property they exist for: that the bytes on the wire can be a different count,
in a different buffer, from the bytes framing measured. Both failure branches
were dead code, and the wire cursor had never carried anything.

## The toy

TLS's shape without its machinery: the client side of an L4-shaped relay
speaks `[u16 big-endian length][payload]` frames, while framing and the
upstream side see plain payload.

- **reading** transforms: frames land in a scratch, un-framed into the relay
  buffer — so the read cannot land where framing reads
- **writing** transforms: payload framed into a scratch, written in **capped
  7-byte windows** so a frame always takes several sends and the transform's
  cursor must survive the resumes

The scratch is the test's own, not a `Conn` field — a slot does not grow a
field for a test, and #75 is about the one it already has.

## What it pins that identity could not

| property | how |
|---|---|
| the read lands outside the relay buffer | `recvBuffer` returns scratch; un-framing writes the relay buffer |
| the wire carries bytes framing never counted | 2 per frame; asserted `received_len > unframed_len` |
| the framed debt settles only at drain | `creditSend` advances the wire cursor, credits the debt only when the frame is fully out |
| `transformIn` → null is reachable | a client frame declaring a length past `payload_max` |
| `transformOut` → false is reachable | an origin chunk too large to stage |

Oracle: byte-exactness both ways under the adversary's 1-byte deliveries
across **15 seeds**, plus pool drain and counter reconcile in every scenario.

## The bug only a real transform could reveal

**A transform may legally yield nothing from a read** — what arrived is a
fragment of a unit it can only decode whole. Framing must never see that as a
zero-length chunk, because `feed` reporting `consumed == 0` means *end of
message* and `onRecv` asserts `fr.done` there. So the read is re-armed and the
transform keeps the fragment.

TLS would have hit this on its first split record, as an assertion failure
rather than a wrong answer. It is contract 3 in the pump's header now, since a
policy whose transform can do this must tolerate `beforeRecv` twice with no
send in between (the production L4 policy would assert — verified).

## Verified load-bearing, not just green

Both halves were sabotaged and restored:

- settling the framed debt on every partial send instead of at drain → the
  byte-exactness test crashes
- removing the empty-chunk re-read → same test crashes

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer`: **no violations**. It traced the re-arm against the §5
slot lifecycle (the armed bit is cleared by `delivered` before the branch, so
no double-arm; not recursion), confirmed all three header claims and both
failure branches are genuinely reachable, and checked no assertion passes
vacuously. Four of its five judgement calls are addressed here (header
contract list, an assertion on the re-arm, `bed` over `h`, the counter note,
and a payload sized to drive the outbound scratch to its exact bound). The
fifth — this file cannot cover teardown's deadline-cancel interleaving, having
no armed timer — is disclosed in the harness docstring rather than papered
over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)