### PR TITLE
refactor: one channel for every client-directed write (§7, §8 — PLANS B3)

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -848,8 +848,6 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(rendered.len >= 1);
-            conn.l7.rendered_response_len = @intCast(rendered.len);
-            conn.l7.response_head_sent = 0;
             conn.l7.response_framing = framingFromParsed(response.framing);
 
             // Feed the framing tracker over the body excess that arrived
@@ -860,120 +858,128 @@ pub fn Proxy(comptime IoType: type) type {
                 upstreamFailed(server, conn);
                 return;
             }
-            const direction = &conn.directions[1];
             // The common small response arrives from the origin in one
             // piece; forward it in one piece too. Appending the excess to
             // the rendered head trades a bounded memcpy for a whole ring
-            // round trip per response. The fallback sends the same bytes
-            // as head, then excess from upstream.head.
+            // round trip per response. The fallback writes the head, then
+            // the excess from upstream.head as the channel's next write.
+            var head_write_len: u32 = @intCast(rendered.len);
             if (rendered.len + feed.consumed <= conn.head.len) {
                 @memcpy(
                     conn.head[rendered.len..][0..feed.consumed],
                     excess[0..feed.consumed],
                 );
-                conn.l7.rendered_response_len = @intCast(rendered.len + feed.consumed);
-                // The excess rides the head send: this leg owes nothing.
-                direction.owe(0);
+                head_write_len = @intCast(rendered.len + feed.consumed);
+                conn.l7.response_excess_len = 0; // It rides the head write.
             } else {
-                direction.owe(feed.consumed);
+                conn.l7.response_excess_len = feed.consumed;
             }
 
             conn.l7.response_leg = .sending_head;
-            armResponseHeadSend(server, conn);
+            // Committed to answering: no verdict may intervene from here (§7).
+            conn.l7.response_started = true;
+            armClientWrite(server, conn, conn.head[0..head_write_len], .response_excess);
         }
 
-        fn armResponseHeadSend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .sending_head);
-            const l7 = &conn.l7;
-            assert(l7.response_head_sent < l7.rendered_response_len);
-            l7.response_started = true;
+        // -- the client-write channel (§7, §8) --
+        //
+        // Every client-directed send outside the body pump goes through this
+        // one pair: the rendered response head, the body excess that arrived
+        // coalesced with it, and the static error responses. They differ only
+        // in their bytes and their continuation, which is what
+        // `Conn.ClientWrite` holds — so the cursor, the short-write resume,
+        // the teardown interlock and the error handling exist once each.
+        // Under a transforming client side (§4) this is also the single place
+        // these three writers turn plaintext into wire bytes.
+
+        fn armClientWrite(
+            server: *ServerType,
+            conn: *ConnType,
+            bytes: []const u8,
+            then: conn_module.ClientWrite.Then,
+        ) void {
+            assert(bytes.len >= 1);
+            assert(conn.state == .l7_exchanging or conn.state == .l7_responding);
+            // One write at a time: the channel is the only writer of this op,
+            // and a previous write either drained or ended in teardown.
+            assert(conn.client_write.pending.len == 0);
+            conn.client_write = .{ .pending = bytes, .then = then };
+            resumeClientWrite(server, conn);
+        }
+
+        fn resumeClientWrite(server: *ServerType, conn: *ConnType) void {
+            assert(conn.client_write.pending.len >= 1);
             conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.send(
                 conn.client_socket,
-                conn.head[l7.response_head_sent..l7.rendered_response_len],
+                conn.client_write.pending,
                 &conn.op_data_upstream_to_client.completion,
                 ConnType,
                 conn,
-                onResponseHeadSent,
+                onClientWritten,
             );
         }
 
-        fn onResponseHeadSent(conn: *ConnType, result: Io.SendError!u32) void {
+        fn onClientWritten(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
             conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
             }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .sending_head);
-            // response_started blocks the verdict, so none is pending in
-            // any response-send handler (negative space).
-            assert(conn.l7.pending_verdict == .none);
+            assert(conn.state == .l7_exchanging or conn.state == .l7_responding);
+            const write = &conn.client_write;
             const sent = result catch |err| {
-                // The client is gone; nothing to answer anyone.
+                // The client is gone; there is no one left to answer.
                 server.witnessKernelPressure(err);
                 server.beginTeardown(conn);
                 return;
             };
             assert(sent >= 1);
-            conn.l7.response_head_sent += sent;
-            assert(conn.l7.response_head_sent <= conn.l7.rendered_response_len);
-            if (conn.l7.response_head_sent < conn.l7.rendered_response_len) {
-                armResponseHeadSend(server, conn);
+            assert(sent <= write.pending.len);
+            write.pending = write.pending[sent..];
+            if (write.pending.len > 0) {
+                resumeClientWrite(server, conn); // Short send resumes (§6).
                 return;
             }
-            // Head on the wire; forward the coalesced body excess straight
-            // from upstream.head, then pump the rest from the socket.
-            const direction = &conn.directions[1];
-            if (direction.owed() >= 1) {
-                conn.l7.response_leg = .sending_body_excess;
-                armResponseExcessSend(server, conn);
-            } else {
+            if (write.then != .lingering_close) {
+                // `response_started` blocks a verdict, so none can be pending
+                // once response bytes are flowing (negative space).
+                assert(conn.state == .l7_exchanging);
+                assert(conn.l7.pending_verdict == .none);
+            }
+            switch (write.then) {
+                .response_excess => sendResponseExcess(server, conn),
+                .response_body => {
+                    assert(conn.l7.response_leg == .sending_body_excess);
+                    afterResponseExcess(server, conn);
+                },
+                .lingering_close => beginLingeringClose(server, conn),
+            }
+        }
+
+        /// The rendered head is on the wire. Any body excess that arrived
+        /// coalesced with it but did not fit beside it follows straight from
+        /// `upstream.head`; otherwise the body pump takes over.
+        fn sendResponseExcess(server: *ServerType, conn: *ConnType) void {
+            assert(conn.l7.response_leg == .sending_head);
+            const excess_len = conn.l7.response_excess_len;
+            if (excess_len == 0) {
                 afterResponseExcess(server, conn);
+                return;
             }
-        }
-
-        fn armResponseExcessSend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .sending_body_excess);
-            const direction = &conn.directions[1];
+            conn.l7.response_leg = .sending_body_excess;
             const base = conn.l7.response_head_len_marker;
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            server.io.send(
-                conn.client_socket,
-                direction.pending(conn.upstream.?.head[base..]),
-                &conn.op_data_upstream_to_client.completion,
-                ConnType,
+            // These are bytes the origin actually delivered past its head —
+            // the bound `DirectionState.pending` used to check for this write
+            // before the channel owned the cursor.
+            assert(base + excess_len <= conn.upstream.?.head_len);
+            armClientWrite(
+                server,
                 conn,
-                onResponseExcessSent,
+                conn.upstream.?.head[base..][0..excess_len],
+                .response_body,
             );
-        }
-
-        fn onResponseExcessSent(conn: *ConnType, result: Io.SendError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .sending_body_excess);
-            assert(conn.l7.pending_verdict == .none); // response_started.
-            const sent = result catch |err| {
-                server.witnessKernelPressure(err);
-                server.beginTeardown(conn);
-                return;
-            };
-            assert(sent >= 1);
-            const direction = &conn.directions[1];
-            direction.credit(sent);
-            if (direction.owed() >= 1) {
-                armResponseExcessSend(server, conn);
-                return;
-            }
-            afterResponseExcess(server, conn);
         }
 
         /// The head and its coalesced excess are on the wire; finish if the
@@ -1134,6 +1140,10 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.armed.connect);
             assert(!conn.armed.connect_cancel);
             assert(conn.armed.deadline or conn.armed.deadline_cancel);
+            // The channel's cursor lives on the conn, not in `l7`, so the
+            // reset below does not wipe it: assert it drained instead of
+            // trusting the control flow that got us here.
+            assert(conn.client_write.pending.len == 0);
             server.releaseRelayBuffer(conn.relay_buffer.?);
             conn.relay_buffer = null;
             conn.head_len = 0;
@@ -1352,48 +1362,9 @@ pub fn Proxy(comptime IoType: type) type {
             }
             server.counters.increment(counter);
             conn.state = .l7_responding;
-            conn.response_pending = shed.staticResponse(status, .close);
-            assert(conn.response_pending.len >= 1);
-            armResponseSend(server, conn);
-        }
-
-        fn armResponseSend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_responding);
-            assert(conn.response_pending.len >= 1);
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            server.io.send(
-                conn.client_socket,
-                conn.response_pending,
-                &conn.op_data_upstream_to_client.completion,
-                ConnType,
-                conn,
-                onResponseSent,
-            );
-        }
-
-        fn onResponseSent(conn: *ConnType, result: Io.SendError!u32) void {
-            const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
-            if (conn.isTearingDown()) {
-                server.continueTeardown(conn);
-                return;
-            }
-            assert(conn.state == .l7_responding);
-            const sent = result catch |err| {
-                server.witnessKernelPressure(err);
-                server.beginTeardown(conn);
-                return;
-            };
-            assert(sent >= 1);
-            assert(sent <= conn.response_pending.len);
-            conn.response_pending = conn.response_pending[sent..];
-            if (conn.response_pending.len > 0) {
-                // Short send: resume from the new front of the slice (§6).
-                armResponseSend(server, conn);
-            } else {
-                // Response delivered; close it out without RST (§2).
-                beginLingeringClose(server, conn);
-            }
+            // Straight from static memory (§8): the channel carries the slice
+            // and never copies it, so a shed still costs one send.
+            armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
         }
 
         /// A client can still be sending its request — a body, or the rest

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -86,6 +86,36 @@ pub const DirectionState = struct {
     }
 };
 
+/// One client-directed write in flight (§7, §8): the plaintext still to
+/// deliver, and where control goes once it is all out.
+///
+/// Three writes on the L7 path go to the client outside the body pump — the
+/// rendered response head, the body excess that arrived coalesced with it,
+/// and a static error response — and they differ only in which bytes they
+/// carry and what happens next. One channel for all three means one cursor,
+/// one short-write resume, one teardown interlock, and (§4) one place for a
+/// transforming client side to turn plaintext into wire bytes. The body pump
+/// is the fourth client-directed writer and carries that same seam of its
+/// own (`pump.zig`).
+pub const ClientWrite = struct {
+    /// Shrunk from the front as bytes leave, so a resume is the same code
+    /// whether they live in static memory (§8), the head buffer, or an
+    /// upstream head. Empty means no write is in flight.
+    pending: []const u8 = &.{},
+    then: Then = .lingering_close,
+
+    /// What the channel does when `pending` empties.
+    pub const Then = enum(u8) {
+        /// The rendered response head is out: forward any coalesced body
+        /// excess, else move on to the body pump.
+        response_excess,
+        /// The coalesced excess is out: the body pump, or the exchange ends.
+        response_body,
+        /// A static response is out: the lingering close (§2, §8).
+        lingering_close,
+    };
+};
+
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
@@ -126,11 +156,9 @@ pub fn Conn(comptime IoType: type) type {
         /// Bytes of `head` filled so far; the head's end is found by
         /// parsing, the body (or a pipelined next head) follows it.
         head_len: u32,
-        /// The static error response still to be written to the client
-        /// while in `.l7_responding` (§8): a slice into comptime static
-        /// memory, shrunk from the front as bytes are sent. Empty
-        /// otherwise; idle on the L4 path.
-        response_pending: []const u8,
+        /// The client-directed write in flight, if any (§7, §8) — see
+        /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
+        client_write: ClientWrite,
         /// The cluster to dial. Seeded from the listener at admission; on
         /// the L7 path `routeRequest` overwrites it with the request
         /// path's cluster once the head parses (§7).
@@ -237,13 +265,19 @@ pub fn Conn(comptime IoType: type) type {
             /// Bytes of `upstream.head` consumed by the response head;
             /// body excess received with it sits at [marker..head_len].
             response_head_len_marker: u32 = 0,
-            /// Length of the rendered head being sent (request leg: into
-            /// upstream.head; response leg: into conn.head).
+            /// Length of the rendered request head being sent into
+            /// upstream.head, and the cursor over it (short sends resume).
+            /// The response head has no pair here: it goes out through the
+            /// client-write channel, which owns its own cursor
+            /// (`ClientWrite`).
             rendered_request_len: u32 = 0,
-            rendered_response_len: u32 = 0,
-            /// Send cursors over the rendered heads (short sends resume).
             request_head_sent: u32 = 0,
-            response_head_sent: u32 = 0,
+            /// Response body bytes that arrived coalesced with the response
+            /// head and did not fit in `conn.head` beside the rendered head:
+            /// they follow it from `upstream.head[response_head_len_marker..]`
+            /// as the channel's next write. Zero when the excess rode along
+            /// with the head, or when there was none.
+            response_excess_len: u32 = 0,
             /// True once the request head has been forwarded off conn.head
             /// (head sent and any coalesced body excess drained), so the
             /// response head may render into conn.head (§7 buffer rotation).
@@ -360,7 +394,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.armed = .{};
             conn.directions = .{ .{}, .{} };
             conn.head_len = 0;
-            conn.response_pending = &.{};
+            conn.client_write = .{};
             conn.cluster_index = cluster_index;
             // Placeholders until the admission tail installs the
             // listener's real tables (§7); L4 never reads them.
@@ -379,7 +413,7 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.state == state);
             assert(conn.armedCount() == 0);
             assert(conn.head_len == 0);
-            assert(conn.response_pending.len == 0);
+            assert(conn.client_write.pending.len == 0);
             assert(conn.upstream == null);
             assert(conn.l7.request_leg == .idle);
         }


### PR DESCRIPTION
Sixth slice of the [prefactoring plan](docs/PLANS.md) (#70): **B3**, after A5
(#71), A4 (#72), B2 (#73), B1 (#74), B5 (#76).

## Why

Three writes went to the client outside the body pump, each with its own
arm/completion pair and its own cursor:

| write | cursor before |
|---|---|
| rendered response head | `l7.response_head_sent` / `rendered_response_len` |
| coalesced body excess | `conn.directions[1]` — the **pump's** cursor, overloaded |
| static error response | `conn.response_pending`, a slice shrunk from the front |

They differ in their bytes and in what happens when the last byte is out, and
in nothing else — which is why the TLS branch had to thread an
encrypt-and-credit pair through all three by hand.

## What

`Conn.ClientWrite` holds exactly that difference (the plaintext still to
deliver, plus a continuation) and the channel owns the rest: one cursor, one
short-write resume, one teardown interlock, one error path. **Six functions
become four**, `directions[1]` goes back to being the pump's alone, and
`rendered_response_len` / `response_head_sent` / `response_pending` are gone.

Under a transforming client side there is now one place these three writers
turn plaintext into wire bytes — and kTLS will need none.

§8's "static responses are sent directly from static memory" survives intact,
and is now stated where it's enforced: `shed.staticResponse` hands the channel
a slice into comptime memory and the channel writes it through untouched.

## Behaviour preservation

The excess slice is byte-identical to what `DirectionState.pending` produced;
`directions[1]` is provably settled before the body pump's first `owe`; and
`response_started` moves a few statements earlier within the same synchronous
chain — which reads truer, since committing to answer is what closes the
verdict window.

## Gates and review

`zig build ci` (64 sim seeds, the L7 suite) and `zig fmt --check` pass.
`tiger-style-reviewer`: no violations. It confirmed byte-identity, the
one-write-at-a-time invariant on every path into the channel (including the
replay path and abandoned-mid-flight writes), and that `Conn` rather than
`L7State` is the right home. Three of its four judgement calls are fixed here,
all assertions the arm/complete split had thinned:

- the arm site asserts the connection state again
- the `.response_body` continuation asserts its leg
- `resetForNextRequest` asserts the channel drained — its cursor no longer
  rides `l7 = .{}`, so the redundant backstop had to become explicit
- `sendResponseExcess` asserts the excess really is bytes the origin
  delivered, restoring the bound `DirectionState.pending` used to check

The fourth is a watch: `renderResponse` sits at 69 lines, one under the limit.

## A finding this slice does not fix

Filed as #77: sabotaging the non-zero excess branch — dropping body bytes that
arrived with the response head — **fails no test and no sim seed**. The path
predates B3 and the refactor preserves it. It is reachable only when rendering
*grows* the head (the `Connection: close` injection), which leaves ~19 bytes
of head sizes that reach it, and nothing observable proves a test took it. The
issue argues for a counter over a test that would pass vacuously, and asks
whether the branch should exist at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)