### PR TITLE
refactor: name what a head source replaces (§4, §7 — PLANS B4)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -161,7 +161,7 @@ reviews of A5 landed on it, and neither could guard it from here.
 | B1 | Pump transform seam — `recvBuffer`, `transformIn`, `transformOut`, `sendSlice`, `creditSend`, identity by default — and the loop condition becomes *"anything left to write?"* rather than *"cursor reached length"*. **Not done without B5** | 120 | TLS L4 becomes a policy; `tls_relay.zig` never gets written |
 | B5 | A toy transform in the simulator: deterministic and non-identity (XOR mask, or 4-byte length re-framing) on an L4 sim listener, verified byte-exact by the token oracle under the adversary. **Lands with B1, not after it** | 150 | proves the seam *without crypto*, so TLS adds only crypto, not new mechanism risk. The de-risking slice for all of Tier B |
 | B3 | One client-write channel over B2's cursor: `armClientWrite(conn, plaintext)` for all three client-directed sends | 150 | TLS changes one place, kTLS none; also settles what §8's "static responses straight from static memory" means once the bytes must be encrypted |
-| B4 | Head-fill source seam: read through a source (socket today), one "head complete? → parse / 431 / 413 / read again" decision | 100 | removes the parallel TLS completion path and the duplicated limit decision |
+| B4 | Head-fill source seam: read through a source (socket today), one "head complete? → parse / 431 / 413 / read again" decision — *landed at ~40 lines; see below* | 100 | removes the parallel TLS completion path and the duplicated limit decision |
 
 **What B2 landed, and what it left to B1.** The row above asked for a wire
 cursor *field* asserted equal to the framed one. Written out, that field
@@ -198,6 +198,25 @@ existing unverified.
 |---|---|---|---|
 | D1 | Tier-1 gate on achieved rate against offered | 40 | the §9 gates check socket and status errors only, so a run delivering 704 of 2000 req/s passed them |
 | D2 | A large-body band in the harness | 80 | the record layer's per-byte cost is unmeasured, and the kTLS decision (Phase 3b) depends on that number |
+
+**What B4 landed, and why it is small.** The row budgeted 100 lines for a
+source seam. Read against the code, the head loop already had the half that
+mattered: `parseAndDispatch` is the single answer to what accumulated bytes
+mean — read again, 400, 414, 431, or route. What the TLS branch actually
+duplicated came from the two things `armHeadRecv` hardcoded (the read target,
+and through it the completion callback) plus a 413-vs-431 decision it made
+*before* dispatch by re-parsing. So B4 names the read target and the fill
+accounting — the two a source replaces — and writes down the rule that an
+overrun discovered while filling is answered *through* the dispatch rather
+than beside it. Every other state the row implied (a fragment that yields
+nothing, an overrun, head bytes already staged at entry) is unreachable until
+a transforming source exists, so those variants land with TLS, where they will
+have a caller rather than being dormant (§1).
+**If that seam should be *proven* rather than documented**, the shape is B5's:
+a toy head source behind a test-only selection. It costs materially more than
+B5 did — the head path sits inside the L7 state machine (routing, dial,
+render) rather than at a pump's edge, so the selection has to reach into
+`Proxy` instead of being a policy handed to one `Pump`.
 
 **Order.** Critical path to a small TLS slice: **A5 → A4 → B2 →
 (B1 + B5) → B3 → B4**, with A1–A3 and Tier C as fill-in.

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -59,15 +59,69 @@ pub fn Proxy(comptime IoType: type) type {
             armHeadRecv(server, conn);
         }
 
-        fn armHeadRecv(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_reading_head);
+        // -- the head-fill seam: the *request* head (§4, §7) --
+        //
+        // The head accumulates until it parses (§7 detect-and-retry), and
+        // three things make that loop work: where a read lands, how what
+        // arrived becomes head bytes, and what those bytes mean. Only the
+        // first two are a *source's* business, and they are named below, so a
+        // source that does not read plaintext off the socket — §4's TLS
+        // termination reads ciphertext and decrypts into the head — replaces
+        // exactly those two. Unlike `pump.zig`'s transform seam these are
+        // plain functions, not `@hasDecl` hooks on a policy: there is one
+        // source today, and the second one arrives inside `Proxy` rather than
+        // being handed in, so a policy parameter would buy nothing.
+        //
+        // Scoped to the request head deliberately. The origin's *response*
+        // head accumulates the same way in `onResponseHeadRecv`, into the
+        // upstream slot's buffer, and does not need a source: Phase 3a
+        // terminates TLS on the client side only, so the upstream leg stays
+        // plaintext (kTLS on the origin side, if it ever comes, would revisit
+        // this).
+        //
+        // The third stays `parseAndDispatch`, the single answer to "what do
+        // these bytes mean": read again, 400, 414, 431, or route. That matters
+        // most for a source that can overrun the buffer, which a plaintext
+        // read cannot: a transform decoding a whole record at once may yield
+        // more head bytes than the buffer holds, and whether that is a 431
+        // (the head itself is too large) or a 413 (the head fits and the
+        // payload behind it does not) is a question about the *parsed* head.
+        // Such a source records the overrun and lets the dispatch answer it,
+        // rather than deciding first and growing a second copy of the ladder.
+
+        /// Where a head read lands: the free space after what has already
+        /// accumulated.
+        fn headRecvBuffer(conn: *ConnType) []u8 {
             // Parsing turns a full buffer into an oversize verdict before
             // we ever get here, so there is always room to read into.
             assert(conn.head_len < constants.head_bytes_max);
+            return conn.head[conn.head_len..];
+        }
+
+        /// Account for bytes that became head bytes. Named because a
+        /// transforming source appends a different count than the socket
+        /// delivered, and this is where that difference belongs.
+        ///
+        /// The bound is a precondition, not a clamp: a source that can produce
+        /// more head bytes than there is room for — a decrypted record is up
+        /// to 16 KiB against an 8 KiB head — fills what fits, records the
+        /// surplus, and lets `parseAndDispatch` answer it. Handing an overrun
+        /// to this function is a bug, and asserts as one.
+        fn fillHead(conn: *ConnType, appended: u32) void {
+            assert(appended >= 1);
+            assert(conn.head_len + appended <= constants.head_bytes_max);
+            conn.head_len += appended;
+        }
+
+        fn armHeadRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            // Resolved before the arm, so the source's own bound is checked
+            // before any state changes.
+            const into = headRecvBuffer(conn);
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
-                conn.head[conn.head_len..],
+                into,
                 &conn.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -95,8 +149,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(received >= 1);
-            conn.head_len += received;
-            assert(conn.head_len <= constants.head_bytes_max);
+            fillHead(conn, received);
             parseAndDispatch(server, conn);
         }
 


### PR DESCRIPTION
Seventh slice of the [prefactoring plan](docs/PLANS.md) (#70): **B4**, the last
on the plan's critical path, after A5 (#71), A4 (#72), B2 (#73), B1 (#74),
B5 (#76), B3 (#78).

## The plan overestimated this one, and the PR says so

The row budgeted 100 lines for a source seam plus "one head complete? → parse
/ 431 / 413 / read again" decision. Read against the code, **half of it was
already true**: `parseAndDispatch` is the single answer to what accumulated
head bytes mean — read again, 400, 414, 431, or route — and nothing else
decides.

What the TLS branch actually duplicated traces to two things `armHeadRecv`
hardcoded — the read target, and through it the completion callback — plus a
413-vs-431 decision it made *before* dispatch by re-parsing the head.

## What this lands

- **`headRecvBuffer`** — names the read target, the one thing a source that
  doesn't read plaintext off the socket has to replace.
- **`fillHead`** — names the accounting, because a transforming source appends
  a different count than the socket delivered. Its bound is documented as a
  *precondition*: a source that can produce more head bytes than there is room
  for (a decrypted record is up to 16 KiB against an 8 KiB head) fills what
  fits, records the surplus, and lets the dispatch answer it.
- **The contract**, written down: a source replaces exactly those two;
  `parseAndDispatch` stays the only decision, so the 413-vs-431 ladder keeps
  one copy.

## What it deliberately does not build

Every other state the row implied is **unreachable on `main`**: a plaintext
read is bounded by the free space, so it can neither overrun nor yield zero
bytes, and every entry to the loop starts from an empty head (`prepare` and
`resetForNextRequest` both zero it; pipelined leftovers force a close rather
than a turnaround). A result union whose variants no path can reach is the
dormancy §1 rules out — the same call as B2's declined wire-cursor field — so
those variants land with TLS, where they'll have a caller.

PLANS records the deviation and its reasoning rather than leaving a 100-line
estimate looking met. It also notes what it would cost to *prove* this seam
instead of documenting it (B5's shape, a toy head source): materially more than
B5, because the head path sits inside the L7 state machine rather than at a
pump's edge, so the selection has to reach into `Proxy`.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` independently hunted for a live path to each unbuilt
state — the pipelining turnaround, the drain path, both entries to
`l7_reading_head` — and **found none**, confirming the dormancy judgement. It
also confirmed the relocated bound is still asserted on every arm.

Its four judgement calls are all addressed:

- `fillHead`'s doc now states the bound is a precondition and an overrun is the
  caller's to clamp — the assert never compiles out, so a future source calling
  it hopefully would panic rather than degrade
- the seam header says why these are plain functions rather than
  `pump.zig`-style `@hasDecl` policy hooks (one source today; the second
  arrives *inside* `Proxy`, not handed in)
- the header scopes itself to the request head, and says why the origin
  response head needs no source (Phase 3a terminates client-side TLS only)
- `armHeadRecv` resolves the buffer *before* it arms, restoring
  verify-before-mutate — a small ordering regression I had introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)