### PR TITLE
refactor: close out Tier A — lint boundaries as data, pools that may be empty (PLANS A3, A1)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -132,11 +132,32 @@ Sizes are estimates, in diff lines, for sequencing only.
 
 | # | slice | ~ | what it buys |
 |---|---|---|---|
-| A1 | Zero-slot `Pool`: relax `count >= 1`, sentinel `free_head`, one test | 20 | a pool the config never asked for reserves nothing and is permanently exhausted, so its acquire site needs no special case |
-| A2 | `fillRandom` on the Io seam (`getrandom` in XevIo, scenario PRNG in SimIo), with the balancer's p2c seed routed through it | 60 | TLS needs key material through the seam; the side win is seed-replayable p2c in the simulator (§9) |
-| A3 | Lint boundaries as a data table `{import, allowed_prefix, message}` | 50 | the branch's 5th positional bool touched every test call; a new dependency boundary should be one row |
+| A1 | Zero-slot `Pool`: relax `count >= 1`, sentinel `free_head`, one test — *landed, with the requirement moved rather than dropped* | 20 | a pool the config never asked for reserves nothing and is permanently exhausted, so its acquire site needs no special case |
+| A2 | `fillRandom` on the Io seam (`getrandom` in XevIo, scenario PRNG in SimIo), with the balancer's p2c seed routed through it | 60 | ~~TLS needs key material through the seam~~ — **retired, see below** |
+| A3 | Lint boundaries as a data table `{needle, confined_to, message}` — *landed* | 50 | the branch's 5th positional bool touched every test call; a new dependency boundary should be one row |
 | A4 | `abortAdmission(server, conn, socket, rung)` — *landed*, with `releaseConn` as the pool pairing it was missing | 30 | collapses the release + pressure + counter + close quartet that `admitL4`/`admitHttp` already repeat and `admitTls` repeated twice more |
 | A5 | Split `prepare` from `startProtocol(server, conn)` — *landed* | 40 | one protocol fork, callable from accept *or* from a later phase — deletes the branch's duplicated switch and the `tls_protocol` field outright |
+
+**A2 is retired, not deferred.** Its two halves both fail the test this list
+sets. `fillRandom` on the Io seam has no caller here at all — TLS keys and
+session tickets are its only consumers, so it would be a seam method
+implemented in both backends and called by nothing. And routing the balancer's
+p2c seed through it contradicts a settled decision rather than improving on
+it: `balancer.zig` seeds xorshift64* from a fixed named constant *on purpose*
+("determinism is a feature" — the simulator replays every seed twice and
+demands byte-identical traces, §9), and the spread argument for per-process
+randomness does not hold either, since sibling processes behind SO_REUSEPORT
+already diverge through their own lease tables. TLS brings `fillRandom` when
+TLS brings a consumer for it.
+
+**A1 landed by moving the requirement, not removing it.** Relaxing `Pool`'s
+`count >= 1` on its own would have traded a live check for an absent caller's
+convenience. Instead the container now permits an empty pool — a generic
+container has no business insisting otherwise — and `Server.init` asserts that
+its three pools are non-empty, which is where the requirement is actually
+true: a proxy without conn slots, relay buffers or upstream slots cannot serve
+a request. Nothing is unchecked that was checked before, and the zero-slot case
+has a unit test rather than waiting for its first production user.
 
 **What A5 leaves to the phase that hands a connection over.**
 `startProtocol` stores the entry state and the entry deadline even at

--- a/scripts/lint.zig
+++ b/scripts/lint.zig
@@ -18,6 +18,37 @@ const file_bytes_max: u32 = 1024 * 1024;
 
 const syscall_needles = [_][]const u8{ "std.posix", "std.os", "os.linux" };
 
+/// One import boundary: a needle that may appear only under `confined_to`.
+/// Data rather than code, so adding a boundary — the TLS engine's own
+/// wrapper is the next one (§4) — is a row here instead of another
+/// parameter threaded through `lintLine` and every one of its tests.
+const Boundary = struct {
+    needle: []const u8,
+    /// A path prefix (`"io/"`) or an exact file (`"http/parser.zig"`),
+    /// always written with forward slashes; `pathIsUnder` normalizes. Empty
+    /// means the needle is allowed nowhere.
+    confined_to: []const u8,
+    message: []const u8,
+};
+
+const boundaries = [_]Boundary{
+    .{
+        .needle = "@cImport",
+        .confined_to = "",
+        .message = "@cImport is forbidden: no C-FFI dependency (DESIGN.md §4)",
+    },
+    .{
+        .needle = "@import(\"hparse\")",
+        .confined_to = "http/parser.zig",
+        .message = "hparse is imported only by src/http/parser.zig — the trust boundary (DESIGN.md §7)",
+    },
+    .{
+        .needle = "@import(\"xev\")",
+        .confined_to = "io/",
+        .message = "xev may only be imported under src/io/ (DESIGN.md §4)",
+    },
+};
+
 /// The only `std.posix.` members main.zig may name (rlimits + sigaction);
 /// everything else — sockets, files, pipes — stays behind the Io seam.
 /// These are matched as fully-qualified `std.posix.<name>` occurrences,
@@ -76,12 +107,6 @@ fn lintFile(
     path: []const u8,
 ) !u32 {
     assert(path.len > 0);
-    const in_io_directory = std.mem.startsWith(u8, path, "io/") or
-        std.mem.startsWith(u8, path, "io" ++ std.fs.path.sep_str);
-    const is_main = std.mem.eql(u8, path, "main.zig");
-    const is_http_parser = std.mem.eql(u8, path, "http/parser.zig") or
-        std.mem.eql(u8, path, "http" ++ std.fs.path.sep_str ++ "parser.zig");
-
     const contents = try root.readFileAlloc(io, path, arena, .limited(file_bytes_max));
     assert(contents.len < file_bytes_max);
 
@@ -90,7 +115,7 @@ fn lintFile(
     var lines = std.mem.splitScalar(u8, contents, '\n');
     while (lines.next()) |line| {
         line_number += 1;
-        if (lintLine(line, in_io_directory, is_main, is_http_parser)) |message| {
+        if (lintLine(line, path)) |message| {
             std.debug.print("{s}:{d}: {s}\n", .{ path, line_number, message });
             violation_count += 1;
         }
@@ -99,25 +124,53 @@ fn lintFile(
     return violation_count;
 }
 
+comptime {
+    // Every path here — the walked one and the confinements below — is
+    // compared byte-for-byte with '/' as the separator. Rather than
+    // normalizing for a platform this project does not support (§1: Windows
+    // is a non-goal, and the macOS dev box uses '/' too), the assumption is
+    // stated and enforced: on a '\\' platform this lint would need real path
+    // handling, and failing to build says so.
+    assert(std.fs.path.sep == '/');
+}
+
+/// True when `path` is the file named by `confinement`, or lies under it as a
+/// directory prefix. A `confinement` ending in '/' is a directory, anything
+/// else an exact file; empty confines a needle to nowhere.
+fn pathIsUnder(path: []const u8, confinement: []const u8) bool {
+    assert(path.len > 0);
+    // The confinements are written in this file, so a stray separator is a
+    // typo in a table row, not untrusted input.
+    assert(std.mem.indexOfScalar(u8, confinement, '\\') == null);
+    if (confinement.len == 0) return false;
+    if (confinement[confinement.len - 1] != '/') {
+        return std.mem.eql(u8, path, confinement);
+    }
+    const directory = confinement[0 .. confinement.len - 1];
+    assert(directory.len >= 1);
+    if (!std.mem.startsWith(u8, path, directory)) return false;
+    // A sibling whose name merely starts the same is not under it: the byte
+    // after the directory must be the separator, never more name.
+    if (path.len == directory.len) return false;
+    return path[directory.len] == '/';
+}
+
 /// Returns a violation message for the line, or null if the line is clean.
-fn lintLine(
-    line: []const u8,
-    in_io_directory: bool,
-    is_main: bool,
-    is_http_parser: bool,
-) ?[]const u8 {
-    if (std.mem.indexOf(u8, line, "@cImport") != null) {
-        return "@cImport is forbidden: no C-FFI dependency (DESIGN.md §4)";
+fn lintLine(line: []const u8, path: []const u8) ?[]const u8 {
+    assert(path.len > 0);
+    const in_io_directory = pathIsUnder(path, "io/");
+    for (boundaries) |boundary| {
+        if (pathIsUnder(path, boundary.confined_to)) continue;
+        if (std.mem.indexOf(u8, line, boundary.needle) != null) {
+            return boundary.message;
+        }
     }
-    if (!is_http_parser and std.mem.indexOf(u8, line, "@import(\"hparse\")") != null) {
-        return "hparse is imported only by src/http/parser.zig — the trust boundary (DESIGN.md §7)";
-    }
+    // The syscall surfaces are not one needle with one home: they are a set,
+    // and main.zig carries a member-level allowlist rather than a path.
     if (in_io_directory) {
         return null;
     }
-    if (std.mem.indexOf(u8, line, "@import(\"xev\")") != null) {
-        return "xev may only be imported under src/io/ (DESIGN.md §4)";
-    }
+    const is_main = std.mem.eql(u8, path, "main.zig");
     for (syscall_needles) |needle| {
         if (std.mem.indexOf(u8, line, needle) == null) {
             continue;
@@ -164,33 +217,45 @@ fn startsWithAllowedMember(member: []const u8) bool {
 }
 
 test "lintLine: raw syscalls flagged outside io, allowed inside" {
-    try std.testing.expect(lintLine("const x = std.posix.socket();", false, false, false) != null);
-    try std.testing.expect(lintLine("const x = std.os.linux.close(fd);", false, false, false) != null);
-    try std.testing.expect(lintLine("const x = std.posix.socket();", true, false, false) == null);
-    try std.testing.expect(lintLine("const clean = a + b;", false, false, false) == null);
+    try std.testing.expect(lintLine("const x = std.posix.socket();", "net/relay.zig") != null);
+    try std.testing.expect(lintLine("const x = std.os.linux.close(fd);", "net/relay.zig") != null);
+    try std.testing.expect(lintLine("const x = std.posix.socket();", "io/XevIo.zig") == null);
+    try std.testing.expect(lintLine("const clean = a + b;", "net/relay.zig") == null);
 }
 
 test "lintLine: main.zig allowlist admits rlimit and sigaction only" {
-    try std.testing.expect(lintLine("try std.posix.setrlimit(.NOFILE, limits);", false, true, false) == null);
-    try std.testing.expect(lintLine("std.posix.sigaction(.TERM, &action, null);", false, true, false) == null);
-    try std.testing.expect(lintLine("_ = std.posix.setsockopt(fd, 0, 0, &opt);", false, true, false) != null);
+    try std.testing.expect(lintLine("try std.posix.setrlimit(.NOFILE, limits);", "main.zig") == null);
+    try std.testing.expect(lintLine("std.posix.sigaction(.TERM, &action, null);", "main.zig") == null);
+    try std.testing.expect(lintLine("_ = std.posix.setsockopt(fd, 0, 0, &opt);", "main.zig") != null);
     // A comment mentioning SIG must not exempt a real forbidden call.
-    try std.testing.expect(lintLine("const s = std.posix.socket(); // closed on SIGTERM", false, true, false) != null);
+    try std.testing.expect(lintLine("const s = std.posix.socket(); // closed on SIGTERM", "main.zig") != null);
     // A forbidden call sharing a line with an allowed one is still caught.
-    try std.testing.expect(lintLine("std.posix.sigaction(x); std.posix.socket();", false, true, false) != null);
+    try std.testing.expect(lintLine("std.posix.sigaction(x); std.posix.socket();", "main.zig") != null);
     // std.os.linux.* is never allowlisted in main.zig.
-    try std.testing.expect(lintLine("_ = std.os.linux.close(fd);", false, true, false) != null);
+    try std.testing.expect(lintLine("_ = std.os.linux.close(fd);", "main.zig") != null);
 }
 
 test "lintLine: xev import and cImport boundaries" {
-    try std.testing.expect(lintLine("const xev = @import(\"xev\");", false, false, false) != null);
-    try std.testing.expect(lintLine("const xev = @import(\"xev\");", true, false, false) == null);
-    try std.testing.expect(lintLine("const c = @cImport({});", true, false, false) != null);
+    try std.testing.expect(lintLine("const xev = @import(\"xev\");", "Server.zig") != null);
+    try std.testing.expect(lintLine("const xev = @import(\"xev\");", "io/XevIo.zig") == null);
+    try std.testing.expect(lintLine("const c = @cImport({});", "io/XevIo.zig") != null);
 }
 
 test "lintLine: hparse import is confined to the http parser wrapper" {
-    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", false, false, true) == null);
-    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", false, false, false) != null);
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", "http/parser.zig") == null);
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", "http/proxy.zig") != null);
     // Not even src/io/ may reach around the wrapper.
-    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", true, false, false) != null);
+    try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", "io/XevIo.zig") != null);
+}
+
+test "pathIsUnder: exact files, directory prefixes, and near misses" {
+    try std.testing.expect(pathIsUnder("http/parser.zig", "http/parser.zig"));
+    try std.testing.expect(!pathIsUnder("http/parser_test.zig", "http/parser.zig"));
+    try std.testing.expect(pathIsUnder("io/XevIo.zig", "io/"));
+    try std.testing.expect(pathIsUnder("io/sub/deep.zig", "io/"));
+    // A sibling directory whose name merely starts the same is not under it.
+    try std.testing.expect(!pathIsUnder("iommu/thing.zig", "io/"));
+    try std.testing.expect(!pathIsUnder("io", "io/"));
+    // An empty spec confines a needle to nowhere.
+    try std.testing.expect(!pathIsUnder("anything.zig", ""));
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -123,18 +123,18 @@ pub fn Server(comptime IoType: type) type {
         ) error{OutOfMemory}!void {
             assert(config.listeners.len >= 1);
             assert(config.listeners.len <= constants.listeners_max);
-            assert(options.relay_buffers >= 1);
-            assert(options.relay_buffers <= options.conn_slots);
-            server.io = io;
-            server.config = config;
             // `Pool` permits an empty pool — that is how an unconfigured
-            // feature reserves nothing (§5) — so the requirement that *these*
+            // feature reserves nothing (§5) — so the requirement that these
             // three are non-empty lives here, where it is true: a proxy with
             // no conn slots, no relay buffers or no upstream slots cannot
-            // serve a single request.
+            // serve a single request. `relay_buffers` was always checked
+            // here; the other two move down from `Pool.init`.
             assert(options.conn_slots >= 1);
             assert(options.relay_buffers >= 1);
             assert(options.upstream_slots >= 1);
+            assert(options.relay_buffers <= options.conn_slots);
+            server.io = io;
+            server.config = config;
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
             try server.upstreams.init(arena, options.upstream_slots);

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -127,6 +127,14 @@ pub fn Server(comptime IoType: type) type {
             assert(options.relay_buffers <= options.conn_slots);
             server.io = io;
             server.config = config;
+            // `Pool` permits an empty pool — that is how an unconfigured
+            // feature reserves nothing (§5) — so the requirement that *these*
+            // three are non-empty lives here, where it is true: a proxy with
+            // no conn slots, no relay buffers or no upstream slots cannot
+            // serve a single request.
+            assert(options.conn_slots >= 1);
+            assert(options.relay_buffers >= 1);
+            assert(options.upstream_slots >= 1);
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
             try server.upstreams.init(arena, options.upstream_slots);

--- a/src/mem/Pool.zig
+++ b/src/mem/Pool.zig
@@ -35,12 +35,20 @@ pub fn Pool(comptime T: type) type {
         /// In-place init via out-pointer for pointer stability. `arena`
         /// is the config arena — the only allocating region (§5) — and
         /// this is the pool's only allocation, ever.
+        ///
+        /// `count` may be zero: a *disabled* pool, reserving nothing and
+        /// answering every `acquire` with null. That is how a feature the
+        /// config did not ask for costs no memory while its acquire site
+        /// stays one code path — exhaustion, which every caller already
+        /// sheds (§8). Whether a given pool is *allowed* to be empty is the
+        /// caller's policy, not this container's: a proxy cannot serve
+        /// without conn slots, and `Server.init` asserts that where the
+        /// requirement actually lives.
         pub fn init(
             pool: *Self,
             arena: std.mem.Allocator,
             count: u32,
         ) error{OutOfMemory}!void {
-            assert(count >= 1);
             assert(count <= slots_count_max);
 
             const slots = try arena.alloc(T, count);
@@ -52,7 +60,9 @@ pub fn Pool(comptime T: type) type {
 
             pool.* = .{
                 .slots = slots,
-                .free_head = 0,
+                // An empty pool has no first free slot, and `acquire` reads
+                // that as exhausted — which for count == 0 it permanently is.
+                .free_head = if (count == 0) sentinel_none else 0,
                 .acquired_count = 0,
                 .acquired_count_peak = 0,
             };
@@ -211,4 +221,24 @@ test "pool: indexOf is stable across reuse" {
     const reused = pool.acquire().?;
     try std.testing.expectEqual(index, pool.indexOf(reused));
     pool.release(reused);
+}
+
+// A zero-slot pool is how a feature the config never asked for costs no
+// memory (§5): it reserves nothing and is permanently exhausted, so its
+// acquire site needs no special case — the caller's existing shed does.
+test "pool: a zero-slot pool reserves nothing and always sheds" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var pool: Pool(TestItem) = undefined;
+    try pool.init(arena_state.allocator(), 0);
+
+    try std.testing.expectEqual(@as(usize, 0), pool.slots.len);
+    try std.testing.expectEqual(@as(?*TestItem, null), pool.acquire());
+    // Still a well-formed pool: exhaustion is not a broken state, and every
+    // slot it has (none) is released.
+    try std.testing.expect(pool.isFullyReleased());
+    // Repeated acquires keep answering the same way rather than drifting.
+    try std.testing.expectEqual(@as(?*TestItem, null), pool.acquire());
+    try std.testing.expectEqual(@as(u32, 0), pool.acquired_count_peak);
 }


### PR DESCRIPTION
Tier A's leftovers from the [prefactoring plan](docs/PLANS.md) (#70), two
commits. **One of the three is retired rather than landed** — see the last
section.

## A3 — lint boundaries as data

`lintLine` took the line plus three booleans (in-io, is-main, is-parser), and
the TLS branch's fourth boundary added a fifth, touching every test call to
thread a bool most of them didn't care about. Boundaries are now rows of
`{needle, confined_to, message}`, and `lintLine(line, path)` derives the rest —
so the tests read as what they assert:

```zig
try std.testing.expect(lintLine("const hparse = @import(\"hparse\");", "http/proxy.zig") != null);
```

The syscall surfaces stay special on purpose: they're a *set* of needles, and
main.zig's exemption is member-level rather than path-level, so a row can't
express them.

`pathIsUnder` handles exact-file-or-directory matching, and the separator
question is settled by a **comptime assert that `std.fs.path.sep == '/'`**
rather than half-normalizing for a platform §1 calls a non-goal — on a `\`
platform this lint needs real path handling, and failing to build says so. (My
first draft had a speculative Windows branch; review pointed out it was
unreachable, untested, and its directory half didn't normalize anyway.)

**Verified the gate still bites, not just that it passes:** `@import("xev")`
planted in `src/net/relay.zig` makes `zig build lint` exit 1; a clean tree
exits 0. lint's own tests already run under `zig build test`.

## A1 — a pool may be empty; the requirement moves to who owns it

`Pool.init` asserted `count >= 1`, a policy a generic container has no business
holding. TLS engines will want an empty pool — a feature the config didn't ask
for reserving nothing, its acquire site unchanged because exhaustion is what
every caller already sheds (§8).

Relaxing that assert alone would trade a live check for an absent caller's
convenience, so the requirement **moved** instead: `Server.init` asserts all
three of its pools are non-empty, where the claim is actually true. Precisely:
`relay_buffers >= 1` was already asserted there, so `conn_slots` and
`upstream_slots` are what came down from `Pool.init` — the commit message says
so, after review caught my first draft framing all three as newly relocated
(and duplicating the existing line).

The empty pool is a real state, not a promise: `free_head` starts at the
end-of-list sentinel, and a unit test pins that it stays exhausted across
repeated acquires, stays fully released, and never moves its watermark. That
test is the caller A1 would otherwise have lacked.

## A2 — retired, not deferred

Both halves fail the test this plan sets:

- **`fillRandom` has no consumer here.** TLS keys and session tickets are its
  only ones, so it would be a seam method implemented in both backends and
  called by nothing.
- **The balancer half contradicts a settled decision.** `balancer.zig` seeds
  xorshift64* from a fixed named constant *on purpose* — "determinism is a
  feature", since the simulator replays every seed twice and demands
  byte-identical traces (§9). The spread argument for per-process randomness
  doesn't hold either: siblings behind SO_REUSEPORT already diverge through
  their own lease tables.

TLS brings `fillRandom` when TLS brings a consumer for it. PLANS records this.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` found **two violations, both mine, both fixed**: the
duplicate `relay_buffers` assert with an overstating commit message, and
`pathIsUnder` shipping with zero assertions on the diff's highest-risk logic.
It also traced `pathIsUnder` for false negatives — a boundary silently exempted
— across separators, trailing slashes, sibling prefixes and `..` paths, and
found none (the failure direction is the safe one), and confirmed no lint rule
was lost, no `Pool.init` caller anywhere relied on the removed assert, and that
`acquire`/`release`/`isFullyReleased`/`indexOf` all behave at `count == 0`.

Next: Tier C, then #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)