### PR TITLE
refactor: close out Tier C — a self-summing gate identity, named pool sizes (PLANS C2, C1)

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -209,9 +209,39 @@ existing unverified.
 
 | # | slice | ~ | what it buys |
 |---|---|---|---|
-| C1 | Pool descriptors as one comptime table feeding `memoryBytesTotal`, `fdsRequired`, `inFlightOpsMax`, `completionQueueDepthFor` and the startup print | 150 | the branch added positional args to five call sites; a new pool should be one row, and §5's memory table would generate itself |
-| C2 | Counter groups — `admission_shed` vs `post_admission_failure` — with `reconcile` summing the first structurally | 60 | the branch had to reason that `shed_tls_engines` must precede admission while `tls_relay_buffer_unavailable` must not; make the wrong bucket unrepresentable |
-| C3 | Per-resource release with explicit lifetimes instead of a fixed teardown sequence | 60 | kTLS wants the engine back at *handshake completion*, not teardown — illegal in today's shape |
+| C1 | Pool descriptors as one comptime table feeding `memoryBytesTotal`, `fdsRequired`, `inFlightOpsMax`, `completionQueueDepthFor` and the startup print — *landed as a `PoolSizes` struct; see below* | 150 | the branch added positional args to five call sites; a new pool should be one row, and §5's memory table would generate itself |
+| C2 | Counter groups — `admission_shed` vs `post_admission_failure` — with `reconcile` summing the first structurally — *landed as a naming rule, not two groups* | 60 | the branch had to reason that `shed_tls_engines` must precede admission while `tls_relay_buffer_unavailable` must not; make the wrong bucket unrepresentable |
+| C3 | Per-resource release with explicit lifetimes instead of a fixed teardown sequence | 60 | ~~kTLS wants the engine back at handshake completion~~ — **already true, nothing to build; see below** |
+
+**What Tier C landed, and what it did not.** All three rows were written from
+the TLS branch's diff rather than from this tree, and two of them shrank when
+read against it.
+
+- **C2 landed as a naming rule instead of two counter groups.** `reconcile`
+  now sums the gate identity off the field set — every counter named `shed_*`
+  — rather than a hand-written list, which is what makes A4's comptime assert
+  in `abortAdmission` load-bearing: a rung joins the sum by being named, and
+  the two checks are one rule read from both ends. Two groups would have been
+  more machinery for the same guarantee. A test pins today's membership so a
+  new `shed_*` counter has to change the gate identity deliberately (verified
+  by adding one and watching it fail), and a second test pins that an
+  `l7_shed_*` reject lands on the *other* side of the identity.
+- **C1 landed as a `PoolSizes` struct, not a descriptor table.** The table was
+  budgeted against five call sites; there are four, all in `main.zig`, and two
+  of the four functions (`fdsRequired`, `inFlightOps`) take counts only — a
+  TLS engine holds no socket and arms no ring op, so it never enters them.
+  What is genuinely hazardous is `memoryBytesTotal`'s six positional
+  arguments, three of them `u64` byte sizes: transposing two compiles, runs,
+  and prints the wrong total. Named fields make that unrepresentable, and a
+  fourth pool is a field plus a term. Unifying the count-only functions with
+  the sizing one would have coupled things that share nothing.
+- **C3 needs nothing.** The row claims a resource can only be released at
+  teardown; the code already releases per-resource, early, in five places —
+  the relay buffer on a keep-alive turnaround and inside `respond`, the
+  upstream slot mid-exchange and at reject — each the `if (conn.x) |held| {
+  release; conn.x = null; }` shape the row asks for. A TLS engine adds one
+  more such block, and kTLS returning it at handshake completion is already
+  legal. Removed rather than left looking pending.
 
 ### Tier D — measurement readiness
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -236,12 +236,14 @@ read against it.
   fourth pool is a field plus a term. Unifying the count-only functions with
   the sizing one would have coupled things that share nothing.
 - **C3 needs nothing.** The row claims a resource can only be released at
-  teardown; the code already releases per-resource, early, in five places —
+  teardown; the code already releases per-resource and early in five places —
   the relay buffer on a keep-alive turnaround and inside `respond`, the
-  upstream slot mid-exchange and at reject — each the `if (conn.x) |held| {
-  release; conn.x = null; }` shape the row asks for. A TLS engine adds one
-  more such block, and kTLS returning it at handshake completion is already
-  legal. Removed rather than left looking pending.
+  upstream slot when parked, detached, and at reject. Three of those guard on
+  the optional (`if (conn.x) |held|`) and two unwrap it outright, because
+  their preconditions already guarantee it is held; either way the lifetime is
+  the resource's own, not teardown's. A TLS engine adds one more such site,
+  and kTLS returning it at handshake completion is already legal. Removed
+  rather than left looking pending.
 
 ### Tier D — measurement readiness
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -361,7 +361,7 @@ pub fn Server(comptime IoType: type) type {
             if (server.draining) {
                 // An accept completion can already be in flight when the
                 // drain begins; it is shed, not served.
-                server.counters.increment("shed_draining");
+                server.witnessShed("shed_draining");
                 shed.closeQuietly(IoType, server.io, client_socket);
                 return;
             }
@@ -478,12 +478,22 @@ pub fn Server(comptime IoType: type) type {
         fn admitConn(server: *Self, client_socket: IoType.Socket) ?*ConnType {
             assert(!server.draining);
             const conn = server.conns.acquire() orelse {
-                server.counters.increment("shed_conn_slots");
+                server.witnessShed("shed_conn_slots");
                 shed.closeWithRst(IoType, server.io, client_socket);
                 return null;
             };
             server.updateConnPressure();
             return conn;
+        }
+
+        /// Witness one admission-gate shed: a connection the kernel handed us
+        /// that never became `admitted`. The name is checked here because
+        /// `reconcile` sums the gate identity by exactly this prefix (§9), so
+        /// naming a rung is what puts it in the sum — one door for every rung,
+        /// rather than the rule holding only where someone remembered it.
+        fn witnessShed(server: *Self, comptime rung: []const u8) void {
+            comptime assert(std.mem.startsWith(u8, rung, "shed_"));
+            server.counters.increment(rung);
         }
 
         /// Undo an admission that cannot proceed: a connection already
@@ -508,14 +518,11 @@ pub fn Server(comptime IoType: type) type {
             client_socket: IoType.Socket,
             comptime rung: []const u8,
         ) void {
-            // Naming, and only naming: what this witnesses is always a shed.
-            // `reconcile` sums an explicit list (§9), so a new rung has to be
-            // added there too — the simulator's reconcile invariant is what
-            // actually catches a miss, not this assert.
-            comptime assert(std.mem.startsWith(u8, rung, "shed_"));
             assert(!server.draining);
             server.releaseConn(conn);
-            server.counters.increment(rung);
+            // Through the one door, so the gate identity's naming rule holds
+            // here exactly as it does at the other rungs (§9).
+            server.witnessShed(rung);
             shed.closeQuietly(IoType, server.io, client_socket);
         }
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -444,6 +444,11 @@ comptime {
 /// fields make that particular mistake unrepresentable, and a fourth pool
 /// (§4's TLS engines) is a field and a term rather than two more positions
 /// at every call site.
+///
+/// Not `Config.Limits` plus byte sizes, though the three counts appear in
+/// both: `config.zig` imports this file, so the dependency cannot run the
+/// other way. `Limits` is what an operator provisions; this is what the
+/// provisioning costs, and a new pool needs a field in each.
 pub const PoolSizes = struct {
     conn_slots: u32,
     conn_bytes: u64,
@@ -453,7 +458,9 @@ pub const PoolSizes = struct {
     upstream_bytes: u64,
 };
 
-pub fn memoryBytesTotal(sizes: PoolSizes) u64 {
+/// By pointer: `PoolSizes` is past the 16-byte threshold TIGER_STYLE sets
+/// for by-value arguments, and a stack copy of the budget buys nothing.
+pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     assert(sizes.conn_slots >= 1);
     assert(sizes.conn_slots <= conn_slots_max);
     assert(sizes.relay_buffers >= 1);
@@ -499,7 +506,7 @@ test "budgets: memory total matches the closed form" {
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes;
-    try std.testing.expectEqual(expected_max, memoryBytesTotal(.{
+    try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
         .relay_buffers = relay_buffers_max,
@@ -508,7 +515,7 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
     }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
-    try std.testing.expectEqual(expected_small, memoryBytesTotal(.{
+    try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
         .relay_buffers = 8,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -437,26 +437,35 @@ comptime {
 /// §5). Slot sizes are runtime parameters because `Conn` is generic over
 /// the Io backend; the composition site passes `@sizeOf` of the concrete
 /// types and main.zig prints the result at startup.
-pub fn memoryBytesTotal(
+/// What the pools cost: a count and a slot size per pool. A struct rather
+/// than six positional arguments because three of them are `u64` byte sizes
+/// — transposing two of those compiles, runs, and silently prints the wrong
+/// total, which the sanity asserts below could only sometimes catch. Named
+/// fields make that particular mistake unrepresentable, and a fourth pool
+/// (§4's TLS engines) is a field and a term rather than two more positions
+/// at every call site.
+pub const PoolSizes = struct {
     conn_slots: u32,
     conn_bytes: u64,
     relay_buffers: u32,
     relay_buffer_pair_bytes: u64,
     upstream_slots: u32,
     upstream_bytes: u64,
-) u64 {
-    assert(conn_slots >= 1);
-    assert(conn_slots <= conn_slots_max);
-    assert(relay_buffers >= 1);
-    assert(relay_buffers <= relay_buffers_max);
-    assert(upstream_slots >= 1);
-    assert(upstream_slots <= upstream_slots_max);
-    assert(conn_bytes > 0);
-    assert(relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
-    assert(upstream_bytes >= head_bytes_max);
-    const total = @as(u64, conn_slots) * conn_bytes +
-        @as(u64, relay_buffers) * relay_buffer_pair_bytes +
-        @as(u64, upstream_slots) * upstream_bytes;
+};
+
+pub fn memoryBytesTotal(sizes: PoolSizes) u64 {
+    assert(sizes.conn_slots >= 1);
+    assert(sizes.conn_slots <= conn_slots_max);
+    assert(sizes.relay_buffers >= 1);
+    assert(sizes.relay_buffers <= relay_buffers_max);
+    assert(sizes.upstream_slots >= 1);
+    assert(sizes.upstream_slots <= upstream_slots_max);
+    assert(sizes.conn_bytes > 0);
+    assert(sizes.relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
+    assert(sizes.upstream_bytes >= head_bytes_max);
+    const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
+        @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
+        @as(u64, sizes.upstream_slots) * sizes.upstream_bytes;
     assert(total > 0);
     return total;
 }
@@ -490,19 +499,23 @@ test "budgets: memory total matches the closed form" {
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes;
-    try std.testing.expectEqual(expected_max, memoryBytesTotal(
-        conn_slots_max,
-        conn_bytes,
-        relay_buffers_max,
-        pair_bytes,
-        upstream_slots_max,
-        upstream_bytes,
-    ));
+    try std.testing.expectEqual(expected_max, memoryBytesTotal(.{
+        .conn_slots = conn_slots_max,
+        .conn_bytes = conn_bytes,
+        .relay_buffers = relay_buffers_max,
+        .relay_buffer_pair_bytes = pair_bytes,
+        .upstream_slots = upstream_slots_max,
+        .upstream_bytes = upstream_bytes,
+    }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
-    try std.testing.expectEqual(
-        expected_small,
-        memoryBytesTotal(64, conn_bytes, 8, pair_bytes, 8, upstream_bytes),
-    );
+    try std.testing.expectEqual(expected_small, memoryBytesTotal(.{
+        .conn_slots = 64,
+        .conn_bytes = conn_bytes,
+        .relay_buffers = 8,
+        .relay_buffer_pair_bytes = pair_bytes,
+        .upstream_slots = 8,
+        .upstream_bytes = upstream_bytes,
+    }));
 }
 
 test "budgets: c10k ceiling fd count needs a raised NOFILE" {

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -160,13 +160,47 @@ pub const Counters = struct {
 
     /// The §9 invariant: admitted work is completed or still active, and
     /// every accepted connection was admitted or shed — no third outcome.
+    /// The prefix that makes a counter part of the gate identity below.
+    /// Naming is the membership rule on purpose: every rung is witnessed
+    /// through `Server.witnessShed`, which comptime-asserts the name (§8), so
+    /// a new admission shed joins `shedTotal` by being named rather than by
+    /// being remembered — which is what the previous hand-written sum could
+    /// not promise.
+    ///
+    /// The `l7_shed_*` counters sit outside it deliberately: those
+    /// connections were admitted and answered a 503, so they complete
+    /// normally and belong to the flow identity, not the gate one.
+    const shed_prefix = "shed_";
+
+    /// How many counters the prefix selects. Comptime, so a rename that
+    /// emptied the sum would fail the build instead of making the gate
+    /// identity vacuously true.
+    const shed_rung_count: usize = blk: {
+        var count: usize = 0;
+        for (@typeInfo(Counters).@"struct".fields) |field| {
+            if (field.type != Value) continue;
+            if (std.mem.startsWith(u8, field.name, shed_prefix)) count += 1;
+        }
+        break :blk count;
+    };
+
+    /// Every admission shed, summed off the field set rather than a list.
+    fn shedTotal(counters: *const Counters) u64 {
+        comptime assert(shed_rung_count >= 1);
+        var total: u64 = 0;
+        inline for (@typeInfo(Counters).@"struct".fields) |field| {
+            if (field.type != Value) continue;
+            if (comptime !std.mem.startsWith(u8, field.name, shed_prefix)) continue;
+            total += counters.get(field.name);
+        }
+        return total;
+    }
+
     pub fn reconcile(counters: *const Counters, active_count: u32) bool {
         const admitted = counters.get("admitted");
         const completed = counters.get("completed");
         const accepted = counters.get("accepted");
-        const shed = counters.get("shed_conn_slots") +
-            counters.get("shed_relay_buffers") +
-            counters.get("shed_draining");
+        const shed = counters.shedTotal();
         assert(completed <= admitted);
         assert(admitted <= accepted);
         // Every 504 verdict rides a deadline expiry (§8) — the verdict
@@ -247,4 +281,48 @@ test "counters: render bound holds at the maximum value" {
     // one (the "exact" claim in its doc comment).
     try std.testing.expectEqual(Counters.render_bytes_max, text.len);
     try std.testing.expect(std.mem.indexOf(u8, text, "18446744073709551615\n") != null);
+}
+
+test "counters: the gate identity sums exactly today's admission rungs" {
+    // Membership is by name (`shed_prefix`), so this pins what that rule
+    // currently selects: a new `shed_*` counter changes the gate identity,
+    // and should change this list in the same commit that adds it. The
+    // `l7_shed_*` rejects must stay out — those connections were admitted.
+    const expected = [_][]const u8{
+        "shed_conn_slots",
+        "shed_relay_buffers",
+        "shed_draining",
+    };
+    comptime var actual_count: usize = 0;
+    inline for (@typeInfo(Counters).@"struct".fields) |field| {
+        if (field.type != Counters.Value) continue;
+        if (!comptime std.mem.startsWith(u8, field.name, Counters.shed_prefix)) continue;
+        actual_count += 1;
+        comptime var listed = false;
+        inline for (expected) |name| {
+            if (comptime std.mem.eql(u8, name, field.name)) listed = true;
+        }
+        if (!listed) {
+            std.debug.print("unlisted shed counter: {s}\n", .{field.name});
+            return error.UnlistedShedCounter;
+        }
+    }
+    try std.testing.expectEqual(expected.len, actual_count);
+}
+
+test "counters: an admission shed and an L7 reject land on opposite sides" {
+    var counters: Counters = .{};
+    // A rung that fires before admission keeps the gate balanced on its own.
+    counters.increment("accepted");
+    counters.increment("shed_relay_buffers");
+    try std.testing.expect(counters.reconcile(0));
+
+    // The L7 503 is not a gate shed: its connection was admitted, so it has
+    // to complete for the books to balance.
+    counters.increment("accepted");
+    counters.increment("admitted");
+    counters.increment("l7_shed_relay_buffers");
+    try std.testing.expect(!counters.reconcile(0));
+    counters.increment("completed");
+    try std.testing.expect(counters.reconcile(0));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -224,7 +224,7 @@ fn printBudgets(
         limits.upstream_slots,
         @intCast(config.listeners.len),
     );
-    const memory_total = constants.memoryBytesTotal(.{
+    const memory_total = constants.memoryBytesTotal(&.{
         .conn_slots = limits.conn_slots,
         .conn_bytes = @sizeOf(ServerXev.ConnType),
         .relay_buffers = limits.relay_buffers,

--- a/src/main.zig
+++ b/src/main.zig
@@ -224,14 +224,14 @@ fn printBudgets(
         limits.upstream_slots,
         @intCast(config.listeners.len),
     );
-    const memory_total = constants.memoryBytesTotal(
-        limits.conn_slots,
-        @sizeOf(ServerXev.ConnType),
-        limits.relay_buffers,
-        @sizeOf(zoxy.RelayBuffer),
-        limits.upstream_slots,
-        @sizeOf(UpstreamType),
-    );
+    const memory_total = constants.memoryBytesTotal(.{
+        .conn_slots = limits.conn_slots,
+        .conn_bytes = @sizeOf(ServerXev.ConnType),
+        .relay_buffers = limits.relay_buffers,
+        .relay_buffer_pair_bytes = @sizeOf(zoxy.RelayBuffer),
+        .upstream_slots = limits.upstream_slots,
+        .upstream_bytes = @sizeOf(UpstreamType),
+    });
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;


### PR DESCRIPTION
Tier C of the [prefactoring plan](docs/PLANS.md) (#70), two commits. **Two of
the three rows shrank when read against this tree** rather than the TLS
branch's diff, and the third needs nothing at all.

## C2 — the gate identity sums itself, through one door

`reconcile` summed three named shed counters by hand, so a new admission rung
entered `accepted == admitted + shed` only if someone remembered. A4 left that
gap open explicitly — its `abortAdmission` comptime-asserted the `shed_*`
naming, and the comment had to admit the assert pinned naming and nothing more.

The sum now comes off the field set (the same reflection `render` already
uses), so **naming is membership**. `shed_rung_count` is comptime and asserted
non-zero, so a rename that emptied the sum fails the build instead of making
the identity vacuously true.

For that rule to be worth stating, every rung has to pass through it — and
**two didn't**. `shed_conn_slots` and `shed_draining` incremented directly;
only `shed_relay_buffers` went through the asserted path. All three now go
through `witnessShed`, which owns the comptime check. Review caught this: my
first draft's prose claimed a universality the code didn't have.

Two tests, because a rule enforced by reflection needs its membership visible:
one pins exactly which counters the prefix selects today (verified by adding a
`shed_sabotage` field and watching the test name it), the other pins that an
admission shed and an `l7_shed_*` reject land on **opposite sides** of the
identity.

The row asked for two counter *groups*. One naming rule at one door buys the
same guarantee with less machinery.

## C1 — named pool sizes, not a descriptor table

`memoryBytesTotal` took six positional args, alternating counts and `u64` byte
sizes. Transposing two compiles, runs, and prints the wrong total — the sanity
asserts underneath exist *because* the shape invites it, and they only
sometimes catch it. `PoolSizes` makes that unrepresentable; a fourth pool is a
field and a term. Passed `*const`, being past TIGER_STYLE's 16-byte by-value
threshold.

**Not** the descriptor table the row described: it was budgeted against five
call sites, there are four (all in main.zig), and two of the four budget
functions take counts only — `fdsRequired` and `inFlightOps` never see a byte
size, and a TLS engine holds no socket and arms no ring op, so it never enters
them. Unifying them would couple things that share nothing, on the arithmetic
the c10k ceiling is derived from.

## C3 — nothing to build

The row claims a resource can only be released at teardown. Release is already
per-resource and early in five places: the relay buffer on a keep-alive
turnaround and inside `respond`, the upstream slot when parked, detached, and
at reject. kTLS handing an engine back at handshake completion is already
legal. Retired in PLANS rather than left looking pending.

## Gates and review

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.
`tiger-style-reviewer` found **one violation** — `PoolSizes` passed by value at
40 bytes — plus the coverage gap in C2's prose above, `shedTotal` shipping with
no assertions, and an imprecise shape description in the C3 write-up (two of
the five sites unwrap outright rather than guarding). All fixed. It
independently verified the reflected sum is byte-identical to the old
hand-written one, that the `comptime` placement in the `inline for` is exactly
what's required, that the struct conversion is order-preserving at all four
call sites, and my C3 claim.

That closes Tier A and Tier C. Next: **#77**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)