### PR TITLE
bench: gate every band by reflection, not by a list to keep in step (§9)

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -383,23 +383,36 @@ fn benchPassed(
     var bands_ok = true;
     for (bands) |band| {
         const offered = band.scenario.rate(flags);
-        // The direct baseline gates too, and not only on liveness: if the
-        // origin cannot keep up, every proxied band beside it is bounded by
-        // the origin and the comparison measures nothing.
+        // The direct baseline gates on liveness too: if the origin cannot
+        // keep up, every proxied band beside it is bounded by the origin and
+        // the comparison measures nothing.
         if (band.runs.direct.snapshot.counters.completed == 0) {
             std.debug.print("FAIL: {s} direct baseline completed zero requests\n", .{band.label});
             bands_ok = false;
-        } else if (!rateHeld(band.label, "direct", offered, &band.runs.direct)) {
-            std.debug.print("       (the origin, not the proxy, is the limit here)\n", .{});
-            bands_ok = false;
         }
-        // The proxied bands carry the hard §9 invariants: complete requests,
-        // a socket-error rate under 1% (a relay stall must not pass silently;
-        // faithfully relayed 4xx/5xx are excluded), and now an achieved rate
-        // that actually reaches what was offered.
+        // The proxied bands carry the hard §9 invariants: complete requests
+        // and a socket-error rate under 1% (a relay stall must not pass
+        // silently; faithfully relayed 4xx/5xx are excluded).
         if (!proxiesHealthy(band.label, band.runs)) bands_ok = false;
-        if (!rateHeld(band.label, "L4", offered, &band.runs.l4)) bands_ok = false;
-        if (!rateHeld(band.label, "L7", offered, &band.runs.l7)) bands_ok = false;
+        // And *every* path holds its offered rate — by reflection over
+        // `Runs`, so adding a path to that struct is what puts it under the
+        // floor, instead of also remembering a line here. The gate exists
+        // because a band once delivered 704 of 2000 req/s through green
+        // error checks (IMPLEMENTATION_NOTES.md); a gate you have to
+        // remember to extend reopens that hole the first time someone
+        // doesn't. The reference bands are in scope for the same reason the
+        // baseline is: haproxy missing the offer means the *offer* is wrong,
+        // and a comparison against a reference that could not keep up
+        // measures nothing.
+        inline for (@typeInfo(Runs).@"struct".fields) |field| {
+            comptime assert(field.type == zrk.runner.Report);
+            if (!rateHeld(band.label, field.name, offered, &@field(band.runs, field.name))) {
+                bands_ok = false;
+                if (comptime std.mem.eql(u8, field.name, "direct")) {
+                    std.debug.print("       (the origin, not the proxy, is the limit here)\n", .{});
+                }
+            }
+        }
     }
     return rss_flat and bands_ok and drained_cleanly;
 }
@@ -693,6 +706,9 @@ fn loadTest(
 
 /// The five bands of one persistence mode: the direct baseline, zoxy's
 /// two protocols, and the haproxy references.
+/// One scenario's bands. Every field is a path the same offered load ran
+/// against, and `bandsHealthy` reflects over them — so a path added here is
+/// gated by that alone, with no second list to keep in step.
 const Runs = struct {
     direct: zrk.runner.Report,
     l4: zrk.runner.Report,


### PR DESCRIPTION
Second slice of the re-planned Phase 3a (replacing the one 5k-line PR in #84 with landable pieces). No TLS involved; this is an improvement to the §9 gate on its own terms.

## The hole

The rate floor was three hand-written `rateHeld` calls — `direct`, `l4`, `l7`. A band added to `Runs` stayed ungated until someone remembered a fourth line.

That is the same hole the gate was built to close. It exists because a band once delivered **704 of 2000 req/s through green error checks** (IMPLEMENTATION_NOTES.md): the §9 checks looked at *how* requests failed, never *whether* they happened. A gate you have to remember to extend reopens that the first time nobody does — and I hit exactly that while measuring TLS, where the two new bands were silently exempt until I noticed by hand.

Reflecting over `Runs` makes adding the path *be* the act of gating it — the same move `Counters.shedTotal` makes for the gate identity, for the same reason.

## The reference bands, for the first time

This also brings `tcp` and `http` under the floor. Not incidental coverage:

**haproxy missing the offer means the *offer* is wrong, not that zoxy is slow.** On the TLS branch, close-mode delivered zoxy 664 and haproxy 831 of 2000 — and nothing complained about the latter, so the shortfall read as a zoxy problem when both proxies were missing an unreasonable offer. A comparison against a reference that could not keep up measures nothing.

A `comptime assert` pins that every `Runs` field really is a `Report`, so a future field of another type fails the build rather than silently escaping the loop.

## Verified by making it fail

Floor forced to 150%, keep-alive band:

```
FAIL: keep-alive direct delivered 19952 of 20000 req/s offered (150% floor)
FAIL: keep-alive l4     delivered 19960 of 20000 req/s offered (150% floor)
FAIL: keep-alive l7     delivered 19962 of 20000 req/s offered (150% floor)
FAIL: keep-alive tcp    delivered 19969 of 20000 req/s offered (150% floor)
FAIL: keep-alive http   delivered 19961 of 20000 req/s offered (150% floor)
```

All five named, including the two the previous list never checked. Unforced, every band holds its offer on this box across all three scenarios.

The one remaining `zig build bench` failure is the pre-existing overload stall gate (#82), unchanged by this.

## Gates

`zig build ci`, `zig build lint`, `zig fmt --check` green; `zig build bench` run end to end (bench is a merge-time gate, not per-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
