### PR TITLE
http: witness the separately-written response excess (§7, §8)

### DIFF
--- a/src/counters.zig
+++ b/src/counters.zig
@@ -62,6 +62,15 @@ pub const Counters = struct {
     l7_gateway_timeout: Value = Value.init(0),
     /// Completed L7 exchanges: a parsed origin response relayed back.
     l7_responses: Value = Value.init(0),
+    /// Responses whose coalesced body excess did not fit beside the
+    /// rendered head and left in a second write of its own (§7) — one
+    /// extra ring round trip, paid whenever the origin's delivery fills
+    /// the head buffer and the render grows the head. The client receives
+    /// the same bytes either way, so this counter is the only witness
+    /// that the branch ran: without it neither an operator nor a test can
+    /// tell the two paths apart (#77). Pure observability, so it stays
+    /// out of `reconcile`.
+    l7_response_excess_sent: Value = Value.init(0),
     /// Exchanges served over a parked upstream connection instead of a
     /// fresh dial — the §3 reuse win, witnessed.
     upstream_reused: Value = Value.init(0),

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -26,8 +26,10 @@
 //! Buffer ownership rotates, never overlaps: conn.head holds the request
 //! head until it is rendered, then stages the rendered response head;
 //! upstream.head stages the rendered request head, then accumulates the
-//! response head; the relay-buffer halves carry only framed body bytes
-//! (head-adjacent excess is copied across once at each pump start).
+//! response head; the relay-buffer halves carry only framed body bytes.
+//! Head-adjacent excess never enters a relay half — it is forwarded
+//! straight from the head buffer holding it, so a coalesced body larger
+//! than a half is never squeezed through one.
 
 const std = @import("std");
 
@@ -1022,6 +1024,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             conn.l7.response_leg = .sending_body_excess;
+            server.counters.increment("l7_response_excess_sent");
             const base = conn.l7.response_head_len_marker;
             // These are bytes the origin actually delivered past its head —
             // the bound `DirectionState.pending` used to check for this write

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const constants = @import("constants.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
 const Io = @import("io/io.zig");
@@ -49,7 +50,10 @@ const HttpClient = struct {
     drain_on_finish: bool = true,
     sent_len: u32 = 0,
     send_in_flight: bool = false,
-    receive_buffer: [4096]u8 = undefined,
+    /// Twice the proxy's head buffer: a response that fills that buffer and
+    /// then grows in the render exceeds it, and the separate-excess scenario
+    /// needs the whole response in one place to compare against.
+    receive_buffer: [2 * constants.head_bytes_max]u8 = undefined,
     received_len: u32 = 0,
     outcome: Outcome = .pending,
 
@@ -1140,6 +1144,65 @@ test "l7: a body coalesced with the head, larger than a relay buffer, forwards i
     const forwarded_body = bed.origin.conns[0].request_buffer[forwarded.head_len..bed.origin.conns[0].request_len];
     try std.testing.expectEqualStrings(request[head.len..request_len], forwarded_body);
     try bed.expectDrained();
+}
+
+test "l7: a coalesced excess too large to ride the rendered head is written separately" {
+    // The origin's delivery fills upstream.head exactly, so the coalesced
+    // body sits flush against the 8 KiB bound; the `Connection: close`
+    // injection then grows the render past it and the excess cannot ride
+    // along — it leaves as a second write straight from upstream.head (§7).
+    // Sizes derive from the bound rather than being spelled out, so a change
+    // to `head_bytes_max` fails here loudly instead of quietly sliding the
+    // scenario off the branch it exists to cover (#77).
+    const injected_len = "Connection: close\r\n".len;
+    const body_len = 42;
+    const head_len: usize = constants.head_bytes_max - body_len;
+    const prefix = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nX-Pad: ",
+        .{body_len},
+    );
+    const suffix = "\r\n\r\n";
+
+    var response_bytes: [constants.head_bytes_max]u8 = undefined;
+    @memcpy(response_bytes[0..prefix.len], prefix);
+    @memset(response_bytes[prefix.len..][0 .. head_len - prefix.len - suffix.len], 'p');
+    @memcpy(response_bytes[head_len - suffix.len ..][0..suffix.len], suffix);
+    for (response_bytes[head_len..][0..body_len], 0..) |*byte, index| {
+        byte.* = @intCast('a' + (index % 26));
+    }
+
+    // Whole deliveries only: under 1-byte adversarial delivery the head
+    // parses long before the excess lands, and the excess rides the head
+    // write like every other response — a different path, covered elsewhere.
+    // The seeds still vary the clock jitter that orders the two head reads
+    // this response needs, so the branch must not depend on their timing.
+    var seed: u64 = 40;
+    while (seed < 44) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .origin_response = &response_bytes,
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /pad HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+        try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+        // The counter is the assertion that matters: the client receives the
+        // same bytes whichever way the excess left, so nothing below would
+        // fail if the branch stopped being taken.
+        try std.testing.expectEqual(
+            @as(u64, 1),
+            bed.server.counters.get("l7_response_excess_sent"),
+        );
+        const response = bed.client.response();
+        try std.testing.expectEqual(head_len + injected_len + body_len, response.len);
+        try std.testing.expectEqualStrings(
+            response_bytes[head_len..][0..body_len],
+            response[response.len - body_len ..],
+        );
+        try bed.expectDrained();
+    }
 }
 
 test "l7: a connection-close (until-close) response body relays to the client's EOF" {


### PR DESCRIPTION
Closes #77.

The body excess that arrives coalesced with the response head rides along in `conn.head` when it fits beside the rendered head, and otherwise leaves in a write of its own from `upstream.head`. The second arm was reachable but run by no gate: `zig build ci` — 203 unit tests, 64 sim seeds, fuzz corpus, lint — passed with a `@panic` standing in it, so it was never *executed*, not merely unwitnessed.

## It is not the rarity the issue described

The condition is on the whole delivery, not on the head size. Writing `G` for the render's growth:

```
branch taken  ⟺  upstream.head_len > head_bytes_max − G
```

Head plus coalesced body must land within `G` bytes of filling `upstream.head`. The head can be 41 bytes. The "~8 KiB head" shape in the issue is an artifact of the harness: SimIo's socket ring is 4 KiB (`src/io/SimIo.zig:27`), so a small-head response parses on the first ≤4096-byte delivery and the branch cannot fire. Production reads into the whole free buffer, so every response over 8 KiB that is ready at once lands on `upstream.head_len == 8192` exactly and takes the branch whenever `G ≥ 1` — an injected `Connection: close`, or an origin writing `Name:value` without the space the render puts back. HTTP/1.0 clients, `Connection: close` clients, `until_close` responses, draining, relay pressure.

## Why a counter and not a test alone

The client receives the same bytes whichever way the excess left, so a test can only ever *infer* the branch. The issue's two alternatives do not hold up: delivery counting cannot discriminate (the same 4 KiB ring bounds the client's recvs, so an 8211-byte response arrives in ≥3 either way), and deleting the branch is not deletion (`relay_buffer_bytes = 4096` against a ~8 KiB excess, and `pump.zig` has no seed-from-memory entry — "leave it for the pump" is this branch relocated, with a cursor over `upstream.head`).

`l7_response_excess_sent` witnesses it instead. Reflection-driven rendering and the `shed_` prefix sum both pick the field up with no list to update; it stays out of `reconcile` as pure observability.

## Contents

- The counter, incremented in `sendResponseExcess` where the state machine commits to the branch — the same convention `l7_responses` follows.
- A directed test: 8150-byte head + 42-byte body fills `upstream.head` exactly, the close injection makes the render 8169, so 8169 + 42 overflows `conn.head`. Sizes derive from `head_bytes_max`, so moving that bound fails the test rather than sliding it off the branch.
- `HttpClient.receive_buffer` 4096 → `2 * head_bytes_max`; unavoidable, since any test that reaches the branch makes the client receive more than 8 KiB.
- A module-doc correction at `proxy.zig:30`, which had head-adjacent excess "copied across once at each pump start" — there is no such copy on any path.

## Verification

`zig build ci` and `zig fmt --check` pass. The negative control is the load-bearing one: with the original sabotage (`response_excess_len = 0`) reapplied, the new test fails on the counter assertion — `expected 1, found 0` — while every other test still passes. That is the sabotage that previously slipped through every gate.

`tiger-style-reviewer` found no violations; its one judgement call (a hand-picked seed set breaking the file's contiguous-range convention) is addressed.

Follow-up filed as #87: the same 4 KiB ring means any path gated on a head buffer filling from one delivery is unreachable in the sim, and this branch is only the instance #77 happened to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
