### PR TITLE
sim: make the socket ring a per-scenario cap, not a ceiling (§9)

### DIFF
--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -423,6 +423,12 @@ const Http1Bed = struct {
     const Options = struct {
         seed: u64,
         partial_io: bool = false,
+        /// Socket-ring size, null for SimIo's own default (§9). The default
+        /// is narrower than a head buffer, so no delivery can fill one in a
+        /// single read; a scenario that needs the shape production takes
+        /// raises it. Independent of `partial_io`, which fragments what the
+        /// ring was willing to carry.
+        inbox_bytes: ?u32 = null,
         origin_response: []const u8 = "",
         origin_listens: bool = true,
         origin_closes: bool = false,
@@ -459,10 +465,11 @@ const Http1Bed = struct {
         errdefer bed.arena_state.deinit();
         const arena = bed.arena_state.allocator();
 
-        try bed.sim_io.init(arena, .{
-            .seed = options.seed,
-            .adversary = .{ .partial_io = options.partial_io },
-        });
+        var adversary: SimIo.Adversary = .{ .partial_io = options.partial_io };
+        if (options.inbox_bytes) |bytes| {
+            adversary.inbox_bytes = bytes;
+        }
+        try bed.sim_io.init(arena, .{ .seed = options.seed, .adversary = adversary });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
@@ -1273,6 +1280,51 @@ test "l7: a coalesced excess too large to ride the rendered head is written sepa
         );
         try bed.expectDrained();
     }
+}
+
+test "l7: the coalesced excess in the shape production delivers it" {
+    // The same branch as the test above, reached the way production reaches
+    // it: a 41-byte head with a body large enough that one read fills
+    // upstream.head outright. The test above has to grow the *head* to 8 KiB
+    // instead, because the default socket ring is half a head buffer and can
+    // never hand over more than that at once — the branch is common in
+    // production and unrepresentable in the simulator until a scenario opens
+    // the ring (#90).
+    const body_len = 9000;
+    const head = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\n\r\n",
+        .{body_len},
+    );
+    const injected_len = "Connection: close\r\n".len;
+    var response_bytes: [head.len + body_len]u8 = undefined;
+    @memcpy(response_bytes[0..head.len], head);
+    for (response_bytes[head.len..], 0..) |*byte, index| {
+        byte.* = @intCast('a' + (index % 26));
+    }
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 12,
+        .inbox_bytes = constants.head_bytes_max,
+        .origin_response = &response_bytes,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /big HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_response_excess_sent"),
+    );
+    // The body crosses the excess write and the pump behind it intact.
+    const response = bed.client.response();
+    try std.testing.expectEqual(head.len + injected_len + body_len, response.len);
+    try std.testing.expectEqualStrings(
+        response_bytes[head.len..],
+        response[response.len - body_len ..],
+    );
+    try bed.expectDrained();
 }
 
 test "l7: a connection-close (until-close) response body relays to the client's EOF" {

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -24,7 +24,22 @@ const SimIo = @This();
 const sockets_max: u16 = 1024;
 const listeners_max: u16 = 32;
 const accept_queue_max: u16 = 64;
-const inbox_bytes: u32 = 4096;
+/// The widest a scenario may open a socket ring. Sized to the head buffer
+/// so a scenario can reproduce a production-shaped delivery — one read
+/// filling `conn.head`/`upstream.head` outright — which a narrower ring
+/// makes unrepresentable whatever the seed.
+const inbox_bytes_max: u32 = constants.head_bytes_max;
+/// What a scenario gets unless it asks for more. Half the head buffer, so
+/// a head larger than it still arrives in pieces by default and the §7
+/// detect-and-retry re-parse keeps being exercised.
+const inbox_bytes_default: u32 = 4096;
+comptime {
+    assert(inbox_bytes_default >= 1);
+    assert(inbox_bytes_default <= inbox_bytes_max);
+    // The default must stay narrower than a head buffer, or every scenario
+    // silently loses the piecewise head arrival it covers today.
+    assert(inbox_bytes_default < constants.head_bytes_max);
+}
 const pending_ops_max: u32 = constants.in_flight_ops_max;
 const pending_signals_max: u8 = 8;
 /// The clock starts at one virtual second, not zero, so code that would
@@ -60,6 +75,13 @@ const blackholed_addresses_max: u8 = 4;
 pub const Adversary = struct {
     /// Bias deliveries toward 1-byte and full-length reads/writes.
     partial_io: bool = true,
+    /// Usable socket-ring size: the ceiling on what one recv can deliver,
+    /// however much the peer wrote. Where `partial_io` fragments a delivery
+    /// that could have been whole, this bounds how whole "whole" ever gets —
+    /// the two are independent knobs on the same question. Raising it to
+    /// `inbox_bytes_max` is what lets a scenario fill a head buffer in one
+    /// read, the shape production takes and the default cannot express.
+    inbox_bytes: u32 = inbox_bytes_default,
     connect_delay_ns_max: u64 = 0,
     connect_refuse_percent: u8 = 0,
     connect_blackhole_percent: u8 = 0,
@@ -201,13 +223,19 @@ const ListenerEntry = struct {
 };
 
 const Ring = struct {
-    bytes: [inbox_bytes]u8,
+    bytes: [inbox_bytes_max]u8,
     head: u32,
     count: u32,
+    /// What this ring actually wraps at, set per scenario from the
+    /// adversary. The backing array is the widest any scenario may ask
+    /// for; this is what the scenario asked for.
+    capacity: u32,
 
     fn freeSpace(ring: *const Ring) u32 {
-        assert(ring.count <= inbox_bytes);
-        return inbox_bytes - ring.count;
+        assert(ring.capacity >= 1);
+        assert(ring.capacity <= inbox_bytes_max);
+        assert(ring.count <= ring.capacity);
+        return ring.capacity - ring.count;
     }
 
     fn push(ring: *Ring, source: []const u8) u32 {
@@ -215,21 +243,26 @@ const Ring = struct {
         assert(n <= source.len);
         var written: u32 = 0;
         while (written < n) : (written += 1) {
-            ring.bytes[(ring.head + ring.count + written) % inbox_bytes] = source[written];
+            ring.bytes[(ring.head + ring.count + written) % ring.capacity] = source[written];
         }
         ring.count += n;
-        assert(ring.count <= inbox_bytes);
+        assert(ring.count <= ring.capacity);
         return n;
     }
 
     fn pop(ring: *Ring, target: []u8) u32 {
         const n: u32 = @min(@as(u32, @intCast(target.len)), ring.count);
         assert(n <= target.len);
+        // The modulus below is this function's own precondition, not one
+        // borrowed from whoever pushed.
+        assert(ring.capacity >= 1);
+        assert(ring.capacity <= inbox_bytes_max);
+        assert(ring.count <= ring.capacity);
         var read: u32 = 0;
         while (read < n) : (read += 1) {
-            target[read] = ring.bytes[(ring.head + read) % inbox_bytes];
+            target[read] = ring.bytes[(ring.head + read) % ring.capacity];
         }
-        ring.head = (ring.head + n) % inbox_bytes;
+        ring.head = (ring.head + n) % ring.capacity;
         ring.count -= n;
         return n;
     }
@@ -246,6 +279,10 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     assert(options.adversary.reset_percent <= 100);
     assert(options.adversary.kernel_pressure_percent <= 100);
     assert(options.adversary.batch_max >= 1);
+    // A ring that cannot hold a byte can never make progress, and one
+    // wider than the backing array would index past it.
+    assert(options.adversary.inbox_bytes >= 1);
+    assert(options.adversary.inbox_bytes <= inbox_bytes_max);
 
     io.listeners = try arena.alloc(ListenerEntry, listeners_max);
     io.pending = try arena.alloc(*Completion, pending_ops_max);
@@ -822,8 +859,8 @@ fn finishConnect(
     }
     const client_entry = io.sockets.acquire() orelse unreachable;
     const server_entry = io.sockets.acquire() orelse unreachable;
-    initSocketEntry(client_entry);
-    initSocketEntry(server_entry);
+    initSocketEntry(client_entry, io.adversary.inbox_bytes);
+    initSocketEntry(server_entry, io.adversary.inbox_bytes);
     client_entry.peer = @intCast(io.sockets.indexOf(server_entry));
     server_entry.peer = @intCast(io.sockets.indexOf(client_entry));
     listener.accept_queue[listener.accept_queue_len] = io.socketHandle(server_entry);
@@ -1011,7 +1048,9 @@ fn findListener(io: *SimIo, address: std.Io.net.IpAddress) ?*ListenerEntry {
     return null;
 }
 
-fn initSocketEntry(entry: *SocketEntry) void {
+fn initSocketEntry(entry: *SocketEntry, inbox_capacity: u32) void {
+    assert(inbox_capacity >= 1);
+    assert(inbox_capacity <= inbox_bytes_max);
     entry.peer = peer_none;
     entry.fin_received = false;
     entry.read_shutdown = false;
@@ -1022,6 +1061,7 @@ fn initSocketEntry(entry: *SocketEntry) void {
     entry.nodelay = false;
     entry.inbox.head = 0;
     entry.inbox.count = 0;
+    entry.inbox.capacity = inbox_capacity;
 }
 
 fn closeEntry(io: *SimIo, socket: Socket) void {


### PR DESCRIPTION
Closes #90.

SimIo's ring was a fixed 4096-byte array — exactly half of `head_bytes_max` — so one simulated recv could never deliver enough to fill a head buffer. A class of production shapes was unrepresentable whatever the seed: #77's separately-written response excess is reached in production by a 41-byte head with a large body behind it, and the test covering it has to grow the *head* to 8 KiB instead, purely because the ring cannot hand over more than half the buffer at once.

## Why not just raise the constant

That trades one blind spot for another. Today's narrow ring is exactly what guarantees every large head arrives in pieces, and so exercises the §7 detect-and-retry re-parse. A global bump would withdraw that coverage quietly — nothing would fail.

So the backing array grows to `head_bytes_max` while the *usable* size becomes a runtime `capacity`, set per scenario from a new `Adversary.inbox_bytes` that still defaults to 4096. Every index is mod the capacity, so the widened array's upper half is simply never addressed by a scenario that does not opt in; existing behaviour is byte-identical, not merely equivalent.

`inbox_bytes` is independent of `partial_io`: the capacity bounds how much a single delivery *could* carry, `partial_io` decides how much of that it actually uses. Together they span the range from one byte to a full head buffer.

## What opts in

One scenario, reproducing #77's branch in the shape production delivers it (41-byte head, 9000-byte body, one read fills `upstream.head`). It sits beside the head-grown test rather than replacing it — the two now cover the same branch from opposite directions, which is worth keeping given how much trouble that branch has already caused.

## Coverage check

The #90 acceptance bar was that no arm loses coverage. Probe counts per boundary arm, unit and sim separately, before vs after:

| arm | before | after |
|---|---|---|
| request URI too long → 414 | 1 / 10 | 1 / 10 |
| request head too large → 431 | 1 / 0 | 1 / 0 |
| request malformed → 400 | 17 / 2 | 17 / 2 |
| request render oversize → 431 | 1 / 0 | 1 / 0 |
| rewrite target oversize → 431 | 1 / 0 | 1 / 0 |
| response head malformed/oversize → 502 | 2 / 0 | 2 / 0 |
| response render oversize → 502 | 1 / 4 | 1 / 4 |
| response excess written separately | 4 / 0 | **5** / 0 |

Nothing regressed; the excess arm gains the new scenario's hit.

## Cost

Simulator memory only — `sockets_max = 1024` entries, so the socket table goes 4 MiB → 8 MiB, visible as the unit-test binary's MaxRSS moving 34M → 43M. No production or benchmark impact: `SimIo` is referenced only by the tests, `sim/`, `src/testing/origin.zig`, and the seam, and nothing in `constants.zig`'s budget mentions the ring. (#87 claimed bench bands would need comparing here; that was wrong, and #90 records the correction.)

`zig build ci` and `zig fmt --check` pass. `tiger-style-reviewer` found no violations; all three of its judgement calls are applied — `capacity` spelled out rather than abbreviated, `pop` asserting its own modulus precondition rather than borrowing it from `push`, and a comptime assert pinning the default below `head_bytes_max` so a future edit cannot silently erase the piecewise-arrival coverage this design exists to protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
