### PR TITLE
perf: stop zeroing 2 KiB per request, and stop profiling nothing (§9)

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -82,6 +82,11 @@ pub fn main(init: std.process.Init) !u8 {
     // `dedicate` yields null.
     const zoxy_cpu = affinity.dedicate(io, flags.zoxy_cpu).?;
 
+    // Both ways this run can record nothing, settled before the load
+    // window rather than after it (see the two helpers).
+    if (!ptraceScopeAllowsAttach(io)) return refuseNoPtraceAttach();
+    const cycles_event = cyclesEventFor(io, zoxy_cpu);
+
     var origin_child = try spawnNginx(arena, io, environ);
     defer origin_child.kill(io);
 
@@ -94,12 +99,12 @@ pub fn main(init: std.process.Init) !u8 {
     // Warm up and prove the path serves before spending a measured run on it.
     try awaitResponsive(arena, io, &flags);
     std.debug.print(
-        "profile: zoxy pid {d} pinned to cpu {d}; driving {s} listener; origin + load pinned off it\n",
-        .{ zoxy_pid, zoxy_cpu, @tagName(flags.protocol) },
+        "profile: zoxy pid {d} pinned to cpu {d} ({s}); driving {s} listener; origin + load pinned off it\n",
+        .{ zoxy_pid, zoxy_cpu, cycles_event, @tagName(flags.protocol) },
     );
 
     // Record only the zoxy pid for the load's duration while zrk saturates it.
-    var perf_child = try spawnPerf(arena, io, environ, zoxy_pid, &flags);
+    var perf_child = try spawnPerf(arena, io, environ, zoxy_pid, cycles_event, &flags);
     std.debug.print(
         "profile: measuring {d}s at {d} req/s over {d} connections\n",
         .{ flags.duration_s, flags.rate, flags.connections },
@@ -237,23 +242,127 @@ fn spawnZoxy(
     };
 }
 
+/// Reads a small sysfs/procfs file into `buffer`. Null when the file is
+/// absent or unreadable — every caller documents its own fallback.
+fn readSmallFile(io: Io, path: []const u8, buffer: []u8) ?[]const u8 {
+    assert(buffer.len > 0);
+    const file = Io.Dir.cwd().openFile(io, path, .{}) catch return null;
+    defer file.close(io);
+    var read_buffer: [256]u8 = undefined;
+    var file_reader = file.reader(io, &read_buffer);
+    const len = file_reader.interface.readSliceShort(buffer) catch return null;
+    assert(len <= buffer.len);
+    return buffer[0..len];
+}
+
+/// Whether a sysfs cpu mask (`"0-3"`, `"0,2-3"`) names `cpu`.
+///
+/// The content is a kernel-owned sysfs file, but it is still parsed as
+/// untrusted: a segment that does not parse, or whose bounds are
+/// reversed, is skipped rather than trusted or fatal. Skipping can only
+/// ever *narrow* the answer to "not this PMU", and every caller's
+/// fallback for that is a correct-but-less-specific event.
+fn cpuListContains(list: []const u8, cpu: u16) bool {
+    var ranges = std.mem.splitScalar(u8, list, ',');
+    while (ranges.next()) |range_raw| {
+        const range = std.mem.trim(u8, range_raw, " \n\t");
+        if (range.len == 0) continue;
+        const dash = std.mem.indexOfScalar(u8, range, '-');
+        if (dash) |at| assert(at < range.len);
+        const low_text = if (dash) |at| range[0..at] else range;
+        const high_text = if (dash) |at| range[at + 1 ..] else range;
+        // Malformed segment: not a cpu id, so it names no cpu (see above).
+        const low = std.fmt.parseUnsigned(u16, low_text, 10) catch continue;
+        const high = std.fmt.parseUnsigned(u16, high_text, 10) catch continue;
+        if (low > high) continue;
+        assert(low <= high);
+        if (cpu >= low and cpu <= high) return true;
+    }
+    return false;
+}
+
+/// The cycles event to sample zoxy with, qualified by the PMU that owns
+/// the dedicated core.
+///
+/// This matters on a hybrid part. An unqualified `cycles:u` binds to a
+/// single PMU — cpu_atom, as perf resolves it here — while `dedicate`
+/// deliberately pins zoxy to a *P*-core. The two never meet, so the run
+/// records zero samples and still renders a flamegraph, which reads like
+/// a measurement instead of the failure it is. Naming the PMU that owns
+/// the chosen cpu keeps the pairing correct whichever core is picked,
+/// including a `--cpu` override onto an E-core.
+fn cyclesEventFor(io: Io, cpu: u16) []const u8 {
+    var buffer: [256]u8 = undefined;
+    const event = event: {
+        if (readSmallFile(io, "/sys/devices/cpu_core/cpus", &buffer)) |list| {
+            if (cpuListContains(list, cpu)) break :event "cpu_core/cycles/u";
+        }
+        if (readSmallFile(io, "/sys/devices/cpu_atom/cpus", &buffer)) |list| {
+            if (cpuListContains(list, cpu)) break :event "cpu_atom/cycles/u";
+        }
+        break :event "cycles:u";
+    };
+    // Every arm names a cycles event, PMU-qualified or plain. An empty or
+    // unrelated event is what silently records nothing, which is the bug
+    // this function exists to prevent.
+    assert(event.len > 0);
+    assert(std.mem.indexOf(u8, event, "cycles") != null);
+    return event;
+}
+
+/// The remedy for a box whose `ptrace_scope` forbids the attach. Split
+/// out of `main` so the preflight costs it one line, not twelve.
+fn refuseNoPtraceAttach() u8 {
+    std.debug.print(
+        \\profile: kernel.yama.ptrace_scope is not 0, so `perf record -p` cannot
+        \\  attach to zoxy and the recording would come back empty. Either:
+        \\    sudo sysctl -w kernel.yama.ptrace_scope=0
+        \\  or run this profile as root.
+        \\
+    , .{});
+    return 1;
+}
+
+/// Whether `perf record -p` can attach to zoxy at all.
+///
+/// zoxy is spawned as *our* child so it can be pinned, warmed up and
+/// drained on SIGTERM; perf is its sibling, not its ancestor. Under
+/// `yama/ptrace_scope > 0` the kernel refuses that attach — and perf
+/// reports success anyway, writing a header-only perf.data. Checked up
+/// front so a misconfigured box costs a message rather than a full load
+/// window and an empty flamegraph.
+fn ptraceScopeAllowsAttach(io: Io) bool {
+    var buffer: [16]u8 = undefined;
+    const content = readSmallFile(io, "/proc/sys/kernel/yama/ptrace_scope", &buffer) orelse
+        return true;
+    assert(content.len <= buffer.len);
+    const text = std.mem.trim(u8, content, " \n\t");
+    assert(text.len <= content.len);
+    // Absent, empty or unreadable all mean "no yama restriction to prove",
+    // which is the permissive answer every non-yama kernel gives.
+    if (text.len == 0) return true;
+    return std.mem.eql(u8, text, "0");
+}
+
 fn spawnPerf(
     arena: std.mem.Allocator,
     io: Io,
     environ: std.process.Environ,
     zoxy_pid: std.process.Child.Id,
+    event: []const u8,
     flags: *const Flags,
 ) !std.process.Child {
-    // cycles:u + LBR: hardware call-graph from the branch-record MSRs, no frame
+    // LBR: hardware call-graph from the branch-record MSRs, no frame
     // pointers or DWARF CFI needed. `-- sleep N` bounds the recording to the
     // load window; perf self-terminates when sleep exits and writes the data.
+    assert(event.len > 0);
     const pid = try std.fmt.allocPrint(arena, "{d}", .{zoxy_pid});
     const freq = try std.fmt.allocPrint(arena, "{d}", .{flags.freq});
     const seconds = try std.fmt.allocPrint(arena, "{d}", .{flags.duration_s});
     const perf_bin = try spawn_path.resolve(arena, io, environ, "perf");
     return std.process.spawn(io, .{
         .argv = &.{
-            perf_bin, "record", "-p",           pid,   "-e", "cycles:u",
+            perf_bin, "record", "-p",           pid,   "-e", event,
             "-F",     freq,     "--call-graph", "lbr", "-o", perf_data_path,
             "--",     "sleep",  seconds,
         },
@@ -322,13 +431,34 @@ fn printReport(report: *const zrk.runner.Report) void {
 
 fn generateFlamegraph(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !void {
     try runToFile(arena, io, environ, &.{ "perf", "script", "-i", perf_data_path }, script_path);
+    try requireSamples(io);
     try runToFile(arena, io, environ, &.{ "stackcollapse-perf.pl", script_path }, folded_path);
     try runToFile(arena, io, environ, &.{
         "flamegraph.pl", "--title",
-        "zoxy under load (cycles:u, LBR call-graph) — see run for path",
+        "zoxy under load (user cycles, LBR call-graph) — see run for path",
         folded_path,
     }, svg_path);
     std.debug.print("profile: flamegraph -> {s}\n", .{svg_path});
+}
+
+/// A sample-free recording folds and renders exactly like a real one —
+/// into an empty flamegraph that reads as a measurement. The preflight
+/// checks cover the two causes seen so far; this catches every other one,
+/// so a profile is never quietly nothing.
+fn requireSamples(io: Io) !void {
+    var buffer: [1]u8 = undefined;
+    const head = readSmallFile(io, script_path, &buffer) orelse "";
+    assert(head.len <= buffer.len);
+    // One byte of `perf script` output is one sample folded; zero bytes is
+    // a recording that captured nothing at all.
+    if (head.len > 0) return;
+    std.debug.print(
+        \\profile: perf recorded zero samples — no flamegraph written.
+        \\  Check that the event bound to the PMU owning zoxy's core, and that
+        \\  perf could attach (kernel.yama.ptrace_scope, perf_event_paranoid).
+        \\
+    , .{});
+    return error.NoSamplesRecorded;
 }
 
 /// Spawn `argv` with stdout redirected to `out_path` — the Zig stand-in for a

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -121,15 +121,22 @@ pub const ResponseHead = struct {
     head_len: u32,
 };
 
-/// The raw request-line and header outputs hparse fills. Kept in the
-/// caller's frame and written through by pointer so `parseRequestHead`
-/// copies no [headers_max]Header.
+/// The raw request-line outputs hparse fills, written through by pointer
+/// from the caller's frame.
+///
+/// The header array is deliberately *not* a field here. A struct whose
+/// fields carry defaults is initialized with `.{}`, and that lowers to a
+/// zero-fill of the whole aggregate — an `= undefined` array field
+/// included, which defeats the very point of declaring it `undefined`.
+/// As a field it cost a 2080-byte memset on every request — 35% of
+/// zoxy's user CPU under L7 load, the top symbol in the profile; as a
+/// loose local it costs nothing. `parseResponseHead` has always kept its
+/// header array loose for this reason, and measured zero.
 const RawRequest = struct {
     method: hparse.Method = .unknown,
     method_token: ?[]const u8 = null,
     target: ?[]const u8 = null,
     version: hparse.Version = .@"1.0",
-    headers: [constants.headers_max]hparse.Header = undefined,
     header_count: usize = 0,
 };
 
@@ -137,14 +144,19 @@ const RawRequest = struct {
 /// to head errors (§7): a head that cannot complete inside a full buffer
 /// is oversize, not partial (request line still open → 414, else 431);
 /// Invalid is malformed; a full header array is load, not malice.
-fn parseRequestRaw(head: []const u8, head_is_full: bool, raw: *RawRequest) HeadError!u32 {
+fn parseRequestRaw(
+    head: []const u8,
+    head_is_full: bool,
+    raw: *RawRequest,
+    raw_headers: *[constants.headers_max]hparse.Header,
+) HeadError!u32 {
     const head_len = hparse.parseRequest(
         head,
         &raw.method,
         &raw.method_token,
         &raw.target,
         &raw.version,
-        &raw.headers,
+        raw_headers,
         &raw.header_count,
     ) catch |err| switch (err) {
         error.Incomplete => {
@@ -176,7 +188,8 @@ pub fn parseRequestHead(
     }
 
     var raw: RawRequest = .{};
-    const head_len = try parseRequestRaw(head, head_is_full, &raw);
+    var raw_headers: [constants.headers_max]hparse.Header = undefined;
+    const head_len = try parseRequestRaw(head, head_is_full, &raw, &raw_headers);
 
     const target = raw.target.?; // A successful parse always sets the target.
     const method_token = raw.method_token.?; // Same contract as the target.
@@ -185,7 +198,7 @@ pub fn parseRequestHead(
     try validateTarget(target, method);
     const version = versionFromRaw(raw.version);
 
-    const analysis = try analyzeHeaders(raw.headers[0..raw.header_count], headers_storage);
+    const analysis = try analyzeHeaders(raw_headers[0..raw.header_count], headers_storage);
     // An HTTP/1.1 request must carry exactly one Host (RFC 9112 §3.2);
     // duplicates were already rejected during analysis.
     if (version == .http_1_1) {


### PR DESCRIPTION
Two commits from one profiling session. The second is what made the first findable.

## The measurement was broken first

`zig build profile` had been producing empty flamegraphs and presenting them as measurements. Two independent causes, either sufficient alone:

- **The event never bound to the core.** `affinity.detectPCore` deliberately pins zoxy to a P-core, and the recording asked for an unqualified `cycles:u` — which perf resolves to the **cpu_atom** PMU on a hybrid part. The two never meet, so the run samples nothing. The harness docstring already warned that a process straddling the two PMUs "reads as zero"; the pinning exists to prevent exactly that, and the event quietly undid it.
- **perf could not attach.** zoxy is spawned as the harness's child so it can be pinned, warmed up and SIGTERM-drained — which makes perf its *sibling*, and `kernel.yama.ptrace_scope = 1` refuses that attach.

Neither announced itself, and that is the actual defect: a sample-free recording folds and renders exactly like a real one. The fix is three parts — `cyclesEventFor` names the PMU owning the chosen cpu (still correct under a `--cpu` override onto an E-core), a `ptrace_scope` preflight that costs a message naming the remedy instead of a 30 s load window, and `requireSamples`, which fails the run when `perf script` yields nothing so every *other* cause is loud too.

Verified here: the event resolves to `cpu_core/cycles/u` for the auto-picked cpu 3, and the preflight fires with its remedy rather than proceeding.

## What it then found

With both worked around by hand, one symbol dominated every profile taken:

| workload | `compiler_rt.memset` |
|---|---|
| L7, saturated (163,768 req/s) | **35.0%** |
| L7, 60k req/s | 27.7% |

The entire share came from one call site. `parseRequestHead` opened with `var raw: RawRequest = .{}`, and that struct carried `headers: [headers_max]hparse.Header = undefined` — declared `undefined` precisely so it would never be touched. An aggregate initializer zero-fills the whole struct regardless, `= undefined` fields included, so every request paid a 2080-byte memset before parsing a byte:

```
lea -0x8c0(%rbp),%rdi
mov $0x820,%edx
xor %esi,%esi
call compiler_rt.memset
```

## Why not just avoid `.{}` at that one call site

Because the trap stays armed for the next field somebody adds. `parseResponseHead` is the control already in the tree: it does the same job with its header array as a loose `undefined` local rather than a struct field, and contributes **no memset at all**. So the array moves out of `RawRequest` and is threaded to `parseRequestRaw` by pointer, matching the shape that has always measured zero. That makes the cost unrepresentable rather than merely absent.

## Measured

Pinned toolchain, ReleaseFast, zoxy alone on one P-core, user cycles per request at a fixed 60k req/s offered — three runs each:

| run | before | after |
|---|---|---|
| 1 | 4287 | 2973 |
| 2 | 4124 | 2992 |
| 3 | 4265 | 2972 |

~30% fewer user cycles per request, bands non-overlapping, after-spread 0.7%.

## What is deliberately not claimed

**A throughput win.** Saturated req/s is unchanged within noise — the baseline band alone spans 126k–166k — because zoxy is not the bottleneck on a loopback bench against nginx. And with `perf_event_paranoid = 2` the profile is user-space only, so this is 30% of *user* CPU, not of total; the kernel share is unmeasured on this box.

The win is headroom per request, which is what process-per-core scaling (§3) spends. **Share is not headroom** — a symbol's share of samples is what it costs while running, not what removing it buys — so the number claimed here is the one that actually moved.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass on both commits.

`tiger-style-reviewer` on the parser slice: no violations, one judgement call applied (a doc paragraph left stale by the move). It confirmed no invariant was weakened — nothing ever tied `headers` to `header_count` at compile time, and the runtime assert plus the slicing convention moved verbatim.

`tiger-style-reviewer` on the harness slice returned **needs work (3 violations)** first time: `main()` at 78 lines over the 70-line hard limit, four new helpers with zero assertions, and two uncommented `catch continue` sites. All three fixed — `refuseNoPtraceAttach` extracted so `main()` is 69 lines; `cyclesEventFor` restructured to a single labelled-block exit so its postcondition is asserted producer-side rather than borrowed from the caller; `cpuListContains` documented as parsing untrusted content where skipping can only narrow the answer, never wrongly widen it. Re-reviewed clean.

## Follow-ups not in this PR

Both are in the harness commit message, and the reviewer agreed neither should grow this slice:

- `bench/` is not in `build.zig`'s `test_step`, so `cpuListContains` has no unit test — a test block there would be unrunnable dead code until bench is wired in.
- `readSmallFile` duplicates the sysfs read in `affinity.detectPCore`, and the two parse *the same file* with different parsers ("last run of digits" vs proper range handling). Latent divergence risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
