### PR TITLE
http: classify a header name once, not once per decision (§7, §9)

### DIFF
--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -353,8 +353,8 @@ test "filter: firstReject matches on method, host, path, header" {
             .actions = &.{.{ .reject = 403 }},
         },
     };
-    const prod = [_]H{.{ .name = "x-env", .value = "prod" }};
-    const dev = [_]H{.{ .name = "X-Env", .value = "dev" }};
+    const prod = [_]H{H.init("x-env", "prod")};
+    const dev = [_]H{H.init("X-Env", "dev")};
 
     // Full match → 403.
     try std.testing.expectEqual(@as(?u16, 403), firstReject(&rules, .{

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -46,15 +46,132 @@ pub const Version = enum(u1) {
     http_1_1,
 };
 
+/// The header names a §7 decision keys off: the connection-specific set
+/// that is never forwarded, the set a Connection header may not nominate
+/// away, and the framing headers the analysis reads. Everything else is
+/// `other`, which is almost every header on almost every request.
+///
+/// The point of naming them is to compare them *once*. Both the analysis
+/// walk and the render walk used to re-run `std.ascii.eqlIgnoreCase` down
+/// a list of literals for every header — up to four in `analyzeHeaders`
+/// and the whole hop-by-hop and protected lists again in `isHopByHop`, on
+/// both the request and the response head. Classifying on the walk that
+/// already visits every header turns each of those into an integer test.
+///
+/// `render.hop_by_hop_names` and `render.protected_names` stay the
+/// documented source of truth; a comptime check there pins them to
+/// `hopByHop` and `protected` in both directions, so a name added to one
+/// spelling and not the other fails the build rather than opening a §7
+/// hole.
+pub const HeaderName = enum(u8) {
+    /// Any name no §7 decision special-cases.
+    other,
+    host,
+    content_length,
+    transfer_encoding,
+    connection,
+    keep_alive,
+    proxy_connection,
+    te,
+    upgrade,
+
+    /// Connection-specific headers (RFC 9110 §7.6.1): never forwarded.
+    pub fn hopByHop(tag: HeaderName) bool {
+        return switch (tag) {
+            .connection, .keep_alive, .proxy_connection, .te, .upgrade => true,
+            .other, .host, .content_length, .transfer_encoding => false,
+        };
+    }
+
+    /// Headers a Connection value may not nominate away — stripping them
+    /// would desynchronize framing (a smuggling vector) or unroute the
+    /// request.
+    pub fn protected(tag: HeaderName) bool {
+        return switch (tag) {
+            .host, .content_length, .transfer_encoding => true,
+            .other, .connection, .keep_alive, .proxy_connection, .te, .upgrade => false,
+        };
+    }
+
+    /// The canonical lowercase spelling, so the comptime check in
+    /// `render` can compare the lists against the enum both ways.
+    pub fn text(tag: HeaderName) []const u8 {
+        return switch (tag) {
+            .other => "",
+            .host => "host",
+            .content_length => "content-length",
+            .transfer_encoding => "transfer-encoding",
+            .connection => "connection",
+            .keep_alive => "keep-alive",
+            .proxy_connection => "proxy-connection",
+            .te => "te",
+            .upgrade => "upgrade",
+        };
+    }
+};
+
+/// Classify one header name, exactly as the `eqlIgnoreCase` chains it
+/// replaces would have: a variant is returned only where the old compare
+/// matched. Dispatching on length first means the common `other` costs
+/// one integer compare instead of a walk down every literal.
+pub fn classifyHeaderName(name: []const u8) HeaderName {
+    assert(name.len >= 1);
+    const eql = std.ascii.eqlIgnoreCase;
+    const tag: HeaderName = switch (name.len) {
+        2 => if (eql(name, "te")) .te else .other,
+        4 => if (eql(name, "host")) .host else .other,
+        7 => if (eql(name, "upgrade")) .upgrade else .other,
+        10 => length_10: {
+            if (eql(name, "connection")) break :length_10 .connection;
+            if (eql(name, "keep-alive")) break :length_10 .keep_alive;
+            break :length_10 .other;
+        },
+        14 => if (eql(name, "content-length")) .content_length else .other,
+        16 => if (eql(name, "proxy-connection")) .proxy_connection else .other,
+        17 => if (eql(name, "transfer-encoding")) .transfer_encoding else .other,
+        else => .other,
+    };
+    return tag;
+}
+
+comptime {
+    // Every variant must be reachable from the length arm that matches its
+    // canonical spelling: one placed in the wrong arm would simply never
+    // match, silently reclassifying a real header as `other` and
+    // forwarding something §7 means to strip.
+    //
+    // Deliberately comptime. The same check written as a runtime
+    // postcondition in `classifyHeaderName` cost ~540 instructions per
+    // request — it is decidable here for free, and a runtime assert on a
+    // fact the compiler already knows is the expensive way to be sure.
+    for (@typeInfo(HeaderName).@"enum".fields) |field| {
+        const tag: HeaderName = @enumFromInt(field.value);
+        if (tag == .other) continue;
+        assert(classifyHeaderName(tag.text()) == tag);
+    }
+}
+
 /// One parsed header. Both slices point into the head buffer the head was
 /// parsed from — zero-copy, valid only while that buffer holds this head.
+/// `tag` is the §7 classification, assigned once during analysis.
 pub const Header = struct {
     name: []const u8,
     value: []const u8,
+    tag: HeaderName,
+
+    /// Build one, classifying the name. `tag` carries no default and this
+    /// is the only constructor on purpose: a header whose tag disagreed
+    /// with its name would be stripped or forwarded against what it says
+    /// it is, which is a §7 hole rather than a stale field.
+    pub fn init(name: []const u8, value: []const u8) Header {
+        assert(name.len >= 1);
+        return .{ .name = name, .value = value, .tag = classifyHeaderName(name) };
+    }
 };
 
-/// Caller-owned header storage for one parsed head; the connection slot
-/// embeds one of these per direction it parses.
+/// Header storage for one parsed head. A stack local at every call site —
+/// nothing parsed survives the callback that parsed it (§7 detect-and-retry
+/// re-parses from byte 0), so this costs frame, not a connection slot.
 pub const HeaderStorage = [constants.headers_max]Header;
 
 /// How the message body is delimited (RFC 9112 §6.3). `until_close` is
@@ -576,46 +693,48 @@ fn analyzeHeaders(
     };
     for (raw_headers, 0..) |raw_header, index| {
         assert(raw_header.key.len >= 1);
-        headers_storage[index] = .{ .name = raw_header.key, .value = raw_header.value };
-        if (std.ascii.eqlIgnoreCase(raw_header.key, "host")) {
-            // A second Host changes routing depending on who reads which —
-            // a smuggling shape, like an empty one (RFC 9112 §3.2).
-            if (analysis.host != null) {
-                return error.Malformed;
-            }
-            if (raw_header.value.len == 0) {
-                return error.Malformed;
-            }
-            analysis.host = raw_header.value;
-            continue;
-        }
-        if (std.ascii.eqlIgnoreCase(raw_header.key, "content-length")) {
-            // Duplicate Content-Length is rejected outright, identical
-            // values included (§7 "duplicate/garbage Content-Length").
-            if (analysis.content_length != null) {
-                return error.Malformed;
-            }
-            analysis.content_length = try parseContentLength(raw_header.value);
-            continue;
-        }
-        if (std.ascii.eqlIgnoreCase(raw_header.key, "transfer-encoding")) {
-            // A second Transfer-Encoding header is the list form in
-            // disguise; only the single exact "chunked" is ever legal
-            // here, so any repeat is malformed.
-            if (analysis.te_chunked or analysis.te_other) {
-                return error.Malformed;
-            }
-            if (std.ascii.eqlIgnoreCase(raw_header.value, "chunked")) {
-                analysis.te_chunked = true;
-            } else {
-                analysis.te_other = true;
-            }
-            continue;
-        }
-        if (std.ascii.eqlIgnoreCase(raw_header.key, "connection")) {
-            // Multiple Connection headers combine as one list (RFC 9110).
-            scanConnectionTokens(raw_header.value, &analysis);
-            continue;
+        // The one name comparison this header will cost: every later §7
+        // decision, here and in the render walk, tests the tag instead.
+        const header: Header = .init(raw_header.key, raw_header.value);
+        headers_storage[index] = header;
+        switch (header.tag) {
+            .host => {
+                // A second Host changes routing depending on who reads which —
+                // a smuggling shape, like an empty one (RFC 9112 §3.2).
+                if (analysis.host != null) {
+                    return error.Malformed;
+                }
+                if (raw_header.value.len == 0) {
+                    return error.Malformed;
+                }
+                analysis.host = raw_header.value;
+            },
+            .content_length => {
+                // Duplicate Content-Length is rejected outright, identical
+                // values included (§7 "duplicate/garbage Content-Length").
+                if (analysis.content_length != null) {
+                    return error.Malformed;
+                }
+                analysis.content_length = try parseContentLength(raw_header.value);
+            },
+            .transfer_encoding => {
+                // A second Transfer-Encoding header is the list form in
+                // disguise; only the single exact "chunked" is ever legal
+                // here, so any repeat is malformed.
+                if (analysis.te_chunked or analysis.te_other) {
+                    return error.Malformed;
+                }
+                if (std.ascii.eqlIgnoreCase(raw_header.value, "chunked")) {
+                    analysis.te_chunked = true;
+                } else {
+                    analysis.te_other = true;
+                }
+            },
+            .connection => {
+                // Multiple Connection headers combine as one list (RFC 9110).
+                scanConnectionTokens(raw_header.value, &analysis);
+            },
+            .other, .keep_alive, .proxy_connection, .te, .upgrade => {},
         }
     }
     assert(!(analysis.te_chunked and analysis.te_other));
@@ -1347,8 +1466,8 @@ test "http parser: origin smuggling shapes and alien statuses tear down" {
 
 test "http parser: header helpers are case-insensitive" {
     const headers = [_]Header{
-        .{ .name = "Content-Type", .value = "text/plain" },
-        .{ .name = "Upgrade", .value = "h2c" },
+        Header.init("Content-Type", "text/plain"),
+        Header.init("Upgrade", "h2c"),
     };
     try testing.expectEqualStrings("h2c", headerValue(&headers, "upgrade").?);
     try testing.expectEqual(@as(?[]const u8, null), headerValue(&headers, "host"));

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -39,6 +39,39 @@ pub const protected_names = [_][]const u8{
     "transfer-encoding",
 };
 
+/// True when `list` names `name` exactly. Comptime-only, for the check
+/// below; the runtime path compares tags, not strings.
+fn nameListHas(list: []const []const u8, name: []const u8) bool {
+    for (list) |entry| {
+        if (std.mem.eql(u8, entry, name)) return true;
+    }
+    return false;
+}
+
+comptime {
+    // These lists and `parser.HeaderName`'s predicates are two spellings
+    // of one rule, and the runtime path now reads the second. Pin them in
+    // both directions so divergence is a build failure rather than a §7
+    // hole: a list entry no variant claims would stop being stripped, and
+    // a variant no list claims would strip a header nothing documents.
+    for (hop_by_hop_names) |name| {
+        assert(parser.classifyHeaderName(name).hopByHop());
+    }
+    for (protected_names) |name| {
+        assert(parser.classifyHeaderName(name).protected());
+    }
+    for (@typeInfo(parser.HeaderName).@"enum".fields) |field| {
+        const tag: parser.HeaderName = @enumFromInt(field.value);
+        if (tag.hopByHop()) assert(nameListHas(&hop_by_hop_names, tag.text()));
+        if (tag.protected()) assert(nameListHas(&protected_names, tag.text()));
+        // `isHopByHop` tests hop-by-hop first, so a name in both sets
+        // would be stripped despite being protected — the smuggling shape
+        // `protected_names` exists to prevent. Say it, rather than leave
+        // it to whoever next edits a list to notice.
+        assert(!(tag.hopByHop() and tag.protected()));
+    }
+}
+
 /// Renders the upstream request line and end-to-end headers from a
 /// parsed head. The client's version is preserved — framing decisions on
 /// both hops key off the real versions — and `inject_close` announces
@@ -149,8 +182,11 @@ fn appendEndToEndHeaders(
     // O(headers²) — the render's top user-CPU cost under load (§9).
     var connection_values: [constants.headers_max][]const u8 = undefined;
     var connection_count: u32 = 0;
-    for (headers) |header| {
-        if (std.ascii.eqlIgnoreCase(header.name, "connection")) {
+    // Both walks capture by pointer: `parser.Header` is 40 bytes, and
+    // copying one per header is the cost this classification exists to
+    // remove, not to relocate.
+    for (headers) |*header| {
+        if (header.tag == .connection) {
             connection_values[connection_count] = header.value;
             connection_count += 1;
         }
@@ -176,9 +212,9 @@ fn appendEndToEndHeaders(
         }
     }
 
-    for (headers) |header| {
+    for (headers) |*header| {
         assert(header.name.len >= 1);
-        if (isHopByHop(header.name, active_nominations)) {
+        if (isHopByHop(header, active_nominations)) {
             continue;
         }
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
@@ -249,21 +285,20 @@ fn nominatesRealHeader(nominations: []const []const u8) bool {
 /// Connection values that name a real header (empty in the common
 /// close/keep-alive-only case), so this is O(1) then rather than a token
 /// scan per header.
-fn isHopByHop(name: []const u8, nominations: []const []const u8) bool {
-    assert(name.len >= 1);
+fn isHopByHop(header: *const parser.Header, nominations: []const []const u8) bool {
+    assert(header.name.len >= 1);
     assert(nominations.len <= constants.headers_max);
-    for (hop_by_hop_names) |hop_name| {
-        if (std.ascii.eqlIgnoreCase(name, hop_name)) {
-            return true;
-        }
+    if (header.tag.hopByHop()) {
+        return true;
     }
-    for (protected_names) |protected_name| {
-        if (std.ascii.eqlIgnoreCase(name, protected_name)) {
-            return false;
-        }
+    if (header.tag.protected()) {
+        return false;
     }
+    // Only a nomination can still strip this one, and only a Connection
+    // value naming a real header gets here (see `active_nominations`), so
+    // the token scan stays off the common path.
     for (nominations) |value| {
-        if (parser.tokenListHas(value, name)) {
+        if (parser.tokenListHas(value, header.name)) {
             return true;
         }
     }


### PR DESCRIPTION
Follows the profiling that #92 unblocked. With the head-parse zero-fill gone, the flamegraph is flat and the largest remaining block is HTTP head work — parse and render together are **~54% of user CPU** on the L7 path. Most of it turned out to be the same string compared over and over.

## The same name, compared eight ways

`analyzeHeaders` ran up to four `std.ascii.eqlIgnoreCase` on every header key — host, content-length, transfer-encoding, connection. Then `appendEndToEndHeaders` compared each name against `"connection"` *again* to collect nominations, and `isHopByHop` walked all of `hop_by_hop_names` (5 entries) and `protected_names` (3) per header on top of that.

That is roughly **80 case-insensitive string comparisons per head**, and a request pays for two heads — the client's and the origin's.

None of those decisions actually needs the string. `parser.HeaderName` names exactly the headers a §7 decision keys off; `classifyHeaderName` dispatches on **length first**, so the overwhelmingly common `other` costs one integer compare instead of a walk down every literal. The analysis switches on the tag, and the render walk and hop-by-hop test read it instead of comparing bytes.

## Making a wrong tag unrepresentable

This is smuggling-adjacent code — a mis-tagged header is one that gets stripped or forwarded against what it says it is. Two things hold that shut:

- **`Header.tag` has no default, and `Header.init` is the only constructor.** A caller cannot pick a tag; it is derived from the name. The compiler caught three test-literal sites that would otherwise have silently defaulted.
- **A comptime block pins the lists to the enum in both directions.** `hop_by_hop_names` and `protected_names` stay the documented source of truth (the filter compiler still reads them), and the check fails the build if a list entry no variant claims appears, or a variant no list claims does. It also asserts the two sets stay **disjoint** — a name in both would be stripped despite being protected, which is exactly the shape `protected_names` exists to prevent — and that every variant is reachable from the length arm matching its spelling.

## Measured

ReleaseFast, zoxy alone on a P-core, load pinned off it, 60k req/s offered over 128 connections. Three paired runs, arms alternated:

| | before | after |
|---|---|---|
| instructions/request | 6806 | **5998** (−11.9%) |
| cycles/request | 2795 | **2525** (−9.7%) |

Both bands non-overlapping (instructions: baseline min 6760 vs after max 6013).

The two targeted functions are where it came from:

| symbol | share before | share after | absolute cycles/req |
|---|---|---|---|
| `appendEndToEndHeaders` | 11.53% | 7.52% | 319 → 189 (−41%) |
| `analyzeHeaders` | 8.25% | 5.96% | 228 → 150 (−34%) |

The share column understates it, since the denominator shrank too.

**Not claimed: a throughput win.** The loopback bench is harness-bound — same caveat #92 carried, and the reason cycles/request is the number quoted.

## An assertion that wasn't free

Worth recording, because it cost two thirds of the win before it was caught.

The first version of this measured −11.9% instructions. Applying the review's judgement calls dropped it to **−3.7%**. The cause was two runtime assertions: a length postcondition inside `classifyHeaderName`, and — the worse one, mine rather than the reviewer's — a tautological `assert(header.tag == classifyHeaderName(header.name))` in `init`, checking a value it had just computed the same way.

Together they cost **~540 instructions per request**, because their conditions call a function LLVM did not fold away. `std.debug.assert` is not free in ReleaseFast when its condition does real work, and on a per-header path that shows up.

The guarantee was kept and moved to comptime, where it costs nothing and proves strictly more (it checks *every* variant, not just the ones a given request happens to carry). Both the finding and the reasoning are in the commit message, since it cuts against the assertion-density rule on hot per-item paths.

Isolated by measuring three builds — baseline, with-asserts, asserts-at-comptime — rather than guessed.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.

`tiger-style-reviewer` returned **needs work (2 violations)** on the first pass, both fixed:

- `isHopByHop` took `parser.Header` (40 bytes) **by value**, adding a copy per header inside the very loop this change exists to make cheaper. Now `*const`, with pointer capture in both walks.
- The `len == 10` arm of `classifyHeaderName` was an `else if` chain, the shape TIGER_STYLE forbids. Now a labelled block.

It confirmed the parts that mattered most: `classifyHeaderName` is exactly equivalent to the `eqlIgnoreCase` chains it replaces (no length collisions, nothing added or dropped), the `analyzeHeaders` switch preserves the original control flow including every duplicate-header and empty-Host rejection, and the comptime cross-check is genuinely bidirectional.

Both of its judgement calls were taken — the disjointness assertion, and the postcondition, the latter at comptime for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
