### PR TITLE
http: reserve a header line once, not four times (§7, §9)

### DIFF
--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -163,6 +163,43 @@ const Staging = struct {
         staging.len += @intCast(bytes.len);
         assert(staging.len <= staging.buffer.len);
     }
+
+    /// Appends one `Name: value\r\n` line, reserving the whole line once.
+    ///
+    /// Byte-for-byte what four `append` calls emitted, and deliberately so:
+    /// a head has exactly one spelling here, and a second way to write one
+    /// is the kind of divergence §7 correctness is built to avoid. What
+    /// changes is only the bookkeeping around the bytes. Four calls reloaded
+    /// the cursor and re-checked the bound four times per header, twice of
+    /// that to move a two-byte constant — the `addl $0x2` and the cursor
+    /// reloads were the top instructions in this function's profile (§9).
+    fn appendHeaderLine(
+        staging: *Staging,
+        name: []const u8,
+        value: []const u8,
+    ) error{Oversize}!void {
+        assert(staging.len <= staging.buffer.len);
+        assert(name.len >= 1);
+        // `": "` and `"\r\n"`; both name and value are head-buffer bounded,
+        // so the sum cannot overflow.
+        const line_bytes = name.len + 2 + value.len + 2;
+        if (staging.buffer.len - staging.len < line_bytes) {
+            return error.Oversize;
+        }
+        var cursor: usize = staging.len;
+        @memcpy(staging.buffer[cursor..][0..name.len], name);
+        cursor += name.len;
+        staging.buffer[cursor] = ':';
+        staging.buffer[cursor + 1] = ' ';
+        cursor += 2;
+        @memcpy(staging.buffer[cursor..][0..value.len], value);
+        cursor += value.len;
+        staging.buffer[cursor] = '\r';
+        staging.buffer[cursor + 1] = '\n';
+        cursor += 2;
+        staging.len = @intCast(cursor);
+        assert(staging.len <= staging.buffer.len);
+    }
 };
 
 /// Appends every end-to-end header as `Name: value\r\n`, preserving the
@@ -220,21 +257,13 @@ fn appendEndToEndHeaders(
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
             continue;
         }
-        try staging.append(header.name);
-        try staging.append(": ");
-        try staging.append(header.value);
-        try staging.append("\r\n");
+        try staging.appendHeaderLine(header.name, header.value);
     }
     // Injected edits follow the surviving source headers; a `remove`
     // contributes no line (its whole effect is the suppression above).
     for (edits) |edit| {
         switch (edit.kind) {
-            .set, .add => {
-                try staging.append(edit.name);
-                try staging.append(": ");
-                try staging.append(edit.value);
-                try staging.append("\r\n");
-            },
+            .set, .add => try staging.appendHeaderLine(edit.name, edit.value),
             .remove => {},
         }
     }


### PR DESCRIPTION
A small follow-on to #94, and a scope change worth stating up front.

## The idea this was scoped as does not work

The plan was response-head pass-through: when the rendered head would be byte-identical to the origin's bytes, forward them verbatim instead of rebuilding the head line by line.

Checked before writing any code, and the premise is false. Origins send `Connection: keep-alive` — nginx does, and effectively every server does. That header is hop-by-hop and **must** be stripped, so the rendered head is never byte-identical to what arrived, and the fast path would essentially never fire.

A variant does work: coalesce the contiguous runs of *surviving* headers into one memcpy each (4 of nginx's 5 headers survive contiguously). It was not taken. It needs each header's source byte span, it changes OWS normalization, and above all it introduces a **second way to emit a head** in smuggling-adjacent code. §7's discipline is one spelling and one source of truth; a second emission path means two things have to agree forever. That is not a trade to make quietly under a performance banner — if it is ever wanted, it should be its own decision.

## What the profile pointed at instead

`perf annotate` on `appendEndToEndHeaders` put `Staging` bookkeeping at the top, not the copies: the `staging.len` reloads, the bound re-check against the buffer, and `addl $0x2` crediting a two-byte append. Every header cost four `append` calls — name, `": "`, value, `"\r\n"` — each reloading the cursor and re-checking the bound, two of them to move a two-byte constant.

`appendHeaderLine` reserves the whole line once: one bound check, one cursor update, two memcpys and four byte stores. Both call sites use it — source headers, and `set`/`add` filter edits.

## Equivalence

The output is byte-for-byte what the four appends produced, and that is the point rather than a happy accident — only the bookkeeping around the bytes changed.

**The Oversize verdict is also unchanged.** Four sequential bound checks are jointly satisfiable exactly when `name.len + 2 + value.len + 2` fits, which is the single check now made up front. What differs is that a line which does not fit leaves the buffer untouched, where before it could leave a partial name behind. That is unobservable: both callers discard the render entirely on `Oversize` — 431 downstream, upstream teardown — and never read staging afterwards. The reviewer traced both call sites in `proxy.zig` to confirm it, and confirmed the existing Oversize tests assert only the error, never buffer contents.

## Measured

ReleaseFast, zoxy alone on a P-core, load pinned off it, 60k req/s over 128 connections. **Seven** paired rounds, because the effect is small enough that three would not have settled it:

| | before | after |
|---|---|---|
| instructions/request | 6071 | 6015 (−0.9%) |
| cycles/request | 2630 | 2557 (−2.8%) |

**Reported as small.** The instruction delta is negative in 7 of 7 rounds — consistent, if modest. The cycle delta is negative in 5 of 7 and lands within noise twice. This is nothing like the −11.9% instructions #94 gave; it is worth having because the code is also simpler than the four-append sequence it replaces, not because the number is impressive.

No throughput claim, for the same reason as #92 and #94: the loopback bench is harness-bound.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.

`tiger-style-reviewer`: **ready to commit**, no violations. It verified the equivalence argument above, the mixed-width `usize`/`u32` bound comparison (the same idiom `append` already uses, with the `@intCast` proven safe by the guard), and that `assert(name.len >= 1)` documents an invariant that already held — `parser.Header.init` asserts it for parsed headers, and `config.zig` rejects an empty name at load before a filter edit can carry one. Its one cosmetic note is applied: the local cursor is named `cursor`, the word the file's own doc comment uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
