### PR TITLE
docs: name the stall, and stop overclaiming the memory budget (§3, §5)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4,7 +4,8 @@ An L4/L7 proxy in Zig 0.16 in the spirit of Cloudflare's Pingora, with two
 hard constraints: **nothing allocates on the hot path** and **exhaustion
 sheds load — it never crashes, never queues unboundedly, never allocates.**
 Steady-state operation issues zero heap allocations and zero allocating
-syscalls; total memory is a startup-time function of the static limits.
+syscalls; zoxy's own memory is a startup-time function of the static
+limits (the kernel's per-socket buffers are outside that form — §5).
 
 Simplicity is prioritized over feature-richness. The coding rules live in
 [`docs/TIGER_STYLE.md`](TIGER_STYLE.md). The previous iteration of this
@@ -32,7 +33,8 @@ Goals, in priority order:
    aspired to.
 3. **Minimal memory consumption.** Pools are *shared*, sized for concurrent
    *activity*, not for open-connection worst cases multiplied by core count
-   (§5). Total memory is a closed-form function of `src/constants.zig`.
+   (§5). Pool memory is a closed-form function of `src/constants.zig`
+   (kernel socket buffers are outside it — §5).
 4. **Simplicity.** One thread, one event loop, one ring, one writer for
    every pool — no worker threads, no cross-thread queues (§3). Fewer
    moving parts than the previous iteration, not more.
@@ -92,7 +94,8 @@ measured at HAProxy parity on steady-state keep-alive load — ~20k req/s,
 p50 110–122 µs against its 101–105 µs, one core each, same fixture
 certificate and origin. Handshake-heavy load has a lower ceiling that is
 measurably *not* a CPU wall: it scales with connection count, so what
-binds is a per-connection stall under investigation, which no amount of
+binds is a per-connection stall — since identified as a Nagle/delayed-ACK
+deadlock, fix pending (IMPLEMENTATION_NOTES.md) — which no amount of
 threading would remove. Where handshake CPU does eventually bind, the
 levers are session resumption (µs-class for returning clients) and then
 more cores — which this design buys as **N independent processes behind
@@ -137,8 +140,8 @@ measured itself latency-bound with CPU headroom on the data path; the
 only CPU-heavy work is the TLS handshake, measured at ~100–400 µs of
 crypto with ECDSA certs and at HAProxy parity through the whole
 terminated hop in steady state (IMPLEMENTATION_NOTES.md, which also
-records the per-connection handshake stall that is *not* CPU and is
-still open). The loop absorbs it in steps between completions, and the
+records the per-connection handshake stall that is *not* CPU — mechanism
+identified, fix pending). The loop absorbs it in steps between completions, and the
 worst single uninterruptible step — ~275 µs of P-256 sign — is what
 bounds tick inflation. **Horizontal
 scaling is N independent zoxy processes behind SO_REUSEPORT** —
@@ -313,8 +316,23 @@ unmerged behind it, so the pin moves only after re-audit.
 
 ## 5. Memory — shared pools, fixed at startup
 
-Every limit is a named constant in `src/constants.zig`; total memory is a
-closed-form function of those numbers, printed at startup. Per-worker
+Every limit is a named constant in `src/constants.zig`; **zoxy's own**
+memory is a closed-form function of those numbers, printed at startup.
+
+That qualifier is load-bearing. The closed form covers what this process
+allocates — the pools below, and the startup arena. It does **not** cover
+the kernel's per-socket buffers, which are charged to the connection and
+scale with it: on a stock Linux the defaults are 144 KiB per socket and
+an L7 connection holds two, so a deployment sized at the printed default
+carries an order of magnitude more socket memory than the budget names,
+growing further under receive autotuning. The failure mode
+is not OOM but `tcp_mem` pressure, where the kernel starts collapsing
+queues — invisible to this budget, and with no counter of ours on it.
+Closing that gap means setting `SO_RCVBUF`/`SO_SNDBUF` explicitly so the
+per-socket cap becomes a named constant like everything else; the
+measurement and the autotuning trade-off are in
+[`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md), the revisit
+condition in [`PLANS.md`](PLANS.md). Per-worker
 reservation — sizing a pool per core for a worst case that never co-occurs
 on every core at once — multiplies memory by core count for nothing; the
 previous iteration paid that cost, and shared pools sized for concurrent
@@ -776,7 +794,7 @@ src/
   main.zig            // startup: config → reserve pools → print memory → run loop
   Server.zig          // composition root: pools, listeners, admission, teardown;
                       // generic over Io so the simulator instantiates it whole
-  constants.zig       // every static limit; total memory is f(these)
+  constants.zig       // every static limit; pool memory is f(these)
   config.zig          // strict JSON → arena-owned immutable Config
   io/
     io.zig            // the seam: comptime backend select

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -201,9 +201,10 @@ CPU wall, and not the "~1.4 ms of wall time per handshake" the first
 profile's arithmetic suggested. ~40 ms is the signature magnitude of a
 Nagle/delayed-ACK interaction (§4 records the same 40 ms lesson from
 pooled upstream connections), and the recurring ~41.8 ms `max` in the
-keep-alive runs points the same way, but **the mechanism is not yet
-identified**; zoxy sets `TCP_NODELAY` on its own sockets, so it is not
-the obvious half of that classic.
+keep-alive runs points the same way. It is that classic; the mechanism
+and the fix are the section below. The reasoning that dismissed it here —
+"zoxy sets `TCP_NODELAY` on its own sockets" — was the wrong half of the
+pair, and is corrected there.
 
 Two readings to retire, both of them mine:
 
@@ -241,6 +242,139 @@ Measurement caveats worth carrying forward:
   against offered, so a run delivering 704 of 2000 req/s *passed* them.
   Rate-versus-offered is not yet a gate — and it would have caught this
   on the first run.
+
+## The ~45 ms stall, identified — nobody ACKs a silent server (2026-07-26)
+
+The stall above is a Nagle/delayed-ACK deadlock, and zoxy's half of it is
+**sending nothing between the client's `Finished` and the client's first
+request**.
+
+The sequence: the client writes `Finished`, which goes out immediately
+because nothing is outstanding. It then writes the encrypted request —
+and Nagle holds that second small write, because the first is still
+unacknowledged. zoxy has nothing to send back, so no ACK piggybacks, and
+the client waits out Linux's delayed-ACK timer. That timer caps at 40 ms.
+
+**The earlier dismissal was the wrong half of the pair.** `TCP_NODELAY`
+on zoxy's sockets governs what *zoxy* may send without waiting. What is
+held here is the *client's* send, waiting on *zoxy's* ACK. Our own
+NODELAY cannot touch it.
+
+Evidence, all against the same origin:
+
+| | first response byte |
+|---|---|
+| zoxy, curl (its default `TCP_NODELAY`) | 2.1 ms — faster than haproxy |
+| zoxy, curl `--no-tcp-nodelay` | **42–47 ms, every request** |
+| haproxy, curl `--no-tcp-nodelay` | 4.1–6.2 ms |
+| zoxy plaintext, curl `--no-tcp-nodelay` | 0.2–0.8 ms |
+| zoxy, `--no-tcp-nodelay`, 200 KB POST | **2.4 ms** |
+
+The handshake phase stays at 2–5 ms in every stalling run: the gap is
+entirely *after* it. The 200 KB POST is the proof of mechanism rather
+than correlation — a first write larger than the loopback MSS is exempt
+from Nagle, and the stall vanishes. And the load generator never sets
+`TCP_NODELAY`, which is why the bands saw it and curl did not.
+
+**It is not a zoxy bug, and not a TLS bug.** A two-small-writes probe
+issued mid-connection stalls ~41 ms against *everything* — zoxy L4, zoxy
+L7, haproxy, and nginx spoken to directly. What differs is reachability:
+a connection's first data segment is covered by Linux's initial quickack
+window, so the shape needs a pathological client on plaintext. Under
+TLS 1.3 it is unavoidable — every client writes `Finished` then the
+request, always past that window.
+
+**What haproxy does differently is not an ACK policy.** It sends two
+NewSessionTickets the moment the handshake completes; that segment
+carries the ACK and the client's Nagle releases. Probed mid-connection,
+haproxy stalls exactly as hard as zoxy.
+
+So the fix is the message, not the socket: **emit the post-handshake
+flight after processing the client's `Finished`**, which is what every
+other TLS server does and what resumption wants anyway. TLS 1.3 also
+permits sending it alongside the server flight — that would be legal and
+would *not* fix this, because the ACK must cover the `Finished`.
+
+`TCP_QUICKACK` was considered and rejected: it treats universal TCP
+behaviour as a zoxy bug, it is Linux-only on a seam that also serves
+kqueue, and it decays — making it robust means re-arming per read, a
+syscall on the data path.
+
+## Kernel socket buffers are outside the §5 budget (2026-07-26)
+
+The startup printout is a closed form over zoxy's pools and says nothing
+about the kernel memory each connection also costs. On this box the
+stock defaults are `tcp_rmem` 131072 and `tcp_wmem` 16384 — 144 KiB per
+socket, and an L7 connection holds two, client and upstream. Against the
+1386-conn-slot default, whose printout reads **31.5 MiB of pools**, that
+is **~390 MiB of kernel socket memory** — twelve times the advertised
+figure, before receive autotuning, which may take `rmem` to 32 MiB per
+socket. At the 14074-connection ceiling the same arithmetic reaches
+~3.9 GiB against ~251 MiB of pools.
+
+These are caps rather than committed pages — the kernel allocates as data
+arrives, and `tcp_mem` bounds it globally (~3.09 GiB here). That is the
+point: the bound that actually applies is the kernel's, not ours, and
+crossing it means queue collapse rather than an allocation failure we
+would see.
+
+Closing it is cheap, because the options are **inherited**: measured on a
+listener, an accepted socket carries the parent's `SO_RCVBUF`/`SO_SNDBUF`
+(and `TCP_NODELAY`) — so one `setsockopt` at bind makes the per-socket cap
+a named constant covering every accepted connection, at no per-connection
+cost.
+
+The caveat that has to ship with it: setting `SO_RCVBUF` explicitly
+disables receive-window autotuning. On loopback and LAN that is free;
+across a WAN a fixed small buffer caps the window and therefore
+BDP-limited throughput. So this wants a `constants.zig` value with a
+config override sized for the deployment, never a hardcoded shrink.
+
+## Reading the memory hierarchy on this box (2026-07-26)
+
+Chasing whether `Conn`'s layout costs cache misses produced one durable
+tooling lesson and one settled verdict.
+
+**`LLC-load-misses` does not count here — validate the counter first.** A
+randomised pointer chase over 256 MiB, unambiguously DRAM-bound at 552
+cycles per step, reports **exactly zero** LLC load misses. perf accepts
+the event name and silently returns 0 rather than `<not supported>`. The
+events that work are the precise ones: `mem_load_retired.l1_miss`,
+`.l2_miss`, `.l3_miss` — the last reported 20,195,083 against 20,000,000
+designed misses, so it is calibrated. (A first attempt at that chase
+walked memory *sequentially* and was eaten by the prefetcher at 25 cycles
+a step, which is exactly how a dead counter looks plausible.)
+
+**The misses scale with connection count, not with bytes per
+connection.** The 2000-connection baseline reads **2.27–2.31**
+misses/request across runs; single figures below are individual runs
+inside that band, not restatements of one number. Holding the offered
+rate fixed and varying only concurrency, DRAM traffic goes 0.05 → 1.22 →
+2.19 → 2.31 across 128 → 512 → 1000 → 2000 connections. Cutting the
+`Conn` stride 4× at 2000 connections — 19.1 MB of slots down to 4.8 MB,
+from over-L3 to comfortably inside a 12 MiB L3 — bought only 21%
+(2.29 → 1.80). The controlled pair settles it: **512 connections at
+4.9 MB take 1.22 misses; 2000 connections at 4.8 MB take 1.80.** Same
+footprint, 4× the connections, 48% more DRAM traffic.
+
+Two hypotheses died on the way, both worth not re-forming. L3 contention
+with the co-resident load generator: the 12 MiB L3 is shared by cpus 0–3
+only, and moving the generator to the E-cores (4–7, outside that domain)
+changed the result by nothing — 2.32 against 2.27. And `align(8)` to pull
+`state`/`armed` off the struct's last cache line made it *worse*, because
+it split two fields that were sharing one line.
+
+**Verdict on structure-of-arrays for `Conn`: not worth building.** The
+per-completion metadata is a genuine target — `delivered()` touches nine
+bytes (`generation` 4, `armed` 1, the op's `generation_at_submit` 4),
+spread across three cache lines 8 KiB apart, and is 18.9% of all DRAM
+misses on its own. But eliminating that share entirely takes 2.29 → 1.86
+misses/request, about 240 cycles of ~3900: **~6% at 2000 connections and
+nothing below ~500**. Against ~130 call sites and
+breaking `Pool`'s `comptime assert(@FieldType(T, "generation") == u32)`,
+which three pools share. If c10k pressure ever makes this worth
+revisiting, the relay-buffer pool's free list is already 10.9% of misses
+on its own and is the cheaper target.
 
 ## Profile share is not throughput headroom — bounding a wipe (2026-07-25)
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -57,6 +57,14 @@ under [Deferred, revisit on evidence](#deferred-revisit-on-evidence).
   client-only (re-verified against the pinned toolchain and upstream
   master; the stalled upstream server PR ziglang/zig#23005 *is*
   tls.zig, so the fork adopts the same code with more control).
+  **Requirement the ~45 ms stall imposes** (IMPLEMENTATION_NOTES.md):
+  the server must emit its post-handshake flight — a NewSessionTicket —
+  *after* processing the client's `Finished`, not alongside the server
+  flight. Both are legal TLS 1.3; only the first carries the ACK that
+  releases a Nagle-held client request, and without it every terminated
+  connection pays a 40 ms delayed-ACK timer once. This is why resumption
+  is not merely a latency nicety on this engine, and it is the whole of
+  what separates zoxy's close-mode band from haproxy's.
 - **Phase 3b — kTLS record offload.** Linux-only follow-up to 3a: hand
   the negotiated keys to the kernel (`setsockopt(SOL_TLS)`, the fork's
   `Ktls.zig` payloads) so the record layer costs zero userspace CPU
@@ -414,3 +422,24 @@ this way. Known queue, in rough value order:
   one replay per parked conn until the sweep reaps the rest.
 - Dynamic DNS for upstream endpoints (§1).
 - io_uring op upgrades — the verdict table above.
+- **Kernel socket buffers inside the §5 budget** — set
+  `SO_RCVBUF`/`SO_SNDBUF` on each listener (accepted sockets inherit
+  them, so it costs one `setsockopt` at bind) so the per-socket cap is a
+  named constant like every other limit. Today the printed total omits
+  memory larger than the pools it does count
+  (IMPLEMENTATION_NOTES.md). Not deferred for lack of value — the
+  measurement is done and the mechanism is trivial — but because the
+  right *default* needs a deployment to size it against: fixing the
+  buffer disables receive autotuning, which is free on a LAN and caps
+  BDP-limited throughput across a WAN. Revisit with the first
+  deployment that has a real network to size against, or sooner if
+  `tcp_mem` pressure is ever observed.
+- **`somaxconn` clamp check at startup** — the listen backlog asks for
+  `accept_backlog` and the kernel silently clamps it to `somaxconn`. The
+  fd budget is already asserted against `RLIMIT_NOFILE` at startup (§8);
+  this deserves the same treatment rather than a silent downgrade.
+- **`TCP_DEFER_ACCEPT` on http listeners** — a connection that never
+  sends data then costs no conn slot or relay buffer (§7 names the
+  slowloris shape; §8 is why holding no slot is the point).
+  Must be per-protocol: it would break an `l4` listener fronting an
+  origin that speaks first.


### PR DESCRIPTION
Docs only. Two findings from this week's profiling that existed nowhere but a terminal scrollback, plus the corrections they force on claims already in the tree.

## The ~45 ms per-connection stall has a mechanism

`IMPLEMENTATION_NOTES.md` recorded the close-mode ceiling as "a fixed ~45 ms serialized stall per handshake connection" and said **"the mechanism is not yet identified"**, listing "the stall (find it)" as an in-tree lever. This is that.

It is a Nagle/delayed-ACK deadlock, and zoxy's half is **sending nothing between the client's `Finished` and the client's first request**. The client's second small write is held by Nagle waiting for an ACK that never piggybacks, and Linux's delayed-ACK timer caps at 40 ms.

**The note's own dismissal was the wrong half of the pair.** It read: *"zoxy sets `TCP_NODELAY` on its own sockets, so it is not the obvious half of that classic."* But `TCP_NODELAY` governs what *zoxy* may send without waiting; what is held here is the *client's* send, waiting on *zoxy's* ACK. That sentence is corrected in place and points forward.

Two controls are recorded, because they make this mechanism rather than correlation:

- A first write **larger than the MSS** is exempt from Nagle — and the stall vanishes (2.4 ms against 43.7 ms for the same request shape).
- A **two-small-writes probe issued mid-connection** stalls ~41 ms against *everything*: zoxy L4, zoxy L7, haproxy, and nginx spoken to directly. It is plain TCP, not a zoxy defect.

What differs under TLS is reachability, not the mechanism: a connection's first data segment is covered by Linux's initial quickack window, so plaintext needs a pathological client, while TLS 1.3 reaches the shape structurally — every client writes `Finished` then the request, always past that window.

And what haproxy does differently is **not** an ACK policy. Probed mid-connection it stalls exactly as hard. It emits NewSessionTicket the moment the handshake completes, and that segment carries the ACK.

So Phase 3a gains a requirement, added to its entry in `PLANS.md`: the post-handshake flight must be emitted **after** processing the client's `Finished`, not alongside the server flight. Both are legal TLS 1.3; only the first releases the client. `TCP_QUICKACK` is recorded as considered and rejected — Linux-only on a seam that also serves kqueue, and it decays, so making it robust means a syscall per read.

## §5 claimed more than it delivers

> Every limit is a named constant in `src/constants.zig`; total memory is a closed-form function of those numbers, printed at startup.

True of zoxy's pools. Not true of the kernel's per-socket buffers, which are charged per connection and are **larger**: 144 KiB a socket at stock defaults (`tcp_rmem` 131072 + `tcp_wmem` 16384), two sockets per L7 connection, so **~390 MiB beside a printout reading 31.5 MiB** — twelve times the advertised figure, before receive autotuning takes `rmem` further. At the 14074-connection ceiling it is ~3.9 GiB against ~251 MiB of pools.

These are caps, not committed pages, and `tcp_mem` bounds them globally — which is the point. The bound that actually applies is the kernel's, and crossing it means queue collapse rather than an allocation failure zoxy would see. There is no counter of ours on it.

**Four places in `DESIGN.md` made the unqualified claim** — the overview, principle 3, §5 itself, and the `constants.zig` file annotation. All four now say pool memory and point at the gap.

Closing it is cheap: `SO_RCVBUF`/`SO_SNDBUF` are **inherited by accepted sockets** (measured), so one `setsockopt` at bind makes the per-socket cap a named constant covering every connection, at no per-connection cost. It is deferred rather than done because the right *default* needs a real network to size against — fixing the buffer disables receive-window autotuning, free on a LAN and BDP-limiting across a WAN. That condition is written into the `PLANS.md` entry rather than guessed at.

## Also recorded, so it is not re-learned

- **This box's `LLC-load-misses` counts nothing.** A randomised pointer chase over 256 MiB, unambiguously DRAM-bound at 552 cycles a step, reports exactly `0`. perf accepts the event and silently returns zero rather than `<not supported>`. `mem_load_retired.l1_miss/.l2_miss/.l3_miss` are what work — the last reported 20,195,083 against 20,000,000 designed misses. (A first attempt at that chase walked memory sequentially and was eaten by the prefetcher, which is exactly how a dead counter looks plausible.)
- **DRAM misses scale with connection count, not bytes per connection.** The controlled pair: 512 connections at 4.9 MB take 1.22 misses/request; 2000 connections at 4.8 MB take 1.80. Same footprint, 4× the connections, 48% more traffic.
- **Structure-of-arrays on `Conn` is bounded at ~6%** at 2000 connections and nothing below ~500, against ~130 call sites and breaking `Pool`'s `generation` contract that three pools share. Recorded as a verdict so it is not re-litigated — along with the two hypotheses that died proving it (L3 contention with the load generator, and `align(8)` on `state`/`armed`, which made things *worse* by splitting two fields that shared a line).

Two smaller `PLANS.md` entries also land: the `somaxconn` silent-clamp check at startup, and `TCP_DEFER_ACCEPT` on http listeners.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass. No source files touched.

`tiger-style-reviewer` returned **needs work (2 violations)**, both of which would have shipped wrong:

- I qualified the memory claim in two places and left **two identical overclaims standing in the same file**, including the overview at line 7 — which a reader hits long before the caveat. All four now agree.
- I cited the same 2000-connection baseline as 2.31, 2.29 and 2.3 within one subsection. They are genuinely different runs, so the band is now stated explicitly rather than reading as an error.

It also caught a **factual error**: I wrote that `delivered()` touches six bytes when the field widths sum to nine (`generation` 4 + `armed` 1 + `generation_at_submit` 4). Corrected, with the detail that actually matters added — those nine bytes sit on three cache lines 8 KiB apart. Plus a miscited `§8 slowloris` (§7 names the shape) and two unlabelled evidence-table rows.

It independently re-verified the arithmetic against `constants.zig`, confirmed the cross-references land where claimed, and confirmed no unlanded-engine references leaked in — the Phase 3a requirement attaches to this branch's `tls.zig`-fork plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
