### PR TITLE
http: decide Connection nomination once, not once per pass (§7, §9)

### DIFF
--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -219,6 +219,9 @@ pub const RequestHead = struct {
     /// Whether the downstream connection may serve another request after
     /// this exchange, per version defaults and Connection tokens.
     keep_alive: bool,
+    /// Whether a Connection token names a header to strip (§7). Carried
+    /// from the analysis pass so rendering need not re-split the value.
+    connection_nominates_header: bool,
     head_len: u32,
 };
 
@@ -235,6 +238,9 @@ pub const ResponseHead = struct {
     /// Whether the upstream connection may be parked for reuse after this
     /// exchange; always false for `until_close` framing.
     keep_alive: bool,
+    /// Whether a Connection token names a header to strip (§7). Carried
+    /// from the analysis pass so rendering need not re-split the value.
+    connection_nominates_header: bool,
     head_len: u32,
 };
 
@@ -335,6 +341,7 @@ pub fn parseRequestHead(
         .host = analysis.host,
         .framing = framing,
         .keep_alive = keepAliveDefault(version, &analysis),
+        .connection_nominates_header = analysis.connection_nominates_header,
         .head_len = head_len,
     };
 }
@@ -399,6 +406,7 @@ pub fn parseResponseHead(
         .headers = headers_storage[0..raw_header_count],
         .framing = framing,
         .keep_alive = keepAliveDefault(version, &analysis) and framing != .until_close,
+        .connection_nominates_header = analysis.connection_nominates_header,
         .head_len = @intCast(head_len),
     };
 }
@@ -676,6 +684,13 @@ const HeaderAnalysis = struct {
     te_other: bool,
     connection_close: bool,
     connection_keep_alive: bool,
+    /// Whether any Connection token names a header to strip, rather than
+    /// only the `close`/`keep-alive` connection *options*. The render walk
+    /// needs exactly this to decide whether the per-header nomination scan
+    /// can be skipped, and the token pass that sets the two flags above
+    /// already knows it — so it is recorded here rather than recomputed by
+    /// splitting the same value a second time (§9).
+    connection_nominates_header: bool,
 };
 
 fn analyzeHeaders(
@@ -690,6 +705,7 @@ fn analyzeHeaders(
         .te_other = false,
         .connection_close = false,
         .connection_keep_alive = false,
+        .connection_nominates_header = false,
     };
     for (raw_headers, 0..) |raw_header, index| {
         assert(raw_header.key.len >= 1);
@@ -744,9 +760,16 @@ fn analyzeHeaders(
     return analysis;
 }
 
-/// Set the persistence flags from one Connection header value in a single
-/// token pass — scanning the list twice (once per token) was a measured
-/// hot spot (§9). Tokens are OWS-trimmed and matched case-insensitively.
+/// Read one Connection header value in a single token pass — the
+/// persistence flags *and* whether anything here nominates a header to
+/// strip. Scanning the list twice (once per token) was a measured hot
+/// spot (§9), and so was splitting it again in the render walk. Tokens
+/// are OWS-trimmed and matched case-insensitively.
+///
+/// `close` and `keep-alive` are connection options, not header names —
+/// `keep-alive` is itself hop-by-hop and `close` names no forwardable
+/// header — so a value listing only those nominates nothing. Any other
+/// token does.
 fn scanConnectionTokens(value: []const u8, analysis: *HeaderAnalysis) void {
     // The value is a slice of the parsed head (an empty value is legal:
     // `Connection:` with nothing after it), so it is head-buffer bounded.
@@ -757,11 +780,15 @@ fn scanConnectionTokens(value: []const u8, analysis: *HeaderAnalysis) void {
         if (token.len == 0) {
             continue;
         }
-        assert(token.len >= 1); // Only real options are classified below.
+        // Every non-empty token is classified below: close/keep-alive as
+        // connection options, anything else as a nomination.
+        assert(token.len >= 1);
         if (std.ascii.eqlIgnoreCase(token, "close")) {
             analysis.connection_close = true;
         } else if (std.ascii.eqlIgnoreCase(token, "keep-alive")) {
             analysis.connection_keep_alive = true;
+        } else {
+            analysis.connection_nominates_header = true;
         }
     }
 }

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -105,7 +105,7 @@ pub fn renderRequestHead(
         .http_1_0 => " HTTP/1.0\r\n",
         .http_1_1 => " HTTP/1.1\r\n",
     });
-    try appendEndToEndHeaders(&staging, request.headers, edits);
+    try appendEndToEndHeaders(&staging, request.headers, request.connection_nominates_header, edits);
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -139,7 +139,7 @@ pub fn renderResponseHead(
     }
     try staging.append("\r\n");
     // Filters are request-side only (§7); the response carries no edits.
-    try appendEndToEndHeaders(&staging, response.headers, &.{});
+    try appendEndToEndHeaders(&staging, response.headers, response.connection_nominates_header, &.{});
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -210,6 +210,7 @@ const Staging = struct {
 fn appendEndToEndHeaders(
     staging: *Staging,
     headers: []const parser.Header,
+    connection_nominates_header: bool,
     edits: []const filter.AppliedHeaderEdit,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
@@ -229,14 +230,19 @@ fn appendEndToEndHeaders(
         }
     }
     const nominations = connection_values[0..connection_count];
-    // `close` and `keep-alive` are connection options, not header names —
-    // `keep-alive` is already a hop-by-hop name and `close` names no
-    // forwardable header — so a Connection listing only those nominates
-    // nothing to strip. Detect a real nomination once here; the common
-    // case then skips the per-header token scan entirely, splitting the
-    // Connection value once rather than once per header (§9).
+    // Whether anything is nominated was settled by `parser.scanConnectionTokens`,
+    // which already walked these same tokens to decide keep-alive. In the
+    // common case — no nomination — the per-header scan below is skipped
+    // entirely and the value is never split here at all (§9).
+    //
+    // The flag and the values it describes are now filled in by two
+    // different passes, joined only by this bool: a nomination without a
+    // Connection header to have carried it means they have desynchronized.
+    if (connection_nominates_header) {
+        assert(connection_count >= 1);
+    }
     const active_nominations =
-        if (nominatesRealHeader(nominations)) nominations else nominations[0..0];
+        if (connection_nominates_header) nominations else nominations[0..0];
 
     // Only `set`/`remove` edits suppress source copies; `add` never does.
     // Decide once whether any suppressing edit exists, so a request with no
@@ -278,31 +284,6 @@ fn suppressedByEdit(name: []const u8, edits: []const filter.AppliedHeaderEdit) b
         switch (edit.kind) {
             .set, .remove => if (std.ascii.eqlIgnoreCase(name, edit.name)) return true,
             .add => {},
-        }
-    }
-    return false;
-}
-
-/// True when a Connection value names a header to strip beyond the
-/// standard `close`/`keep-alive` options. Splits each token list once so
-/// the per-header hop-by-hop test can skip the (usually empty) nomination
-/// scan in the common case.
-fn nominatesRealHeader(nominations: []const []const u8) bool {
-    assert(nominations.len <= constants.headers_max);
-    for (nominations) |value| {
-        var tokens = std.mem.splitScalar(u8, value, ',');
-        while (tokens.next()) |raw_token| {
-            const token = std.mem.trim(u8, raw_token, " \t");
-            if (token.len == 0) {
-                continue;
-            }
-            if (std.ascii.eqlIgnoreCase(token, "close")) {
-                continue;
-            }
-            if (std.ascii.eqlIgnoreCase(token, "keep-alive")) {
-                continue;
-            }
-            return true;
         }
     }
     return false;
@@ -471,6 +452,26 @@ test "render: nominating a protected header does not strip it" {
     const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
+        rendered,
+    );
+}
+
+test "render: a nomination on a second Connection line still strips" {
+    // Connection is a list field: two header lines combine as one list
+    // (RFC 9110), so the nomination flag has to accumulate across them —
+    // it is set by whichever line carries a non-option token. Pins that
+    // OR, which the render walk now depends on and cannot see for itself.
+    const head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n" ++
+        "Connection: X-Nominated\r\nX-Nominated: v\r\nX-Keep: k\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    try testing.expect(request.connection_nominates_header);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
+    // Both Connection lines are hop-by-hop; X-Nominated goes because the
+    // second line named it; X-Keep is untouched.
+    try testing.expectEqualStrings(
+        "GET / HTTP/1.1\r\nHost: a\r\nX-Keep: k\r\n\r\n",
         rendered,
     );
 }


### PR DESCRIPTION
Third in the line that started with #92 — and the same species of finding each time: work done twice because two consumers each did it independently.

## Four splits of one value

The Connection header value was token-split **four times per request**. `parser.scanConnectionTokens` walked it on each head to set the close/keep-alive flags; `render.nominatesRealHeader` walked it again on each render to ask whether anything named a header to strip. Both split on `,`, OWS-trimmed every token, and compared it case-insensitively against the same two literals.

Attributed precisely:

```
0.78%  request head    -> analyzeHeaders -> scanConnectionTokens -> next
0.74%  response head   -> analyzeHeaders -> scanConnectionTokens -> next
0.76%  request render  -> appendEndToEndHeaders -> nominatesRealHeader -> next
0.77%  response render -> appendEndToEndHeaders -> nominatesRealHeader -> next
```

The second pair asks a question the first pair already had the answer to. `HeaderAnalysis` gains `connection_nominates_header`, set in the token walk's `else` arm — a token that is neither option is a nomination — carried onto both heads and read by the render. `nominatesRealHeader` is deleted.

## Equivalence was tested, not assumed

This is hop-by-hop stripping and Connection nomination, so a green gate is not by itself evidence. The flag was **mutation-tested in both directions**:

| mutation | test that caught it |
|---|---|
| flag forced **false** | `render: request strips hop-by-hop and nominated, keeps the rest` |
| flag forced **true** | `render: standard Connection options do not nominate a same-named header` |

Both bite, which is what makes the passing gate mean something.

## A gap the review found

Connection is a list field: two header lines combine as one list (RFC 9110), so the flag has to accumulate across them. It does — analysis ORs into one struct, exactly as `connection_close` always has — but **nothing in the repo tested that axis.** The deleted function looped over the collected values explicitly; the new flag depends on the OR and the render walk cannot see it for itself.

So a test now pins it: a nomination carried on the *second* `Connection:` line still strips its header, with the flag asserted directly and `X-Keep` surviving alongside.

## Measured

ReleaseFast, zoxy alone on a P-core, load pinned off it, 60k req/s over 128 connections. Three paired rounds after the review fixes; an earlier five-round run on the pre-review build agreed at −6.2%:

| | before | after |
|---|---|---|
| instructions/request | 6060 | **5671** (−6.4%) |
| cycles/request | 2572 | **2445** (−4.9%) |

Where it came from: `appendEndToEndHeaders` **7.35% → 4.96%** of user cycles, `findScalarPos` **4.46% → 2.92%**.

**Larger than the ~1.5% I predicted**, and the reason is worth recording: the estimate counted only the byte-scan slice the profile attributed to `findScalarPos`. Deleting the function also removed its trim, its two compares per token, and its loop — all of which had been folded into `appendEndToEndHeaders`'s own share. Profile attribution under heavy inlining undercounts what deleting a function actually buys.

No throughput claim, as with #92/#94/#95 — the loopback bench is harness-bound.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.

`tiger-style-reviewer`: **ready to commit**, no violations. It traced the equivalence question fully — multiple Connection headers, empty tokens, OWS-only values, `Connection:` with an empty value, duplicate tokens — and confirmed the flag matches the deleted function for all of them. Five of its six judgement calls are applied: the missing cross-header test above, a cross-pass assertion (a nomination implies at least one Connection header was seen, since the flag and the values it describes are now filled in by two decoupled passes), the parameter rename to match the field, and two comment fixes. The sixth — that the three-arm `if/else if/else` is the literal shape TIGER_STYLE's else-if rule names — was left, as the reviewer noted the same mutually-exclusive classification already exists in this file and nesting it would read worse.

Given #94, where added assertions ate two thirds of that win, the build was **re-measured after applying the review fixes**: −6.4%, unchanged. This assert is a trivial condition with no call, so it costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
