### PR TITLE
http: canonicalize a target once per request, not twice (§7, §9)

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -186,7 +186,26 @@ pub fn Proxy(comptime IoType: type) type {
         /// the whole server. A target that will not canonicalize is
         /// BadPath (400). One canonical view, shared by both filter
         /// matching and routing, so they never disagree.
-        const RequestKeys = struct { host: ?[]const u8, path: []const u8 };
+        const RequestKeys = struct {
+            host: ?[]const u8,
+            /// The §7 *match* view: the canonical path, or "/" for OPTIONS
+            /// asterisk-form, which matches and routes as the origin root.
+            path: []const u8,
+            /// The §7 *forward* view: what the origin is sent. The same
+            /// bytes as `path` for origin-form; asterisk-form forwards "*"
+            /// verbatim rather than the "/" it matched as.
+            ///
+            /// Carried here so the canonicalization happens once. Rendering
+            /// needs this exact value and used to recompute it — decoding
+            /// and dot-segment-collapsing the whole path a second time on
+            /// every request (§9).
+            ///
+            /// For origin-form it aliases the caller's scratch and so lives
+            /// exactly as long as that frame; asterisk-form aliases the head
+            /// buffer instead, which outlives it. Treat the shorter of the
+            /// two as the lifetime.
+            target: parser.CanonicalTarget,
+        };
 
         fn requestKeys(
             request: *const parser.RequestHead,
@@ -198,15 +217,41 @@ pub fn Proxy(comptime IoType: type) type {
                 parser.canonicalHost(raw, host_scratch)
             else
                 null;
+            const views = try targetViews(request, scratch);
+            assert(views.match.len >= 1);
+            assert(views.forward.path.len >= 1);
+            return .{ .host = host, .path = views.match, .target = views.forward };
+        }
+
+        /// Both §7 views of a target, from one canonicalization.
+        ///
+        /// They differ in exactly one case, and this is the only place that
+        /// case is written: OPTIONS asterisk-form matches and routes as the
+        /// origin root but is forwarded as `*`. Origin-form canonicalizes,
+        /// and both views are then the same bytes.
+        ///
+        /// Canonicalizing decodes percent-escapes and collapses dot
+        /// segments over the whole path, so it is done once and both
+        /// consumers read the result (§9). The slices alias `scratch`.
+        const TargetViews = struct { match: []const u8, forward: parser.CanonicalTarget };
+
+        fn targetViews(
+            request: *const parser.RequestHead,
+            scratch: *[constants.head_bytes_max]u8,
+        ) error{BadPath}!TargetViews {
+            assert(request.target.len >= 1);
             if (request.target[0] != '/') {
                 // validateTarget admitted only asterisk-form here.
                 assert(request.method == .options);
-                return .{ .host = host, .path = "/" };
+                return .{
+                    .match = "/",
+                    .forward = .{ .path = request.target, .query = "" },
+                };
             }
             const canonical = parser.canonicalTarget(request.target, scratch) catch {
                 return error.BadPath;
             };
-            return .{ .host = host, .path = canonical.path };
+            return .{ .match = canonical.path, .forward = canonical };
         }
 
         /// Answer a §7 filter reject with its runtime policy status — each
@@ -225,19 +270,22 @@ pub fn Proxy(comptime IoType: type) type {
             unreachable;
         }
 
-        /// The canonical bytes to forward for `request` (§7): origin-form
-        /// canonicalizes, OPTIONS asterisk-form passes through. routeRequest
-        /// already proved canonicalization succeeds, so this cannot fail —
-        /// the same bytes are the single source of truth.
+        /// The bytes to forward for `request` (§7), rebuilt after an await.
+        /// routeRequest already proved canonicalization succeeds on these
+        /// same bytes — the single source of truth — so it cannot fail here.
+        ///
+        /// Only the fresh-dial path calls this, and only because the await
+        /// took routeRequest's scratch with it. The reuse path — almost all
+        /// traffic — carries `RequestKeys.target` over instead, since no
+        /// await separates the two and the scratch is still live. Both go
+        /// through `targetViews`, so the asterisk rule has one spelling.
         fn effectiveTarget(
             request: *const parser.RequestHead,
             scratch: *[constants.head_bytes_max]u8,
         ) parser.CanonicalTarget {
-            assert(request.target.len >= 1);
-            if (request.target[0] != '/') {
-                return .{ .path = request.target, .query = "" };
-            }
-            return parser.canonicalTarget(request.target, scratch) catch unreachable;
+            const views = targetViews(request, scratch) catch unreachable;
+            assert(views.forward.path.len >= 1);
+            return views.forward;
         }
 
         /// The forwarded target and header edits after applying the
@@ -358,8 +406,10 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.state = .l7_dialing;
                 // No await happened: this runs in the same callback as the
                 // parse whose result is still live, so the reuse path —
-                // the hot one — skips the re-parse the dial path needs.
-                renderRequestAndStartLegs(server, conn, request);
+                // the hot one — skips the re-parse the dial path needs,
+                // and hands over the canonical target it already built
+                // rather than having it decoded and collapsed again.
+                renderRequestAndStartLegs(server, conn, request, keys.target);
                 return;
             }
             dialUpstream(server, conn, pick);
@@ -451,7 +501,12 @@ pub fn Proxy(comptime IoType: type) type {
                 &storage,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
-            renderRequestAndStartLegs(server, conn, &request);
+            // Only this path pays for canonicalization twice, and it has
+            // to: routeRequest's scratch died with its frame at the dial.
+            // The scratch lives here so the target outlives the call.
+            var scratch: [constants.head_bytes_max]u8 = undefined;
+            const base = effectiveTarget(&request, &scratch);
+            renderRequestAndStartLegs(server, conn, &request, base);
         }
 
         /// Render the request head into the upstream slot's staging
@@ -460,14 +515,18 @@ pub fn Proxy(comptime IoType: type) type {
             server: *ServerType,
             conn: *ConnType,
             request: *const parser.RequestHead,
+            /// The §7 canonical target the router matched on — the base the
+            /// origin sees, unless a filter rewrites the forwarded path.
+            /// Passed in rather than recomputed: canonicalizing decodes and
+            /// collapses the whole path, and the caller already did it
+            /// (§9). Origin-form aliases the caller's stack scratch, so it
+            /// is read out entirely before this returns.
+            base: parser.CanonicalTarget,
         ) void {
             assert(conn.state == .l7_dialing);
             assert(request.head_len == conn.l7.request_head_len);
+            assert(base.path.len >= 1);
             const upstream = conn.upstream.?;
-            // The §7 canonical target the router matched on is the base the
-            // origin sees, unless a filter rewrites the forwarded path.
-            var scratch: [constants.head_bytes_max]u8 = undefined;
-            const base = effectiveTarget(request, &scratch);
             // Apply the listener's filters (empty when none): a rewrite of
             // the forwarded path and any header edits, against the same
             // canonical view the reject/route phase used.

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -730,6 +730,34 @@ test "l7: CONNECT and Upgrade are answered 501" {
     }
 }
 
+test "l7: OPTIONS asterisk-form is forwarded as \"*\", not as the \"/\" it matched" {
+    // §7 keeps two views of a target: the *match* view, which routes and
+    // filters asterisk-form as the origin root, and the *forward* view,
+    // which sends "*" verbatim. They are built together from one
+    // canonicalization, so nothing but this test stops the forward view
+    // from silently becoming the match view — which would turn a
+    // server-wide OPTIONS into a request for the root resource.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 21,
+        .origin_response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("OPTIONS * HTTP/1.1\r\nHost: origin.example\r\n\r\n");
+
+    try std.testing.expect(bed.origin.conns[0].request_complete);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try parser.parseRequestHead(
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
+        false,
+        &storage,
+    );
+    try std.testing.expectEqual(parser.Method.options, forwarded.method);
+    try std.testing.expectEqualStrings("*", forwarded.target);
+    try bed.expectDrained();
+}
+
 test "l7: a GET is proxied and the origin's response relayed back" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{


### PR DESCRIPTION
Last of the run that started with #92, and found the same way: a mechanical sweep of the profile for work reachable from two distinct callers.

## Canonicalized twice, and not for the reason it looks like

`parser.canonicalTarget` — percent-decode plus dot-segment collapse over the whole path — ran twice per request:

```
0.41%  routeRequest → requestKeys → canonicalTarget          (self)
0.41%  requestKeys → canonicalTarget → collapseDotSegments
0.24%  requestKeys → canonicalTarget → decodeTargetPath

0.41%  renderRequestAndStartLegs → effectiveTarget → canonicalTarget   (self)
0.48%  effectiveTarget → canonicalTarget → collapseDotSegments
0.18%  effectiveTarget → canonicalTarget → decodeTargetPath
```

`effectiveTarget` even documented that it knew: *"routeRequest already proved canonicalization succeeds, so this cannot fail — the same bytes are the single source of truth."* It reused routing's **proof** and redid the **work**.

This looks like §7's await trade — state cannot survive a suspension, so recompute — and for the fresh-dial path it is. But `proxy.zig` says the opposite about the other path: *"No await happened: this runs in the same callback as the parse whose result is still live."* On upstream reuse, `routeRequest` calls the renderer **directly, same call stack**, with its `scratch` still on the frame. And reuse is essentially all traffic — `upstream_reused 1508085` against `l7_responses 1509627`, **99.9%**.

So routing hands the canonical target over, and rendering takes it as a parameter. Only the dial path still recomputes, because there an await genuinely took the scratch with it.

## The first attempt was wrong, and how it was wrong is the point

It wrote the OPTIONS asterisk rule in **two** places — `requestKeys` and `effectiveTarget` — which is exactly the duplication this change exists to remove.

That would have been a tidiness complaint, except it was also **invisible to the tests**. Mutating the asterisk branch in `requestKeys` left the entire suite green, because the first request on a connection always dials, so a single-request test exercises `effectiveTarget` and never reaches the routing copy. Two spellings meant one of them was unreachable from the tests.

Restructuring into a single `targetViews` helper returning both §7 views — with `effectiveTarget` now a thin wrapper — fixed both problems at once. With one spelling, both paths run through it, and the same mutation now fails with `expected "*", found "/"`.

Worth stating plainly: **"one spelling" is a testability property here, not only a tidiness one.**

## A gap this exposed

**There was no proxy-level OPTIONS coverage at all.** Nothing checked that asterisk-form is forwarded as `*` rather than as the `/` it matches and routes as — and confusing those two views turns a server-wide OPTIONS into a request for the root resource.

A test now pins the wire bytes the origin receives, and the mutation above confirms it bites.

## Measured

ReleaseFast, zoxy alone on a P-core, load pinned off it, 60k req/s over 128 connections. Four paired rounds; three more after the review fixes agreed at −2.8%, so the assertions added in review are free:

| | before | after |
|---|---|---|
| instructions/request | 5665 | **5512** (−2.7%) |
| cycles/request | 2529 | **2469** (−2.4%) |

All four rounds negative on both metrics, instruction deltas tight (−140 to −166).

No throughput claim — the loopback bench is harness-bound, as with #92/#94/#95/#97.

## Left on the record, not fixed

`planForward` still derives the match view from the forward one itself (`if (origin_form) base.path else "/"`), so the asterisk-matches-as-root rule has a second home. It is pre-existing and costs nothing — no re-canonicalization — but it is a place the rule could drift from `targetViews`, and filters are documented to match the view the reject/route phase saw. Recorded in the commit message rather than quietly left; happy to fold it in if you would rather it went now.

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass.

`tiger-style-reviewer`: **needs work (1 violation)**, fixed — the new test was the only one of 51 in the file omitting `try bed.expectDrained()`, the §8/§9 check that the exchange settles and releases its slot and socket.

It walked all eight exits of `routeRequest` to confirm the lifetime is sound: `keys.target.path` aliases the stack scratch, and the only exit that uses it runs the renderer synchronously to completion before returning. It also corrected a claim of mine about which path the new test covers, and flagged two comments that said "aliases the caller's scratch" when that holds only for origin-form — asterisk-form aliases the longer-lived head buffer. Both tightened, along with postcondition assertions on the two functions that had thinned when their asserts moved into `targetViews`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
