### PR TITLE
shed: keep the connection when the stream allows it, and show the wall coming (§8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -625,7 +625,7 @@ the loop thread.
 | connection slots | accept completion | close immediately (SO_LINGER 0 → RST); accept stays armed |
 | relay buffers (L4) | accept admission | close immediately |
 | relay buffers (L7) | request admission on a kept-alive conn | static `503` from the head buffer, then keep or close per pressure |
-| upstream slots / dial concurrency | upstream checkout | static `503` (L7) / close (L4) |
+| upstream slots / dial concurrency | upstream checkout | static `503` (L7), then keep or close per pressure / close (L4) |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
@@ -635,6 +635,20 @@ the loop thread.
   the connection's head buffer, whose bytes the parsed head's zero-copy
   slices may still reference (§7). Shedding costs one send, no
   allocation, no copy.
+- **A shed keeps the connection when it can.** Closing is not free: it
+  costs the client a handshake and this proxy an accept, a conn slot and
+  an admission — so an always-closing shed is *more* expensive per
+  request than the work it sheds, and a transient overshoot locks itself
+  in as a reconnect loop rather than settling into a plateau. A static
+  response therefore keeps the connection whenever all four hold: the
+  client's byte stream is still on a message boundary (a valid head
+  parsed, no declared body left to read, nothing pipelined past it), the
+  client asked for keep-alive, the proxy is not draining, and relay
+  pressure has not suppressed keep-alive (#57). Otherwise the lingering
+  close (§2) drains the client's inbound and closes. The
+  head-framing rejects — `400` malformed, `414`, `431` — can never keep:
+  where the next request begins is exactly what the parser could not
+  determine, so keeping would hand a smuggler a desynchronized stream.
 - **Accept never pauses.** Accept-and-RST is preferred over un-arming the
   accept: the kernel backlog stays drained, clients get an immediate
   signal instead of a timeout, and there is no re-arm state machine.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -230,7 +230,10 @@ pub fn Server(comptime IoType: type) type {
         fn onSignal(server: *Self, signal: Io.Signal) void {
             switch (signal) {
                 .terminate => server.beginDrain(),
-                .dump_counters => server.counters.dump(),
+                .dump_counters => {
+                    const snapshot = server.gauges();
+                    server.counters.dump(&snapshot);
+                },
             }
         }
 
@@ -812,6 +815,32 @@ pub fn Server(comptime IoType: type) type {
         /// never by closing connections that are doing work.
         pub fn keepAliveSuppressed(server: *const Self) bool {
             return server.relay_pressure;
+        }
+
+        /// The live occupancy of all three pools, read straight off them
+        /// for a scrape or a SIGUSR1 dump (§8). The only producer of
+        /// `Counters.Gauges` — nothing mirrors these levels, so nothing
+        /// can disagree with the pool it reports.
+        ///
+        /// This is what the `*_shed_*` counters cannot show: a shed says
+        /// the wall was *hit*, and by then the connection is already being
+        /// answered 503. The levels show the approach, which is the only
+        /// way to size `limits` before a run rather than after it.
+        pub fn gauges(server: *const Self) counters_module.Counters.Gauges {
+            const snapshot: counters_module.Counters.Gauges = .{
+                .conn_slots_in_use = server.conns.acquired_count,
+                .conn_slots_capacity = server.conns.capacity(),
+                .relay_buffers_in_use = server.relay_buffers.acquired_count,
+                .relay_buffers_capacity = server.relay_buffers.capacity(),
+                .upstream_slots_leased = server.upstreams.leasedCount(),
+                .upstream_slots_parked = server.upstreams.parkedCount(),
+                .upstream_slots_capacity = server.upstreams.capacity(),
+            };
+            // Asserted at the producer, not in the renderer: a level past
+            // its capacity would mean a pool miscounted, and that is a bug
+            // here, not a formatting problem there.
+            assert(snapshot.valid());
+            return snapshot;
         }
 
         /// The §8 upstream-pool acquire/release pair: the pressure flag

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -227,10 +227,13 @@ pub fn Admin(comptime IoType: type) type {
         }
 
         /// Build the full response once, into the fixed buffer: the static
-        /// head then the counters rendering (zero-alloc, §5).
+        /// head then the counters-and-gauges rendering (zero-alloc, §5).
+        /// The gauges are sampled here, at render time, so a scrape reports
+        /// the pool levels as of the response it is answering.
         fn renderResponse(admin: *Self) void {
             @memcpy(admin.response[0..response_head.len], response_head);
-            const body = admin.server.counters.render(admin.response[response_head.len..]);
+            const gauges = admin.server.gauges();
+            const body = admin.server.counters.render(&gauges, admin.response[response_head.len..]);
             admin.response_len = @intCast(response_head.len + body.len);
             admin.sent = 0;
             assert(admin.response_len >= response_head.len);

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -97,11 +97,18 @@ const Harness = struct {
 /// time, before `admin_served` (or any counter this scenario touches) moves,
 /// so the on-the-wire snapshot is always the zero state — checkable
 /// byte-for-byte regardless of what the counters read after the run.
-fn expectedResponse(buffer: []u8) []const u8 {
+///
+/// The gauges are not zero and are not assumed: the admin plane lives
+/// outside the three data-path pools (§8), so an idle scrape reports their
+/// real capacities and an occupancy of zero. Passing the server's own
+/// snapshot keeps this expectation honest — a scrape that rendered stale or
+/// invented levels would fail here rather than quietly matching a
+/// hand-written constant.
+fn expectedResponse(gauges: *const counters_module.Counters.Gauges, buffer: []u8) []const u8 {
     assert(buffer.len >= admin.response_bytes_max);
     var zero: counters_module.Counters = .{};
     @memcpy(buffer[0..admin.response_head.len], admin.response_head);
-    const body = zero.render(buffer[admin.response_head.len..]);
+    const body = zero.render(gauges, buffer[admin.response_head.len..]);
     return buffer[0 .. admin.response_head.len + body.len];
 }
 
@@ -302,12 +309,21 @@ test "admin: a scrape returns the counters as byte-exact Prometheus text" {
 
         try testing.expectEqual(Scrape.Outcome.eof, harness.scrape.outcome);
         var expected_buffer: [admin.response_bytes_max]u8 = undefined;
-        const expected = expectedResponse(&expected_buffer);
+        // The data path is idle at scrape time, so the levels the scrape
+        // rendered are the ones still live here.
+        const gauges = harness.server.gauges();
+        const expected = expectedResponse(&gauges, &expected_buffer);
         try testing.expectEqualStrings(
             expected,
             harness.scrape.recv_buffer[0..harness.scrape.received_len],
         );
         try testing.expectEqual(@as(u64, 1), harness.server.counters.get("admin_served"));
+        // An idle data path renders zero occupancy against real capacities:
+        // the scrape reports the pools, not the admin plane's own slot.
+        try testing.expectEqual(@as(u32, 0), gauges.conn_slots_in_use);
+        try testing.expectEqual(@as(u32, 0), gauges.upstream_slots_leased);
+        try testing.expect(gauges.conn_slots_capacity >= 1);
+        try testing.expect(gauges.upstream_slots_capacity >= 1);
         try harness.expectDrained();
     }
 }
@@ -329,7 +345,8 @@ test "admin: a scrape stays intact and drains under resets" {
         try harness.sim_io.run();
 
         var expected_buffer: [admin.response_bytes_max]u8 = undefined;
-        const expected = expectedResponse(&expected_buffer);
+        const gauges = harness.server.gauges();
+        const expected = expectedResponse(&gauges, &expected_buffer);
         const got = harness.scrape.recv_buffer[0..harness.scrape.received_len];
         try testing.expect(std.mem.startsWith(u8, expected, got));
         try harness.expectDrained();

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -33,22 +33,39 @@ pub const Counters = struct {
     /// L7 reject responses (§7): a malformed head (400), an oversize
     /// request line (414) or header section (431), or an unsupported
     /// method/upgrade (501). Not sheds — the connection was admitted and
-    /// answered a static response, so it completes normally and stays out
-    /// of `reconcile`'s shed sum; these are pure observability.
+    /// answered a static response, so they stay out of `reconcile`'s shed
+    /// sum; these are pure observability.
+    ///
+    /// They do not share one persistence rule, because they do not share
+    /// one cause. `l7_uri_too_long` and `l7_headers_too_large` always
+    /// close: the parser could not find the message boundary, so neither
+    /// can the turnaround. `l7_not_implemented` answers a head that parsed
+    /// cleanly and follows the general keep rule (§8). `l7_bad_request`
+    /// covers both — a parser-rejected head, which closes, and a head that
+    /// parsed but whose target would not canonicalize, which keeps. The
+    /// counter deliberately does not split: the client sees one status,
+    /// and `staticResponseResyncable` decides from the stream rather than
+    /// from the status.
     l7_bad_request: Value = Value.init(0),
     l7_uri_too_long: Value = Value.init(0),
     l7_headers_too_large: Value = Value.init(0),
     l7_not_implemented: Value = Value.init(0),
     /// No route matched the request's canonical path (§7), answered 404.
-    /// Like the other reject counters the connection completes normally.
+    /// A valid head, so the connection keeps serving when its stream is
+    /// still on a message boundary — see `l7_shed_*` below.
     l7_no_route: Value = Value.init(0),
     /// A §7 filter rule rejected the request with its policy status
-    /// (403/404/429/400). A reject, not a shed — the connection completes.
+    /// (403/404/429/400). A reject, not a shed; same persistence rule as
+    /// `l7_no_route`.
     l7_filtered: Value = Value.init(0),
     /// §8 rungs at the L7 request level, answered 503: relay buffers or
-    /// upstream slots exhausted when a valid request needed them. Like
-    /// the reject counters these connections complete normally, so they
-    /// stay out of `reconcile`'s shed sum.
+    /// upstream slots exhausted when a valid request needed them. Like the
+    /// reject counters, the connection was admitted, so these stay out of
+    /// `reconcile`'s shed sum — but it does not necessarily *end* here: a
+    /// shed whose client stream is still on a message boundary keeps
+    /// serving (§8 "then keep or close per pressure"), so one connection
+    /// can carry many of these. Counting them is not counting connections,
+    /// and the ratio to `accepted` is the churn signal.
     l7_shed_relay_buffers: Value = Value.init(0),
     l7_shed_upstream_slots: Value = Value.init(0),
     /// Upstream leg failed before any response byte reached the client:

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -99,6 +99,47 @@ pub const Counters = struct {
 
     const Value = std.atomic.Value(u64);
 
+    /// Live pool occupancy against capacity (§8 "watermarks before
+    /// walls"). Gauges, not counters: they go both ways, and a scrape
+    /// wants the level, not the history.
+    ///
+    /// Read from the pools at render time rather than mirrored on every
+    /// acquire/release — a mirror is one missed release away from
+    /// disagreeing with the pool it describes, and the pools already
+    /// count what this reports. `Server.gauges` is the only producer.
+    ///
+    /// Why they exist: without them a scrape sees a wall only *after* it
+    /// is hit. The `shed_*` and `l7_shed_*` counters fire at exhaustion
+    /// and the `*_pressure_engaged` counters at the 3/4 watermark, so a
+    /// pool can run at 74% forever and look identical to an idle one.
+    /// The occupancy is what shows the approach.
+    pub const Gauges = struct {
+        conn_slots_in_use: u32,
+        conn_slots_capacity: u32,
+        relay_buffers_in_use: u32,
+        relay_buffers_capacity: u32,
+        /// Upstream slots serving a request right now. This is the level
+        /// that reaches `upstream_slots_capacity` and turns a request
+        /// into `l7_shed_upstream_slots` (§8).
+        upstream_slots_leased: u32,
+        /// Upstream slots held open for reuse (§5). Parked slots are
+        /// *occupied*: leased + parked is what the wall is measured
+        /// against, which is why both are reported rather than a single
+        /// in-use figure.
+        upstream_slots_parked: u32,
+        upstream_slots_capacity: u32,
+
+        /// The invariant every producer owes: a level never exceeds its
+        /// own capacity, and the two upstream levels share one.
+        pub fn valid(gauges: *const Gauges) bool {
+            if (gauges.conn_slots_in_use > gauges.conn_slots_capacity) return false;
+            if (gauges.relay_buffers_in_use > gauges.relay_buffers_capacity) return false;
+            const upstream_in_use = @as(u64, gauges.upstream_slots_leased) +
+                gauges.upstream_slots_parked;
+            return upstream_in_use <= gauges.upstream_slots_capacity;
+        }
+    };
+
     /// Loop thread only — the single writer (§8).
     pub fn increment(counters: *Counters, comptime name: []const u8) void {
         const previous = @field(counters, name).fetchAdd(1, .monotonic);
@@ -115,11 +156,13 @@ pub const Counters = struct {
 
     /// Exact byte bound on a full `render` (§5: the caller sizes a fixed
     /// buffer to it, so rendering never allocates and never truncates).
-    /// Per counter: a `# TYPE …` line plus a sample line whose value is at
-    /// most `maxInt(u64)` — 20 digits. Comptime-summed over the real field
-    /// set, so it tracks the counters as they are added or removed.
+    /// Per metric: a `# TYPE …` line plus a sample line whose value is at
+    /// most its type's maximum — 20 digits for a `u64` counter, 10 for a
+    /// `u32` gauge. Comptime-summed over the real field sets, so it tracks
+    /// both as they are added or removed.
     pub const render_bytes_max: usize = blk: {
         const u64_digits_max = 20; // len("18446744073709551615")
+        const u32_digits_max = 10; // len("4294967295")
         var total: usize = 0;
         for (@typeInfo(Counters).@"struct".fields) |field| {
             if (field.type != Value) continue;
@@ -127,15 +170,30 @@ pub const Counters = struct {
             total += "# TYPE ".len + name_len + " counter\n".len;
             total += name_len + " ".len + u64_digits_max + "\n".len;
         }
+        for (@typeInfo(Gauges).@"struct".fields) |field| {
+            assert(field.type == u32);
+            const name_len = metric_prefix.len + field.name.len;
+            total += "# TYPE ".len + name_len + " gauge\n".len;
+            total += name_len + " ".len + u32_digits_max + "\n".len;
+        }
         break :blk total;
     };
 
-    /// Render every counter as Prometheus exposition text into a
+    /// Render every counter and gauge as Prometheus exposition text into a
     /// caller-owned buffer (zero-alloc, §5) — the single renderer shared by
-    /// the SIGUSR1 `dump` and any future admin endpoint. The buffer must be
+    /// the SIGUSR1 `dump` and the admin endpoint. The buffer must be
     /// at least `render_bytes_max`; that bound is exact, so a correctly
     /// sized caller can never truncate. Returns the filled prefix.
-    pub fn render(counters: *const Counters, buffer: []u8) []const u8 {
+    ///
+    /// `gauges` is a snapshot the caller reads off the live pools, not
+    /// state this module owns: `counters.zig` is imported by `Server.zig`,
+    /// so the dependency cannot run the other way.
+    pub fn render(counters: *const Counters, gauges: *const Gauges, buffer: []u8) []const u8 {
+        // `gauges.valid()` is asserted where the snapshot is produced
+        // (`Server.gauges`), not here: the renderer must stay able to emit
+        // every field at its type's maximum, which is what makes
+        // `render_bytes_max` an exactly reachable bound rather than a
+        // merely sufficient one.
         assert(buffer.len >= render_bytes_max);
         var cursor: usize = 0;
         inline for (@typeInfo(Counters).@"struct".fields) |field| {
@@ -151,18 +209,30 @@ pub const Counters = struct {
             ) catch unreachable;
             cursor += written.len;
         }
+        inline for (@typeInfo(Gauges).@"struct".fields) |field| {
+            // Same argument as the counter loop above, against the gauge
+            // half of the bound: the format string is comptime and every
+            // gauge is a u32, whose widest rendering `render_bytes_max`
+            // reserves 10 digits for.
+            const written = std.fmt.bufPrint(
+                buffer[cursor..],
+                "# TYPE " ++ metric_prefix ++ field.name ++ " gauge\n" ++
+                    metric_prefix ++ field.name ++ " {d}\n",
+                .{@field(gauges, field.name)},
+            ) catch unreachable;
+            cursor += written.len;
+        }
         assert(cursor >= 1);
         assert(cursor <= render_bytes_max);
         return buffer[0..cursor];
     }
 
     /// Phase 0 exposure (§8): SIGUSR1 dumps the Prometheus rendering to
-    /// stderr through the signal seam; the admin plane stays deferred
-    /// (docs/PLANS.md). Shares `render` so the dump and a future scrape
-    /// endpoint never disagree on the wire format.
-    pub fn dump(counters: *const Counters) void {
+    /// stderr through the signal seam. Shares `render` so the dump and the
+    /// scrape endpoint never disagree on the wire format.
+    pub fn dump(counters: *const Counters, gauges: *const Gauges) void {
         var buffer: [render_bytes_max]u8 = undefined;
-        const text = counters.render(&buffer);
+        const text = counters.render(gauges, &buffer);
         assert(text.len <= buffer.len);
         std.debug.print("{s}", .{text});
     }
@@ -242,6 +312,17 @@ test "counters: reconcile holds across a lifecycle" {
     try std.testing.expectEqual(@as(u64, 1), counters.get("shed_conn_slots"));
 }
 
+/// A valid, distinguishable snapshot for the render tests.
+const test_gauges: Counters.Gauges = .{
+    .conn_slots_in_use = 7,
+    .conn_slots_capacity = 64,
+    .relay_buffers_in_use = 3,
+    .relay_buffers_capacity = 32,
+    .upstream_slots_leased = 5,
+    .upstream_slots_parked = 11,
+    .upstream_slots_capacity = 16,
+};
+
 test "counters: render emits Prometheus exposition for every field" {
     var counters: Counters = .{};
     counters.increment("accepted");
@@ -249,7 +330,7 @@ test "counters: render emits Prometheus exposition for every field" {
     counters.increment("l7_responses");
 
     var buffer: [Counters.render_bytes_max]u8 = undefined;
-    const text = counters.render(&buffer);
+    const text = counters.render(&test_gauges, &buffer);
 
     // Every counter appears exactly once as a TYPE line and a sample line,
     // and the sample carries the live value.
@@ -259,7 +340,18 @@ test "counters: render emits Prometheus exposition for every field" {
     // Untouched counters still render at zero — a scrape sees the whole set.
     try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_completed 0\n") != null);
 
-    // One TYPE line per counter field: the rendering is complete.
+    // Gauges ride the same rendering, typed `gauge` — a scrape that read
+    // an occupancy as a counter would chart nonsense through `rate()`.
+    try std.testing.expect(std.mem.indexOf(u8, text, "# TYPE zoxy_upstream_slots_leased gauge\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_upstream_slots_leased 5\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_upstream_slots_parked 11\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_upstream_slots_capacity 16\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_conn_slots_in_use 7\n") != null);
+    // No gauge is rendered as a counter, and no counter as a gauge.
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_upstream_slots_leased counter") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_accepted gauge") == null);
+
+    // One TYPE line per counter *and* gauge field: the rendering is complete.
     var type_lines: usize = 0;
     var search: usize = 0;
     while (std.mem.indexOfPos(u8, text, search, "# TYPE ")) |at| {
@@ -270,26 +362,57 @@ test "counters: render emits Prometheus exposition for every field" {
     inline for (@typeInfo(Counters).@"struct".fields) |field| {
         if (field.type == Counters.Value) field_count += 1;
     }
+    field_count += @typeInfo(Counters.Gauges).@"struct".fields.len;
     try std.testing.expectEqual(field_count, type_lines);
+}
+
+test "counters: gauge validity is a level-against-capacity rule" {
+    try std.testing.expect(test_gauges.valid());
+    // Parked slots occupy the pool too: leased + parked is what the wall
+    // is measured against, so a pair that fits individually but not
+    // together is invalid — the case a single in-use figure would hide.
+    var over = test_gauges;
+    over.upstream_slots_parked = 12;
+    try std.testing.expect(!over.valid());
+    var conn_over = test_gauges;
+    conn_over.conn_slots_in_use = conn_over.conn_slots_capacity + 1;
+    try std.testing.expect(!conn_over.valid());
+    var relay_over = test_gauges;
+    relay_over.relay_buffers_in_use = relay_over.relay_buffers_capacity + 1;
+    try std.testing.expect(!relay_over.valid());
+    // A pool sitting exactly at its wall is valid — that is the state the
+    // gauges exist to show.
+    var full = test_gauges;
+    full.upstream_slots_leased = full.upstream_slots_capacity;
+    full.upstream_slots_parked = 0;
+    try std.testing.expect(full.valid());
 }
 
 test "counters: render bound holds at the maximum value" {
     // The render_bytes_max bound must survive every counter at maxInt(u64)
-    // — the widest possible sample line — so a saturated proxy never
-    // truncates or overruns the buffer.
+    // and every gauge at maxInt(u32) — the widest possible sample lines —
+    // so a saturated proxy never truncates or overruns the buffer.
     var counters: Counters = .{};
     inline for (@typeInfo(Counters).@"struct".fields) |field| {
         if (field.type == Counters.Value) {
             @field(counters, field.name).store(std.math.maxInt(u64), .monotonic);
         }
     }
+    var gauges: Counters.Gauges = undefined;
+    inline for (@typeInfo(Counters.Gauges).@"struct".fields) |field| {
+        @field(gauges, field.name) = std.math.maxInt(u32);
+    }
     var buffer: [Counters.render_bytes_max]u8 = undefined;
-    const text = counters.render(&buffer);
-    // With every value at its 20-digit maximum, the render fills the buffer
+    const text = counters.render(&gauges, &buffer);
+    // With every value at its type's maximum, the render fills the buffer
     // exactly — proving render_bytes_max is a tight bound, not just an upper
-    // one (the "exact" claim in its doc comment).
+    // one (the "exact" claim in its doc comment). This is also why `render`
+    // does not assert `gauges.valid()`: an all-maximum snapshot is not a
+    // producible pool state, but it *is* the widest rendering.
     try std.testing.expectEqual(Counters.render_bytes_max, text.len);
     try std.testing.expect(std.mem.indexOf(u8, text, "18446744073709551615\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "4294967295\n") != null);
+    try std.testing.expect(!gauges.valid());
 }
 
 test "counters: the gate identity sums exactly today's admission rungs" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -333,6 +333,34 @@ pub fn Proxy(comptime IoType: type) type {
             return .{ .target = target, .edits = forward.edits };
         }
 
+        /// What the parsed head says about the request itself, recorded on
+        /// the conn before any rung can reject it. `respond` reads these to
+        /// decide whether the client's byte stream is still synchronized
+        /// enough to keep the connection (§8 "then keep or close"), so they
+        /// must land ahead of *every* reject that answers a valid head —
+        /// the 501s included. Those reject the method, not the framing: a
+        /// CONNECT or Upgrade head parsed cleanly and sits on a message
+        /// boundary like any other, and since a 501 forwards nothing there
+        /// is no second parser to disagree with about where it ends. What
+        /// the client does next is either another request (served) or
+        /// tunnel bytes (400, closed) — never a smuggled one.
+        ///
+        /// A malformed or oversize head never reaches here, so it never
+        /// sets these: `request_head_len` staying 0 is exactly what marks a
+        /// stream whose message boundary the parser could not find.
+        fn recordRequestFacts(conn: *ConnType, request: *const parser.RequestHead) void {
+            assert(conn.state == .l7_reading_head);
+            assert(request.head_len >= 1);
+            // Once per request: `resetForNextRequest` and
+            // `resumeAfterStaticResponse` both clear `l7` on the turnaround,
+            // so a second recording would mean a head was routed twice.
+            assert(conn.l7.request_head_len == 0);
+            conn.l7.request_method = request.method;
+            conn.l7.request_framing = framingFromParsed(request.framing);
+            conn.l7.request_head_len = request.head_len;
+            conn.l7.client_keep_alive = request.keep_alive;
+        }
+
         /// Policy gate, then the exchange's admission: tunnels and
         /// upgrades are non-goals (§1, §7) — 501; the canonical path
         /// selects a cluster (400 if it will not canonicalize, 404 if no
@@ -341,6 +369,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len <= conn.head_len);
+            recordRequestFacts(conn, request);
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
@@ -374,10 +403,6 @@ pub fn Proxy(comptime IoType: type) type {
             conn.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
             };
-            conn.l7.request_method = request.method;
-            conn.l7.request_framing = framingFromParsed(request.framing);
-            conn.l7.request_head_len = request.head_len;
-            conn.l7.client_keep_alive = request.keep_alive;
 
             // The §3 reuse win: a parked connection to the picked endpoint
             // beats a fresh dial. A close that slipped through while it
@@ -1050,11 +1075,17 @@ pub fn Proxy(comptime IoType: type) type {
                 resumeClientWrite(server, conn); // Short send resumes (§6).
                 return;
             }
-            if (write.then != .lingering_close) {
-                // `response_started` blocks a verdict, so none can be pending
-                // once response bytes are flowing (negative space).
-                assert(conn.state == .l7_exchanging);
-                assert(conn.l7.pending_verdict == .none);
+            switch (write.then) {
+                .response_excess, .response_body => {
+                    // `response_started` blocks a verdict, so none can be
+                    // pending once response bytes are flowing (negative
+                    // space).
+                    assert(conn.state == .l7_exchanging);
+                    assert(conn.l7.pending_verdict == .none);
+                },
+                // The two static-response endings share one state: `respond`
+                // is the only writer of either, and it always sets it.
+                .lingering_close, .next_request => assert(conn.state == .l7_responding),
             }
             switch (write.then) {
                 .response_excess => sendResponseExcess(server, conn),
@@ -1063,6 +1094,7 @@ pub fn Proxy(comptime IoType: type) type {
                     afterResponseExcess(server, conn);
                 },
                 .lingering_close => beginLingeringClose(server, conn),
+                .next_request => resumeAfterStaticResponse(server, conn),
             }
         }
 
@@ -1255,6 +1287,23 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.client_write.pending.len == 0);
             server.releaseRelayBuffer(conn.relay_buffer.?);
             conn.relay_buffer = null;
+            beginNextRequest(server, conn);
+        }
+
+        /// The turnaround itself, shared by the two paths that reach it: an
+        /// exchange that completed (`resetForNextRequest`) and a static
+        /// response that kept its connection (`resumeAfterStaticResponse`).
+        /// One home so a new per-request field cannot be cleared on one path
+        /// and left stale on the other — which on the resync rule's inputs
+        /// would be a §7 bug, not a cosmetic one.
+        ///
+        /// The preconditions stay with the callers: they differ (one has an
+        /// exchange to have settled, the other never had one), and only they
+        /// can state why they hold.
+        fn beginNextRequest(server: *ServerType, conn: *ConnType) void {
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            assert(conn.client_write.pending.len == 0);
             conn.head_len = 0;
             conn.l7 = .{};
             conn.directions = .{ .{}, .{} };
@@ -1433,10 +1482,53 @@ pub fn Proxy(comptime IoType: type) type {
             respond(server, conn, 502, "l7_bad_gateway");
         }
 
-        /// Answer a comptime static error response, then close (§8). Legal
-        /// from head reading (rejects), dialing (502), and the exchange
-        /// (upstream failures) — every caller guarantees both data ops are
-        /// free, because the send and the lingering drain need them.
+        /// Whether a static response can be followed by the *next* request
+        /// on this connection instead of the lingering close — the keep
+        /// half of §8's "static 503 … then keep or close per pressure".
+        ///
+        /// It is a question about the client's byte stream, not about the
+        /// status: the connection may keep serving only when the stream
+        /// sits exactly on a message boundary. Three conditions, each
+        /// ruling out a way it might not:
+        ///
+        ///   - the request declares no body left to read. A declared body
+        ///     is unread bytes still to come; draining it is what the
+        ///     lingering close is for.
+        ///   - the client sent nothing past the head. Trailing bytes are a
+        ///     pipelined next request, which §2 does not serve — and
+        ///     leaving them buffered to be read as the *start* of the next
+        ///     request is the desynchronization §7 exists to prevent.
+        ///
+        /// Reading `.l7_reading_head` keeps every mid-exchange caller
+        /// (502, 504, the post-edit 431, the malformed-body 400) on the
+        /// close path: by then a request head has gone to the origin and
+        /// the two streams are no longer alignable.
+        ///
+        /// A head that never parsed — the 400/414/431 rejects, which answer
+        /// bytes the parser could not frame — needs no test of its own:
+        /// `request_head_len` is still 0 there while `head_len` is at least
+        /// the byte that triggered the parse, so the boundary check below
+        /// already refuses it. That is asserted rather than re-tested,
+        /// because a second guard for it would be a branch no input can
+        /// reach and no test can pin. `recordRequestFacts` is what makes
+        /// that marker trustworthy: it runs for every valid head and only
+        /// for a valid head.
+        fn staticResponseResyncable(conn: *const ConnType) bool {
+            if (conn.state != .l7_reading_head) return false;
+            // `fillHead` never appends zero bytes and every reject from
+            // this state follows a fill, so an unparsed head cannot tie
+            // with `request_head_len`'s zero.
+            assert(conn.head_len >= 1);
+            assert(conn.l7.request_head_len <= conn.head_len);
+            if (!framingDoneOf(&conn.l7.request_framing)) return false;
+            return conn.head_len == conn.l7.request_head_len;
+        }
+
+        /// Answer a comptime static error response, then keep the
+        /// connection or close it (§8). Legal from head reading (rejects),
+        /// dialing (502), and the exchange (upstream failures) — every
+        /// caller guarantees both data ops are free, because the send and
+        /// the lingering drain need them.
         fn respond(
             server: *ServerType,
             conn: *ConnType,
@@ -1470,10 +1562,61 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream_socket = null;
             }
             server.counters.increment(counter);
+            // §8's "then keep or close per pressure". Closing is not free:
+            // it costs the client a fresh handshake and this proxy a fresh
+            // accept, conn slot and admission — which is how a shed storm
+            // becomes *more* expensive per request than the work it is
+            // shedding, and how a transient overshoot locks itself in as a
+            // reconnect loop. Keeping is one send.
+            //
+            // The same three brakes the render-time persistence decision
+            // honors apply here (§2, §8): the client's own ask, the drain,
+            // and relay pressure — a proxy shedding buffers should not also
+            // be holding connections open for their next request.
+            const keep = staticResponseResyncable(conn) and
+                conn.l7.client_keep_alive and
+                !server.draining and
+                !server.keepAliveSuppressed();
             conn.state = .l7_responding;
             // Straight from static memory (§8): the channel carries the slice
-            // and never copies it, so a shed still costs one send.
-            armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
+            // and never copies it, so a shed still costs one send. Both
+            // spellings are comptime byte arrays; only the choice is runtime,
+            // and it must match what happens after the send — an announced
+            // close that kept serving, or a kept connection the client was
+            // told to stop using, are both §2 violations.
+            if (keep) {
+                armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
+            } else {
+                armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
+            }
+        }
+
+        /// The static response is out and the stream is still synchronized:
+        /// serve the next request on this connection (§2, §8). `respond`
+        /// already released the relay buffer and any attached upstream, so
+        /// this is `resetForNextRequest` minus the exchange it never had.
+        fn resumeAfterStaticResponse(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_responding);
+            assert(conn.client_write.pending.len == 0);
+            // `respond` frees both before the send, so a kept connection
+            // carries nothing into its next request (§5).
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            assert(conn.upstream_socket == null);
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            // The same OR `resetForNextRequest` needs, for the same reason,
+            // and it is not this request's doing: a *previous* request on
+            // this connection may have dialed, re-based its deadline (§8),
+            // and completed before the rebase's cancel drained. That
+            // straggler survives `beginNextRequest` — which touches `l7` and
+            // the state, never the armed bits — so the next request can be
+            // rejected while `deadline` has already cleared and only
+            // `deadline_cancel` is still outstanding. Either one
+            // re-establishes the idle deadline (§4); requiring `deadline`
+            // specifically would fire on ordinary keep-alive traffic.
+            assert(conn.armed.deadline or conn.armed.deadline_cancel);
+            beginNextRequest(server, conn);
         }
 
         /// A client can still be sending its request — a body, or the rest

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -703,6 +703,8 @@ test "l7: a head that fits on arrival but not after forwarding is 431" {
     }
 }
 
+// Both heads parse cleanly and carry no body, so the 501 keeps the
+// connection (§8) — the method is refused, not the framing.
 test "l7: CONNECT and Upgrade are answered 501" {
     {
         var bed: Http1Bed = undefined;
@@ -710,7 +712,7 @@ test "l7: CONNECT and Upgrade are answered 501" {
         defer bed.tearDown();
         try bed.exchange("CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n");
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
@@ -722,7 +724,7 @@ test "l7: CONNECT and Upgrade are answered 501" {
         defer bed.tearDown();
         try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n");
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
@@ -825,12 +827,14 @@ test "l7: an unroutable path is answered 404" {
     defer bed.tearDown();
 
     // The only route is /api; /elsewhere matches nothing, so the origin is
-    // never dialed and the client gets a 404 (§7, §8).
+    // never dialed and the client gets a 404 (§7, §8). The head parsed and
+    // the request has no body, so the reject keeps the connection (§8) —
+    // no `Connection: close`.
     try bed.exchange("GET /elsewhere HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
@@ -844,12 +848,15 @@ test "l7: a structure-changing escape in the path is answered 400" {
     defer bed.tearDown();
 
     // %2F is an encoded slash: it would change the path's structure, so
-    // the canonicalizer rejects it before routing (§7).
+    // the canonicalizer rejects it before routing (§7). Unlike the
+    // malformed-head 400 above, the *head* parsed cleanly here — only the
+    // target would not canonicalize — so the byte stream is still on a
+    // message boundary and the connection keeps serving (§8).
     try bed.exchange("GET /a%2Fb HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -900,7 +907,7 @@ test "l7: a request to a host with no route is answered 404" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
@@ -935,7 +942,7 @@ test "l7: a filter reject answers its policy status before the origin is dialed"
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
@@ -993,12 +1000,257 @@ test "l7: a filter reject survives 1-byte adversarial delivery across seeds" {
         try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nX-Env: prod\r\n\r\n");
 
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
         try bed.expectDrained();
     }
+}
+
+test "l7: an upstream-slot shed keeps the connection, and the client's ask decides" {
+    // The rung that collapsed the c10k benchmark. An empty upstream pool
+    // sheds every request with 503, so this drives the wall directly.
+    //
+    // Both requests are answered on ONE connection: the shed is a static
+    // response, not a teardown (§8 "then keep or close per pressure").
+    // That is the whole point — a close costs the client a handshake and
+    // the proxy an accept plus a conn slot, which is how a shed storm ends
+    // up more expensive per request than the work it sheds.
+    //
+    // The two responses differ in exactly one header, and the difference is
+    // the *client's* ask, not the status: keep-alive is kept, `Connection:
+    // close` is honored (§2). One test, both spellings, so neither branch
+    // can rot into the other.
+    // The single upstream slot goes to a client the origin never answers,
+    // so it stays leased and every other request meets the wall.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 60,
+        .upstream_slots = 1,
+        .origin_mute = true,
+    });
+    defer bed.tearDown();
+
+    // client holds the slot and must not end the run; client2 arrives once
+    // it is held, sheds twice, and winds the scenario down.
+    bed.client.drain_on_finish = false;
+    bed.client2.send_delay_ms = 100;
+    bed.client2.request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n" ++
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_shed_upstream_slots"));
+    // Two sheds, and client2 was accepted once. This is the ratio that
+    // would have caught the collapse: on the old always-close path every
+    // shed cost an accept, and accept/s tracking shed/s one-for-one *was*
+    // the churn loop.
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("accepted"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("admitted"));
+    try bed.expectDrained();
+}
+
+test "l7: a 501 keeps the connection, and the next request is served" {
+    // CONNECT and Upgrade are non-goals (§1, §7), but they are *method*
+    // rejects, not framing ones: the head parsed cleanly and sits on a
+    // message boundary, so the connection keeps serving like any other
+    // valid-head reject. Nothing was forwarded, so there is no second
+    // parser to disagree with about where the message ended.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 70,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /after HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("CONNECT o:443 HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // The 501 keeps, and the request after it is proxied normally — the
+    // connection was never lost to a method it happened not to support.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("accepted"));
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a reject closes when the client pipelined the next request" {
+    // Bytes past the head are a pipelined next request, which §2 does not
+    // serve. Keeping the connection here would leave those bytes sitting in
+    // the head buffer to be read as the *start* of the next request — the
+    // desynchronization a request-smuggler wants (§7). A wide inbox carries
+    // both heads in one delivery, so the trailing bytes are provably
+    // present when the reject is decided.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 62,
+        .filters = &rules,
+        .inbox_bytes = 4096,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET /admin HTTP/1.1\r\nHost: o\r\n\r\n" ++
+            "GET /admin/two HTTP/1.1\r\nHost: o\r\n\r\n",
+    );
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // One response, and it announces the close: the second head is never
+    // answered on this connection.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+    try bed.expectDrained();
+}
+
+test "l7: a reject closes when the body has not arrived with the head" {
+    // The framing-done condition on its own. Under 1-byte delivery the head
+    // completes on the read that carries its final byte, so at reject time
+    // nothing is past the head — `head_len == request_head_len` — and the
+    // *only* thing standing between this and a kept connection is the
+    // request's own declared body, still unread on the socket.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var seed: u64 = 63;
+    while (seed < 67) : (seed += 1) {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = seed,
+            .partial_io = true,
+            .filters = &rules,
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("POST /admin HTTP/1.1\r\nHost: o\r\nContent-Length: 4\r\n\r\nbody");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a drain closes a reject that would otherwise be kept" {
+    // `beginDrain` stops accepting but leaves admitted connections serving,
+    // so a reject arriving mid-drain is a connection the drain is waiting
+    // on. Keeping it would park an idle connection until `drain_deadline_ms`
+    // and turn a clean shutdown into a deadline-forced one — so the drain
+    // is a brake on keeping, exactly as it is on the render path (§2, §8).
+    //
+    // The client connects at once and is admitted, then holds its head back
+    // until after the drain has begun.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 69,
+        .filters = &rules,
+        .send_delay_ms = 100,
+    });
+    defer bed.tearDown();
+
+    bed.armDrainTimer(50);
+    try bed.exchange("GET /admin HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    // The drain finished because the connection left, not because the
+    // deadline shot it — the difference a kept connection would erase.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("drained_at_deadline"));
+    try bed.expectDrained();
+}
+
+test "l7: relay pressure closes a reject that would otherwise be kept" {
+    // §8: relay pressure is what suppresses keep-alive on the render path
+    // (#57), and a reject must honor the same brake — a proxy short of
+    // buffers should not be holding connections open for their next
+    // request. `relay_buffers = 1` puts the watermark at one held buffer,
+    // so the muted client alone engages pressure.
+    //
+    // Identical to the kept 403 above in every respect except the pool
+    // size, so the `Connection: close` here is attributable to pressure
+    // and nothing else.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 68,
+        .relay_buffers = 1,
+        .origin_mute = true,
+        .filters = &rules,
+    });
+    defer bed.tearDown();
+
+    bed.client.drain_on_finish = false;
+    bed.client2.send_delay_ms = 100;
+    bed.client2.request = "GET /admin HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expect(bed.server.counters.get("relay_pressure_engaged") >= 1);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
+    try bed.expectDrained();
+}
+
+test "l7: a reject closes when the request carries a body" {
+    // A declared body is unread bytes still to come, so the stream is not
+    // on a message boundary and the connection cannot resynchronize — the
+    // lingering close is what drains it (§2). Robust to delivery timing:
+    // if the body arrives coalesced with the head it fails the
+    // nothing-past-the-head condition, and if it arrives later it fails the
+    // framing-done one. Either way, close.
+    //
+    // Driven through the filter rung because `respond` is the single exit
+    // every reject and shed leaves by, so the persistence decision cannot
+    // differ between rungs — only the status does.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 61, .filters = &rules });
+    defer bed.tearDown();
+
+    try bed.exchange("POST /admin HTTP/1.1\r\nHost: o\r\nContent-Length: 4\r\n\r\nbody");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+    try bed.expectDrained();
 }
 
 test "l7: filter header edits reach the origin, applied once" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -94,7 +94,8 @@ pub fn main(init: std.process.Init) !void {
 
     // The loop only stops after a completed drain (§8).
     assert(server.isIdle());
-    server.counters.dump();
+    const gauges = server.gauges();
+    server.counters.dump(&gauges);
 }
 
 /// What the command line asked for: run against a config, or one of the

--- a/src/mem/Pool.zig
+++ b/src/mem/Pool.zig
@@ -114,6 +114,14 @@ pub fn Pool(comptime T: type) type {
             return @intCast(index);
         }
 
+        /// Slots the pool was sized to at init — the wall `acquire`
+        /// returns null at. `u32` because `init` bounds `count` by
+        /// `slots_count_max`, so the narrowing can never truncate.
+        pub fn capacity(pool: *const Self) u32 {
+            assert(pool.slots.len <= slots_count_max);
+            return @intCast(pool.slots.len);
+        }
+
         /// The simulator's leak invariant: every scenario ends here (§9).
         pub fn isFullyReleased(pool: *const Self) bool {
             assert(pool.acquired_count <= pool.slots.len);

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -113,6 +113,12 @@ pub const ClientWrite = struct {
         response_body,
         /// A static response is out: the lingering close (§2, §8).
         lingering_close,
+        /// A static response is out and the client's byte stream is still
+        /// synchronized: serve the next request on this connection (§2,
+        /// §8). The keep half of the ladder's "then keep or close per
+        /// pressure" — see `proxy.staticResponseResyncable` for what
+        /// earns it.
+        next_request,
     };
 };
 

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -195,6 +195,19 @@ pub fn UpstreamPool(comptime IoType: type) type {
             return pool.slot_pool.acquired_count - pool.idle_count;
         }
 
+        /// Slots held open on an idle list for reuse (§5). Occupied, not
+        /// free: `leasedCount` plus this is what the wall is measured
+        /// against, which is why the two are reported separately.
+        pub fn parkedCount(pool: *const Self) u32 {
+            assert(pool.idle_count <= pool.slot_pool.acquired_count);
+            return pool.idle_count;
+        }
+
+        /// Slots the pool was sized to — the wall `acquire` sheds at (§8).
+        pub fn capacity(pool: *const Self) u32 {
+            return pool.slot_pool.capacity();
+        }
+
         /// The simulator's leak invariant (§9): every scenario drains
         /// every pool to zero.
         pub fn isFullyReleased(pool: *const Self) bool {


### PR DESCRIPTION
Two slices out of a c10k post-mortem. The first makes the wall visible; the second stops hitting it from costing more than the work it sheds.

## What the benchmark actually showed

A c10k run (`CONNECTIONS` raised, `limits.conn_slots` raised to 14074) collapsed from a clean ~14.5k req/s to a locked-in ~6.4k. The counters at the end of the run:

```
zoxy_l7_shed_upstream_slots   1,015,096      zoxy_shed_conn_slots           0
zoxy_accepted                 1,018,642      zoxy_shed_relay_buffers        0
zoxy_completed                1,018,642      zoxy_l7_shed_relay_buffers     0
zoxy_l7_responses             2,901,842      zoxy_upstream_connect_failed   0
zoxy_upstream_reused          2,900,246      zoxy_kernel_pressure_errors    0
```

35% of all responses were `503 l7_shed_upstream_slots`, and `accepted == completed`. The per-second series is the whole story:

| time | resp/s | shed/s | accept/s |
|---|---|---|---|
| 20:04:20 | 7,837 | 23 | 23 |
| 20:05:05 | 14,578 | 1,727 | 1,538 |
| 20:07:20 | 12,670 | 5,932 | **5,945** |

`accept/s ≡ shed/s` to within 0.2%: one full TCP connection churned per shed. Meanwhile the container sat at **0.78–0.82 of its 1 CPU with zero CFS throttling**, 160–165 MiB against a 512 MiB limit, and zero packet drops. Not CPU-bound, not memory-bound, not lossy — purely the `upstream_slots` wall plus a shed that cost more than the request it refused.

## Slice 1 — `metrics: show the approach to a pool wall, not just the crash`

That diagnosis was only possible *after the fact*. `l7_shed_upstream_slots` fires **at** the wall, and `upstream_pressure_engaged` fires once at the ¾ watermark and never again. Between them, a pool sitting at 74% renders byte-identical to an idle one.

Adds `Counters.Gauges`, rendered as Prometheus `gauge` beside the counters:

```
zoxy_conn_slots_in_use / _capacity
zoxy_relay_buffers_in_use / _capacity
zoxy_upstream_slots_leased / _parked / _capacity
```

Leased and parked are separate because **both occupy the pool** — leased + parked is what the wall is measured against, and collapsing them hides whether a pool is busy or merely full.

Read off the pools at render time by `Server.gauges` (the only producer), never mirrored on acquire/release: a mirror is one missed release away from disagreeing with the pool it describes.

`gauges.valid()` is asserted at the producer rather than in `render`, deliberately. `render_bytes_max` is documented as an *exactly reachable* bound, and the test proving that renders every field at its type's maximum — a snapshot no pool can be in. Asserting validity in the renderer would demote the bound to merely sufficient.

Verified on the real binary at the c10k config: capacities render `14074 / 14074 / 1024` — the 14:1 mismatch between what zoxy admits and what it can forward, which is the finding this whole PR came out of.

## Slice 2 — `http: a shed that keeps its connection, as §8 already specified`

**This is a bug fix against the settled design, not a design change.** DESIGN.md §8's ladder has always read "static `503` from the head buffer, then **keep or close** per pressure". `respond` only ever implemented the close half.

A static response now keeps the connection when four things hold: the client's stream is on a message boundary, the client asked for keep-alive, we are not draining, and relay pressure has not suppressed keep-alive (#57).

The boundary test is about the stream, never the status:

- **framing done** — a declared body is unread bytes still to come
- **nothing past the head** — trailing bytes are a pipelined next request; leaving them buffered to be read as the *start* of the next one is the desynchronization §7 exists to prevent
- **`.l7_reading_head`** — every mid-exchange caller (502, 504, post-edit 431, malformed-body 400) has already sent a head to the origin, so the two streams are no longer alignable

The `400`/`414`/`431` head-framing rejects can never keep and need no guard of their own: `recordRequestFacts` runs only for a valid head, so `request_head_len` is still 0 there while `head_len` is at least the byte that triggered the parse — the boundary test already refuses them. Asserted rather than re-tested, because a second guard would be a branch no input can reach and no test could pin.

`recordRequestFacts` runs **before** the 501 gates. CONNECT and Upgrade reject the *method*, not the framing: the head parsed, nothing was forwarded, so there is no second parser to disagree about where the message ended. The client's next bytes are either a real request (served) or tunnel bytes (400, closed) — never a smuggled one. A CONNECT carrying a body still closes, because `framingDoneOf` checks the declared body is actually exhausted.

## Verified by mutation, not by inspection

9/9 killed:

| mutation | caught by |
|---|---|
| keep never (the old always-close bug) | the 503 / 501 keep tests |
| keep always | malformed-head 400, body, pipelining |
| drop the framing-done guard | body not arrived with the head (1-byte delivery) |
| ignore bytes past the head | client pipelined the next request |
| ignore relay pressure | relay-pressure reject |
| ignore drain | `drained_at_deadline == 0` |
| drop the `client_keep_alive` conjunct | the two spellings in one test |
| drop the `.l7_reading_head` state guard | mid-exchange rejects |
| record request facts after the 501 gates | the 501 keep test |

Two of these were **found by mutation, not by design**: my first pass at the pipelining and split-delivery-body cases both survived, which is what prompted the two dedicated tests. A third — an explicit `request_head_len == 0` guard — survived because it was genuinely unreachable, and became an assert instead of untested code.

Seven new tests, all through the existing sim bed:

- `an upstream-slot shed keeps the connection, and the client's ask decides` — **2 sheds, 1 accept**, both spellings on one connection. The ratio that would have caught the collapse.
- `a 501 keeps the connection, and the next request is served`
- `a reject closes when the client pipelined the next request` (§7 desync)
- `a reject closes when the body has not arrived with the head` (4 seeds, 1-byte delivery)
- `a reject closes when the request carries a body`
- `a drain closes a reject that would otherwise be kept` (asserts the drain finished *clean*, not at its deadline)
- `relay pressure closes a reject that would otherwise be kept`

## Gates

`zig build ci` (64 sim seeds) and `zig fmt --check` pass on both commits.

`tiger-style-reviewer` on both slices. Slice 1 came back ready to commit with one comment-completeness nit, taken. Slice 2 took three rounds and earned it:

1. **501 could never keep** — the fact-recording ran *after* the CONNECT/Upgrade gates, so a 501 always closed, contradicting DESIGN.md's own exception list and my own comment. Fixed by reordering; the reordering is now itself a mutation (M9).
2. **An assert I had wrongly tightened.** I changed `assert(armed.deadline or armed.deadline_cancel)` to require `deadline` specifically, reasoning that `rebaseDeadline` only runs after a successful upstream acquire. That reasoning covered only *this* request. A dial-rebase cancel from a **previous** request on the same connection can still be draining — `beginNextRequest` touches `l7` and the state, never the armed bits — so an ordinary keep-alive connection could trip it. Reverted to the permissive form that `resetForNextRequest` documents, with the cross-request reasoning written down.
3. An orphaned doc comment that had silently merged `respond`'s documentation into its neighbour's.

## What this does not fix

`upstream_slots_max` is still **1024**, and `limits.upstream_slots` already defaults to it — so it cannot be raised from config. That is the wall; this PR only stops hitting it from being self-amplifying. Raising it costs `conn_slots` at 4:1 out of the same CQ budget (8192 upstream slots ⇒ 12285 conn slots, 272 MiB, 32772 fds), and the deeper question — that `upstream_slots` conflates the parked keep-alive cache with the hard cap on concurrent exchanges — is a §8 design call, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
