### PR TITLE
bench: close the c10k revisit of the Conn layout, and gate the measurement tools (§9)

### DIFF
--- a/bench/micro/conn_touch_scaling.zig
+++ b/bench/micro/conn_touch_scaling.zig
@@ -1,0 +1,142 @@
+//! Tier-0 micro bench (§9): what one completion's bookkeeping costs as the
+//! live connection count grows — the memory-hierarchy half of the c10k
+//! question, isolated from the network.
+//!
+//! `Conn.arm`/`Conn.delivered` are three instructions in ReleaseFast (the
+//! assertions compile out), so their cost is not the work — it is reaching
+//! `conn.armed` at all. One conn slot is ~9.5 KiB, so N live connections
+//! spread that byte over N distinct pages, and the completion order across
+//! them is effectively random. At 500 connections the touched set is a few
+//! MiB and lives in L3; at 10k it is over 100 MiB and every touch is a DRAM
+//! access plus a page walk.
+//!
+//! The permutation is the point: a sequential walk measures the prefetcher,
+//! not the proxy. A real loop services whichever connection the ring hands
+//! back next, which has no relation to slot order.
+//!
+//! What this is NOT: the arm and the deliver of a real op are separated by a
+//! kernel round trip, so production may pay the miss twice where this pays
+//! it once. Read the numbers as a floor on the per-connection penalty, and
+//! as a scaling curve rather than an absolute.
+//!
+//!   zig build bench-micro && ./zig-out/bin/zoxy-bench-conn_touch_scaling
+
+const std = @import("std");
+const linux = std.os.linux;
+
+const zoxy = @import("zoxy");
+
+const assert = std.debug.assert;
+
+const ConnType = zoxy.Server(zoxy.Io.XevIo).ConnType;
+
+/// `std.time` carries only constants in 0.16 — `Instant`/`Timer` moved out —
+/// and this bench has no `Io` runtime to borrow a clock from, so it reads
+/// CLOCK_MONOTONIC directly. Precise, not COARSE: XevIo's millisecond
+/// granule is fine for second-scale deadlines but would quantise a
+/// nanosecond-per-op measurement into uselessness.
+fn monotonicNs() u64 {
+    var ts: linux.timespec = undefined;
+    const rc = linux.clock_gettime(linux.CLOCK.MONOTONIC, &ts);
+    assert(std.posix.errno(rc) == .SUCCESS);
+    assert(ts.sec >= 0);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+/// Completions per measured point. Enough that the timer's resolution and
+/// the setup's cache state are both noise against the steady state.
+const ops_per_point: u64 = 4_000_000;
+
+/// Live connection counts to sweep — the bench's 500-connection operating
+/// point, the c10k one, and the compiled ceiling, with steps between so the
+/// knee is visible rather than inferred from the endpoints.
+const points = [_]u32{ 64, 256, 500, 1000, 2000, 5000, 10000, 14074 };
+
+/// The point every ratio is quoted against: the connection count the
+/// Tier-1 bench actually runs at, so the column reads as "what c10k costs
+/// over the operating point we ship against" rather than over an arbitrary
+/// end of the sweep.
+const baseline_conns: u32 = 500;
+
+pub fn main(init: std.process.Init) !void {
+    const arena = init.arena.allocator();
+
+    // Discarded: the first measurement of a run absorbs the core's
+    // frequency ramp, and reading that as a data point made the smallest
+    // (and therefore cache-friendliest) connection count look like the
+    // slowest one.
+    _ = try measure(arena, 1024);
+
+    var results: [points.len]Measurement = undefined;
+    for (points, 0..) |count, index| results[index] = try measure(arena, count);
+
+    var baseline_ns: f64 = 0;
+    for (points, results) |count, result| {
+        if (count == baseline_conns) baseline_ns = result.ns_per_op;
+    }
+    assert(baseline_ns > 0); // `baseline_conns` must be one of `points`.
+
+    std.debug.print(
+        "conn slot = {d} B, {d} completions per point\n\n",
+        .{ @sizeOf(ConnType), ops_per_point },
+    );
+    std.debug.print(
+        "{s:>8} {s:>12} {s:>11} {s:>12} {s:>12}\n",
+        .{ "conns", "touched MiB", "ns/op", "vs 500", "checksum" },
+    );
+    for (points, results) |count, result| {
+        const touched_mib =
+            @as(f64, @floatFromInt(@as(u64, count) * @sizeOf(ConnType))) / (1024.0 * 1024.0);
+        std.debug.print(
+            "{d:>8} {d:>12.1} {d:>11.2} {d:>11.2}x {d:>12}\n",
+            .{ count, touched_mib, result.ns_per_op, result.ns_per_op / baseline_ns, result.checksum },
+        );
+    }
+}
+
+const Measurement = struct {
+    ns_per_op: f64,
+    /// Defeats dead-code elimination: without a consumed result the whole
+    /// loop is legally removable, and the bench would measure nothing at
+    /// impressive speed.
+    checksum: u64,
+};
+
+fn measure(arena: std.mem.Allocator, count: u32) !Measurement {
+    assert(count >= 1);
+    const conns = try arena.alloc(ConnType, count);
+    for (conns, 0..) |*conn, index| {
+        conn.generation = @intCast(index);
+        conn.armed = .{};
+        conn.op_data_client_to_upstream = .{};
+    }
+
+    // A random permutation, walked repeatedly: the completion order a ring
+    // hands back bears no relation to slot order, and a sequential walk
+    // would measure the hardware prefetcher instead.
+    const order = try arena.alloc(u32, count);
+    for (order, 0..) |*slot, index| slot.* = @intCast(index);
+    var prng = std.Random.DefaultPrng.init(0x5eed_c0ffee);
+    prng.random().shuffle(u32, order);
+
+    var checksum: u64 = 0;
+    const started = monotonicNs();
+    var done: u64 = 0;
+    while (done < ops_per_point) {
+        for (order) |index| {
+            const conn = &conns[index];
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            checksum +%= conn.generation;
+        }
+        done += count;
+    }
+    const elapsed_ns = monotonicNs() - started;
+
+    assert(done >= ops_per_point);
+    assert(elapsed_ns >= 1);
+    return .{
+        .ns_per_op = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(done)),
+        .checksum = checksum,
+    };
+}

--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -1,8 +1,14 @@
 //! Tier-0 micro bench (§9): the per-request L7 head CPU — parse the
-//! request head, render it upstream, parse the origin response head,
-//! render it downstream — the work an L7 exchange does that an L4 relay
-//! does not. Realistic small-GET heads (what the Tier-1 loopback bench
-//! drives). poop A/B on hardware counters; decision tool, not a CI gate.
+//! request head, canonicalize its target, render it upstream, parse the
+//! origin response head, render it downstream — the work an L7 exchange
+//! does that an L4 relay does not. Realistic small-GET heads (what the
+//! Tier-1 loopback bench drives). poop A/B on hardware counters; decision
+//! tool, not a CI gate.
+//!
+//! The canonicalization belongs in the loop: since #98 the proxy runs it
+//! exactly once per request, between the parse and the render, so leaving
+//! it out would understate the per-request head cost this bench exists to
+//! report.
 //!
 //! Run: `zig build bench-micro` then
 //! `poop ./zig-out/bin/zoxy-bench-l7_head_pipeline` for the absolute
@@ -29,9 +35,15 @@ const response_head =
     "Content-Type: text/plain\r\n" ++
     "Content-Length: 18\r\n\r\n";
 
+/// No listener filters: the unfiltered path is the one the Tier-1 bench
+/// drives, and a rule set would measure the filter engine rather than the
+/// head pipeline.
+const no_edits: []const zoxy.http.filter.AppliedHeaderEdit = &.{};
+
 pub fn main() void {
     var request_storage: parser.HeaderStorage = undefined;
     var response_storage: parser.HeaderStorage = undefined;
+    var path_scratch: [zoxy.constants.head_bytes_max]u8 = undefined;
     var upstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
     var downstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
 
@@ -39,7 +51,8 @@ pub fn main() void {
     var index: u64 = 0;
     while (index < iterations) : (index += 1) {
         const request = parser.parseRequestHead(request_head, false, &request_storage) catch unreachable;
-        const upstream = render.renderRequestHead(&request, false, &upstream_head) catch unreachable;
+        const target = parser.canonicalTarget(request.target, &path_scratch) catch unreachable;
+        const upstream = render.renderRequestHead(&request, target, no_edits, false, &upstream_head) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
         const downstream = render.renderResponseHead(&response, true, &downstream_head) catch unreachable;
 
@@ -48,6 +61,7 @@ pub fn main() void {
         checksum +%= downstream[downstream.len - 1];
         checksum +%= @intFromEnum(request.method);
         checksum +%= response.status;
+        checksum +%= target.path.len;
     }
     std.debug.print("checksum {d}\n", .{checksum});
 }

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -21,6 +21,7 @@ const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
 const zio = @import("zio");
 const spawn_path = @import("spawn_path.zig");
+const constants = @import("zoxy").constants;
 
 const assert = std.debug.assert;
 
@@ -36,9 +37,14 @@ const report_path = work_directory ++ "/zoxy.report";
 
 const Flags = struct {
     rate: u64 = 100_000,
-    // zrk serves one thread per connection, so this is both the
-    // connection count and the load-thread count.
+    /// Open connections zrk holds. Since zrk 1.x these are coroutines over
+    /// a small thread pool, not a thread each, so this scales to the
+    /// conn-slot ceiling without the load generator taking over the box —
+    /// which is what makes a per-connection-cost sweep possible here.
     connections: u32 = 64,
+    /// zrk's load threads, independent of `connections`. Kept small: they
+    /// share every core except zoxy's.
+    threads: u8 = 2,
     duration_s: u64 = 30,
     freq: u32 = 4000,
     /// Core to dedicate to zoxy; null auto-picks the last P-core (or last cpu).
@@ -90,7 +96,7 @@ pub fn main(init: std.process.Init) !u8 {
     var origin_child = try spawnNginx(arena, io, environ);
     defer origin_child.kill(io);
 
-    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path);
+    var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path, flags.connections);
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
     const zoxy_pid = zoxy_child.id orelse return error.NoZoxyPid;
@@ -139,6 +145,9 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
         } else if (std.mem.eql(u8, arg, "--connections")) {
             index += 1;
             flags.connections = try std.fmt.parseUnsigned(u32, args[index], 10);
+        } else if (std.mem.eql(u8, arg, "--threads")) {
+            index += 1;
+            flags.threads = try std.fmt.parseUnsigned(u8, args[index], 10);
         } else if (std.mem.eql(u8, arg, "--seconds")) {
             index += 1;
             flags.duration_s = try std.fmt.parseUnsigned(u64, args[index], 10);
@@ -164,7 +173,7 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
             zoxy_path_set = true;
         } else {
             std.debug.print(
-                "usage: profile [zoxy-path] [--rate N] [--connections N] " ++
+                "usage: profile [zoxy-path] [--rate N] [--connections N] [--threads N] " ++
                     "[--seconds N] [--freq N] [--cpu N]\n",
                 .{},
             );
@@ -188,7 +197,7 @@ fn spawnNginx(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !s
         \\worker_processes 1;
         \\pid nginx.pid;
         \\error_log logs/error.log crit;
-        \\events {{ worker_connections 1024; }}
+        \\events {{ worker_connections 32768; }}
         \\http {{
         \\    access_log off;
         \\    server {{
@@ -211,10 +220,30 @@ fn spawnNginx(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !s
     };
 }
 
+/// Conn slots for a run of `connections` connections, with headroom for the
+/// churn a reject or a reconnect leaves behind. Without this the config
+/// carried no `limits` block at all, so every run above the default
+/// silently spent its window shedding at the admission wall (§8) — the
+/// profile would have been of the shed path, not the serving path, and
+/// nothing in the output would have said so.
+///
+/// Both bounds come from `constants`, not from literals here: a ceiling
+/// that later moves has to move this with it, and a raised one would
+/// otherwise cap a run below the maximum it was aimed at without saying so.
+fn connSlotsFor(connections: u32) u32 {
+    assert(connections >= 1);
+    const wanted = @as(u64, connections) + connections / 8 + 64;
+    const slots: u32 = @intCast(@min(wanted, constants.conn_slots_max));
+    assert(slots >= 1);
+    assert(slots <= constants.conn_slots_max);
+    return @max(slots, constants.conn_slots_default);
+}
+
 fn spawnZoxy(
     arena: std.mem.Allocator,
     io: Io,
     zoxy_path: []const u8,
+    connections: u32,
 ) !std.process.Child {
     // Both listeners always exist so the flag only picks which one zrk
     // drives; the idle one adds no load.
@@ -226,10 +255,11 @@ fn spawnZoxy(
         \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }}
         \\    ],
         \\    "clusters": {{ "origin": {{ "endpoints": ["127.0.0.1:{d}"] }} }},
-        \\    "timeouts": {{ "connect_ms": 5000, "idle_ms": 60000, "drain_deadline_ms": 5000 }}
+        \\    "timeouts": {{ "connect_ms": 5000, "idle_ms": 60000, "drain_deadline_ms": 5000 }},
+        \\    "limits": {{ "conn_slots": {d} }}
         \\}}
         \\
-    , .{ zoxy_l4_port, zoxy_http_port, origin_port });
+    , .{ zoxy_l4_port, zoxy_http_port, origin_port, connSlotsFor(connections) });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     return std.process.spawn(io, .{
@@ -360,11 +390,19 @@ fn spawnPerf(
     const freq = try std.fmt.allocPrint(arena, "{d}", .{flags.freq});
     const seconds = try std.fmt.allocPrint(arena, "{d}", .{flags.duration_s});
     const perf_bin = try spawn_path.resolve(arena, io, environ, "perf");
+    // `sleep` is resolved for the same reason every argv[0] here is: a
+    // spawned child inherits no PATH, and perf must exec this itself. A
+    // bare "sleep" fails, and perf reports the failure as
+    //   Failed to collect '<event>' for the 'sleep' workload: No such file
+    //   or directory
+    // which reads as a PMU problem and sends you hunting the wrong bug —
+    // it cost an afternoon before the empty-environment repro pinned it.
+    const sleep_bin = try spawn_path.resolve(arena, io, environ, "sleep");
     return std.process.spawn(io, .{
         .argv = &.{
-            perf_bin, "record", "-p",           pid,   "-e", event,
-            "-F",     freq,     "--call-graph", "lbr", "-o", perf_data_path,
-            "--",     "sleep",  seconds,
+            perf_bin, "record",  "-p",           pid,   "-e", event,
+            "-F",     freq,      "--call-graph", "lbr", "-o", perf_data_path,
+            "--",     sleep_bin, seconds,
         },
         .stdout = .ignore,
         .stderr = .inherit,
@@ -376,10 +414,11 @@ fn spawnPerf(
 
 // --- load (zrk, in-process, like bench/run.zig) -----------------------------
 
-fn benchConfig(port: u16, rate: u64, connections: u32) zrk.cli.Config {
+fn benchConfig(port: u16, rate: u64, connections: u32, threads: u8) zrk.cli.Config {
     return .{
         .url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" },
         .connections = connections,
+        .threads = threads,
         .rate = rate,
         .timeout_ns = 2 * std.time.ns_per_s,
         .interval_ns = std.time.ns_per_s,
@@ -392,7 +431,10 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
     const retry_sleep = Io.Duration.fromNanoseconds(200 * std.time.ns_per_ms);
     var attempt: u8 = 0;
     while (attempt < attempts_max) : (attempt += 1) {
-        var config = benchConfig(flags.zoxyPort(), 20_000, 16);
+        // A 16-connection probe over one thread: this only has to prove the
+        // path serves before the measured window, so it deliberately does
+        // not inherit the run's connection count or thread pool.
+        var config = benchConfig(flags.zoxyPort(), 20_000, 16, 1);
         config.duration_ns = std.time.ns_per_s / 2;
         const report = zrk.runner.run(arena, io, &config, 0, null, null) catch {
             if (attempt == attempts_max - 1) return error.TargetUnresponsive;
@@ -406,7 +448,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
 }
 
 fn loadTest(arena: std.mem.Allocator, io: Io, flags: *const Flags) !zrk.runner.Report {
-    var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections);
+    var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections, flags.threads);
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
     return zrk.runner.run(arena, io, &config, 0, null, null);
 }

--- a/build.zig
+++ b/build.zig
@@ -206,7 +206,7 @@ pub fn build(b: *std.Build) void {
     // ReleaseFast `zoxy_fast_module` defined above so the SIMD parser is
     // what gets measured.
     const micro_step = b.step("bench-micro", "Build Tier-0 micro binaries for poop A/B");
-    for ([_][]const u8{ "pool_acquire_release", "relay_chunking", "l7_head_pipeline" }) |micro_name| {
+    for ([_][]const u8{ "pool_acquire_release", "relay_chunking", "l7_head_pipeline", "conn_touch_scaling" }) |micro_name| {
         const micro_exe = b.addExecutable(.{
             .name = b.fmt("zoxy-bench-{s}", .{micro_name}),
             .root_module = b.createModule(.{
@@ -236,6 +236,13 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "zrk", .module = zrk_dependency.module("zrk") },
                 .{ .name = "zio", .module = zio_dependency.module("zio") },
+                // For `constants` alone: the harness sizes the conn-slot
+                // limit it writes into zoxy's config against the compiled
+                // ceiling. Duplicating that number here would track a
+                // *lowered* ceiling loudly (the config is rejected at
+                // startup) but a *raised* one silently — a profile aimed at
+                // the new maximum would cap below it and say nothing.
+                .{ .name = "zoxy", .module = zoxy_fast_module },
             },
         }),
     });
@@ -261,6 +268,18 @@ pub fn build(b: *std.Build) void {
     ci_step.dependOn(test_step);
     ci_step.dependOn(lint_step);
     ci_step.dependOn(sim_step);
+    // Compile — never run — every measurement binary. Their verdicts are
+    // human-read A/Bs and profiles, so running them here would buy nothing
+    // and cost minutes; but they call the same internal APIs the proxy
+    // does, and nothing else in the gate does. Left ungated,
+    // `l7_head_pipeline` silently stopped compiling when
+    // `renderRequestHead` grew two parameters and stayed broken across four
+    // merged slices — discovered only when someone next reached for it,
+    // which is the worst time to find out a measurement tool is dead. A
+    // build is enough to catch that, and it is the cheapest thing that is.
+    ci_step.dependOn(micro_step);
+    ci_step.dependOn(&bench_exe.step);
+    ci_step.dependOn(&profile_harness.step);
 
     // Line coverage via kcov (Linux-only, in the dev shell): the unit-test
     // binary plus a simulator sweep, merged — the simulator reaches error

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -376,6 +376,69 @@ which three pools share. If c10k pressure ever makes this worth
 revisiting, the relay-buffer pool's free list is already 10.9% of misses
 on its own and is the cheaper target.
 
+That revisit happened — see the next section. The answer was no, by three
+orders of magnitude. Do not open it a third time.
+
+## `delivered()` at c10k — the revisit, and why it closed (2026-07-27)
+
+The paragraph above bounded structure-of-arrays at "~6% at 2000
+connections and nothing below ~500" and invited a revisit under c10k
+pressure. A cloud c10k run supplied the pressure: at 10,000 connections
+zoxy served 21,396 req/s at 0.758 CPU, against 44,000 req/s at 0.859 CPU
+with 500 connections on the same build. **19.5 µs → 35.4 µs of CPU per
+request, a 1.8× per-request penalty**, with nothing saturated anywhere —
+no CFS throttling, upstream pool at 74%, origin at 24%, zero packet
+drops. The working-set hypothesis fit: 500 slots touch 4.6 MiB and live
+in L3, 10,000 touch 91 MiB and do not.
+
+`bench/micro/conn_touch_scaling.zig` measures exactly that, on the real
+`Conn` and the real `arm`/`delivered` pair, walked in a random
+permutation (a sequential walk measures the prefetcher, not the proxy).
+Median of four pinned runs, ns per arm/deliver pair:
+
+| conns | touched | ns/op | vs 500 |
+|---|---|---|---|
+| 500 | 4.6 MiB | 2.81 | 1.00× |
+| 1000 | 9.1 MiB | 2.76 | 0.98× |
+| 2000 | 18.2 MiB | 2.87 | 1.02× |
+| 5000 | 45.5 MiB | 3.34 | 1.19× |
+| 10000 | 91.1 MiB | 3.97 | 1.41× |
+| 14074 | 128.2 MiB | 7.18 | 2.55× |
+
+The mechanism is confirmed — the knee is real and lands between 2000 and
+5000 connections, where the touched set stops fitting L3. The magnitude
+is what kills it. The 500 → 10,000 delta is **1.2 ns per pair**; a
+keep-alive L7 request does four or five pairs (head recv, request-head
+send, response-head recv, client write, body pump), so the effect is
+**~5.8 ns/request against a measured 15,900 ns/request penalty —
+0.04%**. Doubling it for the kernel round trip that separates a real arm
+from its deliver still leaves under 0.1%.
+
+Two methodology notes, both learned by getting them wrong first. The
+bench discards a warm-up measurement: reading the first point of a run as
+data absorbed the core's frequency ramp and inflated the whole curve —
+before the warm-up the 10,000-connection ratio read 2.08× rather than
+1.41×, which would have overstated the case for acting by 50%. And the
+smallest swept point (64 connections) still reads slow despite being the
+most cache-friendly; it is left in the sweep and out of the conclusions,
+because a number nobody can explain is not a number to reason from.
+
+**So the c10k penalty is essentially all outside zoxy's data
+structures**, consistent with the 2026-07-12 finding that zoxy user code
+is a single-digit share of cycles. At 10,000 connections it is kernel
+work: TCP state for ~20,000 sockets, softirq, io_uring bookkeeping. No
+`Conn` layout change reaches it.
+
+Two harness defects surfaced doing this, both fixed in the same slice.
+`bench/profile.zig` emitted no `limits` block, so every profile run above
+the 1386 default spent its window at the admission wall — it was
+profiling the *shed* path, and nothing in the output said so. And
+`bench/micro/l7_head_pipeline.zig` had not compiled since
+`renderRequestHead` grew two parameters, staying broken across four
+merged slices because `bench-micro` was not in any gate. It is now a
+`ci` dependency: compiled, never run, which is the cheapest thing that
+would have caught it.
+
 ## Profile share is not throughput headroom — bounding a wipe (2026-07-25)
 
 Same profile: `compiler_rt.memset` at 11.2% of zoxy's CPU, ~84% of it


### PR DESCRIPTION
Closes the structure-of-arrays revisit that the c10k work reopened, and fixes the three reasons the measurement tooling could not have answered it.

## The revisit

`IMPLEMENTATION_NOTES` carried a verdict declining SoA for `Conn`, bounded at *"~6% at 2000 connections and nothing below ~500"*, with an explicit invitation to revisit under c10k pressure. The pressure arrived — same build, two operating points:

| | 500 conns | 10,000 conns |
|---|---|---|
| real req/s | 44,000 | 21,396 |
| zoxy CPU | 0.859 | 0.758 |
| **CPU per request** | **19.5 µs** | **35.4 µs** |

zoxy uses *less* CPU while doing half the work, with nothing saturated: no CFS throttling, upstream pool at 74%, origin at 24%, zero packet drops. The working-set hypothesis fit — 500 slots touch 4.6 MiB and live in L3; 10,000 touch 91 MiB and do not.

## The measurement

`conn_touch_scaling` walks real `Conn` structs in a random permutation (a sequential walk measures the prefetcher, not the proxy), calling the real `arm`/`delivered` pair. Median of four pinned runs:

| conns | touched | ns/op | vs 500 |
|---|---|---|---|
| 500 | 4.6 MiB | 2.81 | 1.00× |
| 2000 | 18.2 MiB | 2.87 | 1.02× |
| 5000 | 45.5 MiB | 3.34 | 1.19× |
| 10000 | 91.1 MiB | 3.97 | 1.41× |
| 14074 | 128.2 MiB | 7.18 | 2.55× |

**The mechanism is confirmed and the magnitude closes it.** The knee is real and lands where the touched set stops fitting L3. But the 500 → 10,000 delta is 1.2 ns per pair; a keep-alive request does four or five pairs, so ~5.8 ns against a measured 15,900 ns/request penalty — **0.04%**. Double it for the kernel round trip separating a real arm from its deliver and it is still under 0.1%.

Corroborated from the other side: `arm` and `delivered` are fully inlined and appear **nowhere** in a real 34-symbol profile at either 500 or 10,000 connections. The micro bench was the only instrument that could isolate them.

So the c10k penalty is essentially all outside zoxy's data structures. Do not open this a third time.

## Three harness defects, one cause

Nothing built or ran these tools, so they rotted unobserved.

1. **`bench/profile.zig` emitted no `limits` block.** Every profile run above the 1386 default spent its window at the admission wall — profiling the *shed* path, with nothing in the output saying so. Any earlier conclusion drawn from a high-connection profile was drawn from the wrong code. `conn_slots` now derives from `--connections` against `constants`, not literals, so a ceiling that later moves takes this with it.

2. **`zig build profile` could never have completed.** The harness resolves argv[0] for its own children because they inherit no PATH — but `sleep` is argv passed *to perf*, which must exec it itself. perf reports that as `Failed to collect '<event>' for the 'sleep' workload: No such file or directory`, which reads as a PMU fault and sends you hunting the wrong bug. It now runs end-to-end for the first time.

3. **`bench/micro/l7_head_pipeline.zig` had not compiled** since `renderRequestHead` grew `target` and `edits`. It now canonicalizes the target too — what the proxy does once per request since #98; leaving it out understated the head cost the bench exists to report.

`ci` therefore compiles, and never runs, every measurement binary. Their verdicts are human-read A/Bs, so running them buys nothing and costs minutes; a build is the cheapest thing that catches a dead tool before someone reaches for it.

## Methodology corrections recorded with the result

Both changed the answer's size, so both are in the notes rather than lost:

- The bench **discards a warm-up measurement**. Reading the first point as data absorbed the core's frequency ramp and put 10,000 connections at 2.08× instead of 1.41× — overstating the case for acting by 50%.
- The **64-connection point still reads slow** despite being the most cache-friendly. It stays in the sweep and out of the conclusions: a number nobody can explain is not a number to reason from.

## Gates

`zig build ci` (64 sim seeds, now including the measurement-binary compiles) and `zig fmt --check` pass. The generated profile config was checked against a real zoxy at both ends of `connSlotsFor` with two listeners, and the harness was run end-to-end at 500, 2000 and 10,000 connections.

`tiger-style-reviewer`: **ready to commit**, with all three of its judgement calls taken — `constants` wired through instead of magic numbers, the `assert` alias convention, and the printed table re-baselined on 500 so it matches what the notes quote.

## Incidental confirmation of #101

The 10,000-connection local run recorded 1,295 upstream-slot sheds against `accepted == completed == 10016` — only 16 connections beyond the 10,000 held open. On the old always-close path that would have been ~1,295 extra accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)