### PR TITLE
counters: say which syscall failed and why, not just that something did (§8)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,15 +32,30 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        // Audited fork: zoxy-io/libxev branch zoxy-cqsize = upstream
+        // Audited fork: zoxy-io/libxev branch zoxy-op-errno = upstream
         // 9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf (the audited snapshot)
-        // plus two commits: one exposing io_uring setup flags through
-        // Options, one exposing the CQ depth (IORING_SETUP_CQSIZE) — the
-        // c10k lever. Diff against that upstream commit to audit; the pin
-        // moves only after re-audit.
+        // plus three commits, each its own stacked PR:
+        //   c369817 expose io_uring setup flags through Options
+        //   6bd950d expose the CQ depth (IORING_SETUP_CQSIZE) — the c10k
+        //           lever
+        //   b3d6b55 keep the raw errno on the Completion (zoxy-io/libxev#2)
+        // Diff against that upstream commit to audit; the pin moves only
+        // after re-audit.
+        //
+        // Re-audit for b3d6b55: one `posix.E` field on `Completion`
+        // defaulting to `.SUCCESS`, one assignment at the top of `invoke`
+        // from the same `-errno` encoding every arm already decodes, and a
+        // test. No error set, result, or control-flow change — the whole
+        // diff is additive, so every existing call path behaves as before.
+        // Scope: **io_uring only**. `kqueue.Completion` has no such field,
+        // so `XevIo.recordPressure` reports unclassified there rather than
+        // failing to compile on the macOS dev box (§4).
+        // It exists because the mapping's `else => posix.unexpectedErrno`
+        // arms discard which errno failed, which is what left a c10k run
+        // reporting 227,628 indistinguishable failures.
         .libxev = .{
-            .url = "git+https://github.com/zoxy-io/libxev#6bd950d789629d62c985eb7c625f6439e693ec87",
-            .hash = "libxev-0.0.0-86vtcxUcFAAKN43dhrvWh-caogydO84cmzT2QuHxyc-P",
+            .url = "git+https://github.com/zoxy-io/libxev#b3d6b55bfbea1de0401d11f69ad9755fed9a6144",
+            .hash = "libxev-0.0.0-86vtc6cnFACJYqPSG_os9Ea-nUgWmjAqi3CwCQGiFj2z",
         },
         .zrk = .{
             .url = "git+https://github.com/zoxy-io/zrk#f05cc6a2e7657409767c3cf63c68fcd54d2621e3",

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -491,6 +491,29 @@ memory (`fds_max = 29188` at the ceiling, so a c10k deployment raises
 comptime-asserts it. The remaining ceiling lever — `splice` — is fork
 work, in PLANS.md "c10k".
 
+## libxev error surfacing is lossy — resolved by the fork (2026-07-27)
+
+The section below stood for months and is kept for the reasoning; the
+wall it describes is gone. zoxy-io/libxev#2 adds
+`Completion.result_errno`, recorded at the top of `invoke` *before* the
+per-operation mapping runs — which is the only place the errno still
+exists, since every arm's `else` hands it to `posix.unexpectedErrno` and
+keeps nothing. The pin moved to b3d6b55 after re-audit: one field, one
+assignment, one test, no error-set or control-flow change.
+
+What forced it: a c10k run reported 227,628 `kernel_pressure_errors`
+against 736,843 churned connections, and three runs in a row were
+undiagnosable because "something failed" is not a diagnosis. The counter
+is now partitioned twice over — by op (which syscall) and by cause (what
+to do about it: shed load, raise a limit, widen the port range) — with
+`kernel_pressure_last_errno` as a gauge so an unclassified errno stays a
+lead rather than a dead end. Both partitions are asserted equal to the
+total in `reconcile` and again in the witness that maintains them.
+
+The generalization in the note below still holds and is worth keeping:
+any *other* feature needing a particular errno on a data op now has the
+field to read, rather than a fork to negotiate first.
+
 ## libxev error surfacing is lossy
 
 The io_uring backend keeps only a few named errnos on data ops:

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -68,6 +68,11 @@ pub fn Server(comptime IoType: type) type {
         /// co-armed exactly the budgeted worst case, not merely stayed
         /// under it.
         armed_ops_peak: u8,
+        /// The raw errno of the most recent kernel-pressure failure, or 0
+        /// (§8). Reported as a gauge rather than a counter because it is a
+        /// level — "what is failing now" — and because an errno space is
+        /// far too wide for a counter each.
+        last_pressure_errno: u16,
         drain_deadline_completion: IoType.Completion,
         /// The one timer covering every parked upstream (§5): a parked
         /// connection holds no armed op, so this sweep compares stored
@@ -147,6 +152,7 @@ pub fn Server(comptime IoType: type) type {
             server.conn_pressure = false;
             server.upstream_pressure = false;
             server.armed_ops_peak = 0;
+            server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
@@ -756,6 +762,19 @@ pub fn Server(comptime IoType: type) type {
             if (err != error.Unexpected) return;
             server.counters.increment("kernel_pressure_errors");
             server.counters.increment(comptime op.counter());
+            // The seam classified this while the completion was still in
+            // hand; reading it here is why the op and the cause always
+            // describe the same failure. Both partition the same total.
+            const pressure = server.io.lastPressure();
+            switch (pressure.cause) {
+                inline else => |cause| server.counters.increment(
+                    comptime counters_module.Counters.causeCounter(cause),
+                ),
+            }
+            // Kept raw so an `.other` is a lead rather than a dead end: the
+            // classification names only the errnos worth acting on
+            // differently, and this is how the rest stay visible.
+            server.last_pressure_errno = pressure.errno;
             // The partition, checked where it is maintained rather than
             // only where `reconcile` happens to run. A site that increments
             // the total on its own leaves the two unequal, and the next
@@ -763,6 +782,8 @@ pub fn Server(comptime IoType: type) type {
             // site was found still doing exactly that, on a path SimIo
             // cannot fail and so 64 sim seeds could never reach.
             assert(server.counters.kernelPressureTotal() ==
+                server.counters.get("kernel_pressure_errors"));
+            assert(server.counters.kernelPressureCauseTotal() ==
                 server.counters.get("kernel_pressure_errors"));
         }
 
@@ -858,6 +879,7 @@ pub fn Server(comptime IoType: type) type {
                 .upstream_slots_leased = server.upstreams.leasedCount(),
                 .upstream_slots_parked = server.upstreams.parkedCount(),
                 .upstream_slots_capacity = server.upstreams.capacity(),
+                .kernel_pressure_last_errno = server.last_pressure_errno,
             };
             // Asserted at the producer, not in the renderer: a level past
             // its capacity would mean a pool miscounted, and that is a bug

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -348,7 +348,7 @@ pub fn Server(comptime IoType: type) type {
                 // the loop. Back off through a short timer instead; the
                 // shed ladder never engages here because there is no
                 // socket to shed (§8).
-                server.counters.increment("kernel_pressure_errors");
+                server.witnessKernelPressure(.accept, err);
                 if (!server.draining) {
                     server.io.timerStart(
                         &state.retry_completion,
@@ -550,8 +550,8 @@ pub fn Server(comptime IoType: type) type {
                 entryState(listener.protocol),
                 listener.cluster_index,
             );
-            server.io.setNodelay(client_socket) catch {
-                server.counters.increment("kernel_pressure_errors");
+            server.io.setNodelay(client_socket) catch |err| {
+                server.witnessKernelPressure(.set_option, err);
             };
             // The L7 path routes and filters once the head parses (§7);
             // every connection gets its listener's tables and the protocol
@@ -621,14 +621,20 @@ pub fn Server(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .connecting);
-            const socket = result catch {
+            const socket = result catch |err| {
                 server.counters.increment("upstream_connect_failed");
+                // Refused/timed-out/unreachable arrive typed and are the
+                // origin's verdict; anything else is resource pressure on
+                // our side — ephemeral ports and socket memory both land
+                // here — and wants the opposite response. The dial counter
+                // cannot tell them apart, so witness the pressure too (§8).
+                server.witnessKernelPressure(.connect, err);
                 server.beginTeardown(conn);
                 return;
             };
             conn.upstream_socket = socket;
-            server.io.setNodelay(socket) catch {
-                server.counters.increment("kernel_pressure_errors");
+            server.io.setNodelay(socket) catch |err| {
+                server.witnessKernelPressure(.set_option, err);
             };
             conn.state = .relaying;
             server.storeDeadline(conn, server.idleTimeoutMs());
@@ -730,17 +736,34 @@ pub fn Server(comptime IoType: type) type {
             server.maybeStopAfterDrain();
         }
 
-        /// §8 kernel-pressure rung on the data path: a non-orderly op
-        /// failure on a live socket is resource exhaustion (ENOBUFS/
-        /// ENOMEM), which the seam collapses to Unexpected. Orderly
-        /// failures (EndOfStream, Reset, Canceled) are peeled off by the
-        /// caller; only Unexpected is witnessed here, matching the
-        /// accept/connect/setNodelay sites. Shared by the L4 relay and the
-        /// L7 state machine.
-        pub fn witnessKernelPressure(server: *Self, err: anyerror) void {
-            if (err == error.Unexpected) {
-                server.counters.increment("kernel_pressure_errors");
-            }
+        /// §8 kernel-pressure rung: a non-orderly op failure on a live
+        /// socket is resource exhaustion (ENOBUFS/ENOMEM), which the seam
+        /// collapses to Unexpected. Orderly failures (EndOfStream, Reset,
+        /// Canceled) are peeled off by the caller; only Unexpected is
+        /// witnessed here. Shared by every site — the accept and
+        /// setNodelay ones included, so no path can reach the total
+        /// without naming the op it failed on.
+        ///
+        /// `op` is comptime and mandatory for that reason. The errno is
+        /// gone before this is called (libxev discards it), so the op is
+        /// the only thing left to distinguish a full NIC queue from an
+        /// exhausted fd table — and those want opposite responses.
+        pub fn witnessKernelPressure(
+            server: *Self,
+            comptime op: counters_module.Counters.KernelPressureOp,
+            err: anyerror,
+        ) void {
+            if (err != error.Unexpected) return;
+            server.counters.increment("kernel_pressure_errors");
+            server.counters.increment(comptime op.counter());
+            // The partition, checked where it is maintained rather than
+            // only where `reconcile` happens to run. A site that increments
+            // the total on its own leaves the two unequal, and the next
+            // witness call trips here — which is how the third `setNodelay`
+            // site was found still doing exactly that, on a path SimIo
+            // cannot fail and so 64 sim seeds could never reach.
+            assert(server.counters.kernelPressureTotal() ==
+                server.counters.get("kernel_pressure_errors"));
         }
 
         /// §8 watermarks before walls: recompute one pool's pressure flag

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -184,7 +184,7 @@ pub fn Admin(comptime IoType: type) type {
                 // spin starving the loop (§8). Witness it and back off through
                 // the shared retry delay, exactly as `Server.onAccept` does;
                 // Canceled cannot occur outside a drain, handled above.
-                admin.server.witnessKernelPressure(err);
+                admin.server.witnessKernelPressure(.accept, err);
                 admin.armAcceptRetry();
                 return;
             };
@@ -265,7 +265,7 @@ pub fn Admin(comptime IoType: type) type {
                 // A reset or unexpected error mid-response: nothing left to
                 // deliver, tear down. Witness kernel pressure (§8) like every
                 // other data-op site.
-                admin.server.witnessKernelPressure(err);
+                admin.server.witnessKernelPressure(.send, err);
                 admin.beginTeardown();
                 return;
             };
@@ -316,7 +316,7 @@ pub fn Admin(comptime IoType: type) type {
                 error.Canceled => admin.beginTeardown(),
                 // Kernel pressure on the drain read (§8): witness and tear down.
                 error.Unexpected => {
-                    admin.server.witnessKernelPressure(err);
+                    admin.server.witnessKernelPressure(.recv, err);
                     admin.beginTeardown();
                 },
             }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -6,6 +6,8 @@
 
 const std = @import("std");
 
+const io_module = @import("io/io.zig");
+
 const assert = std.debug.assert;
 
 pub const Counters = struct {
@@ -104,18 +106,11 @@ pub const Counters = struct {
     kernel_pressure_errors: Value = Value.init(0),
     /// The same failures split by the syscall that produced them.
     ///
-    /// Why the split exists: the seam collapses every unmapped errno to
-    /// `error.Unexpected` (libxev discards it — see IMPLEMENTATION_NOTES),
-    /// so the total alone says only that *something* failed. A c10k run
-    /// recorded 227,628 of them against 736,843 churned connections, and
-    /// the total could not distinguish "the NIC queue is full on send"
-    /// from "we are out of fds on accept" — opposite problems with
-    /// opposite fixes. The op is the one bit of information that costs no
-    /// dependency change to keep, and it is usually the one that matters:
-    /// a send failure at 90% of link capacity needs no errno to read.
-    ///
-    /// Recovering the errno itself needs the libxev fork to stop throwing
-    /// it away; that is the follow-up this split does not block on.
+    /// Why the split exists: a c10k run recorded 227,628 of these against
+    /// 736,843 churned connections, and one number could not distinguish
+    /// "the NIC queue is full on send" from "we are out of fds on accept"
+    /// — opposite problems with opposite fixes. The op says which syscall
+    /// to look at; the cause counters below say what to do about it.
     ///
     /// `kernelPressureTotal` must equal `kernel_pressure_errors` — every
     /// witness increments exactly one of these alongside the total, which
@@ -125,6 +120,23 @@ pub const Counters = struct {
     kernel_pressure_recv: Value = Value.init(0),
     kernel_pressure_send: Value = Value.init(0),
     kernel_pressure_set_option: Value = Value.init(0),
+    /// The same failures split a second way — by *why* the kernel refused,
+    /// recovered from the errno the audited libxev fork now keeps on the
+    /// completion (zoxy-io/libxev#2). Two partitions of one total, because
+    /// the op and the cause answer different questions: the op says which
+    /// syscall to look at, the cause says what to do about it.
+    ///
+    /// Shed load for `out_of_buffers`/`out_of_memory`; raise a limit for
+    /// `fd_limit`; widen the port range or reuse connections for
+    /// `address_unavailable`. Reading them off one number was the original
+    /// problem — `.other` keeps that honest by never pretending to be a
+    /// classification, and `kernel_pressure_last_errno` (a gauge) carries
+    /// the raw value so an unlisted errno is still a lead.
+    kernel_pressure_out_of_buffers: Value = Value.init(0),
+    kernel_pressure_out_of_memory: Value = Value.init(0),
+    kernel_pressure_fd_limit: Value = Value.init(0),
+    kernel_pressure_address_unavailable: Value = Value.init(0),
+    kernel_pressure_other_cause: Value = Value.init(0),
     /// Admin/metrics scrapes whose full response was written (§8, PLANS.md
     /// §243). Pure observability: the admin plane sits entirely outside
     /// `reconcile`'s accepted/admitted/shed accounting, so these never enter
@@ -169,6 +181,12 @@ pub const Counters = struct {
         /// in-use figure.
         upstream_slots_parked: u32,
         upstream_slots_capacity: u32,
+        /// The raw errno of the most recent kernel-pressure failure, or 0
+        /// for "none since start". A gauge, not a counter: the question is
+        /// which errno is failing *now*, and the `kernel_pressure_*` cause
+        /// counters already carry the history. This is what keeps an
+        /// `other_cause` diagnosable instead of merely counted.
+        kernel_pressure_last_errno: u32,
 
         /// The invariant every producer owes: a level never exceeds its
         /// own capacity, and the two upstream levels share one.
@@ -340,12 +358,35 @@ pub const Counters = struct {
         }
     };
 
+    /// The counter for an `Io.Pressure.Cause`. Lives here rather than on
+    /// the seam's enum so `io.zig` stays free of counter names.
+    pub fn causeCounter(cause: io_module.Pressure.Cause) []const u8 {
+        return switch (cause) {
+            .out_of_buffers => "kernel_pressure_out_of_buffers",
+            .out_of_memory => "kernel_pressure_out_of_memory",
+            .fd_limit => "kernel_pressure_fd_limit",
+            .address_unavailable => "kernel_pressure_address_unavailable",
+            .other => "kernel_pressure_other_cause",
+        };
+    }
+
     /// The per-op split summed — equal to `kernel_pressure_errors` by
     /// construction, and asserted so in `reconcile`.
     pub fn kernelPressureTotal(counters: *const Counters) u64 {
         var total: u64 = 0;
         inline for (comptime std.enums.values(KernelPressureOp)) |op| {
             total += counters.get(comptime op.counter());
+        }
+        return total;
+    }
+
+    /// The per-cause split summed. The second partition of the same total,
+    /// so it must agree with `kernelPressureTotal` as well as with the
+    /// total itself — both asserted in `reconcile`.
+    pub fn kernelPressureCauseTotal(counters: *const Counters) u64 {
+        var total: u64 = 0;
+        inline for (comptime std.enums.values(io_module.Pressure.Cause)) |cause| {
+            total += counters.get(comptime causeCounter(cause));
         }
         return total;
     }
@@ -367,6 +408,7 @@ pub const Counters = struct {
         // incremented one without the other would make the split lie about
         // where the pressure is, which is the only thing it exists to say.
         assert(counters.kernelPressureTotal() == counters.get("kernel_pressure_errors"));
+        assert(counters.kernelPressureCauseTotal() == counters.get("kernel_pressure_errors"));
         const flow_holds = admitted == completed + active_count;
         const gate_holds = accepted == admitted + shed;
         return flow_holds and gate_holds;
@@ -400,6 +442,7 @@ const test_gauges: Counters.Gauges = .{
     .upstream_slots_leased = 5,
     .upstream_slots_parked = 11,
     .upstream_slots_capacity = 16,
+    .kernel_pressure_last_errno = 105, // ENOBUFS on Linux
 };
 
 test "counters: render emits Prometheus exposition for every field" {
@@ -541,11 +584,16 @@ test "counters: every kernel-pressure op has its own counter, and they partition
     }
     try std.testing.expectEqual(std.enums.values(Counters.KernelPressureOp).len, index);
 
-    // Each op moves its own counter and the total together, never one
-    // alone — the invariant `reconcile` asserts.
+    // The cause split is a second partition of the same total, so every
+    // witness moves three counters together: the total, one op, one cause.
+    inline for (comptime std.enums.values(io_module.Pressure.Cause)) |cause| {
+        try std.testing.expectEqual(@as(u64, 0), counters.get(comptime Counters.causeCounter(cause)));
+    }
     counters.increment("kernel_pressure_errors");
     counters.increment("kernel_pressure_send");
+    counters.increment("kernel_pressure_out_of_buffers");
     try std.testing.expectEqual(@as(u64, 1), counters.kernelPressureTotal());
+    try std.testing.expectEqual(@as(u64, 1), counters.kernelPressureCauseTotal());
     try std.testing.expect(counters.reconcile(0));
 
     // A total that moved without an op is exactly the old behaviour: the

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -99,8 +99,32 @@ pub const Counters = struct {
     upstream_idle_reaped: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
-    /// recv/send data path).
+    /// recv/send data path). The total; `kernel_pressure_by_op` below
+    /// partitions it.
     kernel_pressure_errors: Value = Value.init(0),
+    /// The same failures split by the syscall that produced them.
+    ///
+    /// Why the split exists: the seam collapses every unmapped errno to
+    /// `error.Unexpected` (libxev discards it — see IMPLEMENTATION_NOTES),
+    /// so the total alone says only that *something* failed. A c10k run
+    /// recorded 227,628 of them against 736,843 churned connections, and
+    /// the total could not distinguish "the NIC queue is full on send"
+    /// from "we are out of fds on accept" — opposite problems with
+    /// opposite fixes. The op is the one bit of information that costs no
+    /// dependency change to keep, and it is usually the one that matters:
+    /// a send failure at 90% of link capacity needs no errno to read.
+    ///
+    /// Recovering the errno itself needs the libxev fork to stop throwing
+    /// it away; that is the follow-up this split does not block on.
+    ///
+    /// `kernelPressureTotal` must equal `kernel_pressure_errors` — every
+    /// witness increments exactly one of these alongside the total, which
+    /// `reconcile` asserts.
+    kernel_pressure_accept: Value = Value.init(0),
+    kernel_pressure_connect: Value = Value.init(0),
+    kernel_pressure_recv: Value = Value.init(0),
+    kernel_pressure_send: Value = Value.init(0),
+    kernel_pressure_set_option: Value = Value.init(0),
     /// Admin/metrics scrapes whose full response was written (§8, PLANS.md
     /// §243). Pure observability: the admin plane sits entirely outside
     /// `reconcile`'s accepted/admitted/shed accounting, so these never enter
@@ -292,6 +316,40 @@ pub const Counters = struct {
         return total;
     }
 
+    /// Which syscall a kernel-pressure failure came from (§8). Closed set:
+    /// a new op has to name itself here and grow a counter, rather than
+    /// disappearing into the total.
+    pub const KernelPressureOp = enum {
+        accept,
+        connect,
+        recv,
+        send,
+        set_option,
+
+        /// The counter this op increments. A `switch` rather than a name
+        /// built by concatenation, so a typo is a compile error and the
+        /// mapping reads in one place.
+        pub fn counter(op: KernelPressureOp) []const u8 {
+            return switch (op) {
+                .accept => "kernel_pressure_accept",
+                .connect => "kernel_pressure_connect",
+                .recv => "kernel_pressure_recv",
+                .send => "kernel_pressure_send",
+                .set_option => "kernel_pressure_set_option",
+            };
+        }
+    };
+
+    /// The per-op split summed — equal to `kernel_pressure_errors` by
+    /// construction, and asserted so in `reconcile`.
+    pub fn kernelPressureTotal(counters: *const Counters) u64 {
+        var total: u64 = 0;
+        inline for (comptime std.enums.values(KernelPressureOp)) |op| {
+            total += counters.get(comptime op.counter());
+        }
+        return total;
+    }
+
     pub fn reconcile(counters: *const Counters, active_count: u32) bool {
         const admitted = counters.get("admitted");
         const completed = counters.get("completed");
@@ -305,6 +363,10 @@ pub const Counters = struct {
         // Every §7 replay rides a checkout: only a reused connection's
         // early failure is blamed on staleness.
         assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));
+        // The op split partitions the total exactly: a witness that
+        // incremented one without the other would make the split lie about
+        // where the pressure is, which is the only thing it exists to say.
+        assert(counters.kernelPressureTotal() == counters.get("kernel_pressure_errors"));
         const flow_holds = admitted == completed + active_count;
         const gate_holds = accepted == admitted + shed;
         return flow_holds and gate_holds;
@@ -457,6 +519,43 @@ test "counters: the gate identity sums exactly today's admission rungs" {
         }
     }
     try std.testing.expectEqual(expected.len, actual_count);
+}
+
+test "counters: every kernel-pressure op has its own counter, and they partition the total" {
+    // The mapping must be total and injective: an op sharing a counter
+    // with another would silently re-create the bucket this split exists
+    // to break up.
+    var counters: Counters = .{};
+    var seen: [std.enums.values(Counters.KernelPressureOp).len][]const u8 = undefined;
+    var index: usize = 0;
+    inline for (comptime std.enums.values(Counters.KernelPressureOp)) |op| {
+        const name = comptime op.counter();
+        // Names an existing field: `get` would not compile otherwise, and
+        // the zero read here pins that it starts clean.
+        try std.testing.expectEqual(@as(u64, 0), counters.get(name));
+        for (seen[0..index]) |previous| {
+            try std.testing.expect(!std.mem.eql(u8, previous, name));
+        }
+        seen[index] = name;
+        index += 1;
+    }
+    try std.testing.expectEqual(std.enums.values(Counters.KernelPressureOp).len, index);
+
+    // Each op moves its own counter and the total together, never one
+    // alone — the invariant `reconcile` asserts.
+    counters.increment("kernel_pressure_errors");
+    counters.increment("kernel_pressure_send");
+    try std.testing.expectEqual(@as(u64, 1), counters.kernelPressureTotal());
+    try std.testing.expect(counters.reconcile(0));
+
+    // A total that moved without an op is exactly the old behaviour: the
+    // two diverge, and `reconcile` would trip its assertion rather than
+    // return false — which is why it is not called here. The sim runs
+    // `reconcile` under every seed, so that assertion is the enforcement;
+    // this pins the divergence it fires on.
+    counters.increment("kernel_pressure_errors");
+    try std.testing.expectEqual(@as(u64, 1), counters.kernelPressureTotal());
+    try std.testing.expectEqual(@as(u64, 2), counters.get("kernel_pressure_errors"));
 }
 
 test "counters: an admission shed and an L7 reject land on opposite sides" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -146,7 +146,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // instead of closing. The witness filters internally: only
                 // Unexpected (kernel pressure) is counted, so orderly
                 // EndOfStream/Reset pass through it uncounted.
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.recv, err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -484,15 +484,18 @@ pub fn Proxy(comptime IoType: type) type {
                 respond(server, conn, 504, "l7_gateway_timeout");
                 return;
             }
-            const socket = result catch {
+            const socket = result catch |err| {
                 server.counters.increment("upstream_connect_failed");
+                // Same split as the L4 dial: the origin's verdict arrives
+                // typed, our own resource exhaustion does not (§8).
+                server.witnessKernelPressure(.connect, err);
                 respond(server, conn, 502, "l7_bad_gateway");
                 return;
             };
             conn.upstream.?.socket = socket;
             conn.upstream_socket = socket;
-            server.io.setNodelay(socket) catch {
-                server.counters.increment("kernel_pressure_errors");
+            server.io.setNodelay(socket) catch |err| {
+                server.witnessKernelPressure(.set_option, err);
             };
             renderAndStartLegs(server, conn);
         }
@@ -612,7 +615,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             const sent = result catch |err| {
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.send, err);
                 upstreamFailed(server, conn);
                 return;
             };
@@ -698,7 +701,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             const sent = result catch |err| {
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.send, err);
                 upstreamFailed(server, conn);
                 return;
             };
@@ -792,12 +795,12 @@ pub fn Proxy(comptime IoType: type) type {
             pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
                 // EOF mid-body is a truncated request; any failure here
                 // dooms the exchange in the client's own direction.
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.recv, err);
                 server.beginTeardown(conn);
             }
 
             pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.send, err);
                 upstreamFailed(server, conn);
             }
 
@@ -866,7 +869,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             const received = result catch |err| {
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.recv, err);
                 upstreamFailed(server, conn);
                 return;
             };
@@ -1064,7 +1067,7 @@ pub fn Proxy(comptime IoType: type) type {
             const write = &conn.client_write;
             const sent = result catch |err| {
                 // The client is gone; there is no one left to answer.
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.send, err);
                 server.beginTeardown(conn);
                 return;
             };
@@ -1175,12 +1178,12 @@ pub fn Proxy(comptime IoType: type) type {
                     // Truncated inside a length-delimited body: the client
                     // must see the truncation too, so tear down.
                 }
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.recv, err);
                 server.beginTeardown(conn);
             }
 
             pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.send, err);
                 server.beginTeardown(conn);
             }
 
@@ -1660,7 +1663,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // close is a clean FIN, not a data-discarding RST. Kernel
                 // pressure on the drain recv is still witnessed (§8) —
                 // this op fires most during a reject storm under load.
-                server.witnessKernelPressure(err);
+                server.witnessKernelPressure(.recv, err);
                 server.beginTeardown(conn);
                 return;
             };

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1056,6 +1056,38 @@ test "l7: an upstream-slot shed keeps the connection, and the client's ask decid
     try bed.expectDrained();
 }
 
+test "l7: kernel pressure on a socket option is witnessed per op, on both sockets" {
+    // A fresh L7 exchange sets TCP_NODELAY twice: once on the accepted
+    // client socket (`Server` admission) and once on the dialled upstream
+    // (`onUpstreamConnect`). The second site is the one the per-op split
+    // originally shipped without — it kept incrementing the aggregate
+    // counter alone — and nothing could reach it in simulation until
+    // SimIo learned to fail a socket option at all.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 71,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    bed.sim_io.injectSetOptionError();
+    bed.sim_io.injectSetOptionError();
+    try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("kernel_pressure_set_option"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("kernel_pressure_errors"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_recv"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_send"));
+    // TCP_NODELAY is best-effort (§6): failing it costs latency, never
+    // correctness, so the exchange is byte-for-byte unaffected.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
 test "l7: a 501 keeps the connection, and the next request is served" {
     // CONNECT and Upgrade are non-goals (§1, §7), but they are *method*
     // rejects, not framing ones: the head parsed cleanly and sits on a

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -71,6 +71,12 @@ adversary: Adversary,
 /// bumping the aggregate counter alone, and 64 seeds stayed green because
 /// nothing could make the call fail.
 pending_set_option_errors: u8,
+/// The cause `lastPressure` reports for the next injected failure (§8).
+/// Scenario-controlled so a test can drive each classification arm: the
+/// real errno comes from the kernel, which a virtual socket table has
+/// none of.
+pressure_cause: Io.Pressure.Cause,
+last_pressure: Io.Pressure,
 stopped: bool,
 dump_on_deadlock: bool,
 /// FNV-1a over every delivery; two runs of one seed must end equal (§9).
@@ -305,6 +311,8 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.prng = std.Random.DefaultPrng.init(options.seed);
     io.adversary = options.adversary;
     io.pending_set_option_errors = 0;
+    io.pressure_cause = .out_of_buffers;
+    io.last_pressure = Io.Pressure.none;
     io.stopped = false;
     io.dump_on_deadlock = options.dump_on_deadlock;
     io.trace_hash = std.hash.Fnv1a_64.init().value;
@@ -600,6 +608,7 @@ pub fn setLingerRst(io: *SimIo, socket: Socket) Io.SetOptionError!void {
 fn takeSetOptionError(io: *SimIo) ?Io.SetOptionError {
     if (io.pending_set_option_errors == 0) return null;
     io.pending_set_option_errors -= 1;
+    io.recordPressure();
     return error.Unexpected;
 }
 
@@ -645,6 +654,34 @@ pub fn injectAcceptError(io: *SimIo, listener: Listener) void {
     assert(entry.active);
     assert(entry.pending_accept_errors < std.math.maxInt(u8));
     entry.pending_accept_errors += 1;
+}
+
+/// The classified cause of the op currently being delivered (§8) — the
+/// seam contract `Server.witnessKernelPressure` reads. Production learns
+/// this from the kernel's errno; a virtual socket table has none, so the
+/// scenario states the cause it is simulating and this reports it back.
+///
+/// Valid only inside the callback for the failure it describes, exactly as
+/// on XevIo: every fault site records immediately before returning its
+/// error, and anything reading it later sees the previous failure's answer
+/// rather than an absent one. A fault site that forgets to record is the
+/// specific bug this warning is about — the accept path shipped that way
+/// once, reporting whatever the last unrelated op had left behind.
+pub fn lastPressure(io: *const SimIo) Io.Pressure {
+    return io.last_pressure;
+}
+
+/// Stamp the scenario's chosen cause onto the failure being delivered.
+/// The errno is 0 because there is no kernel here to have produced one —
+/// which is exactly what a `.errno` of 0 is defined to mean, so the sim
+/// does not have to invent a plausible number.
+fn recordPressure(io: *SimIo) void {
+    io.last_pressure = .{ .cause = io.pressure_cause, .errno = 0 };
+}
+
+/// Scenario control: which cause the next injected failures report.
+pub fn setPressureCause(io: *SimIo, cause: Io.Pressure.Cause) void {
+    io.pressure_cause = cause;
 }
 
 /// Targeted scenario control: the next `setNodelay`/`setLingerRst` fails
@@ -860,6 +897,7 @@ fn finishAccept(io: *SimIo, listener_index: u16) Io.AcceptError!Socket {
     }
     if (entry.pending_accept_errors > 0) {
         entry.pending_accept_errors -= 1;
+        io.recordPressure();
         return error.Unexpected;
     }
     assert(entry.accept_queue_len >= 1);
@@ -902,6 +940,7 @@ fn finishRecv(io: *SimIo, socket: Socket, buffer: []u8) Io.RecvError!u32 {
     if (entry.kernel_pressure) {
         // Transient op failure: consume the flag, leave the socket usable.
         entry.kernel_pressure = false;
+        io.recordPressure();
         return error.Unexpected;
     }
     if (entry.reset) {
@@ -924,6 +963,7 @@ fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
     if (entry.kernel_pressure) {
         // Transient op failure: consume the flag, leave the socket usable.
         entry.kernel_pressure = false;
+        io.recordPressure();
         return error.Unexpected;
     }
     if (entry.reset) {

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -63,6 +63,14 @@ signal_userdata: ?*anyopaque,
 now_ns_value: u64,
 prng: std.Random.DefaultPrng,
 adversary: Adversary,
+/// Pending one-shot `setNodelay`/`setLingerRst` failures (§9). A virtual
+/// socket table has no reason to refuse a socket option, so without this
+/// the whole set-option path is unreachable in simulation — and a bug
+/// there is invisible under every seed. That is not hypothetical: the
+/// per-op kernel-pressure split shipped with one `setNodelay` site still
+/// bumping the aggregate counter alone, and 64 seeds stayed green because
+/// nothing could make the call fail.
+pending_set_option_errors: u8,
 stopped: bool,
 dump_on_deadlock: bool,
 /// FNV-1a over every delivery; two runs of one seed must end equal (§9).
@@ -296,6 +304,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.now_ns_value = clock_start_ns;
     io.prng = std.Random.DefaultPrng.init(options.seed);
     io.adversary = options.adversary;
+    io.pending_set_option_errors = 0;
     io.stopped = false;
     io.dump_on_deadlock = options.dump_on_deadlock;
     io.trace_hash = std.hash.Fnv1a_64.init().value;
@@ -576,11 +585,22 @@ pub fn signalWait(
 }
 
 pub fn setNodelay(io: *SimIo, socket: Socket) Io.SetOptionError!void {
+    if (io.takeSetOptionError()) |err| return err;
     io.socketEntry(socket).nodelay = true;
 }
 
 pub fn setLingerRst(io: *SimIo, socket: Socket) Io.SetOptionError!void {
+    if (io.takeSetOptionError()) |err| return err;
     io.socketEntry(socket).linger_rst = true;
+}
+
+/// Consume one injected set-option failure, if any. Returns the error to
+/// propagate rather than propagating it here, so both option setters read
+/// the same single line.
+fn takeSetOptionError(io: *SimIo) ?Io.SetOptionError {
+    if (io.pending_set_option_errors == 0) return null;
+    io.pending_set_option_errors -= 1;
+    return error.Unexpected;
 }
 
 pub fn shutdown(io: *SimIo, socket: Socket, how: Io.ShutdownHow) void {
@@ -625,6 +645,15 @@ pub fn injectAcceptError(io: *SimIo, listener: Listener) void {
     assert(entry.active);
     assert(entry.pending_accept_errors < std.math.maxInt(u8));
     entry.pending_accept_errors += 1;
+}
+
+/// Targeted scenario control: the next `setNodelay`/`setLingerRst` fails
+/// with error.Unexpected — the kernel-pressure path on a socket option,
+/// which production can hit (ENOBUFS-class, process-wide) and a virtual
+/// socket table never would (§9).
+pub fn injectSetOptionError(io: *SimIo) void {
+    assert(io.pending_set_option_errors < std.math.maxInt(u8));
+    io.pending_set_option_errors += 1;
 }
 
 pub fn scheduleSignal(io: *SimIo, signal: Io.Signal, at_ns: u64) void {

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -37,6 +37,12 @@ signal_callback: ?*const fn (?*anyopaque, Io.Signal) void,
 signal_userdata: ?*anyopaque,
 listeners: []ListenerEntry,
 listeners_count: u16,
+/// The classified cause of the most recent op failure (§8). Written by the
+/// callback adapters from the forked `Completion.result_errno` just before
+/// they hand `error.Unexpected` to the caller, and read by the witness in
+/// the same callback — the loop is single-threaded and callbacks do not
+/// nest, so "most recent" is "the one being delivered".
+last_pressure: Io.Pressure,
 
 pub const Socket = enum(i32) { _ };
 
@@ -76,6 +82,7 @@ pub fn init(io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
     errdefer io.timer.deinit();
     io.listeners = try arena.alloc(ListenerEntry, constants.listeners_max);
     io.listeners_count = 0;
+    io.last_pressure = Io.Pressure.none;
     io.notifier_completion = .{};
     io.signal_mask = std.atomic.Value(u8).init(0);
     io.signal_callback = null;
@@ -271,6 +278,7 @@ pub fn accept(
         ) xev.CallbackAction {
             const io_inner: *XevIo = @fieldParentPtr("loop", loop);
             io_inner.clearArmedAccept(accept_completion);
+            io_inner.recordPressure(accept_completion);
             callback(context.?, if (result) |conn|
                 @as(Socket, @enumFromInt(conn.fd))
             else |err| switch (err) {
@@ -318,8 +326,8 @@ pub fn connect(
             socket: xev.TCP,
             result: xev.ConnectError!void,
         ) xev.CallbackAction {
-            _ = loop;
-            _ = connect_completion;
+            const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+            io_inner.recordPressure(connect_completion);
             if (result) |_| {
                 callback(context.?, @as(Socket, @enumFromInt(socket.fd)));
             } else |err| {
@@ -393,8 +401,8 @@ pub fn recv(
             read_buffer: xev.ReadBuffer,
             result: xev.ReadError!usize,
         ) xev.CallbackAction {
-            _ = loop;
-            _ = read_completion;
+            const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+            io_inner.recordPressure(read_completion);
             _ = tcp_inner;
             _ = read_buffer;
             // anyerror: kqueue's ReadError has no ConnectionResetByPeer.
@@ -431,8 +439,8 @@ pub fn send(
             write_buffer: xev.WriteBuffer,
             result: xev.WriteError!usize,
         ) xev.CallbackAction {
-            _ = loop;
-            _ = write_completion;
+            const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+            io_inner.recordPressure(write_completion);
             _ = tcp_inner;
             _ = write_buffer;
             // anyerror: kqueue's WriteError has no ConnectionResetByPeer.
@@ -554,26 +562,89 @@ pub fn notifySignalFromHandler(io: *XevIo, signal: Io.Signal) void {
     io.notifier.notify() catch {};
 }
 
+/// The classified cause of the op currently being delivered (§8). Valid
+/// only inside a completion callback: the adapters set it immediately
+/// before invoking the caller, so anything reading it later sees a stale
+/// answer. `Server.witnessKernelPressure` reads it in the callback, which
+/// is the only place it means anything.
+pub fn lastPressure(io: *const XevIo) Io.Pressure {
+    return io.last_pressure;
+}
+
+/// Classify the completion's recorded errno into a cause the operator can
+/// act on. The errno itself rides along, so a `.other` is still a lead
+/// rather than a dead end.
+///
+/// `result_errno` comes from the audited fork (zoxy-io/libxev#2): libxev's
+/// own mapping funnels every unnamed errno through `posix.unexpectedErrno`
+/// and keeps nothing, so without that field this classification would have
+/// no input at all.
+fn recordPressure(io: *XevIo, completion: *const Completion) void {
+    // io_uring only: `result_errno` is the audited fork's field, and the
+    // fork touched only that backend. kqueue keeps macOS usable as a dev
+    // box (§4) and must build, so it reports unclassified rather than
+    // guessing — the same honest fallback `setNodelay` uses when it has no
+    // completion to read. If macOS ever needs the classification, the
+    // kqueue backend needs the field first.
+    if (comptime xev.backend != .io_uring) {
+        io.last_pressure = Io.Pressure.none;
+        return;
+    }
+    const errno = completion.result_errno;
+    io.last_pressure = .{
+        .cause = switch (errno) {
+            .NOBUFS => .out_of_buffers,
+            .NOMEM => .out_of_memory,
+            .MFILE, .NFILE => .fd_limit,
+            .ADDRNOTAVAIL => .address_unavailable,
+            else => .other,
+        },
+        .errno = @intFromEnum(errno),
+    };
+}
+
 pub fn setNodelay(io: *XevIo, socket: Socket) Io.SetOptionError!void {
-    _ = io;
     const enable: i32 = 1;
     posix.setsockopt(
         @intFromEnum(socket),
         posix.IPPROTO.TCP,
         posix.TCP.NODELAY,
         std.mem.asBytes(&enable),
-    ) catch return error.Unexpected;
+    ) catch {
+        // Synchronous, so there is no completion to read: `setsockopt`
+        // already mapped the errno to a Zig error and kept nothing either.
+        // Reported as unclassified rather than guessed at.
+        io.last_pressure = Io.Pressure.none;
+        return error.Unexpected;
+    };
+}
+
+comptime {
+    // `recordPressure` reaches for a field only the io_uring backend has.
+    // Pinning that here means a kqueue build fails at this assertion with
+    // a reason, rather than at the field access with a bare "no field
+    // named result_errno" three call layers away.
+    if (xev.backend == .io_uring) {
+        assert(@hasField(Completion, "result_errno"));
+    }
 }
 
 pub fn setLingerRst(io: *XevIo, socket: Socket) Io.SetOptionError!void {
-    _ = io;
     const value: posix.linger = .{ .onoff = 1, .linger = 0 };
     posix.setsockopt(
         @intFromEnum(socket),
         posix.SOL.SOCKET,
         posix.SO.LINGER,
         std.mem.asBytes(&value),
-    ) catch return error.Unexpected;
+    ) catch {
+        // Same reasoning as `setNodelay`: synchronous, no completion, so
+        // unclassified rather than guessed. Symmetric on purpose — today
+        // the only caller swallows this error (§8 shedding never blocks),
+        // but a future one that witnesses it must not read the *previous*
+        // failure's cause.
+        io.last_pressure = Io.Pressure.none;
+        return error.Unexpected;
+    };
 }
 
 pub fn shutdown(io: *XevIo, socket: Socket, how: Io.ShutdownHow) void {

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -90,6 +90,42 @@ pub const SetOptionError = error{
     Unexpected,
 };
 
+/// Why the most recent op failed with `error.Unexpected`, as much as the
+/// backend can tell (§8). `Unexpected` is the right shape for *control
+/// flow* — no caller should switch on twenty errnos — but it is the wrong
+/// shape for an operator, who needs to know whether to shed load or widen
+/// a limit. This carries that answer alongside the error rather than
+/// widening every error set with cases nobody branches on.
+///
+/// A backend-neutral cause rather than a raw errno because the numbers are
+/// platform-specific and the *response* is not: "out of buffers" means the
+/// same thing wherever it comes from. The raw errno rides along anyway, so
+/// a cause of `.other` is still diagnosable.
+pub const Pressure = struct {
+    cause: Cause,
+    /// The platform errno, or 0 when the backend could not supply one.
+    /// Reported as a gauge so an `.other` is never a dead end.
+    errno: u16,
+
+    pub const Cause = enum {
+        /// ENOBUFS — socket buffer memory. Shed load.
+        out_of_buffers,
+        /// ENOMEM — kernel allocation. Shed load.
+        out_of_memory,
+        /// EMFILE/ENFILE — the fd table, per-process or system-wide.
+        /// Raise the limit; shedding does not help if the fds are leaked.
+        fd_limit,
+        /// EADDRNOTAVAIL — the ephemeral port range is exhausted. Widen
+        /// the range or reuse connections; unrelated to memory.
+        address_unavailable,
+        /// Outside the set worth acting on differently. Not a failure to
+        /// classify — read `errno` to see which one.
+        other,
+    };
+
+    pub const none: Pressure = .{ .cause = .other, .errno = 0 };
+};
+
 pub const RunError = error{
     /// SimIo only: pending work exists but nothing can ever become ready —
     /// a liveness bug in the scenario or the data path (§9 invariant).
@@ -122,6 +158,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "setLingerRst",
             "shutdown",
             "closeNow",
+            "lastPressure",
             "nowNs",
             "run",
             "stop",

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -179,7 +179,7 @@ fn Base(comptime direction: Direction) type {
         }
 
         pub fn onSendError(server: *ServerSim, conn: *ConnSim, err: Io.SendError) void {
-            server.witnessKernelPressure(err);
+            server.witnessKernelPressure(.send, err);
             server.beginTeardown(conn);
         }
 

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -113,12 +113,12 @@ pub fn Relay(comptime IoType: type) type {
                         maybeFinish(server, conn);
                         return;
                     }
-                    server.witnessKernelPressure(err);
+                    server.witnessKernelPressure(.recv, err);
                     server.beginTeardown(conn);
                 }
 
                 pub fn onSendError(server: *ServerType, conn: *ConnType, err: Io.SendError) void {
-                    server.witnessKernelPressure(err);
+                    server.witnessKernelPressure(.send, err);
                     server.beginTeardown(conn);
                 }
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -399,6 +399,43 @@ test "relay: a kernel-pressure data-op failure is witnessed and tears down" {
     try bed.expectDrained();
 }
 
+test "server: the pressure cause travels from the seam to its own counter" {
+    // The other half of the diagnosis. The op says which syscall failed;
+    // the cause says what to do about it — shed load for out-of-buffers,
+    // raise a limit for fd_limit, widen the port range for
+    // address_unavailable. Production recovers it from the errno the
+    // audited libxev fork keeps on the completion; the sim states it.
+    //
+    // Driven per cause so no arm of the classification is plumbing nobody
+    // exercised: all five landed on one counter before this.
+    const cases = [_]struct { cause: Io.Pressure.Cause, counter: []const u8 }{
+        .{ .cause = .out_of_buffers, .counter = "kernel_pressure_out_of_buffers" },
+        .{ .cause = .out_of_memory, .counter = "kernel_pressure_out_of_memory" },
+        .{ .cause = .fd_limit, .counter = "kernel_pressure_fd_limit" },
+        .{ .cause = .address_unavailable, .counter = "kernel_pressure_address_unavailable" },
+        .{ .cause = .other, .counter = "kernel_pressure_other_cause" },
+    };
+    // `inline`: `counters.get` names its field at comptime, so the case
+    // table has to be unrolled rather than iterated.
+    inline for (cases, 0..) |case, index| {
+        var bed: TestBed = undefined;
+        try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 60 + index } });
+        defer bed.tearDown();
+
+        bed.sim_io.setPressureCause(case.cause);
+        bed.sim_io.injectSetOptionError();
+        bed.startClients(1, true);
+        try bed.sim_io.run();
+
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_errors"));
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get(case.counter));
+        // The op partition is unaffected by which cause it was: both
+        // describe the same single failure.
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_set_option"));
+        try bed.expectDrained();
+    }
+}
+
 test "server: kernel-pressure on a socket option is witnessed and the connection serves on" {
     // The set-option path had no simulation coverage at all before this:
     // a virtual socket table never refuses an option, so every bug on it
@@ -436,9 +473,17 @@ test "server: kernel-pressure accept failure backs off and recovers" {
     // The next accept completes with an ENFILE-class error. The gate must
     // not spin: it backs off through the retry timer, re-arms, and then
     // serves the client that was waiting in the backlog all along.
+    // ENFILE-class is what an accept actually runs out of, so the cause is
+    // stated and asserted here rather than left to whatever the previous
+    // completion happened to leave behind — the accept fault site shipped
+    // without recording one, and nothing downstream could have noticed.
+    bed.sim_io.setPressureCause(.fd_limit);
     bed.sim_io.injectAcceptError(bed.server.listeners[0].listener);
     bed.startClients(1, true);
     try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_fd_limit"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_out_of_buffers"));
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_errors"));
     // Attributed to the accept, and to nothing on the data path — the

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -385,6 +385,46 @@ test "relay: a kernel-pressure data-op failure is witnessed and tears down" {
     try std.testing.expect(bed.server.counters.get("kernel_pressure_errors") >= 1);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("shed_relay_buffers"));
+    // The split must attribute this to the data path and nowhere else.
+    // Paired with the accept test below, this is the discrimination the
+    // single counter could not make: both scenarios used to land on one
+    // number, so a run reporting 227,628 of them said nothing about
+    // whether the NIC queue or the fd table was the problem.
+    const data_ops = bed.server.counters.get("kernel_pressure_recv") +
+        bed.server.counters.get("kernel_pressure_send");
+    try std.testing.expect(data_ops >= 1);
+    try std.testing.expectEqual(data_ops, bed.server.counters.get("kernel_pressure_errors"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_accept"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_connect"));
+    try bed.expectDrained();
+}
+
+test "server: kernel-pressure on a socket option is witnessed and the connection serves on" {
+    // The set-option path had no simulation coverage at all before this:
+    // a virtual socket table never refuses an option, so every bug on it
+    // was invisible under every seed — which is how a `setNodelay` site
+    // shipped still bumping the aggregate counter without naming its op.
+    //
+    // Setting TCP_NODELAY is best-effort (§6): failing it costs latency,
+    // not correctness, so the connection must still serve.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 52 } });
+    defer bed.tearDown();
+
+    bed.sim_io.injectSetOptionError();
+    bed.startClients(1, true);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_errors"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_set_option"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_accept"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_recv"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_send"));
+    // Best-effort means the exchange completed regardless.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    const client = &bed.scenario.clients[0];
+    try std.testing.expectEqual(Client.Outcome.eof, client.outcome);
+    try std.testing.expectEqualStrings(echo_token, client.receive_buffer[0..client.received_len]);
     try bed.expectDrained();
 }
 
@@ -401,6 +441,11 @@ test "server: kernel-pressure accept failure backs off and recovers" {
     try bed.sim_io.run();
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_errors"));
+    // Attributed to the accept, and to nothing on the data path — the
+    // other half of the discrimination (see the relay test above).
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_accept"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_recv"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("kernel_pressure_send"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("accepted"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     const client = &bed.scenario.clients[0];


### PR DESCRIPTION
Three c10k runs in a row ended at *"something failed 110,000–228,000 times"*. This makes that a diagnosis.

**Depends on [zoxy-io/libxev#2](https://github.com/zoxy-io/libxev/pull/2)** — the pin bumps to that branch's commit. Merge order: libxev#2 → this.

## The problem

`zoxy_kernel_pressure_errors = 227,628` against 736,843 churned connections, and the counter could not say what failed. Two independent losses of information:

| loss | why | fixed by |
|---|---|---|
| **the op** | ~19 sites all incremented one counter | commit 1, in-repo |
| **the errno** | libxev's `else => posix.unexpectedErrno(errno)` keeps nothing | commit 2, needs the fork |

"The NIC queue is full on send" and "we are out of fds on accept" are opposite problems with opposite fixes, and both read as one number.

## Commit 1 — by op

`kernel_pressure_{accept,connect,recv,send,set_option}` partition the existing total. `witnessKernelPressure` takes a **mandatory comptime op**, so no path can reach the total without naming where it failed.

Same bug found a second time on the way: both upstream-dial sites did `catch {` and counted every failure as `upstream_connect_failed` — "the origin refused" and "we are out of ephemeral ports" were one number. Refused/timed-out/unreachable arrive typed; anything else is our own exhaustion, and now says so.

## Commit 2 — by cause

`Completion.result_errno` from the fork, classified at the seam into a backend-neutral cause:

```
out_of_buffers    ENOBUFS          shed load
out_of_memory     ENOMEM           shed load
fd_limit          EMFILE/ENFILE    raise the limit
address_unavail   EADDRNOTAVAIL    widen the port range, reuse connections
other_cause       everything else  read the errno gauge
```

Two partitions of one total, answering different questions: **the op says which syscall to look at, the cause says what to do about it.** `kernel_pressure_last_errno` is a gauge — the errno space is far too wide for a counter each, and it keeps `other_cause` a lead rather than a dead end.

## Invariants

`reconcile` asserts *both* partitions equal the total, and so does `witnessKernelPressure` — the second is the one that matters, since it fires at the site that maintains them rather than wherever `reconcile` happens to run. That assert earned itself: it caught a third `setNodelay` site still bumping the aggregate alone.

The cause travels by seam side channel (`io.lastPressure()`, valid only inside the failing callback). Safe — one loop thread, callbacks don't nest, every fault site records immediately before returning — but it's a discipline rather than a type, so both backends document it where a reader will look.

## What review caught that the gate did not

Three findings, each a path no seed could reach:

1. **`result_errno` is io_uring-only** — the fork never touched kqueue, so reading it unconditionally **broke the macOS build**. §4 keeps kqueue as a usable dev box. Now reports unclassified there, with a comptime assert pinning the field's presence on the backend that has it. `zig build ci` is Linux-only locally; the `macos-latest` workflow job is what would have caught this at PR time — worth knowing that local green is not enough for seam changes.
2. **SimIo's accept fault never recorded a cause**, so `lastPressure()` returned whatever the previous unrelated completion left behind — the exact staleness the contract warns about, on the one op with no test asserting a cause. Fixed; removing the record now fails that test.
3. The witness asserted only the op partition after gaining a second one.

Earlier in the same slice, review also caught a missed `setNodelay` site whose entire path — set-option failure — was **unreachable in simulation**, which is why 64 seeds stayed green. `SimIo` grew `injectSetOptionError`, and both sites now have tests.

## Verified by mutation, not inspection

| mutation | caught by |
|---|---|
| an unnamed increment on the relay path | the partition assert in the witness |
| the L7 `setNodelay` site reverted to its shipped-broken form | the new L7 set-option test |
| the sim accept fault stops recording its cause | the accept backoff test |

Plus a table-driven test driving **all five causes** end to end, so no arm of the classification is plumbing nobody exercised.

## Gates

`zig build ci` (64 sim seeds), `zig fmt --check`, and an `aarch64-macos` cross-build all pass. All twelve metrics render on a real ReleaseFast binary.

`tiger-style-reviewer` on both commits — first passed, second returned three violations, all taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)