### PR TITLE
constants: give the upstream pool a range, not just a wall (§1, §5)

### DIFF
--- a/bench/micro/conn_touch_scaling.zig
+++ b/bench/micro/conn_touch_scaling.zig
@@ -48,9 +48,10 @@ fn monotonicNs() u64 {
 const ops_per_point: u64 = 4_000_000;
 
 /// Live connection counts to sweep — the bench's 500-connection operating
-/// point, the c10k one, and the compiled ceiling, with steps between so the
+/// point, the c10k one, and the compiled ceiling (read from `constants`, so
+/// a ceiling change moves the sweep with it), with steps between so the
 /// knee is visible rather than inferred from the endpoints.
-const points = [_]u32{ 64, 256, 500, 1000, 2000, 5000, 10000, 14074 };
+const points = [_]u32{ 64, 256, 500, 1000, 2000, 5000, 10000, zoxy.constants.conn_slots_max };
 
 /// The point every ratio is quoted against: the connection count the
 /// Tier-1 bench actually runs at, so the column reads as "what c10k costs

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -381,10 +381,19 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 14074 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 14074 | 2 × 4 KiB |
-| upstream slots | 1024 | 1024 | ~40 B state + 8 KiB head |
-| **pool memory** | **~32 MiB** | **~251 MiB** | |
+| conn slots | 1386 | 12282 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 12282 | 2 × 4 KiB |
+| upstream slots | 1024 | 8192 | ~40 B state + 8 KiB head |
+| **pool memory** | **~32 MiB** | **~272 MiB** | |
+
+The two ceilings sit on one completion-queue line — a conn slot costs
+`conn_ops_max` ring ops, an upstream slot one — so raising either lowers
+the other. Both clear 10k at this pair, which is what §1 asks for: c10k
+*reachable*, not a shape tuned for it. Upstream slots were 1024 at both
+default and ceiling until 2026-07-27, which made that pool the one thing
+an operator could only shrink; the measurements that moved it are in
+IMPLEMENTATION_NOTES.md. Whether the pair should be ours to choose at all
+is an open question in PLANS.md.
 
 Rules:
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -309,8 +309,9 @@ socket, and an L7 connection holds two, client and upstream. Against the
 1386-conn-slot default, whose printout reads **31.5 MiB of pools**, that
 is **~390 MiB of kernel socket memory** — twelve times the advertised
 figure, before receive autotuning, which may take `rmem` to 32 MiB per
-socket. At the 14074-connection ceiling the same arithmetic reaches
-~3.9 GiB against ~251 MiB of pools.
+socket. At the conn-slot ceiling — 14074 when this was measured, 12282
+since the upstream pool took its share of the CQ line — the same
+arithmetic reaches ~3.9 GiB against ~251 MiB of pools.
 
 These are caps rather than committed pages — the kernel allocates as data
 arrives, and `tcp_mem` bounds it globally (~3.09 GiB here). That is the
@@ -405,6 +406,10 @@ Median of four pinned runs, ns per arm/deliver pair:
 | 10000 | 91.1 MiB | 3.97 | 1.41× |
 | 14074 | 128.2 MiB | 7.18 | 2.55× |
 
+(The last row was the conn-slot ceiling when the sweep ran; it is 12282
+since the upstream pool took its share of the CQ line. The bench reads
+the constant, so a rerun sweeps to whatever it is now.)
+
 The mechanism is confirmed — the knee is real and lands between 2000 and
 5000 connections, where the touched set stops fitting L3. The magnitude
 is what kills it. The 500 → 10,000 delta is **1.2 ns per pair**; a
@@ -484,12 +489,49 @@ CQ at 2 × SQ = 8192 and it capped `relay_buffers_max` at
 11259` at ⅞. Serializing teardown closes behind the full armed-set
 drain then cut `conn_ops_max` to 4 (the five-op teardown-vs-dial race
 became structurally unreachable, proven by a pinned-seed sim test), so
-`conn_slots_max` / `relay_buffers_max` now ceiling at
-`(57344 − 23 − upstream_slots_max) / 4 = 14074`. fds bind next, not
-memory (`fds_max = 29188` at the ceiling, so a c10k deployment raises
-`RLIMIT_NOFILE` at startup, §8). `constants.zig` owns the arithmetic and
-comptime-asserts it. The remaining ceiling lever — `splice` — is fork
-work, in PLANS.md "c10k".
+`conn_slots_max` / `relay_buffers_max` ceiling at
+`(57344 − 23 − upstream_slots_max) / 4`, which was 14074 while
+`upstream_slots_max` was 1024 and is **12282** since it rose to 8192
+(2026-07-27, below). fds bind next, not memory (`fds_max = 32772` at the
+ceiling, so a c10k deployment raises `RLIMIT_NOFILE` at startup, §8).
+`constants.zig` owns the arithmetic and comptime-asserts it — the two
+ceilings are one line, so the assert is what keeps a change to either
+from silently overcommitting the ring. The remaining ceiling lever —
+`splice` — is fork work, in PLANS.md "c10k".
+
+## The upstream pool was a wall, not a range (2026-07-27)
+
+`upstream_slots_default` and `upstream_slots_max` were both 1024, so that
+pool was the one thing an operator could only shrink — while conn slots
+had the two-layer shape the design intends (1386 default, 14074 ceiling
+then — 12282 now,
+climb through `limits`). At 10k connections the missing range bites: the
+pool pins, and every request that cannot get a slot is answered 503.
+
+Measured on one 1-CPU box, 10k connections, same build and workload:
+
+| | upstream 1024 | upstream 8192 |
+|---|---|---|
+| pool | pinned at 1024 leased | 5771/8192, never pinned |
+| `l7_shed_upstream_slots` | 5,852,702 (35% of responses) | 10,576 (0.35%) |
+| real req/s at high offered | decayed to 5,315 | flat ~20,000 |
+
+Raised to 8192, which drops `conn_slots_max` to 12282 — the two are one
+CQ line (`conn × 4 + upstream + 23 ≤ 57344`), so the ceiling pair is a
+policy choice, not two independent numbers. Both clear 10k at this point,
+which is the §1 requirement; the out-of-box footprint is byte-identical
+(32,259 KiB, 3,805 fds) because only the *ceiling* moved and
+`upstream_slots_default` stayed at 1024 rather than tracking it.
+
+Provisional. PLANS.md carries the standing question of whether the
+operator should pick the pair instead of inheriting ours — the machinery
+(`cqFillFits`, `ensureFdBudget`, effective-size pools) already exists;
+what it would cost is a §5 amendment, spelled out there.
+
+Note for anyone reading older benchmark numbers: every c10k run before
+this date that behaved well used a **build-time `sed`** of these
+constants in the bench image. Runs at the shipped 1024 are the collapse
+case, not a baseline.
 
 ## libxev error surfacing is lossy — resolved by the fork (2026-07-27)
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -371,7 +371,9 @@ current ceiling — the CQSIZE lever (#61, `IORING_SETUP_CQSIZE` off the
 fixed 2 × SQ, in-flight fill tunable via `limits.cq_fill_eighths`, ⅞
 default) and the `conn_ops_max` 5 → 4 cut (teardown closes serialized
 behind the full armed-set drain, #64) — putting `conn_slots_max` /
-`relay_buffers_max` at 14074 at ⅞ fill, with `fds_max` 29188 (a c10k
+`relay_buffers_max` at `(57344 − 23 − upstream_slots_max) / 4` at ⅞ fill;
+that read 14074 while `upstream_slots_max` was 1024 and is **12282**
+since it rose to 8192 (below), with `fds_max` **32772** (a c10k
 deployment raises the documented `RLIMIT_NOFILE` at startup, §8). The
 arithmetic and its history live in IMPLEMENTATION_NOTES.md.
 
@@ -380,34 +382,64 @@ saturation, still libxev-fork work (a re-audit); TLS and chunked L7
 bodies fall back to copy regardless.
 
 Entry gate for further ceiling work: demonstrate a workload that actually
-saturates the 14074 ceiling first — the splice lever costs a re-audit,
-not worth spending blind.
+saturates the *current* conn-slot ceiling first — the splice lever costs
+a re-audit, not worth spending blind. Note what the c10k runs of
+2026-07-27 did and did not show: they saturated the **upstream** pool
+comprehensively (which is why its ceiling moved), and never came close to
+the conn-slot one, sitting at ~10k held connections against 12282.
 
 ## Pool ceilings: policy we chose, or a range the operator picks?
 
-**Open decision (2026-07-27), evidence gathered, not yet taken.**
+**Interim taken 2026-07-27; the question below stays open.**
+
+The ceiling pair moved to `upstream_slots_max = 8192` /
+`conn_slots_max = 12282`, with `upstream_slots_default` held at 1024 so
+the out-of-box footprint is unchanged (byte-identical: 32,259 KiB, 3,805
+fds). That fixes the immediate defect — the upstream pool had *no range*,
+default and ceiling being the same number — and both ceilings clear 10k,
+so §1's "able to operate at c10k" holds on either axis. Measurements in
+IMPLEMENTATION_NOTES.md.
+
+It does **not** answer the question below. A pair chosen at compile time
+is still a policy decision made on the operator's behalf; this one is
+merely a better-evidenced choice than the last. What follows is why that
+may be worth changing, and what it would cost.
+
+One correction to the cost stated here originally: raising the ceilings
+does **not** balloon `SimIo`'s `ready_buffer`. That array is sized by
+`in_flight_ops_max`, which is already 57,343 against a 57,344 budget — it
+is the budget, near enough. Define it *as* the budget rather than as the
+ceilings' product and it does not move, and
+`assert(in_flight_ops_max <= completion_queue_entries)` survives as a
+stronger claim: the budget we enforce fits the ring, rather than one
+chosen point does.
 
 §1 says zoxy must be *able* to operate at c10k — not that it is tuned for
 it. The two-layer shape that serves that goal already exists for conn
 slots: a lean default the out-of-box deployment runs at, and a higher
 ceiling the operator climbs to through `limits`.
 
+As it stood before the interim fix:
+
     conn_slots_default      1386     ~32 MiB out of the box
     conn_slots_max         14074     operator opts up
     upstream_slots_default  1024
     upstream_slots_max      1024     <- same number: no range at all
 
-Upstream slots have no such range. An operator can only go *down*, and at
-c10k the upstream pool is precisely the one that needs to go up. Every
-c10k run that behaved did so on a build-time `sed` of the constant.
+Upstream slots had no such range. An operator could only go *down*, and
+at c10k the upstream pool is precisely the one that needs to go up. Every
+c10k run that behaved did so on a build-time `sed` of the constant. The
+interim fix gave that pool a range (default 1024, ceiling 8192, and
+`conn_slots_max` down to 12282 to pay for it on the shared CQ line).
 
 The measurements, on one 1-CPU box at 10k connections (2026-07-27):
 
-| | 1024 (shipped) | 8192 (sed) |
-|---|---|---|
-| pool state | pinned at 1024 leased | 5771/8192, never pinned |
-| `l7_shed_upstream_slots` | 5,852,702 (35% of responses) | 10,576 (0.35%) |
-| real req/s at high offered | decayed to 5,315 | flat ~20,000 |
+Summarised: at 1024 the pool pinned, a third of all responses became 503,
+and real throughput decayed to a quarter of its peak; at 8192 the pool
+never pinned, sheds fell by three orders of magnitude, and throughput
+held flat. The figures live in IMPLEMENTATION_NOTES.md ("The upstream
+pool was a wall, not a range") — restating them here is what let this
+section drift out of date once already.
 
 ### Why a better default does not fix it, and neither does a build option
 
@@ -460,13 +492,13 @@ kernel maximum, the u16 index widths, the watermark relationships, and
 
 ### Known cost beyond the amendment
 
-`SimIo` sizes a **stack** array from the ceiling —
-`var ready_buffer: [pending_ops_max]*Completion` where `pending_ops_max
-= constants.in_flight_ops_max`, ~458 KB today. Raising the ceilings
-inflates it past anything sane; it moves to the arena or gets a bound of
-its own. Production pools are unaffected: they already allocate from the
-*effective* config (`conns.init(arena, options.conn_slots)`), so the
-ceiling drives no allocation there.
+Nothing further, once `in_flight_ops_max` is defined as the budget (see
+the correction above). `SimIo` sizes a **stack** array from it —
+`var ready_buffer: [pending_ops_max]*Completion`, ~448 KB — and that is
+already the budget's size, so it neither grows nor needs moving to the
+arena. Production pools were never affected either: they allocate from
+the *effective* config (`conns.init(arena, options.conn_slots)`), so a
+ceiling drives no allocation at all.
 
 ### Entry gate
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1492,7 +1492,11 @@ test "config: limits shrink pools below the ceilings, never past them" {
         );
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.relay_buffers);
-        try std.testing.expectEqual(constants.upstream_slots_max, parsed.limits.upstream_slots);
+        // The *default*, which is deliberately below the ceiling: an
+        // omitted `upstream_slots` must not silently reserve the c10k
+        // maximum. These were the same number until the ceiling rose.
+        try std.testing.expectEqual(constants.upstream_slots_default, parsed.limits.upstream_slots);
+        try std.testing.expect(constants.upstream_slots_default < constants.upstream_slots_max);
         // The CQ fill defaults to ⅞ when the block omits it.
         try std.testing.expectEqual(constants.cq_fill_eighths_default, parsed.limits.cq_fill_eighths);
     }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -58,13 +58,20 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
 /// parked-upstream and admin reservations carved out first, this caps at
-/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 14074` —
+/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 12282` —
 /// comptime-derived below (the 23 is the fixed ops: two per config and
 /// admin listener [18], the admin client's op budget [3], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
-pub const conn_slots_max: u32 = 14074;
+///
+/// This and `upstream_slots_max` sit on one line — a conn slot costs
+/// `conn_ops_max` ring ops, an upstream slot one — so raising either
+/// lowers the other. **Both clear 10k at this point**, which is what §1
+/// asks for: c10k reachable on either axis, not a shape tuned for it.
+/// The pair is provisional; PLANS.md holds the standing question of
+/// whether an operator should pick it rather than inherit ours.
+pub const conn_slots_max: u32 = 12282;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -141,10 +148,20 @@ pub const chunked_trailer_bytes_max: u32 = 1024;
 /// on keep-alive (§3, §5). Counted in the §8 budgets below: a parked
 /// upstream holds a socket (fd budget) and, once keep-alive lands, one
 /// armed idle-timer op (ring budget) — both reserved now so composing
-/// keep-alive does not re-cut the budgets. Sized as the largest power of
-/// two the fd and CQ budgets accommodate alongside the conn-slot
-/// ceiling.
-pub const upstream_slots_max: u32 = 1024;
+/// keep-alive does not re-cut the budgets.
+///
+/// This is the *ceiling*, not the out-of-box size — `upstream_slots_default`
+/// stays lean below it, the same two-layer shape conn slots have. It was
+/// 1024, where ceiling and default were the same number and an operator
+/// could only go *down*; at 10k connections that pool pinned and shed a
+/// third of all responses. 8192 is measured, not guessed — the numbers
+/// live in IMPLEMENTATION_NOTES.md ("The upstream pool was a wall, not a
+/// range"), which is their one home.
+///
+/// Provisional. It trades against `conn_slots_max` on one CQ line, so
+/// this pair is still a policy choice made on the operator's behalf —
+/// PLANS.md carries the open question of handing it to them instead.
+pub const upstream_slots_max: u32 = 8192;
 
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
@@ -357,7 +374,17 @@ pub const fds_max: u32 =
 /// the resulting footprint at startup.
 pub const conn_slots_default: u32 = 1386;
 pub const relay_buffers_default: u32 = conn_slots_default;
-pub const upstream_slots_default: u32 = upstream_slots_max;
+/// Deliberately *not* `upstream_slots_max`. It used to be, which left the
+/// two identical and the pool the one thing an operator could only shrink
+/// — the defect the raised ceiling exists to fix. The default answers a
+/// different question than the ceiling does: the ceiling is how far a
+/// c10k deployment may climb, this is what an unconfigured one costs, and
+/// 8192 slots would put 66 MiB of upstream pool in a footprint budgeted
+/// at ~32 MiB total. What it has to cover is in-flight *exchanges*
+/// (rate × latency) plus parked keep-alive connections — not one per
+/// conn slot — which is why it sits below `conn_slots_default` rather
+/// than tracking it.
+pub const upstream_slots_default: u32 = 1024;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -526,13 +553,15 @@ test "budgets: memory total matches the closed form" {
 }
 
 test "budgets: c10k ceiling fd count needs a raised NOFILE" {
-    // At the c10k ceiling the fd budget is ~29k — well past the common
+    // At the c10k ceiling the fd budget is ~33k — well past the common
     // 4096 unprivileged hard limit, so a deployment that configures up to
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 29188), fds_max);
+    try std.testing.expectEqual(@as(u32, 32772), fds_max);
     try std.testing.expect(fds_max <= 65536);
+    // The out-of-box side of this is pinned by "the default deployment is
+    // lean" below, not restated here.
 }
 
 test "budgets: the default deployment is lean" {


### PR DESCRIPTION
Option A from [PLANS.md's pool-ceiling question](https://github.com/zoxy-io/zoxy/pull/105), taken as an **interim** measure. The question itself stays open.

## The defect

`upstream_slots_default` and `upstream_slots_max` were **both 1024** — so that pool was the one thing an operator could only *shrink*, while conn slots had the two-layer shape the design intends:

```
conn_slots_default      1386     lean out of the box
conn_slots_max         14074     climb via limits
upstream_slots_default  1024
upstream_slots_max      1024     ← same number: no range at all
```

At 10k connections the missing range bites: the pool pins, and every request that can't get a slot is answered 503. Same build, same workload, one constant apart:

| | upstream 1024 | upstream 8192 |
|---|---|---|
| pool | **pinned** at 1024 leased | 5,771 / 8,192, never pinned |
| `l7_shed_upstream_slots` | 5,852,702 (35% of responses) | 10,576 (0.35%) |
| real req/s at high offered | decayed to 5,315 | flat ~20,000 |

Every c10k run that behaved today did so on a **build-time `sed`** of that constant in the bench image. The configuration that performs isn't the one that ships.

## The change

`upstream_slots_max` → 8192, which drops `conn_slots_max` → 12282. They sit on one CQ line (`conn × 4 + upstream + 23 ≤ 57,344`) and the existing comptime assert derives one from the other, so they can't move independently — which is also precisely what makes the pair a *policy choice* rather than two numbers.

**Both ceilings clear 10k**, which is what §1 asks for: c10k *reachable*, not a shape tuned for it.

`upstream_slots_default` stays 1024 rather than tracking the ceiling. **That's the actual fix** — the two stop being the same number. What the default has to cover is in-flight exchanges plus parked keep-alive connections, not one slot per connection, so it belongs below `conn_slots_default`; and 8192 would put 66 MiB of upstream pool in a footprint budgeted at ~32 MiB.

## Verified on a real binary, both ends

```
out of the box   32,259 KiB pools, 3,805 fds     ← byte-identical to before
at the ceiling  278,775 KiB pools, 32,765 fds, 57,329 of a 57,344 op budget
one slot past   refused: LimitConnSlotsOutOfRange
```

The out-of-box footprint is unchanged. Everything the ceiling costs is opt-in.

## Explicitly interim

A pair chosen at compile time is still a policy decision made on the operator's behalf. This one is merely better-evidenced than the last. PLANS.md carries the open question of handing the choice over, and this PR marks it as taken-but-provisional rather than closing it.

It also **corrects one cost I'd overstated there**: raising the ceilings does *not* balloon `SimIo`'s `ready_buffer`. That array is sized by `in_flight_ops_max`, which is already 57,343 against a 57,344 budget — define it *as* the budget and it doesn't move, and `assert(in_flight_ops_max <= completion_queue_entries)` survives as a stronger claim.

## Docs swept, not patched around

The old numbers were load-bearing in more places than the table: DESIGN.md §5's pool table, the CQSIZE arithmetic in PLANS.md, and its **entry gate — which still gated further ceiling work on "saturating the 14074 ceiling", a ceiling that no longer exists**. Plus three IMPLEMENTATION_NOTES passages stating 14074 as current fact. All annotated with before/after rather than silently rewritten, since they record measurements taken at the old value.

`bench/micro/conn_touch_scaling.zig` now reads `constants.conn_slots_max` instead of hardcoding 14074, so its sweep follows the constant.

The measured figures now live in **one** place. Restating them in four is what let PLANS.md contradict itself *within a single section* — review caught exactly that.

## Gates

`zig build ci` (64 sim seeds), `zig fmt --check`, and an `aarch64-macos` build pass.

`tiger-style-reviewer`: two violations, both self-contradicting docs I'd introduced by adding a correction without sweeping the text it corrected. Both fixed, judgement calls taken.

## Follow-up for the bench repo

`UPSTREAM_SLOTS_MAX`/`CONN_SLOTS_MAX` overrides in `proxies/zoxy/Dockerfile` are now unnecessary for the 8192/12282 shape — it's the default. Worth removing so future runs measure the shipped binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)