### PR TITLE
constants: pin the upstream ceiling to the conn ceiling (§1, §5)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -381,19 +381,36 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 12282 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 12282 | 2 × 4 KiB |
-| upstream slots | 1024 | 8192 | ~40 B state + 8 KiB head |
-| **pool memory** | **~32 MiB** | **~272 MiB** | |
+| conn slots | 1386 | 11464 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 11464 | 2 × 4 KiB |
+| upstream slots | 1024 | 11464 | ~40 B state + 8 KiB head |
+| **pool memory** | **~32 MiB** | **~284 MiB** | |
 
-The two ceilings sit on one completion-queue line — a conn slot costs
-`conn_ops_max` ring ops, an upstream slot one — so raising either lowers
-the other. Both clear 10k at this pair, which is what §1 asks for: c10k
-*reachable*, not a shape tuned for it. Upstream slots were 1024 at both
-default and ceiling until 2026-07-27, which made that pool the one thing
-an operator could only shrink; the measurements that moved it are in
-IMPLEMENTATION_NOTES.md. Whether the pair should be ours to choose at all
-is an open question in PLANS.md.
+The ceilings sit on one completion-queue line — a conn slot costs
+`conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
+is **pinned to the conn ceiling**, so that line has a single divisor:
+`conn_ops_max + 1` ring ops per admitted connection, 11464 of them. On
+the L7 path a connection that is mid-exchange holds an upstream slot as
+well as its conn slot, and at saturation every admitted connection can be
+mid-exchange at once — so an upstream ceiling below the conn ceiling is
+admission capacity that cannot be served, and one above it is a pool that
+can never be drawn down. Both clear 10k, which is what §1 asks for: c10k
+*reachable*, not a shape tuned for it.
+
+The two moved apart twice before they were pinned: upstream slots were
+1024 at both default and ceiling until 2026-07-27, which made that pool
+the one thing an operator could only shrink, and then 8192 against a conn
+ceiling of 12282, which left ~2200 conn slots idle while the pool they
+depend on pinned. Both measurements are in IMPLEMENTATION_NOTES.md.
+Whether the ceiling should be ours to choose at all is an open question
+in PLANS.md.
+
+The *defaults* are not pinned to each other, and deliberately: the
+out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than
+by admission (matching 1386 would cost 4167 fds), and an L4 deployment
+never touches the upstream pool at all — an L4 dial holds no upstream
+slot. A deployment that means to fill its conn pool raises both together
+through `limits`.
 
 Rules:
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -309,9 +309,10 @@ socket, and an L7 connection holds two, client and upstream. Against the
 1386-conn-slot default, whose printout reads **31.5 MiB of pools**, that
 is **~390 MiB of kernel socket memory** — twelve times the advertised
 figure, before receive autotuning, which may take `rmem` to 32 MiB per
-socket. At the conn-slot ceiling — 14074 when this was measured, 12282
-since the upstream pool took its share of the CQ line — the same
-arithmetic reaches ~3.9 GiB against ~251 MiB of pools.
+socket. At the conn-slot ceiling — 14074 when this was measured, and
+~3.9 GiB then — the same arithmetic reaches **~3.1 GiB** against ~284 MiB
+of pools at the 11464 the ceiling became once the upstream pool was
+pinned to it on the CQ line.
 
 These are caps rather than committed pages — the kernel allocates as data
 arrives, and `tcp_mem` bounds it globally (~3.09 GiB here). That is the
@@ -406,8 +407,8 @@ Median of four pinned runs, ns per arm/deliver pair:
 | 10000 | 91.1 MiB | 3.97 | 1.41× |
 | 14074 | 128.2 MiB | 7.18 | 2.55× |
 
-(The last row was the conn-slot ceiling when the sweep ran; it is 12282
-since the upstream pool took its share of the CQ line. The bench reads
+(The last row was the conn-slot ceiling when the sweep ran; it is 11464
+since the upstream pool was pinned to it on the CQ line. The bench reads
 the constant, so a rerun sweeps to whatever it is now.)
 
 The mechanism is confirmed — the knee is real and lands between 2000 and
@@ -490,22 +491,24 @@ CQ at 2 × SQ = 8192 and it capped `relay_buffers_max` at
 drain then cut `conn_ops_max` to 4 (the five-op teardown-vs-dial race
 became structurally unreachable, proven by a pinned-seed sim test), so
 `conn_slots_max` / `relay_buffers_max` ceiling at
-`(57344 − 23 − upstream_slots_max) / 4`, which was 14074 while
-`upstream_slots_max` was 1024 and is **12282** since it rose to 8192
-(2026-07-27, below). fds bind next, not memory (`fds_max = 32772` at the
-ceiling, so a c10k deployment raises `RLIMIT_NOFILE` at startup, §8).
-`constants.zig` owns the arithmetic and comptime-asserts it — the two
-ceilings are one line, so the assert is what keeps a change to either
-from silently overcommitting the ring. The remaining ceiling lever —
-`splice` — is fork work, in PLANS.md "c10k".
+`(57344 − 23 − upstream_slots_max) / 4` — 14074 while
+`upstream_slots_max` was 1024, 12282 once it rose to 8192 (2026-07-27,
+below). Pinning the upstream ceiling to the conn ceiling (2026-07-28,
+below) collapsed that to one divisor, `(57344 − 23) / (4 + 1) =
+**11464**`. fds bind next, not memory (`fds_max = 34408` at the ceiling,
+so a c10k deployment raises `RLIMIT_NOFILE` at startup, §8).
+`constants.zig` owns the arithmetic and comptime-asserts it — one line,
+one divisor, so the assert is what keeps a change from silently
+overcommitting the ring. The remaining ceiling lever — `splice` — is
+fork work, in PLANS.md "c10k".
 
 ## The upstream pool was a wall, not a range (2026-07-27)
 
 `upstream_slots_default` and `upstream_slots_max` were both 1024, so that
 pool was the one thing an operator could only shrink — while conn slots
 had the two-layer shape the design intends (1386 default, 14074 ceiling
-then — 12282 now,
-climb through `limits`). At 10k connections the missing range bites: the
+then — 11464 now, climb through `limits`). At 10k connections the
+missing range bites: the
 pool pins, and every request that cannot get a slot is answered 503.
 
 Measured on one 1-CPU box, 10k connections, same build and workload:
@@ -523,15 +526,70 @@ which is the §1 requirement; the out-of-box footprint is byte-identical
 (32,259 KiB, 3,805 fds) because only the *ceiling* moved and
 `upstream_slots_default` stayed at 1024 rather than tracking it.
 
-Provisional. PLANS.md carries the standing question of whether the
-operator should pick the pair instead of inheriting ours — the machinery
-(`cqFillFits`, `ensureFdBudget`, effective-size pools) already exists;
-what it would cost is a §5 amendment, spelled out there.
+"Both clear 10k" was true of the numbers and wrong about the shape: 8192
+still sat below the conn ceiling, and the next section is what that cost.
 
 Note for anyone reading older benchmark numbers: every c10k run before
 this date that behaved well used a **build-time `sed`** of these
 constants in the bench image. Runs at the shipped 1024 are the collapse
 case, not a baseline.
+
+## The upstream pool tracks connections, not requests (2026-07-28)
+
+The previous section sized the upstream pool against in-flight
+*exchanges* — rate × latency — and reasoned that it therefore sits below
+the conn-slot count. That model is wrong, and the gauges added with it
+are what showed it. Two runs of the same binary (4572b4a), same `/1k`
+workload, same 200→67000 ramp, one 1-CPU box:
+
+| | 500 connections | 10,000 connections |
+|---|---|---|
+| sustained (achieved ≥ 90% of offered) | **44,611 req/s** | **22,481 req/s** |
+| `conn_slots_in_use` peak | 500 | 10,095 of 12282 |
+| `upstream_slots_leased` peak | **492** | 8,017 |
+| leased + parked | ≤ ~500 | **pinned at 8192**, six scrapes |
+| `l7_shed_upstream_slots` | 0 | 22,568 (0.44%) |
+| `accepted` | 501 | 67,517 |
+| `kernel_pressure_errors` | 0 | 0 |
+
+Leased peak tracks the connection count, not the request rate: 492 of
+500. An upstream is leased for a whole exchange and parked between
+requests, so at saturation — every admitted connection mid-request —
+demand is one upstream slot per conn slot. A pool below the conn ceiling
+is admission capacity that cannot be served, which is exactly what the
+c10k column shows: ~2200 conn slots idle while the pool they depend on
+sat at its own ceiling. Hence the pinned pair, 11464/11464.
+
+What it is *not*: the cost of concurrency. Per-request CPU at matched
+offered rate is the same at both connection counts —
+
+| offered | 500 conns | 10,000 conns |
+|---|---|---|
+| 9,107 | 20.4 µs | 19.6 µs |
+| 12,447 | 23.6 µs | 24.2 µs |
+| 15,787 | 24.9 µs | 25.7 µs |
+
+— which is the end-to-end confirmation of the `delivered()`/SoA finding
+above (0.04%). 10k connections cost nothing per request.
+
+Nor was it the environment. At the c10k plateau the NIC carried 502
+Mbit/s where the 500-connection run had carried 914 Mbit/s through the
+same interface; zoxy held 78% of its 1-CPU quota with 0.17% of periods
+throttled; the origin idled 3.2 of 4 cores. Worth recording for anyone
+reading cloud numbers: the 2-core proxy VM showed **32% steal**, charged
+straight against that quota.
+
+Open, and deliberately not designed for yet: past ~16k req/s the c10k
+run's per-request CPU climbs 25.7 → 34.7 µs while the 500-connection
+run's *falls* to 18.6 µs at 44.6k. Named hypothesis — partial writes to
+backed-up client sockets costing several sends per response — but it is
+a hypothesis, and this file's rule is that it stays one until measured.
+
+PLANS.md carries the standing question of whether the operator should
+pick the ceiling instead of inheriting ours — the machinery (`cqFillFits`,
+`ensureFdBudget`, effective-size pools) already exists; what it would
+cost is a §5 amendment, spelled out there. Pinning narrows that question
+to one number rather than settling it.
 
 ## libxev error surfacing is lossy — resolved by the fork (2026-07-27)
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -372,10 +372,12 @@ fixed 2 × SQ, in-flight fill tunable via `limits.cq_fill_eighths`, ⅞
 default) and the `conn_ops_max` 5 → 4 cut (teardown closes serialized
 behind the full armed-set drain, #64) — putting `conn_slots_max` /
 `relay_buffers_max` at `(57344 − 23 − upstream_slots_max) / 4` at ⅞ fill;
-that read 14074 while `upstream_slots_max` was 1024 and is **12282**
-since it rose to 8192 (below), with `fds_max` **32772** (a c10k
-deployment raises the documented `RLIMIT_NOFILE` at startup, §8). The
-arithmetic and its history live in IMPLEMENTATION_NOTES.md.
+that read 14074 while `upstream_slots_max` was 1024 and 12282 once it
+rose to 8192 (below). Pinning the upstream ceiling to the conn ceiling
+(2026-07-28) made it one divisor — `(57344 − 23) / (4 + 1)` = **11464**,
+with `fds_max` **34408** (a c10k deployment raises the documented
+`RLIMIT_NOFILE` at startup, §8). The arithmetic and its history live in
+IMPLEMENTATION_NOTES.md.
 
 The one remaining lever is **`splice`** (above) — an independent win at
 saturation, still libxev-fork work (a re-audit); TLS and chunked L7
@@ -385,25 +387,33 @@ Entry gate for further ceiling work: demonstrate a workload that actually
 saturates the *current* conn-slot ceiling first — the splice lever costs
 a re-audit, not worth spending blind. Note what the c10k runs of
 2026-07-27 did and did not show: they saturated the **upstream** pool
-comprehensively (which is why its ceiling moved), and never came close to
-the conn-slot one, sitting at ~10k held connections against 12282.
+comprehensively (which is why its ceiling moved, and then why it was
+pinned to the conn ceiling), and never came close to the conn-slot one,
+sitting at ~10k held connections against 12282 — which was the point:
+those 2200 spare slots were unservable, not spare.
 
 ## Pool ceilings: policy we chose, or a range the operator picks?
 
-**Interim taken 2026-07-27; the question below stays open.**
+**Interim taken 2026-07-27, narrowed 2026-07-28; the question below
+stays open.**
 
-The ceiling pair moved to `upstream_slots_max = 8192` /
-`conn_slots_max = 12282`, with `upstream_slots_default` held at 1024 so
-the out-of-box footprint is unchanged (byte-identical: 32,259 KiB, 3,805
-fds). That fixes the immediate defect — the upstream pool had *no range*,
-default and ceiling being the same number — and both ceilings clear 10k,
-so §1's "able to operate at c10k" holds on either axis. Measurements in
-IMPLEMENTATION_NOTES.md.
+The ceiling pair first moved to `upstream_slots_max = 8192` /
+`conn_slots_max = 12282`, which fixed the immediate defect — the upstream
+pool had *no range*, default and ceiling being the same number. The next
+c10k run showed that pair was still the wrong shape: leased upstreams
+track the *connection* count, so a pool below the conn ceiling makes the
+top of that ceiling unservable. The upstream ceiling is now **pinned** to
+the conn ceiling, and the shared CQ line has one divisor rather than two
+numbers that must be edited together: `conn_slots_max =
+upstream_slots_max = 11464`. `upstream_slots_default` stays at 1024, so
+the out-of-box footprint is still byte-identical (32,259 KiB, 3,805 fds).
+Measurements in IMPLEMENTATION_NOTES.md.
 
-It does **not** answer the question below. A pair chosen at compile time
-is still a policy decision made on the operator's behalf; this one is
-merely a better-evidenced choice than the last. What follows is why that
-may be worth changing, and what it would cost.
+It does **not** answer the question below — it narrows it. There is now
+one number, not a pair, and §1's "able to operate at c10k" holds on both
+axes at once. But a ceiling chosen at compile time is still a policy
+decision made on the operator's behalf. What follows is why that may be
+worth changing, and what it would cost.
 
 One correction to the cost stated here originally: raising the ceilings
 does **not** balloon `SimIo`'s `ready_buffer`. That array is sized by
@@ -430,29 +440,35 @@ Upstream slots had no such range. An operator could only go *down*, and
 at c10k the upstream pool is precisely the one that needs to go up. Every
 c10k run that behaved did so on a build-time `sed` of the constant. The
 interim fix gave that pool a range (default 1024, ceiling 8192, and
-`conn_slots_max` down to 12282 to pay for it on the shared CQ line).
-
-The measurements, on one 1-CPU box at 10k connections (2026-07-27):
+`conn_slots_max` down to 12282 to pay for it on the shared CQ line); the
+follow-up pinned the ceiling to `conn_slots_max` outright, which is the
+shape it should have had from the start.
 
 Summarised: at 1024 the pool pinned, a third of all responses became 503,
-and real throughput decayed to a quarter of its peak; at 8192 the pool
-never pinned, sheds fell by three orders of magnitude, and throughput
-held flat. The figures live in IMPLEMENTATION_NOTES.md ("The upstream
-pool was a wall, not a range") — restating them here is what let this
+and real throughput decayed to a quarter of its peak; at 8192 sheds fell
+by three orders of magnitude and throughput held flat, but a full c10k
+run still drove the pool to its ceiling — 0.44% of responses shed with
+~2200 conn slots idle. The figures live in IMPLEMENTATION_NOTES.md ("The
+upstream pool was a wall, not a range" and "The upstream pool tracks
+connections, not requests") — restating them here is what let this
 section drift out of date once already.
 
 ### Why a better default does not fix it, and neither does a build option
 
-The two ceilings share one completion-queue budget at 4:1 — a conn slot
-costs `conn_ops_max` ring ops, an upstream slot one:
+The two ceilings share one completion-queue budget — a conn slot costs
+`conn_ops_max` ring ops, an upstream slot one:
 
     conn_slots × 4 + upstream_slots + fixed <= 57344   (⅞ of a 65536 CQ)
 
-They are points on a line. **Choosing one at compile time is tuning for a
-deployment shape**, which is the thing §1 says not to do; a build option
-only moves who does the tuning. And zoxy ships prebuilt release binaries,
-so a build-time knob is invisible to anyone who installs rather than
-compiles.
+They are points on a line, and pinning the pair picks the diagonal of
+that line rather than getting off it. The diagonal is the right point for
+an L7 deployment — that is what the measurement says — but **choosing any
+point at compile time is tuning for a deployment shape**, which is the
+thing §1 says not to do. An L4-only deployment, for one, wants no
+upstream slots at all and would rather spend the whole budget on conn
+slots. A build option only moves who does the tuning; and zoxy ships
+prebuilt release binaries, so a build-time knob is invisible to anyone
+who installs rather than compiles.
 
 ### The shape that follows
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1554,15 +1554,24 @@ test "config: limits shrink pools below the ceilings, never past them" {
     try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":0}}");
     try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":8}}");
     // A fill tighter than the ceiling was derived at cannot serve the full
-    // conn-slot ceiling — the completion queue it would need exceeds the
-    // compiled ring, so the combination is rejected (§8).
+    // ceiling shape — the completion queue it would need exceeds the
+    // compiled ring, so the combination is rejected (§8). Both pools are
+    // named at their ceiling because that is the shape the derivation
+    // budgets for: the pair is pinned, so a conn slot's worst case
+    // includes the upstream slot it may hold (see `conn_slots_max`).
     {
         var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena_state.deinit();
         const json = try std.fmt.allocPrint(
             arena_state.allocator(),
-            "{s}{s}\"limits\":{{\"conn_slots\":{d},\"cq_fill_eighths\":{d}}}}}",
-            .{ head, tail, constants.conn_slots_max, constants.cq_fill_eighths_max - 1 },
+            "{s}{s}\"limits\":{{\"conn_slots\":{d},\"upstream_slots\":{d},\"cq_fill_eighths\":{d}}}}}",
+            .{
+                head,
+                tail,
+                constants.conn_slots_max,
+                constants.upstream_slots_max,
+                constants.cq_fill_eighths_max - 1,
+            },
         );
         try std.testing.expectError(error.LimitConnSlotsOverCqFill, parse(arena_state.allocator(), json));
     }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -58,20 +58,31 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
 /// parked-upstream and admin reservations carved out first, this caps at
-/// `(57344 - 23 - upstream_slots_max) / conn_ops_max = 12282` —
+/// `(57344 - 23) / (conn_ops_max + 1) = 11464` —
 /// comptime-derived below (the 23 is the fixed ops: two per config and
 /// admin listener [18], the admin client's op budget [3], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
 ///
-/// This and `upstream_slots_max` sit on one line — a conn slot costs
-/// `conn_ops_max` ring ops, an upstream slot one — so raising either
-/// lowers the other. **Both clear 10k at this point**, which is what §1
-/// asks for: c10k reachable on either axis, not a shape tuned for it.
-/// The pair is provisional; PLANS.md holds the standing question of
-/// whether an operator should pick it rather than inherit ours.
-pub const conn_slots_max: u32 = 12282;
+/// `upstream_slots_max` is pinned to this, and the `+ 1` in the divisor
+/// is that pin: on the L7 path an admitted connection that is mid-exchange
+/// holds one upstream slot as well as its conn slot, and at saturation
+/// every admitted connection can be mid-exchange at once. A conn ceiling
+/// above the upstream ceiling is therefore capacity that cannot be served
+/// — slots that admit connections the pool has no upstream for — and one
+/// below it is a pool that can never be drawn down. `11464` is the
+/// largest N with `N * (conn_ops_max + 1) <= 57321`, which keeps both
+/// ceilings clear of a round 10k: what §1 asks for, c10k reachable on
+/// either axis rather than a shape tuned for it.
+///
+/// It was 12282 against an upstream ceiling of 8192, which measured out
+/// as ~2200 conn slots that stayed idle while the pool they depend on
+/// pinned at its own ceiling; IMPLEMENTATION_NOTES.md ("The upstream pool
+/// tracks connections, not requests") is the one home for those numbers.
+/// The pair is still a policy choice made on the operator's behalf;
+/// PLANS.md holds the standing question of handing it to them instead.
+pub const conn_slots_max: u32 = 11464;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -154,14 +165,21 @@ pub const chunked_trailer_bytes_max: u32 = 1024;
 /// stays lean below it, the same two-layer shape conn slots have. It was
 /// 1024, where ceiling and default were the same number and an operator
 /// could only go *down*; at 10k connections that pool pinned and shed a
-/// third of all responses. 8192 is measured, not guessed — the numbers
-/// live in IMPLEMENTATION_NOTES.md ("The upstream pool was a wall, not a
-/// range"), which is their one home.
+/// third of all responses. Then 8192, which still sat below
+/// `conn_slots_max` — and since the pool holds one live upstream per live
+/// client connection, a conn ceiling the pool cannot cover is unreachable
+/// capacity. Both are measured, not guessed; IMPLEMENTATION_NOTES.md
+/// ("The upstream pool was a wall, not a range" and "The upstream pool
+/// tracks connections, not requests") is their one home.
 ///
-/// Provisional. It trades against `conn_slots_max` on one CQ line, so
-/// this pair is still a policy choice made on the operator's behalf —
-/// PLANS.md carries the open question of handing it to them instead.
-pub const upstream_slots_max: u32 = 8192;
+/// Pinned to `conn_slots_max`, the same way `relay_buffers_max` is and
+/// for the same reason: a slot past the conn-slot count could never be
+/// acquired, and a slot short of it admits a connection nothing can
+/// serve. The two trade against each other on one CQ line, so pinning
+/// them collapses that line to a single divisor — `conn_ops_max + 1` ring
+/// ops per admitted connection — instead of two numbers that must be
+/// edited together and can silently drift apart.
+pub const upstream_slots_max: u32 = conn_slots_max;
 
 /// Listen backlog for every listener.
 pub const accept_backlog: u31 = 1024;
@@ -377,13 +395,19 @@ pub const relay_buffers_default: u32 = conn_slots_default;
 /// Deliberately *not* `upstream_slots_max`. It used to be, which left the
 /// two identical and the pool the one thing an operator could only shrink
 /// — the defect the raised ceiling exists to fix. The default answers a
-/// different question than the ceiling does: the ceiling is how far a
-/// c10k deployment may climb, this is what an unconfigured one costs, and
-/// 8192 slots would put 66 MiB of upstream pool in a footprint budgeted
-/// at ~32 MiB total. What it has to cover is in-flight *exchanges*
-/// (rate × latency) plus parked keep-alive connections — not one per
-/// conn slot — which is why it sits below `conn_slots_default` rather
-/// than tracking it.
+/// different question than the ceiling does: the ceiling is how far an
+/// L7 deployment may climb, this is what an unconfigured one costs.
+///
+/// It sits *below* `conn_slots_default` even though a saturated L7
+/// deployment needs one upstream slot per busy conn slot (see
+/// `conn_slots_max`), because the out-of-box shape is bounded by the
+/// stock 4096 `RLIMIT_NOFILE` rather than by admission: matching 1386
+/// would put the default at 4167 fds, over that line, for capacity an
+/// unconfigured proxy is not there to serve. An L4 deployment never
+/// leases from this pool at all — an L4 dial reads its `leased_counts`
+/// for the P2C draw and holds no slot. A deployment that means to fill its conn
+/// pool raises both together in `limits` — which is what the ceilings
+/// exist to permit and what the c10k benchmark configuration does.
 pub const upstream_slots_default: u32 = 1024;
 
 comptime {
@@ -446,11 +470,16 @@ comptime {
     // count whose worst-case ops fit the ⅞-CQ budget (at the default =
     // loosest fill) after the fixed ops — the parked-upstream reservation
     // and the admin listener plus its one client op — are carved out (§8).
+    // The pair is pinned (`upstream_slots_max = conn_slots_max`), so the
+    // shared CQ line has one divisor — an admitted connection costs
+    // `conn_ops_max` conn ops plus the one op of the upstream slot it may
+    // need — rather than one ceiling subtracting from the other.
+    assert(upstream_slots_max == conn_slots_max);
     assert(conn_slots_max == @divFloor(
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * (@as(u32, listeners_max) + admin_listeners) -
-            admin_conns * admin_conn_ops_max - 1 - 1 - upstream_slots_max,
-        conn_ops_max,
+            admin_conns * admin_conn_ops_max - 1 - 1,
+        conn_ops_max + 1,
     ));
     assert(admin_listeners >= 1);
     assert(admin_conns >= 1);
@@ -558,7 +587,7 @@ test "budgets: c10k ceiling fd count needs a raised NOFILE" {
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 32772), fds_max);
+    try std.testing.expectEqual(@as(u32, 34408), fds_max);
     try std.testing.expect(fds_max <= 65536);
     // The out-of-box side of this is pinned by "the default deployment is
     // lean" below, not restated here.


### PR DESCRIPTION
The upstream pool holds one live connection per live *client connection*, not per in-flight request: an upstream is leased for a whole exchange and parked between requests, so at saturation — every admitted connection mid-request — demand is one upstream slot per conn slot.

Measured on one 1-CPU box, same binary (4572b4a), same `/1k` workload and 200→67000 ramp, at two connection counts:

| | 500 connections | 10,000 connections |
|---|---|---|
| sustained (achieved ≥ 90% of offered) | 44,611 req/s | 22,481 req/s |
| `conn_slots_in_use` peak | 500 | 10,095 of 12282 |
| `upstream_slots_leased` peak | **492** | 8,017 |
| leased + parked | ≤ ~500 | **pinned at 8192**, six scrapes |
| `l7_shed_upstream_slots` | 0 | 22,568 (0.44%) |
| `kernel_pressure_errors` | 0 | 0 |

Leased peak tracks the connection count, not the request rate — 492 of 500. So a `conn_slots_max` above `upstream_slots_max` is admission capacity that cannot be served, and 12282/8192 measured out as exactly that: ~2200 conn slots idle while the pool they depend on sat at its own ceiling.

## The change

Pin the two, the way `relay_buffers_max` already is and for the same argument — a slot past the conn count could never be acquired, one short of it admits a connection nothing can serve. The shared CQ line collapses to a single divisor, `conn_ops_max + 1` ring ops per admitted connection:

    (57344 - 23) / (4 + 1) = 11464

Both ceilings clear a round 10k, which is what §1 asks for.

| | before | after |
|---|---|---|
| conn / upstream ceiling | 12282 / 8192 | **11464 / 11464** |
| ceiling pools | 272 MiB | 284 MiB |
| `fds_max` | 32,772 | 34,408 |
| out-of-box | 32,259 KiB, 3,805 fds | **unchanged, byte-identical** |

The **defaults stay unpinned on purpose**: the out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than by admission (matching 1386 would cost 4167 fds), and an L4 deployment never leases from this pool — an L4 dial reads `leased_counts` for the P2C draw and holds no slot.

## Docs

The previous rationale — that the pool sizes to in-flight exchanges, rate × latency, and so sits below the conn count — is what this refutes, so it is removed rather than left standing next to the correction. Same sweep for PLANS.md's "at 8192 the pool never pinned": the full c10k run pinned it.

New IMPLEMENTATION_NOTES section records what this was *not*: per-request CPU at matched offered rate is the same at both connection counts (19.6/24.2/25.7 µs vs 20.4/23.6/24.9 µs at 9.1k/12.4k/15.8k offered) — the end-to-end confirmation of the earlier `delivered()`/SoA finding. Nor the environment: 502 Mbit/s on a NIC that carried 914 in the other run, 78% of a 1-CPU quota with 0.17% throttling, origin idling 3.2 of 4 cores. The 2-core proxy VM showed 32% steal, worth recording for anyone reading cloud numbers.

Left open and deliberately not designed for: past ~16k req/s the c10k run's per-request CPU climbs 25.7 → 34.7 µs while the 500-connection run's *falls* to 18.6 µs at 44.6k. Named hypothesis (partial writes to backed-up client sockets), still a hypothesis.

PLANS.md's standing question — whether the operator should pick the ceiling rather than inherit ours — is narrowed to one number, not settled.

## Gates

`zig build ci` and `zig fmt --check` pass. `tiger-style-reviewer` run on the diff; its two documentation-accuracy findings fixed before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)