### PR TITLE
http: give §8 a rung that sheds on time, not exhaustion (§8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -655,6 +655,26 @@ the loop thread.
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
+Every rung but one sheds on a *resource* running out. That is a real gap
+and it was measured, not theorised: at c10k the upstream pool's ceiling
+was the only thing saying no, and once it was given enough headroom to
+stop firing (§5), nothing bounded an overloaded exchange at all —
+latency grew until the *client* gave up, and this proxy went on spending
+CPU answering requests whose callers had left. The numbers are in
+IMPLEMENTATION_NOTES.md.
+
+The rung that answers on **time** rather than on exhaustion is the
+request deadline, and `timeouts.request_ms` is what arms it: an absolute
+cap on one exchange, from the moment a request head is routed to the
+last response byte. It is deliberately **not** refreshed by activity —
+that is the whole difference from `idle_ms`, which bounds a stalled
+exchange but never a merely slow one. It rides the same per-connection
+deadline timer, clamping it the way `max_lifetime_ms` does, and is
+retired the moment any rung commits to an answer, so a deadline can
+never cut short the delivery of the verdict it caused. `0` (the default)
+disables it: what counts as too slow is a property of the operator's
+origin, not one this proxy can pick for them.
+
 - **Static error responses.** `400`/`404`/`414`/`431`/`501`/`503`/`504`
   are comptime byte arrays sent directly from static memory — never
   staged through

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -591,6 +591,48 @@ pick the ceiling instead of inheriting ours — the machinery (`cqFillFits`,
 cost is a §5 amendment, spelled out there. Pinning narrows that question
 to one number rather than settling it.
 
+## The 503 was the only backpressure, and it was accidental (2026-07-28)
+
+The run that verified the pinned pair did what it was built to do, and
+exposed something else. Same 10k-connection ramp, same binary except the
+ceilings:
+
+| | upstream 8192 | pinned 11464 |
+|---|---|---|
+| `l7_shed_upstream_slots` | 22,568 | **0** |
+| pool peak (leased + parked) | pinned at 8192, six scrapes | 8,749 of 11,464 |
+| **sustained** | **22,481 req/s** | **22,385 req/s** |
+| `accepted` | 67,517 | **220,144** |
+| loadgen connect errors | 32,891 | 186,265 |
+| loadgen timeouts | 58,999 | 142,478 |
+| loadgen error rate | 2.2% | **6.3%** |
+| errors before the knee (t<95s) | 29,299 | 16,488 |
+
+Throughput did not move, which was the prediction: sheds were 0.44%, so
+they were never the limiter. Pre-knee behaviour improved — half the
+errors, and the stall that used to sit at t≈85s is gone.
+
+Past the knee it got worse, and the mechanism is the finding. The 503
+was a *fast, bounded, connection-keeping* answer. With nothing shedding,
+the same request instead queues until the client's own 1 s timeout kills
+it and reconnects — 3.3× the connection churn. The receipt: zoxy served
+**5,001,502** responses while the loadgen counted **4,860,555**. The
+140,947 gap matches the 142,478 timeouts. That work was done for callers
+who had already left.
+
+So until this run, upstream-pool exhaustion was doing double duty as
+zoxy's capacity signal — and a second mechanism keyed off the same flag,
+`parkedTimeoutMs`'s pressure-shortened reap, went dormant with it
+(`upstream_pressure_engaged` = 2 across the whole run). Both were reading
+an accident. Removing the accident was right; what it left behind was a
+§8 ladder where every rung but one sheds on a resource running out, and
+nothing at all bounds an exchange that is merely slow.
+
+`timeouts.request_ms` is the answer to that: the request-deadline rung
+already existed, it was simply never armed by anything but a stalled
+dial. Opt-in, because how slow is too slow is a property of the
+operator's origin.
+
 ## libxev error surfacing is lossy — resolved by the fork (2026-07-27)
 
 The section below stood for months and is kept for the reasoning; the

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -258,6 +258,15 @@ const Harness = struct {
                 10 + random.uintAtMost(u32, 90)
             else
                 0,
+            // Same shape for the §8 request deadline: a third of seeds arm
+            // it, over a range that straddles both the connect and idle
+            // timeouts drawn above — so it sometimes fires inside a dial,
+            // sometimes mid-exchange, and sometimes never, all under the
+            // adversary. 0 leaves it disabled.
+            .request_timeout_ms = if (random.uintLessThan(u8, 3) == 0)
+                10 + random.uintAtMost(u32, 90)
+            else
+                0,
         };
     }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -965,7 +965,37 @@ pub fn Server(comptime IoType: type) type {
                     @as(u64, server.config.max_lifetime_ms) * std.time.ns_per_ms;
                 deadline_ns = @min(deadline_ns, cap_ns);
             }
+            // The §8 request deadline rides the same timer for the same
+            // reason, one exchange rather than one connection: zero while
+            // no request is in flight (L4 never sets it, and a keep-alive
+            // turnaround clears `l7`), so the clamp is inert outside an
+            // exchange. Its arming side re-bases the armed timer, which is
+            // what makes it fire *on* time rather than at the next tick.
+            if (conn.l7.request_deadline_ns != 0) {
+                deadline_ns = @min(deadline_ns, conn.l7.request_deadline_ns);
+            }
             conn.deadline_ns = deadline_ns;
+        }
+
+        /// Retire this exchange's §8 request deadline. One rule, two
+        /// moments that satisfy it: the deadline fires, or some other rung
+        /// commits to an answer first. After either, the cap is in the past
+        /// or irrelevant, and leaving it in place would clamp the very
+        /// writes that deliver the answer — expiring the connection a
+        /// second time before a byte of the verdict reached the client. A
+        /// deadline must never cut short the delivery of the answer it
+        /// caused. What is left to bound is a client that will not read:
+        /// the idle timeout's job, and the keep-alive turnaround installs a
+        /// fresh cap for the next request.
+        ///
+        /// Caller obligation, because this only retires the *cap*:
+        /// `conn.deadline_ns` still stands wherever the cap clamped it, so
+        /// every caller must store a fresh deadline afterwards or the
+        /// retirement changes nothing that is already armed. `respond`
+        /// widens to the idle budget; `expireDeadline`'s two verdict
+        /// branches store their fixed grace window.
+        pub fn clearRequestDeadline(conn: *ConnType) void {
+            conn.l7.request_deadline_ns = 0;
         }
 
         fn armDeadline(server: *Self, conn: *ConnType) void {
@@ -989,7 +1019,12 @@ pub fn Server(comptime IoType: type) type {
         /// (so the cancel cannot match the fresh timer). A path that already
         /// delivered the timer has no armed op to re-base, so it arms fresh.
         pub fn rebaseDeadline(server: *Self, conn: *ConnType) void {
-            assert(conn.state == .l7_dialing);
+            // Two callers, both storing a target earlier than the armed
+            // timer: the dial's per-try connect budget (`.l7_dialing`) and
+            // the request deadline installed at routing (`.l7_reading_head`,
+            // §8) — which must re-base here because the reuse path never
+            // reaches the dial.
+            assert(conn.state == .l7_dialing or conn.state == .l7_reading_head);
             // A prior dial's rebase cancel can still be draining if the
             // exchange outran it across a keep-alive turnaround. It re-arms
             // the timer at the target this dial just stored (deadline_ns is
@@ -1090,6 +1125,10 @@ pub fn Server(comptime IoType: type) type {
             // rebase cancel first, or it could match the fresh timer (§8).
             assert(!conn.armed.deadline_cancel);
             server.counters.increment("deadline_expired");
+            // Before either verdict branch stores its grace window: both
+            // grace deadlines run through `storeDeadline`, which would
+            // clamp them straight back to this already-expired cap.
+            clearRequestDeadline(conn);
             if (conn.state == .l7_exchanging and
                 conn.l7.pending_verdict == .none and
                 Proxy.expiryAnswerable(conn))

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -70,6 +70,7 @@ const Harness = struct {
             .idle_timeout_ms = 1000,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
+            .request_timeout_ms = 0,
         };
         try harness.server.init(arena, &harness.sim_io, &harness.config, .{
             .conn_slots = 4,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -147,6 +147,7 @@ fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Conf
         .idle_timeout_ms = 1,
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
+        .request_timeout_ms = 0,
     };
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,6 +31,17 @@ pub const Config = struct {
     /// where zero is legal (an unbounded connection age), so it is optional
     /// in the JSON and defaults off.
     max_lifetime_ms: u32,
+    /// Cap on one L7 exchange, from the moment a request head is routed to
+    /// the last response byte (§8). Unlike the idle timeout it is *not*
+    /// refreshed by activity, so it bounds a request that is progressing
+    /// too slowly, not merely one that has stalled — the difference
+    /// between shedding on time and shedding only when a resource runs
+    /// out. It rides the same per-connection deadline timer, clamping it
+    /// the way `max_lifetime_ms` does, and expires into the §8 request-
+    /// deadline rung: `504` if no response byte has been sent, teardown
+    /// otherwise. `0` disables it, so it is optional in the JSON and
+    /// defaults off. L4 connections never set it.
+    request_timeout_ms: u32,
     /// Effective pool sizes (§5, §8). The comptime constants stay the
     /// hard, budget-asserted ceilings; config may only shrink below them
     /// — for capacity planning, and so the overload benchmark can hit
@@ -172,6 +183,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .idle_timeout_ms = parsed.timeouts.idle_ms,
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
+        .request_timeout_ms = parsed.timeouts.request_ms,
         .limits = limits,
         .admin_bind = admin_bind,
     };
@@ -501,6 +513,10 @@ pub const TimeoutsJson = struct {
     /// Optional: absent or `0` means "no cap" (§6). The default keeps every
     /// pre-existing config valid and leaves max-lifetime opt-in.
     max_lifetime_ms: u32 = 0,
+    /// Optional, same shape: absent or `0` means "no cap" (§8). Opt-in
+    /// because a request deadline is a policy an operator sets against
+    /// their own origin's latency, not a value zoxy can pick for them.
+    request_ms: u32 = 0,
 
     pub const schema_doc = "Connection lifecycle deadlines, in milliseconds.";
     pub const schema_fields = .{
@@ -521,6 +537,11 @@ pub const TimeoutsJson = struct {
         },
         .max_lifetime_ms = .{
             .desc = "Absolute connection-age cap; 0 disables it.",
+            .minimum = 0,
+            .maximum = constants.timeout_ms_max,
+        },
+        .request_ms = .{
+            .desc = "Cap on one L7 exchange, not refreshed by activity; 0 disables it.",
             .minimum = 0,
             .maximum = constants.timeout_ms_max,
         },
@@ -1158,10 +1179,13 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
             return error.TimeoutOverLimit;
         }
     }
-    // max_lifetime_ms is the one optional bound (§6): 0 means "no cap", so
-    // only the shared ceiling is enforced — zero stays legal.
-    if (timeouts.max_lifetime_ms > constants.timeout_ms_max) {
-        return error.TimeoutOverLimit;
+    // The two optional bounds (§6, §8): 0 means "no cap" on either, so only
+    // the shared ceiling is enforced — zero stays legal.
+    const optional = [_]u32{ timeouts.max_lifetime_ms, timeouts.request_ms };
+    for (optional) |value| {
+        if (value > constants.timeout_ms_max) {
+            return error.TimeoutOverLimit;
+        }
     }
 }
 
@@ -1199,6 +1223,58 @@ test "config: max_lifetime_ms is optional and defaults to disabled" {
         \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
     );
     try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+    // The shipped example names neither optional bound, so both must land
+    // disabled — the §8 request deadline is opt-in like the age cap.
+    try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
+}
+
+test "config: request_ms is optional, defaults off, and shares the timeout ceiling" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+    ;
+    // Absent: pre-existing configs stay valid and the §8 request deadline
+    // defaults off, the same shape as max_lifetime_ms.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}",
+        );
+        try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
+    }
+    // Explicit 0 is legal — "no cap", not a TimeoutZero.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1,\"request_ms\":0}}",
+        );
+        try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
+    }
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1,\"request_ms\":250}}",
+        );
+        try std.testing.expectEqual(@as(u32, 250), parsed.request_timeout_ms);
+    }
+    // The shared ceiling still binds — an optional cap is not an unbounded
+    // one.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const json = try std.fmt.allocPrint(
+            arena_state.allocator(),
+            "{s}\"timeouts\":{{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1,\"request_ms\":{d}}}}}",
+            .{ head, @as(u64, constants.timeout_ms_max) + 1 },
+        );
+        try std.testing.expectError(error.TimeoutOverLimit, parse(arena_state.allocator(), json));
+    }
 }
 
 test "config: max_lifetime_ms accepts zero (the one legal zero timeout) and real values" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -361,6 +361,26 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.client_keep_alive = request.keep_alive;
         }
 
+        /// Start this exchange's §8 deadline, if the deployment set one.
+        /// Storing the cap is not enough on its own: the armed timer is the
+        /// idle one this connection has carried since its last turnaround,
+        /// due far later, and the lazy re-arm only ever fires *at* the armed
+        /// target (§4) — so a cap stored under it would be noticed one idle
+        /// timeout late, which is the whole failure it exists to prevent.
+        /// Re-base once, here, and every later `storeDeadline` on this
+        /// exchange clamps under a timer already due on time.
+        fn armRequestDeadline(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.l7.request_deadline_ns == 0);
+            if (server.config.request_timeout_ms == 0) return;
+            const now_ns = server.io.nowNs();
+            conn.l7.request_deadline_ns = now_ns +
+                @as(u64, server.config.request_timeout_ms) * std.time.ns_per_ms;
+            assert(conn.l7.request_deadline_ns > now_ns);
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            server.rebaseDeadline(conn);
+        }
+
         /// Policy gate, then the exchange's admission: tunnels and
         /// upgrades are non-goals (§1, §7) — 501; the canonical path
         /// selects a cluster (400 if it will not canonicalize, 404 if no
@@ -370,6 +390,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len <= conn.head_len);
             recordRequestFacts(conn, request);
+            armRequestDeadline(server, conn);
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
@@ -1446,6 +1467,12 @@ pub fn Proxy(comptime IoType: type) type {
                 .request_head_len = conn.l7.request_head_len,
                 .client_keep_alive = conn.l7.client_keep_alive,
                 .replay_used = true,
+                // The §8 cap rides across too: a replay is the *same*
+                // client-visible request taking its one free retry, not a
+                // new exchange, so it must not win itself a fresh budget.
+                // Dropping it here would silently uncap the rest of the
+                // exchange, since `storeDeadline` stops clamping at zero.
+                .request_deadline_ns = conn.l7.request_deadline_ns,
                 // upstream_was_reused stays default-false: the replay try
                 // is a fresh dial, and a second early failure answers 502.
             };
@@ -1564,6 +1591,17 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream = null;
                 conn.upstream_socket = null;
             }
+            // A rung committed to an answer: retire the §8 request deadline
+            // so it cannot expire the connection out from under the write
+            // that delivers it (`clearRequestDeadline` owns the rule).
+            // Retiring the *cap* is only half of it — `conn.deadline_ns` is
+            // still standing wherever the cap clamped it, and the armed
+            // timer is still aimed there, so widen it back to the idle
+            // budget that owns a slow-reading client. No arm: whatever
+            // timer is already out re-arms itself for the remainder once it
+            // sees the later target (§4's lazy tick-and-compare).
+            ServerType.clearRequestDeadline(conn);
+            server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment(counter);
             // §8's "then keep or close per pressure". Closing is not free:
             // it costs the client a fresh handshake and this proxy a fresh

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -213,6 +213,11 @@ const HttpOrigin = struct {
     /// Read the whole request, then never answer — the stalled origin
     /// that drives the §8 request-deadline 504 verdict.
     mute: bool = false,
+    /// Stall from the Nth request onward instead of from the first:
+    /// `maxInt` (the default) never stalls, `1` stalls the second and
+    /// later. The only way to reach the *reuse* path with a stalled
+    /// exchange — a parked upstream exists only after one was served.
+    mute_after_served: u32 = std.math.maxInt(u32),
     /// Close the second accepted connection immediately: the replayed
     /// try fails too, pinning the one-replay budget (§7).
     close_second_at_accept: bool = false,
@@ -292,9 +297,14 @@ const HttpOrigin = struct {
                 return;
             }
             oconn.request_complete = true;
-            if (oconn.origin.mute) {
+            if (oconn.origin.mute or
+                oconn.origin.requests_served >= oconn.origin.mute_after_served)
+            {
                 // The stalled origin: request read in full, no answer, no
                 // armed op — the proxy's deadline is the only way out.
+                // `mute_after_served` stalls only from the Nth request on,
+                // so a test can park an upstream on a served exchange and
+                // then stall the *reused* one.
                 return;
             }
             oconn.armSend();
@@ -434,6 +444,10 @@ const Http1Bed = struct {
         origin_closes: bool = false,
         /// The origin reads the whole request and never answers (§8 504).
         origin_mute: bool = false,
+        /// The origin answers this many requests and stalls from then on,
+        /// so a test can stall a *reused* upstream rather than a fresh
+        /// dial. Default never stalls.
+        origin_mute_after_served: u32 = std.math.maxInt(u32),
         /// The origin closes the second accepted connection at accept —
         /// the replayed try fails too, pinning the one-replay budget.
         close_second_at_accept: bool = false,
@@ -445,6 +459,10 @@ const Http1Bed = struct {
         /// exchange outlives clamps every stored deadline to it, so a
         /// re-based target can already be in the past.
         max_lifetime_ms: u32 = 0,
+        /// The §8 per-exchange cap; 0 (the default) disables it. Unlike the
+        /// age cap it starts at routing, so a test sets it against the
+        /// origin's response delay rather than the connection's birth.
+        request_timeout_ms: u32 = 0,
         /// Hold the client's head back this long after it connects, so it
         /// lands at a chosen instant rather than at once.
         send_delay_ms: u32 = 0,
@@ -486,6 +504,7 @@ const Http1Bed = struct {
             .idle_timeout_ms = idle_timeout_ms,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = options.max_lifetime_ms,
+            .request_timeout_ms = options.request_timeout_ms,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -497,6 +516,7 @@ const Http1Bed = struct {
             .response = options.origin_response,
             .close_after_response = options.origin_closes,
             .mute = options.origin_mute,
+            .mute_after_served = options.origin_mute_after_served,
             .close_second_at_accept = options.close_second_at_accept,
         };
         if (options.origin_listens) {
@@ -1939,6 +1959,159 @@ test "l7: a dial re-basing an already-expired deadline defers past the cancel" {
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
         try bed.expectDrained();
     }
+}
+
+test "l7: the request deadline fires 504 ahead of the connect and idle budgets" {
+    // §8's request deadline is the rung that answers on *time* rather than
+    // on a resource running out. The origin here accepts and then says
+    // nothing, so the dial succeeds and only a deadline can end the
+    // exchange — and the one that ends it must be this one, which is set
+    // tighter than either budget the connection already carries.
+    const request_ms: u32 = 20;
+    comptime {
+        assert(request_ms < Http1Bed.connect_timeout_ms);
+        assert(Http1Bed.connect_timeout_ms < Http1Bed.idle_timeout_ms);
+    }
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 61,
+        .origin_mute = true,
+        .request_timeout_ms = request_ms,
+    });
+    defer bed.tearDown();
+
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /slow HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // The dial *worked*: this is a slow exchange, not a hung or refused
+    // one, which is exactly the case no other rung covers.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    // The verdict lands at the request budget, well inside the connect
+    // budget the dial re-bases to and nowhere near the idle timeout the
+    // head read was armed under.
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+    try std.testing.expect(elapsed_ms >= request_ms);
+    try std.testing.expect(elapsed_ms < Http1Bed.connect_timeout_ms);
+    try bed.expectDrained();
+}
+
+test "l7: the request deadline binds a reused upstream, which no dial re-bases" {
+    // The test above cannot pin `armRequestDeadline`'s re-base: a fresh
+    // dial re-bases the timer itself, so the cap would be honoured either
+    // way. The reuse path is where the re-base is load-bearing — it skips
+    // `dialUpstream` entirely, so the only armed timer is the idle one
+    // from the keep-alive turnaround, 50× looser than the cap. Serve the
+    // first request, stall the second: the second rides the parked
+    // upstream and only this exchange's own deadline can end it.
+    const request_ms: u32 = 20;
+    comptime assert(request_ms < Http1Bed.idle_timeout_ms);
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 62,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_mute_after_served = 1,
+        .request_timeout_ms = request_ms,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\n\r\n";
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    // One upstream connection served both tries, so the second never
+    // dialed — `accepted_count` is the oracle for that.
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // Honest limit of this bed, measured rather than assumed: deleting the
+    // re-base in `armRequestDeadline` does not move this number. Both
+    // exchanges start at ~t=0 here, so the timer request one re-based is
+    // already sitting on the exact instant request two's cap wants, and
+    // the lazy re-arm covers for the missing call. The case that needs it
+    // — a connection idle for minutes, its timer armed a whole idle
+    // timeout out, taking a request with a 200 ms cap — needs a gap
+    // between the two requests that this bed cannot express (issue #106).
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+    try std.testing.expect(elapsed_ms >= request_ms);
+    try std.testing.expect(elapsed_ms < Http1Bed.idle_timeout_ms);
+    try bed.expectDrained();
+}
+
+test "l7: an exchange inside the request deadline is untouched by it" {
+    // Negative space for the rung above: a deadline that binds a slow
+    // exchange must not touch a prompt one, and must not survive its own
+    // exchange — the second request on the same connection gets a fresh
+    // budget, not the remainder of the first one's.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 50,
+        .origin_response = response,
+        .request_timeout_ms = 500,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+    try bed.expectDrained();
+
+    // Both exchanges completed, the second off the parked upstream — the
+    // reuse path, which never reaches the dial and so is the one that
+    // depends on `armRequestDeadline` arming the budget itself.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_responses"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_gateway_timeout"));
+}
+
+test "l7: the §7 replay inherits the request deadline, it does not restart it" {
+    // A replay is the same client request taking its one free retry, so
+    // the §8 cap must ride across it. `beginReplay` rebuilds `l7` field by
+    // field, which is exactly where a cap can be dropped silently — and a
+    // dropped cap does not fail loudly, it just stops clamping.
+    //
+    // Serve request one and close behind it, so the parked upstream is
+    // stale; request two checks it out, fails on first use, and replays
+    // onto a fresh dial that then stalls. The only budget left is the one
+    // installed when request two was routed.
+    const request_ms: u32 = 20;
+    comptime assert(request_ms < Http1Bed.idle_timeout_ms);
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 63,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_closes = true,
+        .origin_mute_after_served = 1,
+        .request_timeout_ms = request_ms,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\n\r\n";
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // The discriminator: drop `request_deadline_ns` from `beginReplay`'s
+    // literal and `storeDeadline` stops clamping, so the stalled replay
+    // waits out the whole idle timeout instead of this budget.
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+    try std.testing.expect(elapsed_ms >= request_ms);
+    try std.testing.expect(elapsed_ms < Http1Bed.idle_timeout_ms);
+    try bed.expectDrained();
 }
 
 test "l7: the 504 verdict path allocates nothing after init" {

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -284,6 +284,20 @@ pub fn Conn(comptime IoType: type) type {
             /// as the channel's next write. Zero when the excess rode along
             /// with the head, or when there was none.
             response_excess_len: u32 = 0,
+            /// Absolute cap on this exchange, set at routing from
+            /// `request_timeout_ms` (§8); `storeDeadline` clamps every
+            /// deadline to it, so unlike the idle timeout no activity can
+            /// push it out. `0` when the timeout is disabled. It lives in
+            /// `l7` rather than beside `birth_ns` precisely so the
+            /// per-request lifetime is structural: every keep-alive
+            /// turnaround clears `l7` wholesale, so the cap cannot outlive
+            /// the exchange that set it even if a rung forgets to retire
+            /// it. Rungs that answer early *do* retire it explicitly, via
+            /// `Server.clearRequestDeadline`. The §7 replay is the one
+            /// place `l7` is rebuilt mid-exchange, so it carries this field
+            /// across by hand — a replay is the same request retrying, not
+            /// a new one earning a fresh budget.
+            request_deadline_ns: u64 = 0,
             /// True once the request head has been forwarded off conn.head
             /// (head sent and any coalesced body excess drained), so the
             /// response head may render into conn.head (§7 buffer rotation).

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -619,6 +619,7 @@ const Harness = struct {
             .idle_timeout_ms = 5000,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
+            .request_timeout_ms = 0,
         };
         // The Server owns the pools, the clock and teardown. Its own
         // listeners stay unbound: this scenario drives the pump directly, so

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -231,6 +231,9 @@ pub const TestBed = struct {
             .idle_timeout_ms = options.idle_timeout_ms,
             .drain_deadline_ms = options.drain_deadline_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
+            // L4 only: the §8 request deadline is an L7 exchange bound and
+            // this bed never routes one.
+            .request_timeout_ms = 0,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, options.server);
         try bed.server.start();


### PR DESCRIPTION
Every rung in the §8 ladder but one sheds on a *resource* running out. The c10k run that verified the pinned pool ceiling (#108) showed what that costs.

| | upstream 8192 | pinned 11464 |
|---|---|---|
| `l7_shed_upstream_slots` | 22,568 | **0** |
| sustained | 22,481 req/s | 22,385 req/s |
| `accepted` | 67,517 | **220,144** |
| loadgen connect errors | 32,891 | 186,265 |
| loadgen timeouts | 58,999 | 142,478 |
| loadgen error rate | 2.2% | **6.3%** |

Throughput did not move, as predicted — sheds were 0.44%, never the limiter. But with the pool given enough headroom to stop shedding, **nothing bounded an overloaded exchange at all**. zoxy served 5,001,502 responses while the loadgen counted 4,860,555; the 140,947 gap matches its 142,478 timeouts. That work was done for callers who had already left.

The 503 had been doing double duty as a capacity signal, on a signal it had no business reading — pool undersizing. Removing the accident was right. This adds the thing it was standing in for.

## The change

`timeouts.request_ms` caps one exchange, from the moment a request head is routed to the last response byte. Unlike `idle_ms` it is **not refreshed by activity**, which is the whole point: it bounds an exchange that is merely slow, not only one that has stalled. It rides the existing per-connection deadline timer, clamping it the way `max_lifetime_ms` does, and expires into the §8 request-deadline rung that already existed — `504` with no response byte sent, teardown otherwise.

`0` (the default) disables it. How slow is too slow is a property of the operator's origin, not one this proxy can pick for them.

The cap lives in `conn.l7`, so a keep-alive turnaround retires it structurally.

## Two review findings, both real

**The §7 replay dropped the cap.** `beginReplay` rebuilds `l7` field by field; omitting `request_deadline_ns` reset it to `0`, and `storeDeadline` stops clamping at `0` — a replayed exchange ran silently uncapped. A replay is the same request retrying, not a new one earning a fresh budget, so the cap now rides across.

**`respond()` retired the cap but left the deadline it had clamped.** Zeroing the field does not move `conn.deadline_ns`, and the armed timer was still aimed at the tight target — so the 504's own delivery could be cut short by the deadline that caused it. It now widens back to the idle budget.

Each has a test that fails without its fix; verified by re-introducing both bugs.

## Mutation results

| line | verdict |
|---|---|
| clamp in `storeDeadline` | killed (3 tests) |
| clear in `expireDeadline` | killed (2 tests) |
| replay preservation | killed (1 test) |
| `rebaseDeadline` in `armRequestDeadline` | **survives** |

The survivor is coverage debt, not a redundant line: it matters when a long-idle keep-alive connection has its timer armed a whole idle timeout out and then takes a request with a tight cap. The bed cannot put a gap between two requests on one connection — both start at ~t=0, so the stale timer happens to sit exactly where the new cap wants it, and elapsed measures 20 ms either way. Documented in the test and the commit; same family as #106.

## Testing

Three new proxy tests (fires ahead of the connect and idle budgets; binds a reused upstream that no dial re-bases; the replay inherits rather than restarts it), one negative-space test (a prompt exchange is untouched), and config parse/validation tests. The test origin gained `mute_after_served` so a stalled *reused* upstream is expressible at all.

The sim arms the timeout on a third of seeds, over a range straddling the connect and idle timeouts it draws — so it fires inside a dial, mid-exchange, and never, all under the adversary.

`zig build ci` (235 tests + 64 sim seeds) and `zig fmt --check` pass. `tiger-style-reviewer` run on the diff; both violations above are its findings, fixed before landing.

## Next

Set `request_ms` in the bench template and rerun: it should sit above the sub-knee p99 and below the loadgen's 1 s timeout, so overload converts to bounded 504s before the client gives up. If churn does not fall, the diagnosis was wrong — also worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)