### PR TITLE
bench: move the profiler to zrk 1.3.1, and size both pools for c10k (§9)

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -174,7 +174,7 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
         } else {
             std.debug.print(
                 "usage: profile [zoxy-path] [--rate N] [--connections N] [--threads N] " ++
-                    "[--seconds N] [--freq N] [--cpu N]\n",
+                    "[--seconds N] [--freq N] [--cpu N] [--protocol l4|http]\n",
                 .{},
             );
             return error.InvalidArguments;
@@ -230,6 +230,13 @@ fn spawnNginx(arena: std.mem.Allocator, io: Io, environ: std.process.Environ) !s
 /// Both bounds come from `constants`, not from literals here: a ceiling
 /// that later moves has to move this with it, and a raised one would
 /// otherwise cap a run below the maximum it was aimed at without saying so.
+/// Effective pool size for a run of `connections` clients — used for both
+/// pools, because they are pinned to each other at the ceiling and for the
+/// same reason at the effective size: on the L7 path a busy client
+/// connection holds an upstream slot, so leaving `upstream_slots` at its
+/// lean default would profile the §8 shed path instead of the proxy. That
+/// is not hypothetical — it is what a cloud c10k run measured before the
+/// ceilings were pinned (IMPLEMENTATION_NOTES.md).
 fn connSlotsFor(connections: u32) u32 {
     assert(connections >= 1);
     const wanted = @as(u64, connections) + connections / 8 + 64;
@@ -256,10 +263,16 @@ fn spawnZoxy(
         \\    ],
         \\    "clusters": {{ "origin": {{ "endpoints": ["127.0.0.1:{d}"] }} }},
         \\    "timeouts": {{ "connect_ms": 5000, "idle_ms": 60000, "drain_deadline_ms": 5000 }},
-        \\    "limits": {{ "conn_slots": {d} }}
+        \\    "limits": {{ "conn_slots": {d}, "upstream_slots": {d} }}
         \\}}
         \\
-    , .{ zoxy_l4_port, zoxy_http_port, origin_port, connSlotsFor(connections) });
+    , .{
+        zoxy_l4_port,
+        zoxy_http_port,
+        origin_port,
+        connSlotsFor(connections),
+        connSlotsFor(connections),
+    });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     return std.process.spawn(io, .{
@@ -436,7 +449,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
         // not inherit the run's connection count or thread pool.
         var config = benchConfig(flags.zoxyPort(), 20_000, 16, 1);
         config.duration_ns = std.time.ns_per_s / 2;
-        const report = zrk.runner.run(arena, io, &config, 0, null, null) catch {
+        const report = zrk.runner.run(arena, io, &config, 0, null, null, null) catch {
             if (attempt == attempts_max - 1) return error.TargetUnresponsive;
             io.sleep(retry_sleep, .awake) catch {};
             continue;
@@ -450,7 +463,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void 
 fn loadTest(arena: std.mem.Allocator, io: Io, flags: *const Flags) !zrk.runner.Report {
     var config = benchConfig(flags.zoxyPort(), flags.rate, flags.connections, flags.threads);
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
-    return zrk.runner.run(arena, io, &config, 0, null, null);
+    return zrk.runner.run(arena, io, &config, 0, null, null, null);
 }
 
 fn printReport(report: *const zrk.runner.Report) void {

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -234,7 +234,7 @@ fn runOverload(
     const rss_before_kb = try readRssKb(arena, io, child.id);
     var config = benchConfig(overload_http_port, overload_connections, flags.rate, "/");
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
-    const report = try zrk.runner.run(arena, io, &config, 0, null, null);
+    const report = try zrk.runner.run(arena, io, &config, 0, null, null, null);
     const rss_after_kb = try readRssKb(arena, io, child.id);
 
     std.debug.print("-- overload (offered >> capacity) --\n", .{});
@@ -632,7 +632,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, port: u16, label: []const u
     while (attempt < probe_attempts_max) : (attempt += 1) {
         var config = benchConfig(port, 4, 100, "/");
         config.duration_ns = std.time.ns_per_s / 2;
-        const report = zrk.runner.run(arena, io, &config, 0, null, null) catch |err| {
+        const report = zrk.runner.run(arena, io, &config, 0, null, null, null) catch |err| {
             if (attempt == probe_attempts_max - 1) return err;
             io.sleep(retry_sleep, .awake) catch {};
             continue;
@@ -699,7 +699,7 @@ fn loadTest(
     if (scenario == .close) {
         config.headers = &close_headers;
     }
-    const report = try zrk.runner.run(arena, io, &config, 0, null, null);
+    const report = try zrk.runner.run(arena, io, &config, 0, null, null, null);
     assert(report.launched >= 1);
     return report;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -57,18 +57,29 @@
             .url = "git+https://github.com/zoxy-io/libxev#b3d6b55bfbea1de0401d11f69ad9755fed9a6144",
             .hash = "libxev-0.0.0-86vtc6cnFACJYqPSG_os9Ea-nUgWmjAqi3CwCQGiFj2z",
         },
+        // Load generator, §9 Tier 0/1 only — never linked into the proxy
+        // (no `src/` file imports it), so a bump moves what the benchmark
+        // measures *with*, not what it measures. Held at the same version
+        // the cloud benchmark runs, so a local band and a fleet number
+        // come off the same generator; runs on mismatched versions are not
+        // comparable, which is a trap this pin exists to close.
         .zrk = .{
-            .url = "git+https://github.com/zoxy-io/zrk#f05cc6a2e7657409767c3cf63c68fcd54d2621e3",
-            .hash = "zrk-1.1.1-WqdFOyINBACoGOEBa8pY7REiDy4i88WibHjSDDvnQezq",
+            .url = "git+https://github.com/zoxy-io/zrk#3940a4570c02ff70094c46d1507ecebadf3e6404",
+            .hash = "zrk-1.3.1-WqdFOzSEBABi11K0XkWd67ny1dp-nYFBXRtIOLqLBiB7",
         },
-        // zrk 1.1.1 embeds its load off a zio (io_uring) runtime, not the
-        // default std.Io.Threaded backend — plain Threaded is missing
-        // pieces zrk now calls (e.g. connect-with-timeout is still a TODO
-        // stub there). Same pin zrk's own build.zig.zon carries; the bench
-        // harness constructs its own zio.Runtime to match (see bench/run.zig).
+        // zrk embeds its load off a zio (io_uring) runtime, not the default
+        // std.Io.Threaded backend — plain Threaded is missing pieces zrk
+        // calls (e.g. connect-with-timeout is still a TODO stub there). The
+        // bench harness constructs its own zio.Runtime to match (see
+        // bench/run.zig), so this pin must stay *exactly* the one zrk's own
+        // build.zig.zon carries: two zio copies would be two runtimes, and
+        // zrk's runner would be handed an `Io` from the wrong one.
+        // zoxy-io/zio is our fork of lalinsky/zio; its main is at the same
+        // commit zrk 1.3.1 pins upstream, which is what makes this
+        // substitution a no-op today rather than a divergence to audit.
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio#a8a88c0e85ba87525ec9555aa409544873443142",
-            .hash = "zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2",
+            .url = "git+https://github.com/zoxy-io/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
+            .hash = "zio-0.16.0-xHbVVDxFJADhW5CgWRdQmPa8bg_YrOAiPFHTKGFq8jwk",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -73,12 +73,12 @@
         // bench harness constructs its own zio.Runtime to match (see
         // bench/run.zig), so this pin must stay *exactly* the one zrk's own
         // build.zig.zon carries: two zio copies would be two runtimes, and
-        // zrk's runner would be handed an `Io` from the wrong one.
-        // zoxy-io/zio is our fork of lalinsky/zio; its main is at the same
-        // commit zrk 1.3.1 pins upstream, which is what makes this
-        // substitution a no-op today rather than a divergence to audit.
+        // zrk's runner would be handed an `Io` from the wrong one. Upstream
+        // rather than a fork, deliberately — a fork of a dependency we do
+        // not patch is a second thing to keep in sync with zrk's pin, and
+        // the only way it can differ from upstream is by being wrong.
         .zio = .{
-            .url = "git+https://github.com/zoxy-io/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
+            .url = "git+https://github.com/lalinsky/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
             .hash = "zio-0.16.0-xHbVVDxFJADhW5CgWRdQmPa8bg_YrOAiPFHTKGFq8jwk",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7


### PR DESCRIPTION
The local profiler was still on zrk 1.1.1 while the cloud benchmark runs 1.3.1, so a local band and a fleet number came off different generators — not comparable, which is the trap the pin exists to close.

## Dependencies

**zrk 1.1.1 → 1.3.1.** Twelve commits, of which one matters to what we measure: *"make -c10000 measure the server instead of the client"* (zrk #37). The rest is a vectorized histogram merge, SIGINT/SIGTERM partial-run reporting, and a canceled-run fix. `runner.run` gained a seventh parameter for that last one (an interrupt flag); every call site passes `null`.

**zio → the commit zrk 1.3.1 pins**, from `lalinsky/zio` upstream. It has to stay exactly zrk's own pin: two zio copies would be two runtimes, and zrk's runner would be handed an `Io` from the wrong one. Upstream rather than a fork, deliberately — the audited-fork policy exists for dependencies we patch (libxev, hparse), and zio is not one. A fork of code we do not patch is a second thing to keep in sync, whose only way to differ from upstream is by being wrong.

Neither dependency is linked into the proxy — no file under `src/` imports either — so this moves what the benchmark measures *with*, never what it measures.

## Harness

The generated config now sets `upstream_slots` as well as `conn_slots`. Since the ceilings were pinned to each other (#108), leaving the upstream pool at its lean 1024 default while asking for 10k connections profiles the §8 shed path rather than the proxy — exactly what a cloud c10k run measured before the ceilings moved. Both pools now track the connection count. `--protocol` was also missing from the usage string.

## What the first c10k profile shows

10,000 connections, L7, one pinned core, loopback origin. Controlled comparison at the same offered rate:

| | 64 conns (1386 slots) | 10,000 conns (11,314 slots) |
|---|---|---|
| achieved | 39,988 req/s | 39,500 req/s |
| perf samples | 103,141 | 94,689 |
| **samples/request** | **0.0860** | **0.0794** |
| p50 | 87 µs | 121 µs |
| p99 | 1,953 µs | 54,832 µs |

**Big pools are 7.6% cheaper per request, not dearer.** No pool, queue, sweep, or reap symbol appears anywhere in the profile. What c10k costs is tail latency (28× p99), not throughput.

Saturating the same setup reaches **65,190 req/s at 10,000 connections on one core**. (At 120k offered the loadgen itself logs `Failed to get io_uring SQE for cancel` and zoxy's own CPU is only ~61%, so treat that as loadgen-limited — a floor on zoxy's ceiling, not a measurement of it.)

Where the time goes at c10k, unsaturated:

| | |
|---|---|
| libxev recv completion callbacks (2 instantiations) | **29.1%** |
| `main.main` — the event loop | 17.6% |
| HTTP parsing (response + headers + request) | 15.7% |
| `memcpy` | 9.2% |
| `IoUring.enter` | 4.0% |

The single largest line item is libxev's generic stream completion dispatch, not zoxy's logic. That is what multishot recv attacks — its PLANS entry asked for a measurement before any design work, and this is it.

Per-request CPU, same binary and connection count: **19.9 µs local** (40k offered), against **70.7 µs** at the cloud plateau. That gap bundles NIC, virtio, a slower vCPU and 32% measured steal; splitting it is a measurement not yet made. But it does say the c10k plateau is not a zoxy ceiling.

## Gates

`zig build ci` (235 tests + 64 sim seeds) and `zig fmt --check` pass. `zig build ci` compiles the bench and profile targets, which is what caught the `runner.run` signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)