### PR TITLE
teardown: close synchronously once the armed set drains (§5, §8)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -448,9 +448,10 @@ Rules:
   embedded in the slot, and the slot header tracks which are armed.
   Teardown is a *state*, not an event: shutdown both fds — a pending recv
   never completes otherwise — cancel the timer (§4 — teardown and the §8
-  dial re-base are the only cancels), then wait — the
-  last terminal completion (success, error, or cancellation) releases
-  the slot. An active completion is never resubmitted (libxev's
+  dial re-base are the only cancels), then wait — the last terminal
+  completion (success, error, or cancellation) empties the armed set,
+  closes both fds synchronously (no op references them any more, so the
+  closes need no ring completions of their own), and releases the slot. An active completion is never resubmitted (libxev's
   intrusive queues corrupt on re-enqueue) — overlapping ops on the same
   connection get their own completions instead of sharing one — and LIFO
   reuse turns a straggler completion landing in a recycled slot into

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -649,8 +649,8 @@ pub fn Server(comptime IoType: type) type {
 
         /// Teardown is a state, not an event (§5): shutdown both fds,
         /// cancel pending connect/timer (the only legal cancels, §4),
-        /// then closes once every armed op drains; the last terminal
-        /// completion releases the slot.
+        /// then wait; the delivery that empties the armed set closes
+        /// both fds synchronously and releases the slot.
         pub fn beginTeardown(server: *Self, conn: *ConnType) void {
             if (conn.isTearingDown()) return;
             assert(conn.isLive());
@@ -681,48 +681,26 @@ pub fn Server(comptime IoType: type) type {
             server.continueTeardown(conn);
         }
 
-        /// Public for the relay: a non-close completion delivered during
-        /// teardown re-enters here (§5). Closes are serialized behind the
-        /// full drain — submitted only once every other op (data,
-        /// connect, deadline, both cancels) has delivered — so a dial
-        /// completing against its own teardown peaks at four armed ops,
-        /// never five: the `conn_ops_max` budget the CQ is sized by (§8).
+        /// Public for the relay: a completion delivered during teardown
+        /// re-enters here (§5). The delivery that empties the armed set
+        /// finishes the whole teardown synchronously: nothing references
+        /// either fd any more, so the closes are plain syscalls — the
+        /// same close-after-full-drain discipline `detachUpstream` and
+        /// the parked reap already use — and the slot releases in the
+        /// same call instead of waiting out two close completions. A
+        /// dial completing against its own teardown still peaks at four
+        /// armed ops: the `conn_ops_max` budget the CQ is sized by (§8).
         pub fn continueTeardown(server: *Self, conn: *ConnType) void {
-            // Only non-close deliveries route here, and a non-close op can
-            // be armed only before .closing; closes deliver into
-            // maybeRelease instead.
             assert(conn.state == .tearing_down);
             if (conn.armedCount() != 0) return;
-            conn.state = .closing;
-            conn.arm(&conn.op_close_client, "close_client");
-            server.io.close(
-                conn.client_socket,
-                &conn.op_close_client.completion,
-                ConnType,
-                conn,
-                onCloseClient,
-            );
+            // Nothing armed: no op references either fd, which is what
+            // makes the synchronous closes and the release safe.
+            assert(conn.armedCount() == 0);
+            server.io.closeNow(conn.client_socket);
             if (conn.upstream_socket) |socket| {
-                conn.arm(&conn.op_close_upstream, "close_upstream");
-                server.io.close(
-                    socket,
-                    &conn.op_close_upstream.completion,
-                    ConnType,
-                    conn,
-                    onCloseUpstream,
-                );
+                server.io.closeNow(socket);
+                conn.upstream_socket = null;
             }
-            // Postcondition: .closing holds the closes and nothing else.
-            assert(conn.armed.close_client);
-            assert(conn.armedCount() <= 2);
-        }
-
-        /// §5 release rule: closes submitted and the armed-op set empty —
-        /// only then does the slot go back to the pool.
-        fn maybeRelease(server: *Self, conn: *ConnType) void {
-            assert(conn.isTearingDown());
-            if (conn.state != .closing) return;
-            if (conn.armedCount() != 0) return;
             // An idle L7 connection holds no relay buffer (§5); only
             // release one that was actually acquired.
             if (conn.relay_buffer) |buffer| {
@@ -730,13 +708,14 @@ pub fn Server(comptime IoType: type) type {
                 conn.relay_buffer = null;
             }
             // The leased upstream slot rides the same release rule: its
-            // socket (if any) was closed by this teardown's
-            // close_upstream, so the slot is inert by the time the armed
-            // set empties (§5). Parking replaces this with reuse later.
+            // socket (if any) was closed just above, so the slot is
+            // inert (§5). Parking replaces this with reuse later.
             if (conn.upstream) |leased| {
                 server.releaseUpstream(leased);
                 conn.upstream = null;
             }
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
             server.releaseConn(conn);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
@@ -1072,9 +1051,9 @@ pub fn Server(comptime IoType: type) type {
             } else |err| {
                 assert(err == error.Canceled);
                 if (conn.isTearingDown()) {
-                    // Closes wait for this delivery (and every other
-                    // armed op) before they are submitted, so the state
-                    // here is always .tearing_down, never .closing.
+                    // The teardown waits for this delivery (and every
+                    // other armed op) before it closes and releases, so
+                    // the slot is still live here.
                     server.continueTeardown(conn);
                     return;
                 }
@@ -1199,16 +1178,6 @@ pub fn Server(comptime IoType: type) type {
         fn onDeadlineCancel(conn: *ConnType) void {
             conn.delivered(&conn.op_deadline_cancel, "deadline_cancel");
             conn.server.continueTeardown(conn);
-        }
-
-        fn onCloseClient(conn: *ConnType) void {
-            conn.delivered(&conn.op_close_client, "close_client");
-            conn.server.maybeRelease(conn);
-        }
-
-        fn onCloseUpstream(conn: *ConnType) void {
-            conn.delivered(&conn.op_close_upstream, "close_upstream");
-            conn.server.maybeRelease(conn);
         }
     };
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -198,12 +198,15 @@ pub const ring_entries: u16 = 4096;
 /// Two peaks tie: a teardown racing its own upstream dial holds
 /// {connect, deadline, connect_cancel, deadline_cancel}, and a relay
 /// teardown holds {both data ops, deadline, deadline_cancel}. Closes
-/// never join either set — `continueTeardown` submits them only once
-/// every other op has drained (serialize cancel-then-close), which is
-/// what cut this budget from five: before that, a dial completing
-/// against its own cancel co-armed the closes with the deadline and
-/// both cancels. `Conn.arm` asserts the budget on every arm, and the
-/// drain-vs-dial sim test pins seeds that reach exactly four (§8, §9).
+/// never join either set — they are not ring ops at all:
+/// `continueTeardown` closes synchronously once every armed op has
+/// drained, nothing referencing the fds by then. Serializing them
+/// behind the drain is what cut this budget from five (a dial
+/// completing against its own cancel used to co-arm the closes with
+/// the deadline and both cancels); making them synchronous then
+/// removed their two completions outright. `Conn.arm` asserts the
+/// budget on every arm, and the drain-vs-dial sim test pins seeds
+/// that reach exactly four (§8, §9).
 pub const conn_ops_max: u32 = 4;
 
 /// Completions drained per loop tick before control returns to the kernel;

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -737,10 +737,30 @@ pub fn run(io: *SimIo) Io.RunError!void {
         io.maybeInjectReset();
         io.maybeInjectKernelPressure();
     }
-    // The loop was stopped (a completed drain). A raced accept whose CQE
-    // beat the listener close but was never delivered before stop() is an
-    // accepted-but-unshed fd — reclaimed at process exit in production, so
-    // model that here rather than flagging it as an operational leak.
+    // The loop was stopped (a completed drain). What is already *ready*
+    // still delivers, with the virtual clock frozen so nothing new
+    // becomes due. In production these effects live kernel-side — the
+    // peer of a socket the drain closed observes its FIN/RST whether or
+    // not this process takes another tick — but the simulator's peers
+    // observe through delivery, so cutting them off at stop() would
+    // strand exactly the observations production guarantees. The server
+    // is quiescent by stop's precondition (§8: every pool released,
+    // every op delivered), so this settles harness actors only; the
+    // adversary stays out of a world that is no longer running.
+    var flush_passes: u32 = 0;
+    while (true) : (flush_passes += 1) {
+        // Each pass retires pending ops; a harness that keeps
+        // generating fresh ready work under a frozen clock is a
+        // liveness bug, not a schedule (§9).
+        assert(flush_passes <= pending_ops_max);
+        const ready = io.collectReady(&ready_buffer);
+        if (ready.len == 0) break;
+        io.deliverBatch(ready);
+    }
+    // A raced accept whose CQE beat the listener close but was never
+    // delivered before stop() is an accepted-but-unshed fd — reclaimed
+    // at process exit in production, so model that here rather than
+    // flagging it as an operational leak.
     io.reclaimRacedSockets();
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -188,8 +188,6 @@ pub fn Conn(comptime IoType: type) type {
         op_data_upstream_to_client: Op,
         op_connect: Op,
         op_connect_cancel: Op,
-        op_close_client: Op,
-        op_close_upstream: Op,
         op_deadline: Op,
         op_deadline_cancel: Op,
 
@@ -212,18 +210,17 @@ pub fn Conn(comptime IoType: type) type {
             l7_exchanging,
             l7_responding,
             l7_draining_request,
-            /// Teardown begun: sockets shut down, pending ops draining,
-            /// closes not yet submitted.
+            /// Teardown begun: sockets shut down, pending ops draining.
+            /// The delivery that empties the armed set closes both fds
+            /// synchronously and releases the slot (§5) — there is no
+            /// second phase, because with nothing armed nothing can
+            /// straggle into the closes.
             tearing_down,
-            /// Closes submitted; the slot releases when the armed set
-            /// empties (§5). Splitting this from `tearing_down` lets an
-            /// assertion tell "still draining ops" from "awaiting closes".
-            closing,
         };
 
-        /// True once teardown has begun, in either teardown phase.
+        /// True once teardown has begun.
         pub fn isTearingDown(conn: *const Self) bool {
-            return conn.state == .tearing_down or conn.state == .closing;
+            return conn.state == .tearing_down;
         }
 
         /// True in any pre-teardown serving state — the states from which
@@ -238,7 +235,7 @@ pub fn Conn(comptime IoType: type) type {
                 .l7_responding,
                 .l7_draining_request,
                 => true,
-                .tearing_down, .closing => false,
+                .tearing_down => false,
             };
         }
 
@@ -374,13 +371,13 @@ pub fn Conn(comptime IoType: type) type {
         };
 
         /// One bit per embedded op; release requires all clear (§5).
-        pub const Armed = packed struct(u8) {
+        /// Closes carry no bit: they are synchronous syscalls once this
+        /// set is empty, never ring ops (`Server.continueTeardown`).
+        pub const Armed = packed struct(u6) {
             data_client_to_upstream: bool = false,
             data_upstream_to_client: bool = false,
             connect: bool = false,
             connect_cancel: bool = false,
-            close_client: bool = false,
-            close_upstream: bool = false,
             deadline: bool = false,
             deadline_cancel: bool = false,
         };
@@ -426,8 +423,6 @@ pub fn Conn(comptime IoType: type) type {
             conn.op_data_upstream_to_client = .{};
             conn.op_connect = .{};
             conn.op_connect_cancel = .{};
-            conn.op_close_client = .{};
-            conn.op_close_upstream = .{};
             conn.op_deadline = .{};
             conn.op_deadline_cancel = .{};
             assert(conn.state == state);
@@ -468,7 +463,7 @@ pub fn Conn(comptime IoType: type) type {
         }
 
         pub fn armedCount(conn: *const Self) u8 {
-            return @popCount(@as(u8, @bitCast(conn.armed)));
+            return @popCount(@as(u6, @bitCast(conn.armed)));
         }
     };
 }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -718,12 +718,13 @@ test "teardown: a drain racing its own upstream dial peaks at four armed ops" {
     // The §8 worst case the ring budget must cover: the drain deadline
     // reaps a connection whose upstream dial is still in flight, teardown
     // arms both cancels on top of {connect, deadline}, and the delayed
-    // dial then completes against its own cancel. Closes serialize
-    // behind the full drain (continueTeardown), so the peak stays at
-    // conn_ops_max = 4 — before the serialization these exact seeds
-    // co-armed five ops ({deadline, both cancels, both closes}), found
-    // by sweeping 1..400 against the old code and pinned here so the
-    // race, not just some teardown, is what every run witnesses.
+    // dial then completes against its own cancel. Closes are synchronous
+    // after the full drain (continueTeardown, not ring ops at all), so
+    // the peak stays at conn_ops_max = 4 — when closes were ring ops
+    // merely submitted eagerly, these exact seeds co-armed five ops
+    // ({deadline, both cancels, both closes}), found by sweeping 1..400
+    // against that code and pinned here so the race, not just some
+    // teardown, is what every run witnesses.
     const race_seeds = [_]u64{ 40, 109, 116, 163, 211, 334 };
     for (race_seeds) |seed| {
         var bed: TestBed = undefined;


### PR DESCRIPTION
## What

Teardown closes were ring ops: a `.closing` state armed `close_client`/`close_upstream`, and the second close CQE released the slot. But the precondition for submitting them was that the armed set is empty — no op references either fd — which is exactly the condition under which `detachUpstream`, `respond`'s disposal, and the parked reap already close with a plain syscall. `continueTeardown` now `closeNow`'s both fds and releases the slot in the same delivery.

Deleted with it: the `.closing` state, both close ops and armed bits (`Armed` shrinks to `packed struct(u6)`, the conn slot by 272 B), `maybeRelease`, and both close callbacks. Two ring ops per connection lifetime gone; the slot returns to its pool one loop tick earlier. `conn_ops_max` stays 4 — the peak is the dial-vs-teardown race, which closes never joined since the serialization cut (the pinned-seed sim test still witnesses it).

## Sim fidelity

The one behavioral shift is drain timing: `stop()` now fires in the same delivery that releases the last slot, where before the close CQEs gave the sim scheduler slack to deliver peers' FIN/RST observations first. That slack was never the contract — in production those observations are kernel-side and survive the loop stopping — so `SimIo.run` now models it: after stop, already-ready events still deliver under a frozen clock (bounded, asserted), and only then does the run end. The pinned drain-race seeds and the admin drain race both witnessed the gap before this.

## Measured (Tier-1, 2×ABAB + one quiet-box candidate run)

- Latency bands (keep-alive / close-mode / large-body hop p50): overlap with baseline — expected, this removes per-connection work, not per-request work. Quiet-box run: L4 +40 µs, L7 +55 µs keep-alive; close-mode L7 +119 µs (baseline clean run: +54/+57/+117).
- Overload band (256 conns vs 64 slots — constant teardown churn): completed requests **86k/92k (baseline) → 101k/111k/118k (this branch)** per 10 s, bands non-overlapping, +10–28%.
- RSS witness unchanged; overload stall gate fails on this box for baseline and branch alike (box-sensitive, pre-existing).

Gates: `zig build ci` (237 tests, 64-seed sim sweep) and `zig fmt --check` clean; tiger-style-reviewer verdict: ready to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
