### PR TITLE
bench: report what the ring did, not just what the CPU did (§9)

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -126,7 +126,9 @@ pub fn main(init: std.process.Init) !u8 {
         "profile: measuring {d}s at {d} req/s over {d} connections\n",
         .{ flags.duration_s, flags.rate, flags.connections },
     );
+    const ring_before = readRingSample(io, zoxy_pid);
     const report = try loadTest(arena, io, &flags);
+    printRingDelta(io, zoxy_pid, ring_before, report.snapshot.counters.completed);
     const perf_term = try perf_child.wait(io);
     if (perf_term != .exited or perf_term.exited != 0) {
         std.debug.print("profile: perf record exited abnormally ({any})\n", .{perf_term});
@@ -488,6 +490,139 @@ fn preflight(io: Io, flags: *const Flags, zoxy_cpu: u16) !?[]const u8 {
     // Before anything is spawned, so the wait is not itself adding load.
     try awaitQuietBox(io, flags);
     return cycles_event;
+}
+
+/// One sample of the loop's io_uring and scheduling counters, every field
+/// cumulative since process start (§9) — deltas across the measured window
+/// are what mean anything, the absolutes include startup.
+///
+/// All of it comes from `/proc`, so the proxy needs no instrumentation and
+/// the numbers are the kernel's own rather than something zoxy reports
+/// about itself.
+const RingSample = struct {
+    /// SQEs the loop has written: every op it has submitted.
+    sqes: u64,
+    /// CQEs the kernel has produced: every completion delivered.
+    cqes: u64,
+    /// Times this process blocked and was woken. The loop blocks in
+    /// `io_uring_enter`, so this is the nearest thing to an enter count
+    /// obtainable here — the syscall tracepoint needs a
+    /// `perf_event_paranoid` this box does not grant, and counting inside
+    /// libxev would be a fork change. It counts the enters that *slept*,
+    /// which is the half that matters: completions per wake is the loop's
+    /// batch depth, and batch depth is what separates "submission-bound"
+    /// from "already coalescing".
+    wakes: u64,
+    /// Whether the CQ has overflowed. Overflowed completions are parked in
+    /// a kernel list and delivered late, or dropped outright once that
+    /// fills — either way the §8 budget that sized the ring was wrong, and
+    /// nothing else in this harness would notice.
+    overflowed: bool,
+};
+
+/// Highest fd number scanned when looking for the ring. The fd is not
+/// assumed because it depends on how many files the process opened first,
+/// which is not this harness's business to know; the bound is what keeps
+/// the search finite.
+const ring_fd_scan_max: u8 = 64;
+
+/// The `u64` after `key:` in a `/proc` `key:<whitespace>value` table, or
+/// null when the key is absent or its value will not parse. Kernel-owned
+/// text, still parsed as untrusted: every caller's fallback for null is to
+/// report nothing rather than to report a zero.
+fn procField(content: []const u8, key: []const u8) ?u64 {
+    assert(key.len >= 1);
+    assert(content.len >= 1);
+    var lines = std.mem.tokenizeScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, key)) continue;
+        if (line.len <= key.len or line[key.len] != ':') continue;
+        const value = std.mem.trim(u8, line[key.len + 1 ..], " \t");
+        return std.fmt.parseUnsigned(u64, value, 10) catch null;
+    }
+    return null;
+}
+
+/// Whether a `/proc` list section named by `header` has any entry under
+/// it. fdinfo prints list headers unconditionally and indents their
+/// entries, while the next section's key starts at column zero — so the
+/// first line after the header is the whole answer. Absent header, or a
+/// header at end of file, is "no entries": a list that is not there cannot
+/// be non-empty.
+fn procListHasEntry(content: []const u8, header: []const u8) bool {
+    assert(header.len >= 1);
+    const at = std.mem.indexOf(u8, content, header) orelse return false;
+    const rest = content[at + header.len ..];
+    const newline = std.mem.indexOfScalar(u8, rest, '\n') orelse return false;
+    const next_line = rest[newline + 1 ..];
+    if (next_line.len == 0) return false;
+    return next_line[0] == ' ' or next_line[0] == '\t';
+}
+
+/// Sample the ring and scheduling counters for `pid`, or null if the ring
+/// fdinfo cannot be found or read — a harness that cannot measure must say
+/// so, not print zeroes that read as "no work happened".
+fn readRingSample(io: Io, pid: i32) ?RingSample {
+    var buffer: [4096]u8 = undefined;
+    var path_buffer: [64]u8 = undefined;
+    var fd: u8 = 0;
+    while (fd < ring_fd_scan_max) : (fd += 1) {
+        const path = std.fmt.bufPrint(
+            &path_buffer,
+            "/proc/{d}/fdinfo/{d}",
+            .{ pid, fd },
+        ) catch continue;
+        const content = readSmallFile(io, path, &buffer) orelse continue;
+        // `SqMask` is io_uring's own marker: no other fd type prints it.
+        if (std.mem.indexOf(u8, content, "SqMask:") == null) continue;
+        const sqes = procField(content, "SqTail") orelse return null;
+        const cqes = procField(content, "CqTail") orelse return null;
+        // The list header is always printed, so its presence proves
+        // nothing; what distinguishes an overflow is an *entry* under it.
+        // Entries are indented (`PollList` prints its own the same way)
+        // and the next section key is not, so the first following line
+        // decides it. Getting this backwards reads `NAPI:` as an overflow
+        // and cries wolf on every run.
+        const overflowed = procListHasEntry(content, "CqOverflowList:");
+        var status_buffer: [4096]u8 = undefined;
+        const status_path = std.fmt.bufPrint(&path_buffer, "/proc/{d}/status", .{pid}) catch return null;
+        const status = readSmallFile(io, status_path, &status_buffer) orelse return null;
+        const wakes = procField(status, "voluntary_ctxt_switches") orelse return null;
+        return .{ .sqes = sqes, .cqes = cqes, .wakes = wakes, .overflowed = overflowed };
+    }
+    return null;
+}
+
+/// Report what the ring did across the measured window: ops and
+/// completions per request, and the batch depth that says whether the loop
+/// is submission-bound. Silent when either sample is missing — see
+/// `readRingSample`.
+fn printRingDelta(io: Io, pid: i32, before: ?RingSample, completed: u64) void {
+    const start = before orelse return;
+    const end = readRingSample(io, pid) orelse return;
+    if (completed == 0 or end.cqes < start.cqes or end.wakes < start.wakes) return;
+    const sqes = end.sqes -| start.sqes;
+    const cqes = end.cqes -| start.cqes;
+    const wakes = end.wakes -| start.wakes;
+    assert(completed >= 1);
+    const per_request = @as(f64, @floatFromInt(cqes)) / @as(f64, @floatFromInt(completed));
+    const batch = if (wakes >= 1)
+        @as(f64, @floatFromInt(cqes)) / @as(f64, @floatFromInt(wakes))
+    else
+        0;
+    std.debug.print(
+        "profile: ring  sqes {d} ({d:.2}/req)  cqes {d} ({d:.2}/req)  " ++
+            "wakes {d} ({d:.1} cqes/wake)  cq-overflow {s}\n",
+        .{
+            sqes,
+            @as(f64, @floatFromInt(sqes)) / @as(f64, @floatFromInt(completed)),
+            cqes,
+            per_request,
+            wakes,
+            batch,
+            if (end.overflowed) "YES" else "no",
+        },
+    );
 }
 
 /// The 1-minute load average, or null when `/proc/loadavg` is absent, will

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -129,9 +129,10 @@ pub fn main(init: std.process.Init) !u8 {
         "profile: measuring {d}s at {d} req/s over {d} connections\n",
         .{ flags.duration_s, flags.rate, flags.connections },
     );
-    const ring_before = readRingSample(io, zoxy_pid);
+    const ring_scratch = try arena.alloc(u8, proc_scratch_bytes);
+    const ring_before = readRingSample(io, zoxy_pid, ring_scratch);
     const report = try loadTest(arena, io, &flags);
-    printRingDelta(io, zoxy_pid, &ring_before, report.snapshot.counters.completed);
+    printRingDelta(io, zoxy_pid, &ring_before, report.snapshot.counters.completed, ring_scratch);
     const perf_term = try perf_child.wait(io);
     if (perf_term != .exited or perf_term.exited != 0) {
         std.debug.print("profile: perf record exited abnormally ({any})\n", .{perf_term});
@@ -583,16 +584,28 @@ fn procField(content: []const u8, key: []const u8) ?u64 {
 ///
 /// A large internal buffer and a small destination: take one big bite,
 /// keep the head, which is where every counter this harness wants lives.
-fn readProcHead(io: Io, path: []const u8, out: []u8) ?[]const u8 {
+fn readProcHead(io: Io, path: []const u8, out: []u8, scratch: []u8) ?[]const u8 {
     assert(out.len > 0);
+    assert(scratch.len >= out.len);
     const file = Io.Dir.cwd().openFile(io, path, .{}) catch return null;
     defer file.close(io);
-    var read_buffer: [64 * 1024]u8 = undefined;
-    var file_reader = file.reader(io, &read_buffer);
+    var file_reader = file.reader(io, scratch);
     const len = file_reader.interface.readSliceShort(out) catch return null;
     assert(len <= out.len);
     return out[0..len];
 }
+
+/// Scratch for `readProcHead`, sized from the worst case rather than
+/// guessed at — the previous two sizes were both round numbers and both
+/// too small.
+///
+/// io_uring's fdinfo renders a line per pending SQE and CQE, ~89 and ~34
+/// bytes, and `constants.in_flight_ops_max` is what bounds how many there
+/// can be: ~57k ops at the compiled ceiling, so ~5 MB of text at the
+/// worst moment. The kernel appears to want the whole record to fit
+/// rather than handing back a prefix, which is why a 64 KiB buffer still
+/// failed the busiest c10k rows while working on quieter ones.
+const proc_scratch_bytes: usize = 8 << 20;
 
 /// Whether a `/proc` list section named by `header` has any entry under
 /// it, or null when the text does not settle it. fdinfo prints list
@@ -619,7 +632,7 @@ fn procListHasEntry(content: []const u8, header: []const u8) ?bool {
 /// Sample the ring and scheduling counters for `pid`, or null if the ring
 /// fdinfo cannot be found or read — a harness that cannot measure must say
 /// so, not print zeroes that read as "no work happened".
-fn readRingSample(io: Io, pid: i32) ?RingSample {
+fn readRingSample(io: Io, pid: i32, scratch: []u8) ?RingSample {
     assert(pid > 0);
     // A bounded *head* read, deliberately. The counters this exists for
     // sit in the first few hundred bytes; what follows them is a line per
@@ -646,7 +659,7 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
             "/proc/{d}/fdinfo/{d}",
             .{ pid, fd },
         ) catch continue;
-        const content = readProcHead(io, path, &buffer) orelse continue;
+        const content = readProcHead(io, path, &buffer, scratch) orelse continue;
         readable += 1;
         // `SqMask` is io_uring's own marker: no other fd type prints it.
         if (std.mem.indexOf(u8, content, "SqMask:") == null) continue;
@@ -665,7 +678,7 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
         const overflowed = if (truncated) null else procListHasEntry(content, "CqOverflowList:");
         var status_buffer: [4096]u8 = undefined;
         const status_path = std.fmt.bufPrint(&path_buffer, "/proc/{d}/status", .{pid}) catch return null;
-        const status = readProcHead(io, status_path, &status_buffer) orelse return null;
+        const status = readProcHead(io, status_path, &status_buffer, scratch) orelse return null;
         const wakes = procField(status, "voluntary_ctxt_switches") orelse return null;
         assert(cqes <= sqes); // A completion the loop never submitted is impossible.
         return .{ .sqes = sqes, .cqes = cqes, .wakes = wakes, .overflowed = overflowed };
@@ -685,10 +698,10 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
 /// completions per request, and the batch depth that says whether the loop
 /// is submission-bound. Silent when either sample is missing — see
 /// `readRingSample`.
-fn printRingDelta(io: Io, pid: i32, before: *const ?RingSample, completed: u64) void {
+fn printRingDelta(io: Io, pid: i32, before: *const ?RingSample, completed: u64, scratch: []u8) void {
     assert(pid > 0);
     const start = before.* orelse return;
-    const end = readRingSample(io, pid) orelse {
+    const end = readRingSample(io, pid, scratch) orelse {
         std.debug.print("profile: ring  unavailable (no sample at end of window)\n", .{});
         return;
     };

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -128,7 +128,7 @@ pub fn main(init: std.process.Init) !u8 {
     );
     const ring_before = readRingSample(io, zoxy_pid);
     const report = try loadTest(arena, io, &flags);
-    printRingDelta(io, zoxy_pid, ring_before, report.snapshot.counters.completed);
+    printRingDelta(io, zoxy_pid, &ring_before, report.snapshot.counters.completed);
     const perf_term = try perf_child.wait(io);
     if (perf_term != .exited or perf_term.exited != 0) {
         std.debug.print("profile: perf record exited abnormally ({any})\n", .{perf_term});
@@ -512,12 +512,26 @@ const RingSample = struct {
     /// which is the half that matters: completions per wake is the loop's
     /// batch depth, and batch depth is what separates "submission-bound"
     /// from "already coalescing".
+    ///
+    /// Undercounts by every non-blocking enter, and overcounts by every
+    /// other voluntary block on this thread — the second only matters if
+    /// there ever is one, which §3's one-thread-one-loop says there is
+    /// not. Reported batch depth is therefore a lower bound on the truth
+    /// in the first case and an upper bound in the second.
     wakes: u64,
-    /// Whether the CQ has overflowed. Overflowed completions are parked in
-    /// a kernel list and delivered late, or dropped outright once that
-    /// fills — either way the §8 budget that sized the ring was wrong, and
-    /// nothing else in this harness would notice.
-    overflowed: bool,
+    /// Whether the CQ has overflowed, or null when that cannot be told.
+    /// Overflowed completions are parked in a kernel list and delivered
+    /// late, or dropped outright once that fills — either way the §8
+    /// budget that sized the ring was wrong, and nothing else in this
+    /// harness would notice.
+    ///
+    /// Nullable because the one case that must never be reported as a
+    /// confident "no" is the one this exists to catch: fdinfo lists every
+    /// pending SQE and CQE, one line each, *before* `CqOverflowList:`, so
+    /// a ring deep enough to overflow is also a ring whose fdinfo can run
+    /// past any fixed read. A missing header then means "did not read far
+    /// enough", never "no overflow".
+    overflowed: ?bool,
 };
 
 /// Highest fd number scanned when looking for the ring. The fd is not
@@ -544,18 +558,24 @@ fn procField(content: []const u8, key: []const u8) ?u64 {
 }
 
 /// Whether a `/proc` list section named by `header` has any entry under
-/// it. fdinfo prints list headers unconditionally and indents their
-/// entries, while the next section's key starts at column zero — so the
-/// first line after the header is the whole answer. Absent header, or a
-/// header at end of file, is "no entries": a list that is not there cannot
-/// be non-empty.
-fn procListHasEntry(content: []const u8, header: []const u8) bool {
+/// it, or null when the text does not settle it. fdinfo prints list
+/// headers unconditionally and indents their entries, while the next
+/// section's key starts at column zero — so the first line after the
+/// header is the whole answer.
+///
+/// Null rather than false when the header is absent or ends the text,
+/// because for this caller those mean "the read stopped short", and the
+/// read stops short precisely when the ring is busiest. Every other parser
+/// in this file answers "cannot tell" with null; a bare `bool` here would
+/// be the one place that turns an unread file into a confident negative.
+fn procListHasEntry(content: []const u8, header: []const u8) ?bool {
     assert(header.len >= 1);
-    const at = std.mem.indexOf(u8, content, header) orelse return false;
+    assert(content.len >= 1);
+    const at = std.mem.indexOf(u8, content, header) orelse return null;
     const rest = content[at + header.len ..];
-    const newline = std.mem.indexOfScalar(u8, rest, '\n') orelse return false;
+    const newline = std.mem.indexOfScalar(u8, rest, '\n') orelse return null;
     const next_line = rest[newline + 1 ..];
-    if (next_line.len == 0) return false;
+    if (next_line.len == 0) return null;
     return next_line[0] == ' ' or next_line[0] == '\t';
 }
 
@@ -563,10 +583,18 @@ fn procListHasEntry(content: []const u8, header: []const u8) bool {
 /// fdinfo cannot be found or read — a harness that cannot measure must say
 /// so, not print zeroes that read as "no work happened".
 fn readRingSample(io: Io, pid: i32) ?RingSample {
-    var buffer: [4096]u8 = undefined;
+    assert(pid > 0);
+    // Sized well past a quiet ring's fdinfo, because a busy one is not
+    // quiet text: every pending SQE and CQE prints a line of its own
+    // before the overflow list. A full buffer is therefore evidence of a
+    // truncated read, not of a large-but-complete one — the two are
+    // indistinguishable from the content alone, so the length is what
+    // `overflowed` keys its "cannot tell" off.
+    var buffer: [64 * 1024]u8 = undefined;
     var path_buffer: [64]u8 = undefined;
     var fd: u8 = 0;
     while (fd < ring_fd_scan_max) : (fd += 1) {
+        assert(fd < ring_fd_scan_max);
         const path = std.fmt.bufPrint(
             &path_buffer,
             "/proc/{d}/fdinfo/{d}",
@@ -575,6 +603,8 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
         const content = readSmallFile(io, path, &buffer) orelse continue;
         // `SqMask` is io_uring's own marker: no other fd type prints it.
         if (std.mem.indexOf(u8, content, "SqMask:") == null) continue;
+        // Both counters print near the top, ahead of any per-entry list,
+        // so they survive a truncated read; the overflow flag does not.
         const sqes = procField(content, "SqTail") orelse return null;
         const cqes = procField(content, "CqTail") orelse return null;
         // The list header is always printed, so its presence proves
@@ -582,12 +612,15 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
         // Entries are indented (`PollList` prints its own the same way)
         // and the next section key is not, so the first following line
         // decides it. Getting this backwards reads `NAPI:` as an overflow
-        // and cries wolf on every run.
-        const overflowed = procListHasEntry(content, "CqOverflowList:");
+        // and cries wolf on every run. A filled buffer means the header
+        // may simply lie past what was read, which is "cannot tell".
+        const truncated = content.len == buffer.len;
+        const overflowed = if (truncated) null else procListHasEntry(content, "CqOverflowList:");
         var status_buffer: [4096]u8 = undefined;
         const status_path = std.fmt.bufPrint(&path_buffer, "/proc/{d}/status", .{pid}) catch return null;
         const status = readSmallFile(io, status_path, &status_buffer) orelse return null;
         const wakes = procField(status, "voluntary_ctxt_switches") orelse return null;
+        assert(cqes <= sqes); // A completion the loop never submitted is impossible.
         return .{ .sqes = sqes, .cqes = cqes, .wakes = wakes, .overflowed = overflowed };
     }
     return null;
@@ -597,13 +630,24 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
 /// completions per request, and the batch depth that says whether the loop
 /// is submission-bound. Silent when either sample is missing — see
 /// `readRingSample`.
-fn printRingDelta(io: Io, pid: i32, before: ?RingSample, completed: u64) void {
-    const start = before orelse return;
-    const end = readRingSample(io, pid) orelse return;
-    if (completed == 0 or end.cqes < start.cqes or end.wakes < start.wakes) return;
-    const sqes = end.sqes -| start.sqes;
-    const cqes = end.cqes -| start.cqes;
-    const wakes = end.wakes -| start.wakes;
+fn printRingDelta(io: Io, pid: i32, before: *const ?RingSample, completed: u64) void {
+    assert(pid > 0);
+    const start = before.* orelse return;
+    const end = readRingSample(io, pid) orelse {
+        std.debug.print("profile: ring  unavailable (no sample at end of window)\n", .{});
+        return;
+    };
+    // Every counter is cumulative and this process never restarted, so a
+    // counter that went backwards means the sample is not of the same ring
+    // — say so rather than print a saturated zero that reads as "idle".
+    if (end.sqes < start.sqes or end.cqes < start.cqes or end.wakes < start.wakes) {
+        std.debug.print("profile: ring  discarded (counters went backwards)\n", .{});
+        return;
+    }
+    if (completed == 0) return;
+    const sqes = end.sqes - start.sqes;
+    const cqes = end.cqes - start.cqes;
+    const wakes = end.wakes - start.wakes;
     assert(completed >= 1);
     const per_request = @as(f64, @floatFromInt(cqes)) / @as(f64, @floatFromInt(completed));
     const batch = if (wakes >= 1)
@@ -620,7 +664,7 @@ fn printRingDelta(io: Io, pid: i32, before: ?RingSample, completed: u64) void {
             per_request,
             wakes,
             batch,
-            if (end.overflowed) "YES" else "no",
+            if (end.overflowed) |o| (if (o) "YES" else "no") else "unknown",
         },
     );
 }

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -56,14 +56,17 @@ const Flags = struct {
     /// deadline's arming path on every request, so this is the flag that
     /// makes its cost measurable rather than argued about.
     request_ms: u32 = 0,
-    /// Highest 1-minute load average the box may already carry when the
-    /// measured window opens; 0 disables the gate. Half a core of ambient
-    /// work is the most that leaves the pinned core and the six load
-    /// threads to themselves on a machine this harness assumes it owns.
-    quiesce_load: f64 = 0.5,
-    /// How long to wait for the box to reach `quiesce_load` before giving
-    /// up and refusing the run.
-    quiesce_timeout_s: u64 = 180,
+    /// Optional hard ceiling on the settled load: refuse the run if the
+    /// box flattens above it. 0 (the default) asks only that the load has
+    /// stopped falling, and reports where — see `awaitQuietBox` for why
+    /// no absolute default is defensible.
+    quiesce_load: f64 = 0,
+    /// How long to wait for the load to flatten before measuring anyway
+    /// and saying so. Sized against the decay it exists to wait out: a
+    /// row drives ~7 cores, and a ~60s EWMA needs ~160s to fall from
+    /// there to a low floor, so this leaves real margin rather than the
+    /// 22 seconds the first version left.
+    quiesce_timeout_s: u64 = 300,
     zoxy_path: []const u8 = "zig-out/bin/zoxy-profile",
 
     const Protocol = enum { l4, http };
@@ -540,6 +543,16 @@ const RingSample = struct {
 /// the search finite.
 const ring_fd_scan_max: u8 = 64;
 
+/// The load average counts as "still falling" while each poll is below
+/// the previous one by more than this factor. A ~60s EWMA sampled every
+/// 2s decays by `exp(-2/60)` = 0.967 per poll while it is genuinely
+/// decaying, so anything above 0.99 is flat rather than falling — the gap
+/// between the two is what keeps noise from reading as decay.
+const settle_decay_ratio: f64 = 0.99;
+/// Consecutive flat polls before the box counts as settled. Two, so a
+/// single noisy sample cannot end the wait on its own.
+const settle_polls: u32 = 2;
+
 /// The `u64` after `key:` in a `/proc` `key:<whitespace>value` table, or
 /// null when the key is absent or its value will not parse. Kernel-owned
 /// text, still parsed as untrusted: every caller's fallback for null is to
@@ -696,51 +709,69 @@ fn readLoadAverage(io: Io) ?f64 {
 /// result. So gate on it rather than trusting the operator to notice, and
 /// print the load either way so the report carries the evidence.
 ///
-/// Waiting rather than refusing outright, because both causes are things
-/// that end on their own: a concurrent benchmark or a parallel agent
-/// session that will finish, and this harness's own previous row, whose
-/// load the 1-minute average keeps decaying for two to three minutes after
-/// it exits. Refusing immediately would fail a back-to-back sweep on every
-/// row and pass it on none; the 180s default is sized to that decay, not
-/// to the nominal one-minute window.
+/// There is deliberately **no absolute threshold**. A fixed number cannot
+/// tell a busy neighbour from an ordinary desktop: 0.5 is unreachable on
+/// a box whose idle floor is 1.5, and trivially passed on one idle at 0.1
+/// while a neighbour is spinning up. What is universal is the *shape* —
+/// the 1-minute average is a ~60s EWMA, so after this harness's own
+/// previous row (which drives about seven cores) it falls steeply and
+/// then flattens at whatever this box's floor happens to be. Wait for the
+/// flattening, report the floor it settled at, and let a row taken beside
+/// a neighbour carry that evidence rather than hide it.
+///
+/// The first version got this wrong in a way worth recording. It waited
+/// for load <= 0.5 with a 180s timeout, and decaying from ~7 to 0.5 takes
+/// `60 * ln(14)` = 158s on a *perfectly* idle box. Twenty-two seconds of
+/// margin, so back-to-back rows failed on any ambient load at all — which
+/// read as neighbour contention and was mostly self-inflicted.
+///
+/// `--quiesce-load` still imposes a hard ceiling for anyone who wants
+/// one, but defaults off: the settled value is reported either way, and a
+/// number in the report beats a refusal whose cause has to be guessed.
 fn awaitQuietBox(io: Io, flags: *const Flags) !void {
-    if (flags.quiesce_load == 0) return;
-    assert(flags.quiesce_load > 0);
     assert(flags.quiesce_timeout_s >= 1);
+    assert(flags.quiesce_load >= 0);
     const poll_s: u64 = 2;
     const poll = Io.Duration.fromNanoseconds(poll_s * std.time.ns_per_s);
     const attempts_max: u64 = @max(@divFloor(flags.quiesce_timeout_s, poll_s), 1);
     var attempt: u64 = 0;
-    var observed: f64 = 0;
+    var previous: f64 = 0;
+    var flat_polls: u32 = 0;
     while (attempt < attempts_max) : (attempt += 1) {
         // No procfs is not evidence of a busy box; a gate that cannot read
         // its input must not invent a verdict. It prints nothing either,
         // so a report from such a box is silent about load rather than
         // claiming a clean one.
-        observed = readLoadAverage(io) orelse return;
-        if (observed <= flags.quiesce_load) {
-            assert(observed >= 0);
-            std.debug.print("profile: box quiet, load {d:.2}\n", .{observed});
-            return;
-        }
-        if (attempt == 0) {
+        const observed = readLoadAverage(io) orelse return;
+        assert(observed >= 0);
+        // Falling by less than the decay would predict — or rising, which
+        // means a neighbour just started and waiting only wastes time.
+        const flattened = attempt >= 1 and observed > previous * settle_decay_ratio;
+        flat_polls = if (flattened) flat_polls + 1 else 0;
+        previous = observed;
+        if (flat_polls >= settle_polls) {
+            if (flags.quiesce_load > 0 and observed > flags.quiesce_load) {
+                std.debug.print(
+                    "profile: box settled at load {d:.2}, over the {d:.2} ceiling asked for\n",
+                    .{ observed, flags.quiesce_load },
+                );
+                return error.BoxBusy;
+            }
             std.debug.print(
-                "profile: waiting up to {d}s for the box to go quiet (load {d:.2} > {d:.2})\n",
-                .{ flags.quiesce_timeout_s, observed, flags.quiesce_load },
+                "profile: box settled at load {d:.2} after {d}s\n",
+                .{ observed, attempt * poll_s },
             );
+            return;
         }
         // The only error is cancellation; a cut-short sleep just means the
         // next poll happens sooner, which the loop bound already covers.
         io.sleep(poll, .awake) catch {};
     }
-    assert(observed > flags.quiesce_load);
     std.debug.print(
-        "profile: box still busy after {d}s (load {d:.2} > {d:.2}). A measurement " ++
-            "here records contention, not the proxy — wait, or pass --quiesce-load 0 " ++
-            "to measure anyway.\n",
-        .{ flags.quiesce_timeout_s, observed, flags.quiesce_load },
+        "profile: load never settled in {d}s (last {d:.2}); measuring anyway, " ++
+            "treat this row as suspect\n",
+        .{ flags.quiesce_timeout_s, previous },
     );
-    return error.BoxBusy;
 }
 
 fn awaitResponsive(arena: std.mem.Allocator, io: Io, flags: *const Flags) !void {

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -570,6 +570,30 @@ fn procField(content: []const u8, key: []const u8) ?u64 {
     return null;
 }
 
+/// Read the head of a `/proc` file that may be large, into `out`.
+///
+/// `readSmallFile`'s 256-byte internal buffer is fine for the fixed-size
+/// files this harness otherwise reads, and wrong for io_uring's fdinfo:
+/// procfs regenerates that text on every read, and once the ring carries
+/// thousands of in-flight ops — one printed line each — the read through a
+/// small internal buffer fails outright rather than returning a prefix.
+/// That failure is what made `readRingSample` skip the ring's own fd and
+/// then report no ring at all, on exactly the busy c10k rows the counters
+/// were added for.
+///
+/// A large internal buffer and a small destination: take one big bite,
+/// keep the head, which is where every counter this harness wants lives.
+fn readProcHead(io: Io, path: []const u8, out: []u8) ?[]const u8 {
+    assert(out.len > 0);
+    const file = Io.Dir.cwd().openFile(io, path, .{}) catch return null;
+    defer file.close(io);
+    var read_buffer: [64 * 1024]u8 = undefined;
+    var file_reader = file.reader(io, &read_buffer);
+    const len = file_reader.interface.readSliceShort(out) catch return null;
+    assert(len <= out.len);
+    return out[0..len];
+}
+
 /// Whether a `/proc` list section named by `header` has any entry under
 /// it, or null when the text does not settle it. fdinfo prints list
 /// headers unconditionally and indents their entries, while the next
@@ -597,15 +621,24 @@ fn procListHasEntry(content: []const u8, header: []const u8) ?bool {
 /// so, not print zeroes that read as "no work happened".
 fn readRingSample(io: Io, pid: i32) ?RingSample {
     assert(pid > 0);
-    // Sized well past a quiet ring's fdinfo, because a busy one is not
-    // quiet text: every pending SQE and CQE prints a line of its own
-    // before the overflow list. A full buffer is therefore evidence of a
-    // truncated read, not of a large-but-complete one — the two are
-    // indistinguishable from the content alone, so the length is what
-    // `overflowed` keys its "cannot tell" off.
-    var buffer: [64 * 1024]u8 = undefined;
+    // A bounded *head* read, deliberately. The counters this exists for
+    // sit in the first few hundred bytes; what follows them is a line per
+    // pending SQE and CQE, so the file's length scales with in-flight ops
+    // and is unbounded in practice. Asking for more of it is not free:
+    // procfs regenerates the text per read, so a large destination means
+    // many reads of a file that is changing underneath them, and the read
+    // fails outright. Sizing this at 64 KiB to "be safe" is exactly what
+    // broke four of five c10k rows with `no sample at end of window` —
+    // the counters were unreadable precisely when the ring was busy.
+    //
+    // A full buffer is therefore evidence of a truncated read rather than
+    // of a large complete one; the two are indistinguishable from content
+    // alone, so the length is what `overflowed` keys its "cannot tell"
+    // off, and on a busy ring it will indeed say so.
+    var buffer: [4096]u8 = undefined;
     var path_buffer: [64]u8 = undefined;
-    var fd: u8 = 0;
+    var fd: u32 = 0;
+    var readable: u32 = 0;
     while (fd < ring_fd_scan_max) : (fd += 1) {
         assert(fd < ring_fd_scan_max);
         const path = std.fmt.bufPrint(
@@ -613,7 +646,8 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
             "/proc/{d}/fdinfo/{d}",
             .{ pid, fd },
         ) catch continue;
-        const content = readSmallFile(io, path, &buffer) orelse continue;
+        const content = readProcHead(io, path, &buffer) orelse continue;
+        readable += 1;
         // `SqMask` is io_uring's own marker: no other fd type prints it.
         if (std.mem.indexOf(u8, content, "SqMask:") == null) continue;
         // Both counters print near the top, ahead of any per-entry list,
@@ -631,11 +665,19 @@ fn readRingSample(io: Io, pid: i32) ?RingSample {
         const overflowed = if (truncated) null else procListHasEntry(content, "CqOverflowList:");
         var status_buffer: [4096]u8 = undefined;
         const status_path = std.fmt.bufPrint(&path_buffer, "/proc/{d}/status", .{pid}) catch return null;
-        const status = readSmallFile(io, status_path, &status_buffer) orelse return null;
+        const status = readProcHead(io, status_path, &status_buffer) orelse return null;
         const wakes = procField(status, "voluntary_ctxt_switches") orelse return null;
         assert(cqes <= sqes); // A completion the loop never submitted is impossible.
         return .{ .sqes = sqes, .cqes = cqes, .wakes = wakes, .overflowed = overflowed };
     }
+    // Say which way it failed. "No ring under fd 64" and "no fdinfo at all"
+    // are different bugs — the first means the scan bound is too low for a
+    // process whose low fds are taken, the second means the pid is wrong or
+    // gone — and a bare null made a whole c10k sweep unattributable.
+    std.debug.print(
+        "profile: ring  no io_uring fd under {d} for pid {d} ({d} fdinfo entries readable)\n",
+        .{ ring_fd_scan_max, pid, readable },
+    );
     return null;
 }
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -699,35 +699,48 @@ so the profiler was taught to read the ring — sqes, cqes, and wakes
 `/proc`. Fixed 40k offered throughout, so the only variable is how idle
 each connection is:
 
-| conns | req/s each | ops/req | cqes/wake | p50 |
-|---|---|---|---|---|
-| 64 | 625 | 4.00 | 5.3 | 77 µs |
-| 1000 | 40 | 4.01 | 8.1 | 208 µs |
-| 10000 | 4 | 4.07 | 8.7 | 137 µs |
-| 64 (drift) | 625 | 4.00 | 5.9 | 88 µs |
+The verdict rests on a **bound**, not on a trend. Submission-bound means
+roughly one op submitted and one wake per read — batch depth near 1.
+Across ~15 measurements spanning 64 to 10,000 connections and settled
+loads from 0.4 to 3.1, the lowest `cqes/wake` ever observed is **2.9**,
+and most rows sit near 4. The enter is amortised several ways at every
+point measured, so multishot's saving — the per-read re-arm — has little
+left to take.
 
-Batch depth **rises** as connections idle, 5.3 → 8.7. Submission-bound is
-the opposite: an op per read, a wake per op, depth collapsing toward 1.
-At c10k the loop wakes ~18,600 times a second and drains ~8 completions
-each, so the enter is already amortised eight ways and multishot's saving
-— the per-read re-arm — has little left to take. The verdict stands, now
-on the workload it named rather than on an echo microbench.
+An earlier reading of this claimed more, and the retraction is the more
+useful record. One sweep showed batch depth *rising* with connection
+count (5.3 / 8.1 / 8.7 at 64 / 1000 / 10000) and that was written up as
+the finding. A bracketed re-run does not reproduce it: the two
+64-connection rows came out 3.3 and 4.2, and the 64-connection row
+*exceeded* the 1000-connection row. Sorting every row of that re-run by
+settled load instead:
 
-The four rows above were taken at settled loads of 0.41–0.50, which is
-what makes them comparable: batch depth is load-sensitive, and the same
-c10k row reads 3.7–3.8 on a box settled at 1.2–1.9. The direction of the
-trend is the finding, and reading it required rows measured under the
-same conditions — which is why the harness now reports the settled load
-per row rather than assuming one.
+| settled load | conns | cqes/wake |
+|---|---|---|
+| 1.19 | 64 | 3.3 |
+| 1.76 | 1000 | 3.9 |
+| 2.24 | 1000 | 4.1 |
+| 3.10 | 64 | 4.2 |
 
-Two corrections it forced. First, a c10k profile shows ~29% of self-time
-in libxev's `Readable.read` callback, and that was read here as "what
-multishot attacks". It is not: multishot removes the *submission*, not
-the completion or its callback. The addressable slice sits in
-`IoUring.enter` and `Loop.add`, which is the ~2–4% the 2026-07-12 bench
-measured. Second, `cqes/wake` is **two-sided** and must never be read
-without the latency beside it — see the next section, where 504 per wake
-means the loop never caught up, not that it batched well.
+Monotonic in load. Not ordered by connection count at all. The original
+series ran at 0.41–0.50, close enough that a load effect and a
+connection effect are indistinguishable in it — so the trend is
+withdrawn, and `cqes/wake` is not usable for cross-row comparison on a
+shared machine at all. What it can still support is the bound above,
+which no run has come close to violating.
+
+Two corrections this forced along the way. First, a c10k profile shows
+~29% of self-time in libxev's `Readable.read` callback, and that was read
+here as "what multishot attacks". It is not: multishot removes the
+*submission*, not the completion or its callback. The addressable slice
+sits in `IoUring.enter` and `Loop.add`, which is the ~2–4% the
+2026-07-12 bench measured. Second, `cqes/wake` is **two-sided** and must
+never be read without the latency beside it — see the next section, where
+504 per wake means the loop never caught up, not that it batched well.
+
+Measuring the connection-count trend properly needs a machine nobody
+else is using. On a box shared with other work the signal is smaller
+than the noise, and three sweeps spent proving that is enough.
 
 Ops per request is 4.0 flat across a 156× change in connection count:
 recv client head, send upstream head, recv response, send client
@@ -779,11 +792,12 @@ stored the 60 s idle deadline, and re-arms — arm, cancel, pointless fire,
 which is about the 2.44 seen. Nothing in these counters watches an
 individual timer, so this is the account that fits, not a sighting.
 
-Batch depth is also load-sensitive, which the bracketed sweep exposed and
-the single run could not: the same `request_ms=0` c10k row reads 8.7
-cqes/wake at a settled load of ~0.5 and 3.7–3.8 at 1.2–1.9. Rows are
-therefore only comparable at comparable settled load, which is why every
-row now reports it.
+Batch depth tracks *box load* more closely than it tracks anything this
+harness varies deliberately — see the section above, where sorting a
+bracketed sweep by settled load orders it perfectly and sorting by
+connection count does not. So the 504 figure says the loop stopped
+sleeping, which the 490 ms p50 corroborates independently, but its
+magnitude should not be compared against rows taken at another load.
 
 Also inferred, from one measured (gap, threshold) pair: that the rule is
 about timers generally rather than this timeout — any deadline shorter

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -27,9 +27,11 @@ the durable conclusions.
   would clean the bench bands — environmental work, not zoxy work.
 
 All three candidates this profile ranked have since been measured (ring
-flags: landed; multishot recv: parked; pre-block spin: rejected — all
-below). Remaining wins are environmental (nft bypass) or workload-level
-(`splice`/`send_zc` for large bodies — PLANS.md).
+flags: landed; multishot recv: parked 2026-07-12 and **closed**
+2026-07-28 once its named workload was measured and turned out not to be
+submission-bound; pre-block spin: rejected — all below). Remaining wins
+are environmental (nft bypass) or workload-level (`splice`/`send_zc` for
+large bodies — PLANS.md).
 
 ## Ring setup flags — landed 2026-07-12 (196ffbf)
 
@@ -68,7 +70,7 @@ re-audit is not spent on a non-win. Revisit only under genuine CPU
 saturation with large CQE batches, never loopback. Recorded so the
 profiler's headline symbol is not re-chased.
 
-## Multishot recv — measured and parked (2026-07-12)
+## Multishot recv — measured and parked (2026-07-12), closed (2026-07-28)
 
 Best-case echo microbench (pinned cores, ABBA, single-shot vs multishot
 recv): only ~2–4% CPU and 15–20% fewer enters — does not pay for the
@@ -77,9 +79,14 @@ SimIo emulation). The libxev `recv_ms` patch and the echo harness were
 erased with the perf write-ups; re-derive if ever needed: `recv_ms` op
 = `RECV_MULTISHOT` + `IOSQE_BUFFER_SELECT` over a std `BufferGroup`,
 `F_MORE` keeps the completion armed, `cqe_flags` carries the buffer id;
-harness = pinned-core echo, single-shot vs multishot, ABBA. Do not
-re-propose without a recv-submission-bound workload (many mostly-idle
-connections) — PLANS.md holds the standing verdict.
+harness = pinned-core echo, single-shot vs multishot, ABBA.
+
+That reopening condition — a recv-submission-bound workload, many
+mostly-idle connections — has since been met and answered: c10k is the
+workload, and it is not submission-bound ("The loop is not
+submission-bound", below, 2026-07-28). Do not re-propose without a
+workload whose *measured* `cqes/wake` approaches 1; the shape of the
+workload is not the evidence, the batch depth is.
 
 ## Pre-block spin — rejected (2026-07-12)
 
@@ -143,8 +150,9 @@ carries only the one-line revisit condition per op.
   costs a fork op plus a documented exception to XevIo's
   every-callback-disarms discipline. A Tier-0 churn A/B decides it, but
   only under a churn-heavy workload (`Connection: close` storms).
-- **Multishot recv / buffer rings** — its own verdict above ("measured
-  and parked"). The syscall win does not pay for the relay redesign it
+- **Multishot recv / buffer rings** — its own verdict above, parked here
+  and **closed 2026-07-28** once the workload it was waiting for was
+  measured. The syscall win does not pay for the relay redesign it
   demands; single-shot buffer-select would keep the strict §6 discipline
   but forfeits most of that win.
 - **`send_zc`** — rejected at the deliberate 4 KiB relay buffer. Below
@@ -622,11 +630,17 @@ throttled; the origin idled 3.2 of 4 cores. Worth recording for anyone
 reading cloud numbers: the 2-core proxy VM showed **32% steal**, charged
 straight against that quota.
 
-Open, and deliberately not designed for yet: past ~16k req/s the c10k
-run's per-request CPU climbs 25.7 → 34.7 µs while the 500-connection
-run's *falls* to 18.6 µs at 44.6k. Named hypothesis — partial writes to
-backed-up client sockets costing several sends per response — but it is
-a hypothesis, and this file's rule is that it stays one until measured.
+One line here read, until 2026-07-28: *"past ~16k req/s the c10k run's
+per-request CPU climbs 25.7 → 34.7 µs … named hypothesis, partial writes
+to backed-up client sockets."* Withdrawn. The hypothesis was that a request costs
+more *work* when the client backs up; on a quiet box a request costs a
+flat 4.0 ring ops from 64 connections to 10,000, with no send-side term
+that grows ("The loop is not submission-bound", below). The table above
+still stands as measured — per-request CPU does rise with offered rate at
+both connection counts — but it rises identically at 500 and at 10,000,
+which is the shape of a shared environmental cost, not of a
+concurrency-driven one. Partial writes were a guess at a layer the ring
+counters say is not moving.
 
 PLANS.md carries the standing question of whether the operator should
 pick the ceiling instead of inheriting ours — the machinery (`cqFillFits`,
@@ -675,6 +689,91 @@ nothing at all bounds an exchange that is merely slow.
 already existed, it was simply never armed by anything but a stalled
 dial. Opt-in, because how slow is too slow is a property of the
 operator's origin.
+
+## The loop is not submission-bound — multishot recv closed (2026-07-28)
+
+The 2026-07-12 verdict parked multishot recv "until a recv-submission-
+bound workload: many mostly-idle conns". c10k is that workload by shape,
+so the profiler was taught to read the ring — sqes, cqes, and wakes
+(voluntary context switches, the enters that *slept*) straight out of
+`/proc`. Fixed 40k offered throughout, so the only variable is how idle
+each connection is:
+
+| conns | req/s each | ops/req | cqes/wake | p50 |
+|---|---|---|---|---|
+| 64 | 625 | 4.00 | 5.3 | 77 µs |
+| 1000 | 40 | 4.01 | 8.1 | 208 µs |
+| 10000 | 4 | 4.07 | 8.7 | 137 µs |
+| 64 (drift) | 625 | 4.00 | 5.9 | 88 µs |
+
+Batch depth **rises** as connections idle, 5.3 → 8.7. Submission-bound is
+the opposite: an op per read, a wake per op, depth collapsing toward 1.
+At c10k the loop wakes ~18,600 times a second and drains ~8 completions
+each, so the enter is already amortised eight ways and multishot's saving
+— the per-read re-arm — has little left to take. The verdict stands, now
+on the workload it named rather than on an echo microbench.
+
+Two corrections it forced. First, a c10k profile shows ~29% of self-time
+in libxev's `Readable.read` callback, and that was read here as "what
+multishot attacks". It is not: multishot removes the *submission*, not
+the completion or its callback. The addressable slice sits in
+`IoUring.enter` and `Loop.add`, which is the ~2–4% the 2026-07-12 bench
+measured. Second, `cqes/wake` is **two-sided** and must never be read
+without the latency beside it — see the next section, where 504 per wake
+means the loop never caught up, not that it batched well.
+
+Ops per request is 4.0 flat across a 156× change in connection count:
+recv client head, send upstream head, recv response, send client
+response. That it equals `conn_ops_max` is a coincidence of a different
+quantity — the constant bounds ops *armed per slot* — but the §5 CQ
+budget's arithmetic now has a measurement standing next to it.
+
+## A short timer takes over the loop's wake schedule (2026-07-28)
+
+`timeouts.request_ms` arms a deadline per exchange (§8). Setting it below
+the *per-connection inter-request gap* is what makes that expensive, and
+the cost is not the expiry — measured at 10k connections, 40k offered,
+where the gap is 250 ms:
+
+| | ops/req | wakes | cqes/wake | req/s | p50 | CPU samples | sock err | expiries |
+|---|---|---|---|---|---|---|---|---|
+| `request_ms=0` | 4.07 | 371,617 | 8.7 | 39,075 | 137 µs | 59,139 | 0 | 0 |
+| `request_ms=500` | 4.0 | — | — | 39,530 | 41 µs | 60,893 | 0 | 0 |
+| `request_ms=200` | **6.51** | **6,289** | **504** | 23,240 | **490 ms** | **24,080** | 28,568 | **0** |
+
+(CPU samples are perf samples at 4 kHz over a 20 s window, so they are
+CPU-seconds × 4000 — comparable across rows, and the 59% fall is theirs.)
+
+Zero expiries in every row, including the one that collapses, so whatever
+this costs it is not the expiry path.
+
+Measured: ops per request goes 4.07 → 6.51, **+2.44 ring ops**; sleeps go
+371,617 → 6,289; each remaining sleep drains 504 completions instead of
+8.7. Throughput falls 40% and CPU falls 59% — *less* CPU for *worse*
+service, which is the signature of a loop that stopped sleeping rather
+than one doing more work.
+
+Inferred, and consistent with all of it but not directly observed: the
+extra ops are a timer armed per request that fires *between* requests,
+finds the keep-alive turnaround has already stored the 60 s idle
+deadline, and re-arms — arm, cancel, pointless fire, which is about the
+2.44 seen. Nothing in these counters watches an individual timer, so this
+is the account that fits, not a sighting.
+
+Also inferred, from one measured (gap, threshold) pair: that the rule is
+about timers generally rather than this timeout — any deadline shorter
+than the loop's own wake cadence taking over its wake schedule, with
+`idle_ms` exempt only because 60 s is far longer than anything else in
+flight. What is measured is that 500 ms is free and 200 ms is not, at a
+250 ms gap. A deployment wanting `request_ms` should keep it above the
+per-connection inter-request gap it expects; the c10k benchmark's 200 ms
+was below it, which is why those runs degraded.
+
+Not measured, and the honest gap: *why* the extra ops tip the loop rather
+than merely costing more. That is a question about libxev's submit/wait
+policy, and answering it needs an enter count, which needs either a
+syscall tracepoint (a `perf_event_paranoid` the dev box does not grant)
+or a fork change.
 
 ## libxev error surfacing is lossy — resolved by the fork (2026-07-27)
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -713,6 +713,13 @@ each, so the enter is already amortised eight ways and multishot's saving
 — the per-read re-arm — has little left to take. The verdict stands, now
 on the workload it named rather than on an echo microbench.
 
+The four rows above were taken at settled loads of 0.41–0.50, which is
+what makes them comparable: batch depth is load-sensitive, and the same
+c10k row reads 3.7–3.8 on a box settled at 1.2–1.9. The direction of the
+trend is the finding, and reading it required rows measured under the
+same conditions — which is why the harness now reports the settled load
+per row rather than assuming one.
+
 Two corrections it forced. First, a c10k profile shows ~29% of self-time
 in libxev's `Readable.read` callback, and that was read here as "what
 multishot attacks". It is not: multishot removes the *submission*, not
@@ -735,30 +742,48 @@ the *per-connection inter-request gap* is what makes that expensive, and
 the cost is not the expiry — measured at 10k connections, 40k offered,
 where the gap is 250 ms:
 
-| | ops/req | wakes | cqes/wake | req/s | p50 | CPU samples | sock err | expiries |
-|---|---|---|---|---|---|---|---|---|
-| `request_ms=0` | 4.07 | 371,617 | 8.7 | 39,075 | 137 µs | 59,139 | 0 | 0 |
-| `request_ms=500` | 4.0 | — | — | 39,530 | 41 µs | 60,893 | 0 | 0 |
-| `request_ms=200` | **6.51** | **6,289** | **504** | 23,240 | **490 ms** | **24,080** | 28,568 | **0** |
+Bracketed sweep at 10k connections — three `request_ms=0` rows around the
+two treatments, so drift is measured rather than assumed. CPU is perf
+samples at 4 kHz over 20 s:
 
-(CPU samples are perf samples at 4 kHz over a 20 s window, so they are
-CPU-seconds × 4000 — comparable across rows, and the 59% fall is theirs.)
+| row | settled load | CPU samples | req/s | p50 |
+|---|---|---|---|---|
+| `request_ms=0` (A) | 1.19 | 58,459 | 39,516 | 44 µs |
+| `request_ms=200` | 1.35 | **38,944** | 39,479 | **51,056 µs** |
+| `request_ms=0` (A′) | 1.33 | 59,895 | 39,502 | 43 µs |
+| `request_ms=500` | 1.30 | 60,174 | 39,528 | 43 µs |
+| `request_ms=0` (A″) | 2.25 | 59,162 | 39,577 | 45 µs |
 
-Zero expiries in every row, including the one that collapses, so whatever
-this costs it is not the expiry path.
+The three baselines agree to 2.5% on CPU and 44/43/45 µs on p50, which is
+what makes the rest of the table readable. `request_ms=500` is
+indistinguishable from them: above the gap, nothing spurious fires.
 
-Measured: ops per request goes 4.07 → 6.51, **+2.44 ring ops**; sleeps go
-371,617 → 6,289; each remaining sleep drains 504 completions instead of
-8.7. Throughput falls 40% and CPU falls 59% — *less* CPU for *worse*
-service, which is the signature of a loop that stopped sleeping rather
-than one doing more work.
+`request_ms=200` costs **p50 43 µs → 51 ms** and **34% of CPU**, at
+unchanged throughput and with zero expiries. Less CPU for worse service
+is the signature of a loop that stopped sleeping rather than one doing
+more work.
 
-Inferred, and consistent with all of it but not directly observed: the
-extra ops are a timer armed per request that fires *between* requests,
-finds the keep-alive turnaround has already stored the 60 s idle
-deadline, and re-arms — arm, cancel, pointless fire, which is about the
-2.44 seen. Nothing in these counters watches an individual timer, so this
-is the account that fits, not a sighting.
+An earlier single run of this pair also showed throughput falling 39,075
+→ 23,240, and that is **not reproduced here** — 39,479 against a 39,516
+baseline. One run each, no bracketing; treat the throughput claim as
+withdrawn and the latency and CPU costs as the findings. The same run
+supplied the ring counters below, and its instrument has since been found
+to fail on busy rows, so those carry the same single-run caveat.
+
+From that single run, the ring counters read ops/req 4.07 → **6.51**
+(+2.44) and sleeps 371,617 → 6,289, each draining 504 completions rather
+than 8.7. Inferred from those, and consistent with everything above but
+not directly observed: the extra ops are a timer armed per request that
+fires *between* requests, finds the keep-alive turnaround has already
+stored the 60 s idle deadline, and re-arms — arm, cancel, pointless fire,
+which is about the 2.44 seen. Nothing in these counters watches an
+individual timer, so this is the account that fits, not a sighting.
+
+Batch depth is also load-sensitive, which the bracketed sweep exposed and
+the single run could not: the same `request_ms=0` c10k row reads 8.7
+cqes/wake at a settled load of ~0.5 and 3.7–3.8 at 1.2–1.9. Rows are
+therefore only comparable at comparable settled load, which is why every
+row now reports it.
 
 Also inferred, from one measured (gap, threshold) pair: that the rule is
 about timers generally rather than this timeout — any deadline shorter

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -358,7 +358,7 @@ standing revisit conditions, so the verdicts are not re-litigated:
 | op | verdict | revisit when |
 |---|---|---|
 | multishot accept | parked (unmeasured) | connection-churn workload (`Connection: close` storms) |
-| multishot recv + buffer rings | measured, parked (2026-07-12) | recv-submission-bound workload: many mostly-idle conns |
+| multishot recv + buffer rings | **closed** (2026-07-28) — the named workload arrived and is not submission-bound | a workload whose measured `cqes/wake` approaches 1 |
 | `send_zc` | rejected at 4 KiB buffers | large-body workload with ≥16 KiB sends |
 | `splice` | deferred (the last open c10k lever) | genuine CPU/memory-bandwidth saturation |
 
@@ -545,6 +545,7 @@ this way. Known queue, in rough value order:
    mid-write, miscounted because zoxy's own send adapter left
    `BrokenPipe` unnamed.
 2. `IORING_OP_SPLICE` (the op union is closed today).
+<<<<<<< HEAD
 3. Name the two peer-gone errnos still funneled to `error.Unexpected`
    (#106, the bug-5 shape): ENETUNREACH on connect (a routing failure,
    counted today as §8 dial pressure with only the errno gauge to say
@@ -561,15 +562,19 @@ this way. Known queue, in rough value order:
    Unexpected there (proven by the linger-RST contract test's first
    macos-latest run), so every dev-box data-op failure reads as §8
    pressure until the fork names them too.
-4. Multishot accept/recv ops — only behind the workloads in the verdict
-   table above. **The recv precondition is now met**: a 10k-connection
-   run holds ~20k req/s at 0.8–0.9 of a 1-CPU quota with ~87% of it
-   kernel time and the first non-zero CFS throttling, which is the
-   "recv-submission-bound workload (many mostly-idle connections)" the
-   parked verdict names. The 2–4% figure that parked it was measured on
-   a best-case echo microbench, never against this. Measure before
-   designing — two optimization priors were refuted by measurement the
-   same day (see IMPLEMENTATION_NOTES.md).
+4. Multishot **accept** — only behind the workload in the verdict table
+   above (a `Connection: close` storm), still unmeasured. Multishot
+   **recv is closed**, not pending: its precondition looked met on
+   2026-07-27 (a 10k-connection run at ~20k req/s, ~87% kernel time),
+   and measuring it on 2026-07-28 showed the workload is not
+   submission-bound — batch depth never approaches 1 anywhere measured,
+   the lowest of ~15 rows being 2.9 and most near 4. See
+   IMPLEMENTATION_NOTES.md, "The loop is not submission-bound", which
+   also records what did *not* hold up: a first reading claimed batch
+   depth rises with connection count, and a bracketed re-run showed the
+   number tracks box load instead. Reopen only on a measured
+   `cqes/wake` approaching 1; workload shape was what made this look
+   open twice, and it is not the evidence.
 
 ## Deferred, revisit on evidence
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -545,7 +545,6 @@ this way. Known queue, in rough value order:
    mid-write, miscounted because zoxy's own send adapter left
    `BrokenPipe` unnamed.
 2. `IORING_OP_SPLICE` (the op union is closed today).
-<<<<<<< HEAD
 3. Name the two peer-gone errnos still funneled to `error.Unexpected`
    (#106, the bug-5 shape): ENETUNREACH on connect (a routing failure,
    counted today as §8 dial pressure with only the errno gauge to say


### PR DESCRIPTION
The profile has always said where cycles went and never how many ops bought them. That is the missing half for every question currently open about the loop.

## Why now

Three open questions all need the same number:

- **Multishot recv.** PLANS.md parks it until a *"recv-submission-bound workload: many mostly-idle conns"*. c10k is that workload, but "submission-bound" is a claim about batch depth, and nothing measured it.
- **The timer result.** `request_ms` below the per-connection inter-request gap costs 32% CPU and a 1000× p50 regression with *zero* expiries. The only account on offer is "pending timers push the loop into deeper batching", which is a story until batch depth is a number.
- **The §5 ring budget.** It is comptime-asserted against the ceilings and never compared with what a real deployment actually submits.

## What it reports

Four numbers across the measured window, all from `/proc` — the proxy needs no instrumentation and the counts are the kernel's own rather than something zoxy reports about itself:

| | |
|---|---|
| `sqes/req`, `cqes/req` | what an exchange actually costs the ring |
| `cqes/wake` | the loop's batch depth — what separates "submission-bound" from "already coalescing", and the one multishot recv would move |
| `cq-overflow` | completions delivered late or dropped; the §8 budget being wrong, which nothing else here would notice |

First reading, 64 connections at 20k offered: **4.01 ops/request, 5.5 cqes/wake, no overflow.**

## On the enter count

Wakes are `voluntary_ctxt_switches`, not `io_uring_enter` calls. The syscall tracepoint needs a `perf_event_paranoid` this box does not grant (it is 2, with no debugfs tracing), and counting inside libxev would be a fork change and a pin move for a bench number. Voluntary switches count the enters that *slept*, which is the half that matters for batch depth — a non-blocking enter with work already queued is the cheap case. The field's doc comment says so, so nobody later reads it as an exact syscall count.

## One trap, since the first version fell in it

fdinfo prints `CqOverflowList:`'s header unconditionally, so its presence proves nothing. The next section key (`NAPI:`) reads as an entry unless you check the indentation that distinguishes entries from keys — and the first version duly reported `cq-overflow YES` on a 64-connection run with a 6,579-op budget in an 8,192-entry CQ, which cannot overflow. Entries are indented, section keys are not; `procListHasEntry` encodes exactly that.

## Gates

`zig build ci` (235 tests + 64 sim seeds) and `zig fmt --check` pass. Bench-only: no file under `src/` changed, and the harness reads `/proc` rather than adding a syscall anywhere near the proxy's boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)