### PR TITLE
Raise upstream_slots_default to the fd-budget ceiling (1314)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -372,7 +372,7 @@ Three shared pools, all owned and touched only by the loop thread:
 Sizing shape. The comptime constants are the hard, budget-asserted
 *ceilings*; the config `limits` block sizes the *effective* pools anywhere
 from 1 up to them. An omitted block takes the lean **defaults**, so the
-out-of-box footprint is small (~32 MiB) and an operator opts into more
+out-of-box footprint is small (~33 MiB) and an operator opts into more
 concurrency — up to the c10k ceiling — through `limits`, never a rebuild.
 The fd budget and the requested CQ depth track the effective sizes too
 (§4/§8), so a small deployment neither reserves nor demands the ceiling's
@@ -383,8 +383,8 @@ a raised `RLIMIT_NOFILE`:
 |---|---|---|---|
 | conn slots | 1386 | 11464 | ~1.7 KiB state + 8 KiB head |
 | relay buffers | 1386 | 11464 | 2 × 4 KiB |
-| upstream slots | 1024 | 11464 | ~40 B state + 8 KiB head |
-| **pool memory** | **~32 MiB** | **~284 MiB** | |
+| upstream slots | 1314 | 11464 | ~40 B state + 8 KiB head |
+| **pool memory** | **~33 MiB** | **~284 MiB** | |
 
 The ceilings sit on one completion-queue line — a conn slot costs
 `conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
@@ -407,10 +407,12 @@ in PLANS.md.
 
 The *defaults* are not pinned to each other, and deliberately: the
 out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than
-by admission (matching 1386 would cost 4167 fds), and an L4 deployment
-never touches the upstream pool at all — an L4 dial holds no upstream
-slot. A deployment that means to fill its conn pool raises both together
-through `limits`.
+by admission (matching 1386 would cost 4167 fds), so the upstream default
+sits at 1314 — the largest value that still stays strictly under that
+line — rather than at the conn default. An L4 deployment never touches
+the upstream pool at all — an L4 dial holds no upstream slot. A
+deployment that means to fill its conn pool raises both together through
+`limits`.
 
 Rules:
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -405,9 +405,11 @@ track the *connection* count, so a pool below the conn ceiling makes the
 top of that ceiling unservable. The upstream ceiling is now **pinned** to
 the conn ceiling, and the shared CQ line has one divisor rather than two
 numbers that must be edited together: `conn_slots_max =
-upstream_slots_max = 11464`. `upstream_slots_default` stays at 1024, so
-the out-of-box footprint is still byte-identical (32,259 KiB, 3,805 fds).
-Measurements in IMPLEMENTATION_NOTES.md.
+upstream_slots_max = 11464`. `upstream_slots_default` moved again on
+2026-07-28, from 1024 to 1314 — the largest value that keeps the
+out-of-box fd budget strictly under the stock 4096 `RLIMIT_NOFILE`
+(34,233 KiB, 4095 fds; see `src/constants.zig`'s `upstream_slots_default`
+comment for the arithmetic). Measurements in IMPLEMENTATION_NOTES.md.
 
 It does **not** answer the question below — it narrows it. There is now
 one number, not a pair, and §1's "able to operate at c10k" holds on both

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -380,7 +380,7 @@ pub const fds_max: u32 =
     fdsRequired(conn_slots_max, upstream_slots_max, listeners_max);
 
 /// Default effective pool sizes when the config omits a `limits` block: a
-/// lean out-of-box footprint (~32 MiB of pools, well under a routine 4096
+/// lean out-of-box footprint (~33 MiB of pools, well under a routine 4096
 /// RLIMIT_NOFILE, a shallow ring) rather than the c10k worst case. An
 /// operator opts into more concurrency — up to the compiled ceilings —
 /// through the config `limits` block, and the fd budget (`fdsRequired`,
@@ -406,12 +406,18 @@ pub const relay_buffers_default: u32 = conn_slots_default;
 /// `conn_slots_max`), because the out-of-box shape is bounded by the
 /// stock 4096 `RLIMIT_NOFILE` rather than by admission: matching 1386
 /// would put the default at 4167 fds, over that line, for capacity an
-/// unconfigured proxy is not there to serve. An L4 deployment never
-/// leases from this pool at all — an L4 dial reads its `leased_counts`
-/// for the P2C draw and holds no slot. A deployment that means to fill its conn
-/// pool raises both together in `limits` — which is what the ceilings
-/// exist to permit and what the c10k benchmark configuration does.
-pub const upstream_slots_default: u32 = 1024;
+/// unconfigured proxy is not there to serve. 1314 is the largest value
+/// that still clears that line — `fdsRequired(conn_slots_default, x, 1)`
+/// is `2781 + x`, and that must stay strictly under 4096 (the out-of-box
+/// budget stays *under* the stock limit, not flush against it), so
+/// `4096 - 2781 - 1 = 1314` — the default leans as far toward
+/// `conn_slots_default` as the stock fd budget allows. An L4
+/// deployment never leases from this pool at all — an L4 dial reads its
+/// `leased_counts` for the P2C draw and holds no slot. A deployment that
+/// means to fill its conn pool raises both together in `limits` — which
+/// is what the ceilings exist to permit and what the c10k benchmark
+/// configuration does.
+pub const upstream_slots_default: u32 = 1314;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));


### PR DESCRIPTION
## Summary
- `upstream_slots_default` was an arbitrary 1024; it's now 1314 — the largest value that keeps the out-of-box fd budget (`conn_slots_default = 1386`, one listener) strictly under the stock 4096 `RLIMIT_NOFILE`, so the default leans as far toward `conn_slots_default` as the stock budget allows.
- Updates the `docs/DESIGN.md` table/prose and the `docs/PLANS.md` out-of-box-footprint note to match (measured via the actual startup print: 34,233 KiB, 4095 fds).

## Test plan
- [x] `zig build test` — all pass, including `budgets: the default deployment is lean` which asserts `fdsRequired(conn_slots_default, upstream_slots_default, 1) < 4096`
- [x] `zig build ci`
- [x] `zig fmt --check src scripts build.zig build.zig.zon`
- [x] `tiger-style-reviewer` run on the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)