### PR TITLE
release: build x86_64 release binaries at -Dcpu=x86_64_v3 (AVX2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,19 +52,27 @@ jobs:
           version="${{ steps.ver.outputs.version }}"
           mkdir -p dist
 
-          # zig-target : release-archive-label
+          # zig-target : release-archive-label : -Dcpu value (empty = default)
+          #
+          # x86_64 gets -Dcpu=x86_64_v3 (AVX2/BMI2/FMA, Haswell 2013+ / Zen
+          # 2017+): the default cross-compile baseline is plain SSE2, which
+          # caps hparse's vector width at 128 bits (std.simd.suggestVectorLength
+          # keys off target CPU features, DESIGN.md §7); v3 doubles it to 256.
+          # aarch64 is left at its default baseline — NEON is mandatory in
+          # ARMv8-A, so there is no wider portable win to take there.
           targets="
-            x86_64-linux-musl:x86_64-linux
-            aarch64-linux-musl:aarch64-linux
-            x86_64-macos:x86_64-macos
-            aarch64-macos:aarch64-macos
+            x86_64-linux-musl:x86_64-linux:x86_64_v3
+            aarch64-linux-musl:aarch64-linux:
+            x86_64-macos:x86_64-macos:x86_64_v3
+            aarch64-macos:aarch64-macos:
           "
           for pair in $targets; do
-            zig_t="${pair%%:*}"
-            label="${pair##*:}"
-            echo "::group::$label ($zig_t)"
+            zig_t="$(echo "$pair" | cut -d: -f1)"
+            label="$(echo "$pair" | cut -d: -f2)"
+            cpu="$(echo "$pair" | cut -d: -f3)"
+            echo "::group::$label ($zig_t${cpu:+, -Dcpu=$cpu})"
             devenv shell -- zig build \
-              -Dtarget="$zig_t" -Doptimize=ReleaseFast --prefix "out/$label"
+              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseFast --prefix "out/$label"
             tar czf "dist/zoxy-$version-$label.tar.gz" -C "out/$label/bin" zoxy
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary
- x86_64-linux and x86_64-macos release archives are now built with `-Dcpu=x86_64_v3` (AVX2/BMI2/FMA, Haswell 2013+ / Zen 2017+) instead of the implicit cross-compile default.
- aarch64-linux and aarch64-macos are unchanged — NEON is mandatory in ARMv8-A, so the default baseline already gives `hparse` 128-bit vectors there.

## Why
Without `-Dcpu`, Zig's cross-compile baseline for x86_64 is LLVM's generic model (SSE2 only). `hparse`'s vector width is picked via `std.simd.suggestVectorLength(u8)`, which reads target CPU features at comptime, so the shipped release binaries were only ever getting 128-bit vectors instead of the 256-bit AVX2 vectors modern hardware supports.

Verified locally by cross-compiling both variants and disassembling: baseline `zoxy-release` has 0 AVX2/ymm instructions, `-Dcpu=x86_64_v3` has ~2800.

This is a deliberate compatibility trade: pre-2013 x86_64 CPUs will SIGILL on launch, in exchange for double the SIMD width on essentially all real deployment hardware today. Discussed and chosen over shipping dual baseline+v3 archives, to keep the release matrix simple.

## Test plan
- [ ] `zig build ci` passes (unaffected by this change — release-only build knob)
- [ ] Release workflow run produces working x86_64-linux and x86_64-macos archives
- [x] Locally verified `-Dcpu=x86_64_v3` compiles and disassembly shows AVX2 codegen where the default baseline had none