### PR TITLE
sim: the origin oracle measures one request, not a connection's life (§5, §7, §9)

### DIFF
--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const zoxy = @import("zoxy");
 
 const canon = @import("canon.zig");
+const scripts = @import("scripts.zig");
 
 const Io = zoxy.Io;
 const parser = zoxy.http.parser;
@@ -77,13 +78,36 @@ pub fn HttpOrigin(comptime IoType: type) type {
         const Phase = enum(u8) { head, body, respond };
         const FramingTag = enum(u8) { none, content_length, chunked };
 
+        comptime {
+            // What `compact` makes true, checked rather than trusted:
+            // the buffer measures one request, so every script's wire
+            // bytes must fit it. Add a script past this and the gate
+            // fails at compile time instead of surfacing as a
+            // one-in-200k `OriginSawMalformedBytes`.
+            //
+            // One request is the whole bound. A recv can coalesce this
+            // request's tail with the next one's opening bytes, which
+            // `compact` carries over — but only a later exchange can
+            // supply those, and §5 checkout is exclusive, so the proxy
+            // cannot forward the next request until this response has
+            // fully arrived, which is after `compact` ran. Hence the
+            // carry-over is empty in practice, and the largest
+            // forwarded script (`post_big`, 6055 bytes) leaves 10 KiB
+            // spare even if it were not.
+            for (std.enums.values(scripts.Script)) |script| {
+                assert(scripts.spec(script).request.len <= request_buffer_bytes);
+            }
+        }
+
         pub const Conn = struct {
             origin: *Self = undefined,
             socket: IoType.Socket = undefined,
             recv_completion: IoType.Completion = .{},
             send_completion: IoType.Completion = .{},
-            /// Every request stays captured; the current one starts at
-            /// `request_offset` and parses from there.
+            /// Received and not yet consumed; the current request starts
+            /// at `request_offset` and parses from there. Compacted at
+            /// each keep-alive boundary, so this bounds one request, not
+            /// a reused connection's lifetime.
             request_buffer: [request_buffer_bytes]u8 = undefined,
             request_len: u32 = 0,
             request_offset: u32 = 0,
@@ -291,6 +315,34 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 return true;
             }
 
+            /// Drop what the answered requests consumed, so the buffer
+            /// measures the request in flight rather than everything the
+            /// connection ever carried. §5 parking reuses one upstream
+            /// connection across exchanges, and the reuse count is
+            /// unbounded: without this, enough `post_big` forwards
+            /// (6055 bytes each) fill any buffer, and the oracle reads
+            /// that well-framed traffic as forwarded excess — failing
+            /// the seed on the proxy's own good behavior. Seed 3064744
+            /// was three of them on one connection.
+            fn compact(conn: *Conn) void {
+                assert(conn.phase == .head);
+                assert(conn.request_offset >= 1);
+                assert(conn.request_offset <= conn.request_len);
+                const remaining = conn.request_len - conn.request_offset;
+                // Shifting left, so forwards: every destination write
+                // lands before that offset is read as a source.
+                std.mem.copyForwards(
+                    u8,
+                    conn.request_buffer[0..remaining],
+                    conn.request_buffer[conn.request_offset..conn.request_len],
+                );
+                conn.request_len = remaining;
+                conn.request_offset = 0;
+                // A served request consumed at least its head, so the
+                // compacted buffer always has room for `armRecv`.
+                assert(conn.request_len < conn.request_buffer.len);
+            }
+
             /// A request still incomplete with the buffer full is
             /// forwarded excess the scripts never produce — a violation,
             /// not a capacity shortfall; otherwise read on.
@@ -346,9 +398,10 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     conn.armDrainRecv();
                     return;
                 }
-                // Keep-alive: the next request parses from the new offset
-                // (its bytes may already be buffered).
+                // Keep-alive: the next request parses from the front
+                // again (its bytes may already be buffered).
                 conn.phase = .head;
+                conn.compact();
                 conn.advance();
             }
 


### PR DESCRIPTION
Seed 3064744 failed the §9 gate with `OriginSawMalformedBytes`. The bug was in the oracle, not the proxy.

## Diagnosis

`sim/l7/origin.zig` advanced `request_offset` per parsed request but never reset `request_len`, so its 16 KiB buffer accumulated a connection's **entire lifetime** of forwarded traffic instead of the request in flight. Instrumenting the four violation sites:

```
HEAD ok conn=…@7fff4cc51990 served=0 off=0     len=370   head_len=55 target=/big
HEAD ok conn=…@7fff4cc51990 served=1 off=6055  len=8556  head_len=55 target=/big
HEAD ok conn=…@7fff4cc51990 served=2 off=12110 len=12966 head_len=55 target=/big
VIOLATION buffer-full phase=body off=16384 len=16384 tag=content_length rem=1781
```

§5 parking reuses one upstream connection across exchanges, so three `post_big` forwards (6055 bytes each: 55-byte head + 6000-byte body) landed at offsets 0 / 6055 / 12110 on the same `Conn`, and the third overran the buffer with 1781 body bytes still to come. Every byte in the dumped buffer was a verbatim, canonical, correctly-framed `POST /big` — the gate failed the seed on the proxy's own good behavior.

It also made the oracle's own claim false. *"A full origin buffer is a violation too, not a shortfall"* cannot hold while the buffer measures connection lifetime: the reuse count is unbounded, so no fixed capacity survives it.

## Fix

- **`compact()`** at the keep-alive boundary in `onSend` drops the answered requests' bytes, so the buffer bounds one request and the claim holds by construction.
- A **comptime block**, mirroring the existing idiom in `sim/l7/client.zig`, checks that every script's wire bytes fit the buffer — adding one past it now fails at compile time rather than as a rare seed.

One request is the whole bound, and the buffer stays 16 KiB. A recv can coalesce this request's tail with the next one's opening bytes, which `compact()` carries over, but only a later exchange can supply those and §5 checkout is exclusive (`upstream.park` asserts `!parked`; `unpark` is the only path back to leased), so the proxy cannot forward the next request until this response has fully arrived — which is after `compact()` ran.

## Verification

- `zig build ci` and `zig fmt --check` green.
- Seed 3064744 passes; sweeps of `3060000..3079999` and `3100000..3299999` (220k seeds) pass.
- A **pre-fix census** over that same 220k found exactly one failure — 3064744 itself. That is why the 4096-seed `ci` sweep never saw it: the shape needs three clients all drawing `post_big` (1/16 each) onto one reused connection with a keep-alive origin mode.
- `nightly-sim.yml` sweeps disjoint blocks keyed to run number and never re-sweeps a seed, so the comptime check is the durable guard here, not the seed.

Reviewed with `tiger-style-reviewer`, which caught two things now folded in: the original patch bumped the buffer to 24 KiB on a mechanism claim that does not trace (no recv is armed between the last consume and `compact()`), and that bump added ~262 KiB to `Harness`, a stack local in `runSeed`. Both reverted — the bound is one request, so 16 KiB was already ample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)