### PR TITLE
sim: a failing night reports its whole block, not the first seed (§9)

### DIFF
--- a/.github/workflows/nightly-sim.yml
+++ b/.github/workflows/nightly-sim.yml
@@ -12,6 +12,17 @@ name: Nightly simulation
 # the sweep is a cumulative claim — "seeds 1..N have been swept" — rather
 # than the random walk `zig build sim -- fuzz` would give. Any failure
 # replays exactly, locally, from the seed in the report.
+#
+# The night's block is split across parallel shards, and each shard
+# sweeps with `keep-going`. Both exist because a failure used to cost the
+# rest of the night: run #4 (2026-07-30) stopped at seed 3064744, 6.5%
+# into its million-seed block, so the night proved nothing about the
+# other 935k — and since ranges are keyed to the run number, that
+# remainder is never revisited. Now a shard censuses its own slice
+# instead of stopping, and `fail-fast: false` keeps the siblings running,
+# so a *failing* night still reports its whole block. Sharding also buys
+# the block size back in wall clock: 4M seeds finish in the time 1M used
+# to take.
 
 on:
   schedule:
@@ -20,9 +31,13 @@ on:
   workflow_dispatch:
     inputs:
       seeds:
-        description: "Seeds to sweep this run"
+        description: "Seeds per shard"
         required: false
         default: "1000000"
+      shards:
+        description: "Parallel shards (block = shards x seeds)"
+        required: false
+        default: "4"
       start_seed:
         description: "First seed (blank = continue the nightly range)"
         required: false
@@ -34,14 +49,88 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  soak:
-    name: sim soak
+  # Contiguous, disjoint blocks: run N sweeps the N-th block, so the union
+  # over all runs is a solid range from seed 1 with no repeats. Two things
+  # put holes in that: changing `seeds`/`shards` between runs re-tiles the
+  # blocks, and a manual run with `start_seed` still consumes a run
+  # number, leaving that block unswept. Both are harmless — seeds are
+  # independent — and both are why every report states the exact range
+  # swept rather than implying the union.
+  plan:
+    name: plan block
     runs-on: ubuntu-latest
-    # Measured ~800 seeds/s in Debug on an 8-core dev box; a shared
-    # runner is slower, so 1M seeds is roughly an hour. The cap is
-    # headroom, not a target — a soak that hits it should shrink `seeds`
-    # rather than run longer.
-    timeout-minutes: 180
+    outputs:
+      shards: ${{ steps.range.outputs.shards }}
+      shard_list: ${{ steps.range.outputs.shard_list }}
+      seeds: ${{ steps.range.outputs.seeds }}
+      start: ${{ steps.range.outputs.start }}
+      last: ${{ steps.range.outputs.last }}
+      block: ${{ steps.range.outputs.block }}
+    steps:
+      - name: Compute seed range
+        id: range
+        env:
+          SEEDS: ${{ inputs.seeds || '1000000' }}
+          SHARDS: ${{ inputs.shards || '4' }}
+          START_OVERRIDE: ${{ inputs.start_seed }}
+          RUN_NUMBER: ${{ github.run_number }}
+          # Runs 1..4 swept seeds 1..4,000,000 one job at a time, 1M per
+          # run. The sharded tiling resumes after them rather than
+          # re-deriving from run 1, because a block-size change would
+          # otherwise skip everything between the old tiling's end and the
+          # new block's start — 12M seeds, in this case. Changing
+          # `seeds`/`shards` again wants the same treatment: set the pair
+          # below to the last seed swept and the next run's number.
+          SWEPT_BEFORE: "4000000"
+          FIRST_SHARDED_RUN: "5"
+        run: |
+          set -euo pipefail
+          block=$(( SHARDS * SEEDS ))
+          if [ -n "$START_OVERRIDE" ]; then
+            start="$START_OVERRIDE"
+          elif [ "$RUN_NUMBER" -ge "$FIRST_SHARDED_RUN" ]; then
+            start=$(( SWEPT_BEFORE + 1 + (RUN_NUMBER - FIRST_SHARDED_RUN) * block ))
+          else
+            # Only reachable if the epoch above is edited without moving
+            # FIRST_SHARDED_RUN past the runs it describes.
+            start=$(( 1 + (RUN_NUMBER - 1) * block ))
+          fi
+          {
+            echo "shards=$SHARDS"
+            echo "shard_list=$(seq 0 $(( SHARDS - 1 )) | jq -cs .)"
+            echo "seeds=$SEEDS"
+            echo "start=$start"
+            echo "block=$block"
+            echo "last=$(( start + block - 1 ))"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Summarize the plan
+        env:
+          SHARDS: ${{ steps.range.outputs.shards }}
+          SEEDS: ${{ steps.range.outputs.seeds }}
+          START: ${{ steps.range.outputs.start }}
+          LAST: ${{ steps.range.outputs.last }}
+        run: |
+          set -euo pipefail
+          echo "Sweeping $START..$LAST across $SHARDS shards of $SEEDS seeds." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  soak:
+    name: sim soak ${{ matrix.shard }}
+    needs: plan
+    runs-on: ubuntu-latest
+    strategy:
+      # The point of sharding: one shard's failure must not cancel the
+      # others, or a failing night still reports a single slice.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.plan.outputs.shard_list) }}
+    # Measured on this runner 2026-07-29 (run #3): 1M seeds in 717 s, so
+    # ~1400 seeds/s in Debug — a shared runner is not slower than the dev
+    # box here. A 1M shard is ~12 min; the cap is headroom, not a target,
+    # and a shard that hits it should shrink `seeds` rather than run
+    # longer. `keep-going` never runs past the end of its own slice.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
 
@@ -60,30 +149,6 @@ jobs:
       - name: Install devenv
         run: nix profile install --accept-flake-config github:cachix/devenv/v2.1.2
 
-      # Contiguous, disjoint blocks: run N sweeps the N-th block, so the
-      # union over all runs is a solid range from seed 1 with no repeats.
-      # Two things put holes in that: changing `seeds` between runs
-      # re-tiles the blocks, and a manual run with `start_seed` still
-      # consumes a run number, leaving that block unswept. Both are
-      # harmless — seeds are independent — and both are why the report
-      # states the exact range swept rather than implying the union.
-      - name: Compute seed range
-        id: range
-        env:
-          SEEDS: ${{ inputs.seeds || '1000000' }}
-          START_OVERRIDE: ${{ inputs.start_seed }}
-          RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          set -euo pipefail
-          if [ -n "$START_OVERRIDE" ]; then
-            start="$START_OVERRIDE"
-          else
-            start=$(( 1 + (RUN_NUMBER - 1) * SEEDS ))
-          fi
-          echo "start=$start" >> "$GITHUB_OUTPUT"
-          echo "count=$SEEDS" >> "$GITHUB_OUTPUT"
-          echo "last=$(( start + SEEDS - 1 ))" >> "$GITHUB_OUTPUT"
-
       # Debug, deliberately, and do not "optimize" this. Measured
       # 2026-07-28 on the dev box, 20k seeds: Debug 25 s, ReleaseSafe
       # 88 s, ReleaseFast 3 s. ReleaseFast is the tempting one and is
@@ -99,63 +164,136 @@ jobs:
       - name: Sweep
         id: sweep
         env:
-          START: ${{ steps.range.outputs.start }}
-          COUNT: ${{ steps.range.outputs.count }}
+          START: ${{ needs.plan.outputs.start }}
+          SEEDS: ${{ needs.plan.outputs.seeds }}
+          SHARD: ${{ matrix.shard }}
         run: |
           set -uo pipefail
+          shard_start=$(( START + SHARD * SEEDS ))
+          shard_last=$(( shard_start + SEEDS - 1 ))
           began=$(date +%s)
           set +e
-          devenv shell -- zig build sim -- "$START" "$COUNT" 2>&1 | tee sweep.log
+          devenv shell -- zig build sim -- "$shard_start" "$SEEDS" keep-going 2>&1 \
+            | tee "sweep-${SHARD}.log"
           status=${PIPESTATUS[0]}
           set -e
           elapsed=$(( $(date +%s) - began ))
-          echo "elapsed=$elapsed" >> "$GITHUB_OUTPUT"
-          echo "rate=$(( COUNT / (elapsed > 0 ? elapsed : 1) ))" >> "$GITHUB_OUTPUT"
-          # The simulator names the offending seed on every failure shape
-          # (a failed invariant, the same on replay, and a trace that did
-          # not reproduce), which is the whole handle for reproducing it:
-          # `zig build sim -- N 1`. Anchored to the simulator's own lines
-          # so a `seed=`-shaped string anywhere in the nix or build output
-          # cannot be mistaken for the verdict.
-          seed=$(grep -oE 'sim: (FAILURE|NONDETERMINISM).*' sweep.log \
-            | grep -oE 'seed=[0-9]+' | head -1 | cut -d= -f2 || true)
-          echo "seed=${seed:-}" >> "$GITHUB_OUTPUT"
-          if grep -q 'NONDETERMINISM' sweep.log; then
-            echo "kind=nondeterminism" >> "$GITHUB_OUTPUT"
-          else
-            echo "kind=invariant" >> "$GITHUB_OUTPUT"
+          # The simulator names every failing seed on the summary line and
+          # states the range it actually reached, so a shard that stopped
+          # at the failure cap cannot read as having cleared the rest.
+          # Anchored to the simulator's own lines so a `seed=`-shaped
+          # string anywhere in the nix or build output cannot be mistaken
+          # for the verdict.
+          seeds_failed=$(grep -oE '^sim: [0-9]+ seed\(s\) failed: .*' "sweep-${SHARD}.log" \
+            | sed 's/^.*failed: //' | head -1 || true)
+          swept_last=$(grep -oE '^sim: swept [0-9]+\.\.[0-9]+' "sweep-${SHARD}.log" \
+            | grep -oE '[0-9]+$' | head -1 || true)
+          extent=exact
+          if [ -z "$swept_last" ]; then
+            if [ "$status" -eq 0 ]; then
+              # A clean pass prints no `swept` line; the whole slice is done.
+              swept_last="$shard_last"
+            else
+              # Neither summary line: the sim panicked rather than
+              # returning, so `keep-going` never ran and how far this
+              # shard got is unknown. Claim nothing — assuming the full
+              # slice here would report a crashed shard as near-fully
+              # verified, which is the false all-clear this whole change
+              # exists to remove.
+              swept_last=$(( shard_start - 1 ))
+              extent=unknown
+            fi
           fi
-          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if grep -q 'NONDETERMINISM' "sweep-${SHARD}.log"; then
+            kind=nondeterminism
+          else
+            kind=invariant
+          fi
+          capped=false
+          if grep -q 'failure cap reached' "sweep-${SHARD}.log"; then capped=true; fi
+          # jq builds the record so a seed list can never break the JSON.
+          jq -n \
+            --argjson shard "$SHARD" \
+            --argjson start "$shard_start" \
+            --argjson last "$shard_last" \
+            --argjson swept_last "$swept_last" \
+            --argjson status "$status" \
+            --argjson elapsed "$elapsed" \
+            --argjson capped "$capped" \
+            --arg kind "$kind" \
+            --arg extent "$extent" \
+            --arg seeds "$seeds_failed" \
+            '{shard: $shard, start: $start, last: $last, swept_last: $swept_last,
+              status: $status, elapsed: $elapsed, capped: $capped, kind: $kind,
+              extent: $extent,
+              failed: ($seeds | split(" ") | map(select(length > 0) | tonumber))}' \
+            > "result-${SHARD}.json"
+          cat "result-${SHARD}.json"
           exit "$status"
 
-      # Reports both outcomes: a soak nobody hears from is indistinguishable
-      # from a soak that silently stopped running.
-      - name: Report to Discord
+      # always(): the record and the log are what the report is built
+      # from, so they must survive the shard failing.
+      - name: Upload shard result
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}
+          path: |
+            result-${{ matrix.shard }}.json
+            sweep-${{ matrix.shard }}.log
+          if-no-files-found: ignore
+
+  # Reports both outcomes, once for the whole block: a soak nobody hears
+  # from is indistinguishable from a soak that silently stopped running.
+  report:
+    name: report
+    needs: [plan, soak]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: shard-*
+          merge-multiple: true
+          path: results
+
+      - name: Report to Discord
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          OUTCOME: ${{ steps.sweep.outcome }}
-          START: ${{ steps.range.outputs.start }}
-          LAST: ${{ steps.range.outputs.last }}
-          COUNT: ${{ steps.range.outputs.count }}
-          ELAPSED: ${{ steps.sweep.outputs.elapsed }}
-          RATE: ${{ steps.sweep.outputs.rate }}
-          SEED: ${{ steps.sweep.outputs.seed }}
-          KIND: ${{ steps.sweep.outputs.kind }}
+          OUTCOME: ${{ needs.soak.result }}
+          START: ${{ needs.plan.outputs.start }}
+          LAST: ${{ needs.plan.outputs.last }}
+          BLOCK: ${{ needs.plan.outputs.block }}
+          SHARDS: ${{ needs.plan.outputs.shards }}
+          SEEDS: ${{ needs.plan.outputs.seeds }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${WEBHOOK:-}" ]; then
-            echo "::warning::DISCORD_WEBHOOK is not set; skipping the report."
-            exit 0
-          fi
-          # printf, not a multi-line literal: the replay block carries
-          # newlines and backticks, and both stay inside one YAML line here.
-          if [ "$OUTCOME" = "success" ]; then
+          # One aggregate over every shard that produced a record. Shards
+          # that never got that far are counted as missing rather than
+          # passing, so a lost shard cannot inflate the claim.
+          records=$(cat results/result-*.json 2>/dev/null | jq -cs . || echo '[]')
+          reported=$(echo "$records" | jq 'length')
+          swept=$(echo "$records" | jq '[.[] | .swept_last - .start + 1] | add // 0')
+          failing=$(echo "$records" | jq '[.[] | select(.status != 0)] | length')
+          capped=$(echo "$records" | jq '[.[] | select(.capped)] | length')
+          seeds=$(echo "$records" | jq -r '[.[] | .failed[]] | sort | .[0:20] | join(" ")')
+          total_seeds=$(echo "$records" | jq '[.[] | .failed | length] | add // 0')
+          missing=$(( SHARDS - reported ))
+          unknown=$(echo "$records" | jq '[.[] | select(.extent == "unknown")] | length')
+          elapsed=$(echo "$records" | jq '[.[] | .elapsed] | max // 0')
+          # Say when the list is trimmed: "naming 40 seeds" beside 20 of
+          # them otherwise reads as the whole set.
+          shown=""
+          if [ "$total_seeds" -gt 20 ]; then shown=" (first 20)"; fi
+
+          if [ "$OUTCOME" = "success" ] && [ "$missing" -eq 0 ]; then
             title="Nightly simulation passed"
             color=3066993
-            detail=$(printf 'Swept seeds `%s..%s` with every §9 invariant holding.' "$START" "$LAST")
+            detail=$(printf 'Swept seeds `%s..%s` across %s shards with every §9 invariant holding.' \
+              "$START" "$LAST" "$SHARDS")
           elif [ "$OUTCOME" = "cancelled" ]; then
             # Distinct from a failure: nothing was proven, but nothing broke.
             title="Nightly simulation cancelled"
@@ -164,11 +302,33 @@ jobs:
           else
             title="Nightly simulation FAILED"
             color=15158332
-            if [ -n "${SEED:-}" ]; then
-              detail=$(printf 'Seed `%s` failed (%s). Replay it exactly:\n```\nzig build sim -- %s 1\n```' "$SEED" "$KIND" "$SEED")
+            if [ "$total_seeds" -gt 0 ]; then
+              detail=$(printf '%s of %s shards failed, naming %s seed(s)%s. Replay any of them exactly:\n```\nzig build sim -- <seed> 1\n```\nSeeds: `%s`' \
+                "$failing" "$SHARDS" "$total_seeds" "$shown" "$seeds")
             else
-              detail="The sweep failed before naming a seed — see the run log."
+              detail=$(printf '%s of %s shards failed without naming a seed — see the run log.' \
+                "$failing" "$SHARDS")
             fi
+            if [ "$capped" -gt 0 ]; then
+              detail="$detail"$(printf '\n%s shard(s) hit the failure cap, so seeds past their last swept point are unverified.' "$capped")
+            fi
+            # A shard that died before writing its record proved nothing,
+            # and its slice is not in the swept count — say so rather than
+            # letting the passing shards imply the block was covered.
+            if [ "$missing" -gt 0 ]; then
+              detail="$detail"$(printf '\n%s shard(s) produced no record at all; their slices are unswept.' "$missing")
+            fi
+            # A panic prints no summary line, so the sim never named the
+            # seed and the slice counts as zero verified.
+            if [ "$unknown" -gt 0 ]; then
+              detail="$detail"$(printf '\n%s shard(s) crashed rather than returning a verdict; their coverage is unknown and counted as zero. Check the sweep log for the panic.' "$unknown")
+            fi
+          fi
+
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::DISCORD_WEBHOOK is not set; skipping the report."
+            printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
           # jq builds the payload so a seed, a range, or a future message
           # can never break out of the JSON.
@@ -176,8 +336,9 @@ jobs:
             --arg title "$title" \
             --arg detail "$detail" \
             --argjson color "$color" \
-            --arg range "${START:-?}..${LAST:-?} (${COUNT:-?} seeds)" \
-            --arg timing "${ELAPSED:-0}s (~${RATE:-0} seeds/s)" \
+            --arg range "${START:-?}..${LAST:-?} (${BLOCK:-?} seeds)" \
+            --arg shards "${SHARDS:-?} x ${SEEDS:-?}, ${swept} verified" \
+            --arg timing "${elapsed:-0}s slowest shard" \
             --arg sha "${SHA:0:7}" \
             --arg url "$RUN_URL" \
             '{
@@ -189,6 +350,7 @@ jobs:
                 url: $url,
                 fields: [
                   {name: "Range", value: $range, inline: true},
+                  {name: "Shards", value: $shards, inline: true},
                   {name: "Duration", value: $timing, inline: true},
                   {name: "Commit", value: $sha, inline: true}
                 ]
@@ -197,15 +359,4 @@ jobs:
           curl -sS -f -X POST -H "Content-Type: application/json" \
             -d @payload.json "$WEBHOOK" > /dev/null
           echo "Reported: $title"
-
-      # The failing seed is the reproducer, but the log says which
-      # invariant broke — worth keeping past the Discord message.
-      - name: Upload sweep log
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: sweep-log
-          path: sweep.log
-          # A failure before the sweep (build, devenv) leaves no log; that
-          # is not itself an error worth failing the job a second time for.
-          if-no-files-found: ignore
+          printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -773,7 +773,12 @@ so `zig build bench` is invoked deliberately against a real origin, and
 its hard invariants (flat RSS, clean drain, sub-1% socket-error rate)
 are the pass/fail part. `zig build ci` deliberately excludes it.
 
-1. **Deterministic simulation — `zig build sim -- [seed] [iterations]`.**
+1. **Deterministic simulation — `zig build sim -- [seed] [iterations]
+   [keep-going]`.** `keep-going` names every failing seed in the range
+   (up to a cap) instead of stopping at the first, and states the range
+   it actually reached: the nightly soak wants that census, because its
+   blocks are keyed to the run number and a block abandoned mid-sweep is
+   never revisited. `ci` omits it and keeps the first failure, fast.
    The `SimIo` backend (§4) runs the real data path against virtual
    sockets and a virtual clock under a seeded adversarial scheduler:
    partial reads/writes down to 1 byte, delayed/refused/black-holed/

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -1,8 +1,9 @@
 //! The §9 deterministic-simulation gate: `zig build sim -- [seed]
-//! [iterations] | fuzz`. Every seed derives a scenario (sim/Harness.zig)
-//! and runs the *real* serving path over SimIo — twice, asserting the
-//! two trace hashes are identical, so replayability itself is gated. A
-//! failure prints its seed; the same seed replays the exact schedule.
+//! [iterations] [keep-going] | fuzz`. Every seed derives a scenario
+//! (sim/Harness.zig) and runs the *real* serving path over SimIo — twice,
+//! asserting the two trace hashes are identical, so replayability itself
+//! is gated. A failure prints its seed; the same seed replays the exact
+//! schedule.
 
 const std = @import("std");
 
@@ -21,6 +22,25 @@ const default_seed: u64 = 1;
 /// determinism check).
 const default_iterations: u64 = 4096;
 const progress_interval: u64 = 500;
+/// The most failing seeds one `keep-going` sweep names before it stops.
+/// Bounded so a systematically broken build prints a census rather than a
+/// line per seed; the sweep reports the range it actually reached, so a
+/// run that hits this cap never reads as having cleared the remainder.
+const failures_max: u8 = 16;
+
+/// One swept range, and whether a failure ends it.
+const Sweep = struct {
+    first_seed: u64,
+    iterations: u64,
+    /// Name every failing seed in the range (up to `failures_max`)
+    /// instead of stopping at the first. The nightly soak wants the
+    /// census: stopping first means a night's evidence is the one seed
+    /// the sweep happened to reach, and because the soak's ranges are
+    /// keyed to its run number, the abandoned remainder is never
+    /// revisited. `ci` wants the opposite — the first failure, fast — so
+    /// this is opt-in.
+    keep_going: bool,
+};
 
 pub fn main(init: std.process.Init) !u8 {
     const arguments = try init.minimal.args.toSlice(init.arena.allocator());
@@ -28,38 +48,109 @@ pub fn main(init: std.process.Init) !u8 {
     defer arena_state.deinit();
 
     if (arguments.len == 2 and std.mem.eql(u8, arguments[1], "fuzz")) {
-        var count: u64 = 0;
-        while (true) : (count += 1) {
-            var seed_bytes: [8]u8 = undefined;
-            init.io.random(&seed_bytes);
-            const seed = std.mem.readInt(u64, &seed_bytes, .little);
-            checkSeed(&arena_state, seed) catch return 1;
-            if (count % progress_interval == 0) {
-                std.debug.print("sim fuzz: {d} seeds ok, latest {d}\n", .{ count + 1, seed });
-            }
+        return fuzzForever(&arena_state, init.io);
+    }
+    const options = try parseSweep(arguments);
+    return sweep(&arena_state, &options);
+}
+
+/// Random seeds until something breaks: the unbounded companion to the
+/// soak's contiguous blocks, for a developer watching one change.
+fn fuzzForever(arena_state: *std.heap.ArenaAllocator, io: std.Io) !u8 {
+    var count: u64 = 0;
+    while (true) : (count += 1) {
+        var seed_bytes: [8]u8 = undefined;
+        io.random(&seed_bytes);
+        const seed = std.mem.readInt(u64, &seed_bytes, .little);
+        checkSeed(arena_state, seed) catch return 1;
+        if (count % progress_interval == 0) {
+            std.debug.print("sim fuzz: {d} seeds ok, latest {d}\n", .{ count + 1, seed });
         }
     }
+}
 
-    const first_seed = if (arguments.len >= 2)
-        try std.fmt.parseUnsigned(u64, arguments[1], 10)
-    else
-        default_seed;
-    const iterations = if (arguments.len >= 3)
-        try std.fmt.parseUnsigned(u64, arguments[2], 10)
-    else
-        default_iterations;
-    assert(iterations >= 1);
-
-    var seed = first_seed;
-    while (seed < first_seed + iterations) : (seed += 1) {
-        checkSeed(&arena_state, seed) catch return 1;
+fn parseSweep(arguments: []const []const u8) !Sweep {
+    // argv[0] is the program name; the sweep's arguments follow it.
+    assert(arguments.len >= 1);
+    var parsed: Sweep = .{
+        .first_seed = default_seed,
+        .iterations = default_iterations,
+        .keep_going = false,
+    };
+    var positional: u8 = 0;
+    for (arguments[1..]) |argument| {
+        if (std.mem.eql(u8, argument, "keep-going")) {
+            parsed.keep_going = true;
+            continue;
+        }
+        positional += 1;
+        switch (positional) {
+            1 => parsed.first_seed = try std.fmt.parseUnsigned(u64, argument, 10),
+            2 => parsed.iterations = try std.fmt.parseUnsigned(u64, argument, 10),
+            else => return error.TooManyArguments,
+        }
     }
-    std.debug.print("sim: {d} seed(s) ok, {d}..{d}\n", .{
-        iterations,
-        first_seed,
-        first_seed + iterations - 1,
+    if (parsed.iterations == 0) return error.NoIterations;
+    assert(parsed.iterations >= 1);
+    assert(positional <= 2);
+    return parsed;
+}
+
+/// Sweeps the range and returns the process exit code. Every seed is
+/// independent — a fresh `Harness` over a reset arena — so continuing
+/// past a failure cannot contaminate the seeds after it.
+///
+/// This only rescues the *returned* failures: a broken invariant inside
+/// the serving path is a `std.debug.assert`, which panics the process
+/// whatever this flag says.
+fn sweep(arena_state: *std.heap.ArenaAllocator, options: *const Sweep) !u8 {
+    assert(options.iterations >= 1);
+    const end = options.first_seed + options.iterations;
+    var failed: [failures_max]u64 = @splat(0);
+    var failed_count: u8 = 0;
+    var seed = options.first_seed;
+    while (seed < end) : (seed += 1) {
+        checkSeed(arena_state, seed) catch {
+            assert(failed_count < failures_max);
+            failed[failed_count] = seed;
+            failed_count += 1;
+            if (options.keep_going) {
+                if (failed_count == failures_max) break;
+            } else {
+                break;
+            }
+        };
+    }
+    if (failed_count == 0) {
+        assert(seed == end);
+        std.debug.print("sim: {d} seed(s) ok, {d}..{d}\n", .{
+            options.iterations,
+            options.first_seed,
+            end - 1,
+        });
+        return 0;
+    }
+    reportFailures(options, failed[0..failed_count], @min(seed, end - 1));
+    return 1;
+}
+
+/// Names every failing seed, then the range actually covered: a sweep
+/// that stopped early proves nothing about the seeds past it, and saying
+/// so is the difference between a census and a false all-clear.
+fn reportFailures(options: *const Sweep, failed: []const u64, swept_last: u64) void {
+    assert(failed.len >= 1);
+    assert(failed.len <= failures_max);
+    assert(swept_last >= options.first_seed);
+    const last = options.first_seed + options.iterations - 1;
+    std.debug.print("sim: {d} seed(s) failed:", .{failed.len});
+    for (failed) |seed| std.debug.print(" {d}", .{seed});
+    std.debug.print("\nsim: swept {d}..{d} of {d}..{d}{s}\n", .{
+        options.first_seed,
+        swept_last,
+        options.first_seed,
+        last,
+        if (failed.len == failures_max) " (failure cap reached)" else "",
     });
-    return 0;
 }
 
 /// One seed, run twice: the second run must produce a byte-identical


### PR DESCRIPTION
Follow-up to #118. That PR fixed the bug seed 3064744 found; this fixes how little the soak told us while finding it.

## The problem

`zig build sim` stopped at the first failing seed. Nightly run #4 (2026-07-30) aborted at seed 3064744 — **6.5% into its million-seed block** — so the night verified ~65k of 1M. Because ranges are keyed to `github.run_number`, the abandoned 935k is never revisited. One serial job also meant the failure cost the entire block.

## Changes

**`keep-going` (opt-in) censuses the range** instead of stopping: every failing seed up to a cap of 16, then the range the sweep *actually reached*, so a run that stopped early can never read as having cleared the remainder. Seeds are independent — each `runSeed` resets the arena and builds a fresh `Harness` — so continuing cannot contaminate later seeds. It rescues *returned* errors only; a `std.debug.assert` in the serving path still panics, and the soak now says so rather than guessing. `ci` passes no flag and keeps failing fast.

**The nightly shards its block** across parallel jobs with `fail-fast: false`, so one shard's failure no longer cancels its siblings, and a `report` job aggregates one Discord message from per-shard artifacts. Sharding buys the block size back in wall clock: the default **4 × 1M sweeps 4M seeds in the ~12 min one 1M job used to take**. Measured rate is ~1400 seeds/s in Debug on the runner (run #3: 1M in 717 s), so the old "1M is roughly an hour" note was stale by ~5×.

**The tiling stays cumulative** across the block-size change. Runs 1..4 swept 1..4,000,000 at 1M/run; `SWEPT_BEFORE`/`FIRST_SHARDED_RUN` make run 5 resume at exactly 4,000,001 rather than re-deriving from run 1, which would have skipped 4M..16M outright.

**Coverage is never assumed.** A shard that panics prints neither summary line, so its extent is unknown and counted as **zero** verified — assuming the full slice would report a crashed shard as near-fully verified, the exact false all-clear this change exists to remove. Vanished shards, shards that hit the failure cap, and a trimmed seed list are each called out rather than absorbed into a clean-looking total.

## Verification

- `zig build ci` and `zig fmt --check` green; `actionlint` clean at its pre-existing baseline (2 informational SC2016 on the jq filters — same count as `HEAD`).
- Sweep paths exercised against an injected failure every 7th seed: fail-fast stops at the first and reports the short range (`swept 100..105 of 100..149`), `keep-going` censuses all 7, the cap trips at 16 and says `(failure cap reached)`, and a single failing seed reports `swept 105..105 of 105..105`.
- Block math checked for runs 5/6/7: zero gap from seed 4,000,000, contiguous across both shards and runs.
- Shard parsing and report aggregation run against real log formats for clean, failing, capped, crashed, and missing shards — the crashed shard contributes 0 to the verified count, not its million.

`tiger-style-reviewer` caught two violations now fixed: `Sweep` is 24 bytes so it must pass as `*const` (TIGER_STYLE:85), and the crashed-shard coverage fallback described above, which originally claimed the full slice. It also flagged the stale `zig build sim` synopsis in DESIGN.md §9, updated here.

## Note

This deliberately does **not** raise the seed count 10× as first considered. Multiplying a budget that failures truncate gains nothing on a night with a bug — 10M aborts at the same seed 1M does. Sharding delivers the coverage increase where it also helps a *failing* night, and the shard count is one input away if you want 10M/night (~140 min of Actions minutes vs ~56 at the 4-shard default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)