### PR TITLE
health: active TCP health checks for upstream endpoints (§5, §7, §9)

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -3,7 +3,7 @@
         { "bind": "127.0.0.1:8080", "cluster": "origin", "protocol": "l4" }
     ],
     "clusters": {
-        "origin": { "endpoints": ["127.0.0.1:9000"] }
+        "origin": { "endpoints": ["127.0.0.1:9000"], "check": true }
     },
     "timeouts": {
         "connect_ms": 5000,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -389,9 +389,9 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 11464 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 11464 | 2 × 4 KiB |
-| upstream slots | 1314 | 11464 | ~40 B state + 8 KiB head |
+| conn slots | 1386 | 11463 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 11463 | 2 × 4 KiB |
+| upstream slots | 1313 | 11463 | ~40 B state + 8 KiB head |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
 
 The access log (§8) adds one fixed reservation beside the pools — two
@@ -406,7 +406,7 @@ have to be copied out while they are still there.
 The ceilings sit on one completion-queue line — a conn slot costs
 `conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
 is **pinned to the conn ceiling**, so that line has a single divisor:
-`conn_ops_max + 1` ring ops per admitted connection, 11464 of them. On
+`conn_ops_max + 1` ring ops per admitted connection, 11463 of them. On
 the L7 path a connection that is mid-exchange holds an upstream slot as
 well as its conn slot, and at saturation every admitted connection can be
 mid-exchange at once — so an upstream ceiling below the conn ceiling is
@@ -424,8 +424,8 @@ recorded there.
 
 The *defaults* are not pinned to each other, and deliberately: the
 out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than
-by admission (matching 1386 would cost 4167 fds), so the upstream default
-sits at 1314 — the largest value that still stays strictly under that
+by admission (matching 1386 would cost 4168 fds), so the upstream default
+sits at 1313 — the largest value that still stays strictly under that
 line — rather than at the conn default. An L4 deployment never touches
 the upstream pool at all — an L4 dial holds no upstream slot. A
 deployment that means to fill its conn pool raises both together through

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -374,8 +374,11 @@ Three shared pools, all owned and touched only by the loop thread:
    an in-flight op per idle upstream in the ring budget (§8) for a race
    that is already covered: the parked connection's deadline timer serves
    as an idle timeout (kept below typical origin keep-alive windows, so
-   most origin-side closes are pre-empted), and a close that slips through
-   is detected at checkout and absorbed by the stale-replay rung (§7).
+   most origin-side closes are pre-empted), a close that slips through is
+   detected at checkout and absorbed by the stale-replay rung (§7), and
+   active health checks (§7) close the parked connections of an endpoint
+   at its ejection — a parked socket to a dead origin is a stale replay
+   waiting to be spent.
 
 Sizing shape. The comptime constants are the hard, budget-asserted
 *ceilings*; the config `limits` block sizes the *effective* pools anywhere
@@ -654,8 +657,25 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   from a fixed-seed PRNG, the lower leased count wins) by default, `rr`
   for strict rotation. Cluster endpoints are static socket addresses
   resolved once at config load, never on the loop (dynamic DNS is a
-  non-goal, §1). Circuit breakers, outlier ejection, retry budgets,
-  health checks are *deferred* — the previous iteration proved them
+  non-goal, §1).
+- **Active TCP health checks** are per-cluster opt-in (`check` —
+  HAProxy's model) so a request is not routed to an endpoint known to be
+  down. One prober per server sweeps every checked endpoint with a
+  single probe in flight, budgeted like the admin plane (§8:
+  `health_probe_ops_max` ring ops and one fd, reserved unconditionally);
+  each probe is a dial under the `connect_ms` budget, and sweeps pace
+  sweep-end to sweep-start on `timeouts.health_interval_ms`. A SYN/ACK
+  passes; refused, unreachable, timed out, or kernel pressure (witnessed
+  §8) fails. `health_probe_fall` (3) consecutive misses eject the
+  endpoint from balancing and close its parked pooled connections (§5);
+  `health_probe_rise` (2) passes restore it. Endpoints start healthy —
+  probing demotes, never gates startup — and the pick **fails open**: a
+  cluster with every endpoint ejected balances as if none were, because
+  routing nowhere would turn a probe verdict into an outage of its own,
+  and a same-port TCP probe cannot know better than the dial it stands
+  in for. The check is TCP-level: it proves the port accepts, not that
+  the application behind it is well. Circuit breakers, outlier ejection,
+  retry budgets stay *deferred* — the previous iteration proved them
   buildable in this architecture; simplicity says they wait for a
   demonstrated need.
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -35,6 +35,26 @@ const Harness = @This();
 const clients_max: u8 = 6;
 /// Virtual time from scenario start after which stuck work is force-ended.
 const scenario_end_ns: u64 = 2_000_000_000;
+/// The slowest §7 probe pacing a non-outage seed may draw. Named so the
+/// origin-capacity bound below is derived from the same number the draw
+/// uses, not restated in prose.
+const health_interval_floor_ms: u32 = 100;
+/// Upper bound on probe sweeps one scenario can run against a listening
+/// origin: the interval floor paces them across the scenario, plus the
+/// immediate first sweep. Outage seeds pace far tighter but stop their
+/// origin within tens of milliseconds, so their passing probes stay
+/// under this bound too.
+const probe_sweeps_max: u64 =
+    scenario_end_ns / (health_interval_floor_ms * std.time.ns_per_ms) + 1;
+
+comptime {
+    // Passing probes consume origin conn slots (accept-and-vanish, never
+    // recycled), on top of each origin's client-driven worst case: one
+    // conn per L4 client, and the pre-probe capacity of 32 the 4096-seed
+    // sweeps validated for the HTTP origin's dial churn.
+    assert(Origin.conns_max >= @as(u64, clients_max) + probe_sweeps_max);
+    assert(HttpOrigin.conns_max >= 32 + probe_sweeps_max);
+}
 
 io: SimIo,
 server: ServerSim,
@@ -58,6 +78,17 @@ ended_count: u8,
 /// origin, so the L7 oracles demand exact golden outcomes.
 clean: bool,
 end_timer_completion: SimIo.Completion,
+/// Virtual instant at which the HTTP origin stops listening mid-run, or
+/// 0 for never. Drawn on a fraction of checked-http adversarial seeds:
+/// probes then start refusing while parked connections from earlier
+/// exchanges still exist, which is the only schedule that reaches the
+/// §5 parked-close on ejection under the fuzz — chance alone almost
+/// never lines an ejection up with a parked conn. Statistical, not
+/// guaranteed: a scenario that winds down before the drawn instant
+/// never sees its outage, which is fine — the sweep needs the schedule
+/// to land often, not on every draw.
+http_origin_stop_at_ns: u64,
+http_origin_stop_completion: SimIo.Completion,
 scenario_prng: std.Random.DefaultPrng,
 
 fn bindAddress() std.Io.net.IpAddress {
@@ -103,6 +134,26 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
         harness,
         onScenarioEnd,
     );
+    harness.http_origin_stop_completion = .{};
+    if (harness.http_origin_stop_at_ns != 0) {
+        assert(harness.http_origin_stop_at_ns < scenario_end_ns);
+        harness.io.timerStart(
+            &harness.http_origin_stop_completion,
+            harness.http_origin_stop_at_ns,
+            Harness,
+            harness,
+            onHttpOriginStop,
+        );
+    }
+}
+
+/// The mid-run origin outage (§7): refused dials are a fate clients
+/// already meet under the adversary's own knobs, so the prefix oracles
+/// absorb it — what it adds is probes failing against a cluster that
+/// still holds parked connections.
+fn onHttpOriginStop(harness: *Harness, result: Io.TimerError!void) void {
+    result catch return;
+    harness.origin_http.stopListening();
 }
 
 fn deriveAdversary(random: std.Random, clean: bool) SimIo.Adversary {
@@ -145,9 +196,18 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         if (random.boolean()) .p2c else .rr;
     const pick_http: zoxy.config.Config.Cluster.Pick =
         if (random.boolean()) .p2c else .rr;
+    // Each cluster draws §7 active health checks independently, so the
+    // prober runs its whole lifecycle — sweeps, fall/rise transitions
+    // under the adversary's connect fates, parked-close on ejection, and
+    // drain from every state — inside the schedule fuzz. Fail-open keeps
+    // a single-endpoint topology's routing unchanged whatever the
+    // verdicts, so the L7 golden oracles hold on clean seeds (where
+    // probes always pass) and prefix-legality holds under the adversary.
+    const health = deriveHealthChecks(harness.clean, random);
+    harness.http_origin_stop_at_ns = health.http_origin_stop_at_ns;
     harness.clusters = .{
-        .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick_l4 },
-        .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick_http },
+        .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick_l4, .check = health.check_l4 },
+        .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick_http, .check = health.check_http },
     };
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
@@ -180,7 +240,49 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         // schedule fuzz; the fourth leaves it off, which is the shape
         // that must reserve nothing and read no clock (§5, §8).
         .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
+        .health_interval_ms = health.interval_ms,
     };
+}
+
+/// The §7 health-check shape of one scenario: which clusters probe, how
+/// fast, and whether the HTTP origin dies mid-run.
+const HealthDraw = struct {
+    check_l4: bool,
+    check_http: bool,
+    interval_ms: u32,
+    http_origin_stop_at_ns: u64,
+};
+
+/// An eighth of adversarial seeds are outage seeds: the HTTP origin
+/// stops listening while clients are still live and parked connections
+/// still exist — most scenarios wind down within tens of virtual
+/// milliseconds, so the outage lands inside that window, paced in
+/// milliseconds so fall's three misses do too. Outage seeds check only
+/// the http cluster: the tight pacing on a stuck 2 s scenario would
+/// otherwise stream hundreds of passing probes into the L4 origin's
+/// conn table, while the stopped HTTP origin refuses its probes and a
+/// refused probe consumes no origin conn. Everyone else paces from the
+/// `health_interval_floor_ms` the origin-capacity bound is derived at.
+fn deriveHealthChecks(clean: bool, random: std.Random) HealthDraw {
+    const outage = !clean and random.uintLessThan(u8, 8) == 0;
+    const draw: HealthDraw = .{
+        .check_l4 = !outage and random.boolean(),
+        .check_http = outage or random.boolean(),
+        .interval_ms = if (outage)
+            5 + random.uintAtMost(u32, 10)
+        else
+            health_interval_floor_ms + random.uintAtMost(u32, 400),
+        .http_origin_stop_at_ns = if (outage)
+            (10 + random.uintAtMost(u64, 30)) * std.time.ns_per_ms
+        else
+            0,
+    };
+    // An outage always probes the cluster it exists to eject, and the
+    // instant always precedes the scenario-end backstop.
+    assert(draw.http_origin_stop_at_ns == 0 or draw.check_http);
+    assert(draw.http_origin_stop_at_ns < scenario_end_ns);
+    assert(draw.interval_ms >= 1);
+    return draw;
 }
 
 /// The deterministic half of the topology: two listeners, and the §7

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -72,7 +72,11 @@ pub fn HttpOrigin(comptime IoType: type) type {
         violations: u32 = 0,
 
         const Self = @This();
-        pub const conns_max: u8 = 32;
+        /// Sized for the worst case: client-driven dials (fresh, replay,
+        /// post-ejection) plus a `check` scenario's passing probes, each
+        /// of which accepts and vanishes (§7) but still consumes a slot —
+        /// conns are tracked monotonically, never recycled.
+        pub const conns_max: u8 = 64;
         const request_buffer_bytes: u32 = 16384;
 
         const Phase = enum(u8) { head, body, respond };

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -19,6 +19,7 @@ const config_module = @import("config.zig");
 const constants = @import("constants.zig");
 const counters_module = @import("counters.zig");
 const conn_module = @import("net/Conn.zig");
+const health_module = @import("net/health.zig");
 const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
 const proxy = @import("http/proxy.zig");
@@ -92,6 +93,11 @@ pub fn Server(comptime IoType: type) type {
         /// ring op and two staging buffers, both reserved unconditionally
         /// in the budgets and allocated only when it is on.
         access_log: AccessLogType,
+        /// The §7 active health prober: one probe in flight, budgeted
+        /// separately (`constants.health_probe_ops_max`). Off unless a
+        /// cluster sets `check`; its `healthy` mask is what the balancer
+        /// picks through.
+        health: health_module.Checker(IoType),
 
         const Self = @This();
 
@@ -166,6 +172,7 @@ pub fn Server(comptime IoType: type) type {
             server.admin.init(server, config.admin_bind);
             server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
             try server.access_log.reserve(arena);
+            server.health.init(server);
         }
 
         /// Override the admin/metrics bind before `start` — the simulator
@@ -197,6 +204,7 @@ pub fn Server(comptime IoType: type) type {
                 server.armAccept(state);
             }
             try server.admin.start();
+            server.health.start();
             server.io.signalWait(Self, server, onSignal);
         }
 
@@ -215,6 +223,10 @@ pub fn Server(comptime IoType: type) type {
             // The admin listener stops accepting and any in-flight scrape
             // is torn down under the same drain (§8).
             server.admin.beginDrain();
+            // The prober stops too: a drain has no routing decisions left
+            // for its verdicts to inform, and its armed ops must drain
+            // before the loop may stop (§8).
+            server.health.beginStop();
             // Parked upstreams are idle capacity; the drain sheds them
             // first (§8). Synchronous closes: no armed op to wait for.
             server.reapParked(true);
@@ -263,6 +275,8 @@ pub fn Server(comptime IoType: type) type {
             // reading, and stopping the loop over an armed sink write
             // would lose exactly those (§8).
             if (!server.access_log.isQuiescent()) return;
+            // Same rule for the prober's armed ops (§8).
+            if (!server.health.isQuiescent()) return;
             assert(server.relay_buffers.isFullyReleased());
             // beginDrain reaped every parked slot synchronously and no
             // conn is left to lease one, so the pool must be empty.
@@ -325,7 +339,8 @@ pub fn Server(comptime IoType: type) type {
                 server.relay_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
                 server.admin.isQuiescent() and
-                server.access_log.isQuiescent();
+                server.access_log.isQuiescent() and
+                server.health.isQuiescent();
         }
 
         pub fn activeCount(server: *const Self) u32 {
@@ -623,7 +638,11 @@ pub fn Server(comptime IoType: type) type {
             // L4 dials hold no Upstream slot, so the load table reflects
             // L7 leases only — the P2C draw still spreads L4 dials by the
             // observed L7 load, and evenly when there is none.
-            const pick = server.balancer.pick(cluster_index, &server.upstreams.leased_counts);
+            const pick = server.balancer.pick(
+                cluster_index,
+                &server.upstreams.leased_counts,
+                &server.health.healthy,
+            );
             // An L4 dial holds no slot to record the endpoint on, so the
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
@@ -962,6 +981,8 @@ pub fn Server(comptime IoType: type) type {
                 .upstream_slots_parked = server.upstreams.parkedCount(),
                 .upstream_slots_capacity = server.upstreams.capacity(),
                 .kernel_pressure_last_errno = server.last_pressure_errno,
+                .health_endpoints_checked = server.health.checked_count,
+                .health_endpoints_unhealthy = server.health.unhealthy_count,
             };
             // Asserted at the producer, not in the renderer: a level past
             // its capacity would mean a pool miscounted, and that is a bug

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -53,12 +53,15 @@ pub const Balancer = struct {
     /// Choose the endpoint to dial for `cluster_index` under the
     /// cluster's configured policy. `leased_counts` is the pool's
     /// per-endpoint load table (indexed by `upstream.endpointKey`),
-    /// consulted by p2c and ignored by rr. Bounded work, no allocation,
-    /// and a validated config guarantees at least one endpoint.
+    /// consulted by p2c and ignored by rr; `healthy` is the §7 health
+    /// mask (same index) — the prober owns that truth the way the pool
+    /// owns the load. Bounded work, no allocation, and a validated
+    /// config guarantees at least one endpoint.
     pub fn pick(
         balancer: *Balancer,
         cluster_index: u16,
         leased_counts: *const [upstream.endpoint_keys_max]u16,
+        healthy: *const [upstream.endpoint_keys_max]bool,
     ) Pick {
         assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
@@ -66,12 +69,15 @@ pub const Balancer = struct {
         assert(cluster.endpoints.len <= constants.endpoints_per_cluster_max);
         if (cluster.endpoints.len == 1) {
             // Neither a rotation nor a draw: single-endpoint clusters
-            // stay branch-cheap and policy state is untouched.
+            // stay branch-cheap and policy state is untouched. The mask
+            // is moot too — one endpoint ejected is the fail-open case.
             return .{ .address = cluster.endpoints[0], .endpoint_index = 0 };
         }
+        var eligible: [constants.endpoints_per_cluster_max]u16 = undefined;
+        const count = eligibleEndpoints(cluster_index, cluster, healthy, &eligible);
         const chosen = switch (cluster.pick) {
-            .rr => balancer.pickRoundRobin(cluster_index, cluster),
-            .p2c => balancer.pickPowerOfTwo(cluster_index, cluster, leased_counts),
+            .rr => balancer.pickRoundRobin(cluster_index, eligible[0..count]),
+            .p2c => balancer.pickPowerOfTwo(cluster_index, eligible[0..count], leased_counts),
         };
         assert(chosen < cluster.endpoints.len);
         return .{
@@ -80,42 +86,80 @@ pub const Balancer = struct {
         };
     }
 
-    /// Strict rotation: the cursor modulo the endpoint count, then
-    /// incremented — every endpoint sees exactly its share, in order.
+    /// The §7-eligible endpoints: the healthy ones — or, the fail-open
+    /// rule, every endpoint when the whole cluster is ejected. Dialing a
+    /// maybe-dead endpoint reports the outage the way it always did;
+    /// routing nowhere would turn a probe verdict into an outage of its
+    /// own, and a same-port TCP probe cannot know better than the dial.
+    fn eligibleEndpoints(
+        cluster_index: u16,
+        cluster: *const config_module.Config.Cluster,
+        healthy: *const [upstream.endpoint_keys_max]bool,
+        eligible: *[constants.endpoints_per_cluster_max]u16,
+    ) u16 {
+        assert(cluster.endpoints.len >= 2); // pick() short-circuited 1.
+        var count: u16 = 0;
+        for (0..cluster.endpoints.len) |endpoint_index| {
+            const index: u16 = @intCast(endpoint_index);
+            if (healthy[upstream.endpointKey(cluster_index, index)]) {
+                eligible[count] = index;
+                count += 1;
+            }
+        }
+        if (count == 0) {
+            for (0..cluster.endpoints.len) |endpoint_index| {
+                eligible[endpoint_index] = @intCast(endpoint_index);
+            }
+            count = @intCast(cluster.endpoints.len);
+        }
+        assert(count >= 1);
+        assert(count <= cluster.endpoints.len);
+        return count;
+    }
+
+    /// Strict rotation over the eligible set: the cursor modulo its
+    /// size, then incremented — every eligible endpoint sees its share,
+    /// in order. Ejections shift the rotation phase; the share stays
+    /// exact for whatever set is eligible at each pick.
     fn pickRoundRobin(
         balancer: *Balancer,
         cluster_index: u16,
-        cluster: *const config_module.Config.Cluster,
+        eligible: []const u16,
     ) u16 {
-        assert(cluster.pick == .rr);
-        assert(cluster.endpoints.len >= 2); // pick() short-circuited 1.
-        const chosen: u16 =
-            @intCast(balancer.cursors[cluster_index] % cluster.endpoints.len);
+        assert(balancer.config.clusters[cluster_index].pick == .rr);
+        assert(eligible.len >= 1);
+        const slot: u16 = @intCast(balancer.cursors[cluster_index] % eligible.len);
         balancer.cursors[cluster_index] += 1;
-        assert(chosen < cluster.endpoints.len);
-        return chosen;
+        assert(slot < eligible.len);
+        return eligible[slot];
     }
 
-    /// P2C: two distinct uniform candidates, the lower leased count
-    /// wins, a tie goes to the first.
+    /// P2C over the eligible set: two distinct uniform candidates, the
+    /// lower leased count wins, a tie goes to the first. A mask narrowed
+    /// to one endpoint skips the draw the way a one-endpoint cluster
+    /// does — no candidates to compare, no PRNG state spent.
     fn pickPowerOfTwo(
         balancer: *Balancer,
         cluster_index: u16,
-        cluster: *const config_module.Config.Cluster,
+        eligible: []const u16,
         leased_counts: *const [upstream.endpoint_keys_max]u16,
     ) u16 {
-        assert(cluster.pick == .p2c);
-        const endpoint_count = cluster.endpoints.len;
-        assert(endpoint_count >= 2); // pick() short-circuited 1.
-        const first: u16 = @intCast(balancer.next() % endpoint_count);
-        var second: u16 = @intCast(balancer.next() % (endpoint_count - 1));
-        // Skip past `first`, mapping the (n-1)-range draw onto the other
-        // n-1 endpoints uniformly.
-        if (second >= first) {
-            second += 1;
+        assert(balancer.config.clusters[cluster_index].pick == .p2c);
+        assert(eligible.len >= 1);
+        if (eligible.len == 1) {
+            return eligible[0];
         }
-        assert(first != second);
-        assert(second < endpoint_count);
+        const first_slot: u16 = @intCast(balancer.next() % eligible.len);
+        var second_slot: u16 = @intCast(balancer.next() % (eligible.len - 1));
+        // Skip past `first_slot`, mapping the (n-1)-range draw onto the
+        // other n-1 eligible slots uniformly.
+        if (second_slot >= first_slot) {
+            second_slot += 1;
+        }
+        assert(first_slot != second_slot);
+        assert(second_slot < eligible.len);
+        const first = eligible[first_slot];
+        const second = eligible[second_slot];
         const first_load = leased_counts[upstream.endpointKey(cluster_index, first)];
         const second_load = leased_counts[upstream.endpointKey(cluster_index, second)];
         return if (second_load < first_load) second else first;
@@ -138,6 +182,10 @@ pub const Balancer = struct {
 };
 
 const test_counts_len = upstream.endpoint_keys_max;
+
+/// The no-prober baseline every pre-mask test picks through: all healthy,
+/// exactly what `Checker.init` hands a server whose clusters never check.
+const test_healthy_all = [_]bool{true} ** upstream.endpoint_keys_max;
 
 fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Config {
     return .{
@@ -169,7 +217,7 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     counts[upstream.endpointKey(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &counts);
+        const picked = balancer.pick(0, &counts, &test_healthy_all);
         try std.testing.expectEqual(want_index, picked.endpoint_index);
         try std.testing.expectEqual(trio[want_index], picked.address);
     }
@@ -190,7 +238,7 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &counts);
+        const picked = balancer.pick(0, &counts, &test_healthy_all);
         try std.testing.expectEqual(solo, picked.address);
         try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
     }
@@ -218,7 +266,7 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     counts[upstream.endpointKey(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &counts);
+        const picked = balancer.pick(0, &counts, &test_healthy_all);
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -242,7 +290,7 @@ test "balancer: p2c spreads across endpoints under equal load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 300) : (round += 1) {
-        const picked = balancer.pick(0, &counts);
+        const picked = balancer.pick(0, &counts, &test_healthy_all);
         hits[picked.endpoint_index] += 1;
     }
     for (hits) |hit_count| {
@@ -270,9 +318,114 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            left.pick(0, &counts).endpoint_index,
-            right.pick(0, &counts).endpoint_index,
+            left.pick(0, &counts, &test_healthy_all).endpoint_index,
+            right.pick(0, &counts, &test_healthy_all).endpoint_index,
         );
+    }
+}
+
+test "balancer: rr rotates over the healthy endpoints only" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Endpoint 1 is ejected (§7): rotation covers the survivors exactly,
+    // never the ejected one.
+    var healthy = test_healthy_all;
+    healthy[upstream.endpointKey(0, 1)] = false;
+    const counts = [_]u16{0} ** test_counts_len;
+    const expected = [_]u16{ 0, 2, 0, 2, 0 };
+    for (expected) |want_index| {
+        const picked = balancer.pick(0, &counts, &healthy);
+        try std.testing.expectEqual(want_index, picked.endpoint_index);
+    }
+}
+
+test "balancer: p2c never picks an ejected endpoint" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Even the least-loaded endpoint is off the table while ejected —
+    // health outranks load (§7).
+    var healthy = test_healthy_all;
+    healthy[upstream.endpointKey(0, 1)] = false;
+    var counts = [_]u16{0} ** test_counts_len;
+    counts[upstream.endpointKey(0, 0)] = 50;
+    counts[upstream.endpointKey(0, 2)] = 50;
+    var round: u32 = 0;
+    while (round < 200) : (round += 1) {
+        const picked = balancer.pick(0, &counts, &healthy);
+        try std.testing.expect(picked.endpoint_index != 1);
+    }
+}
+
+test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+    const state_before = balancer.pick_state;
+
+    // One survivor: the pick is forced, so the PRNG must not advance —
+    // the same no-draw rule as a single-endpoint cluster.
+    var healthy = test_healthy_all;
+    healthy[upstream.endpointKey(0, 0)] = false;
+    const counts = [_]u16{0} ** test_counts_len;
+    var round: u32 = 0;
+    while (round < 10) : (round += 1) {
+        const picked = balancer.pick(0, &counts, &healthy);
+        try std.testing.expectEqual(@as(u16, 1), picked.endpoint_index);
+    }
+    try std.testing.expectEqual(state_before, balancer.pick_state);
+}
+
+test "balancer: a fully-ejected cluster fails open to every endpoint" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Every endpoint ejected: the mask must not brick the cluster —
+    // rotation runs over the full set as if no prober existed (§7).
+    var healthy = test_healthy_all;
+    healthy[upstream.endpointKey(0, 0)] = false;
+    healthy[upstream.endpointKey(0, 1)] = false;
+    healthy[upstream.endpointKey(0, 2)] = false;
+    const counts = [_]u16{0} ** test_counts_len;
+    const expected = [_]u16{ 0, 1, 2, 0, 1 };
+    for (expected) |want_index| {
+        const picked = balancer.pick(0, &counts, &healthy);
+        try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
 
@@ -294,7 +447,7 @@ test "balancer: policies keep independent state across clusters" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 1, 0 };
     for (expected) |want_index| {
-        try std.testing.expectEqual(want_index, balancer.pick(0, &counts).endpoint_index);
-        _ = balancer.pick(1, &counts);
+        try std.testing.expectEqual(want_index, balancer.pick(0, &counts, &test_healthy_all).endpoint_index);
+        _ = balancer.pick(1, &counts, &test_healthy_all);
     }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -42,6 +42,13 @@ pub const Config = struct {
     /// otherwise. `0` disables it, so it is optional in the JSON and
     /// defaults off. L4 connections never set it.
     request_timeout_ms: u32,
+    /// Pause between §7 health-probe sweeps over every `check` cluster's
+    /// endpoints. Probing itself is enabled per cluster (`Cluster.check`);
+    /// this only paces it, so it is optional in the JSON and defaults to
+    /// HAProxy's `inter` (`constants.health_interval_ms_default`). Zero is
+    /// rejected — a pause of nothing would probe in a tight loop. Each
+    /// probe dials under `connect_timeout_ms`, its own budget.
+    health_interval_ms: u32 = constants.health_interval_ms_default,
     /// Effective pool sizes (§5, §8). The comptime constants stay the
     /// hard, budget-asserted ceilings; config may only shrink below them
     /// — for capacity planning, and so the overload benchmark can hit
@@ -120,6 +127,14 @@ pub const Config = struct {
         /// (predictable spread, cache warming, pure-L4 clusters whose
         /// load p2c cannot see).
         pick: Pick = .p2c,
+        /// §7 active TCP health checks for every endpoint in this
+        /// cluster: the server's prober dials each endpoint every
+        /// `health_interval_ms`, and the balancer skips endpoints that
+        /// failed `constants.health_probe_fall` consecutive probes until
+        /// `constants.health_probe_rise` successes restore them. The
+        /// JSON field is optional and defaults off — probing is opt-in
+        /// per cluster.
+        check: bool = false,
 
         pub const Pick = enum(u1) {
             rr,
@@ -215,6 +230,7 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
         .request_timeout_ms = parsed.timeouts.request_ms,
+        .health_interval_ms = parsed.timeouts.health_interval_ms,
         .limits = limits,
         .admin_bind = admin_bind,
         .access_log_sink = access_log_sink,
@@ -593,6 +609,9 @@ pub const ClusterJson = struct {
     /// Optional §7 pick policy; absent means `p2c` (the design's
     /// trajectory), `rr` opts back into strict rotation.
     pick: []const u8 = "p2c",
+    /// Optional §7 active TCP health checks; absent means off, so a
+    /// config that never heard of probing keeps its exact behavior.
+    check: bool = false,
 
     pub const schema_doc = "One upstream cluster: its endpoints and pick policy.";
     pub const schema_fields = .{
@@ -604,6 +623,9 @@ pub const ClusterJson = struct {
         .pick = .{
             .desc = "Endpoint-pick policy: p2c (power-of-two-choices) or rr (strict round-robin).",
             .enum_type = Config.Cluster.Pick,
+        },
+        .check = .{
+            .desc = "Active TCP health checks for every endpoint in this cluster (default off).",
         },
     };
 };
@@ -619,6 +641,10 @@ pub const TimeoutsJson = struct {
     /// because a request deadline is a policy an operator sets against
     /// their own origin's latency, not a value zoxy can pick for them.
     request_ms: u32 = 0,
+    /// Optional §7 health-probe pacing; absent means HAProxy's `inter`
+    /// default. Unlike the two caps above, zero is rejected: probing is
+    /// switched per cluster (`check`), never by zeroing its interval.
+    health_interval_ms: u32 = constants.health_interval_ms_default,
 
     pub const schema_doc = "Connection lifecycle deadlines, in milliseconds.";
     pub const schema_fields = .{
@@ -645,6 +671,11 @@ pub const TimeoutsJson = struct {
         .request_ms = .{
             .desc = "Cap on one L7 exchange, not refreshed by activity; 0 disables it.",
             .minimum = 0,
+            .maximum = constants.timeout_ms_max,
+        },
+        .health_interval_ms = .{
+            .desc = "Pause between health-probe sweeps over checked clusters.",
+            .minimum = 1,
             .maximum = constants.timeout_ms_max,
         },
     };
@@ -806,6 +837,7 @@ fn resolveClusters(
             .name = entry.name,
             .endpoints = try resolveEndpoints(arena, entry.cluster.endpoints),
             .pick = try pickOf(entry.cluster.pick),
+            .check = entry.cluster.check,
         };
     }
     assert(clusters.len == count);
@@ -1281,7 +1313,13 @@ fn clusterIndexOf(
 fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
     // The three lifecycle timeouts are correctness bounds — a 0 ms connect,
     // idle, or drain deadline would reap instantly, so zero is a mistake.
-    const required = [_]u32{ timeouts.connect_ms, timeouts.idle_ms, timeouts.drain_deadline_ms };
+    // The health-probe interval rides the same rule from the other side:
+    // zero would probe in a tight loop (§7) — probing is switched by the
+    // cluster `check` flag, never by zeroing its pace.
+    const required = [_]u32{
+        timeouts.connect_ms,        timeouts.idle_ms,
+        timeouts.drain_deadline_ms, timeouts.health_interval_ms,
+    };
     for (required) |value| {
         if (value == 0) {
             return error.TimeoutZero;
@@ -1297,6 +1335,12 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
         if (value > constants.timeout_ms_max) {
             return error.TimeoutOverLimit;
         }
+    }
+    // Postconditions: reaching here means every required bound is in
+    // range — what every consumer of these values relies on.
+    for (required) |value| {
+        assert(value >= 1);
+        assert(value <= constants.timeout_ms_max);
     }
 }
 
@@ -1317,10 +1361,13 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
     try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].getPort());
+    try std.testing.expectEqual(true, parsed.clusters[0].check);
     try std.testing.expectEqual(@as(u32, 5000), parsed.connect_timeout_ms);
     try std.testing.expectEqual(@as(u32, 60000), parsed.idle_timeout_ms);
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
     try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+    // The example omits the probe interval: the HAProxy-inter default.
+    try std.testing.expectEqual(constants.health_interval_ms_default, parsed.health_interval_ms);
 }
 
 test "config: max_lifetime_ms is optional and defaults to disabled" {
@@ -1663,6 +1710,69 @@ test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"pick":"pc2"}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+}
+
+test "config: cluster check flag parses, defaults off, rejects non-bool" {
+    // Explicit true and false both resolve; absent defaults off (§7:
+    // probing is opt-in per cluster).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"check":true},
+            \\   "b":{"endpoints":["127.0.0.1:3"],"check":false},
+            \\   "c":{"endpoints":["127.0.0.1:4"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(true, parsed.clusters[0].check);
+        try std.testing.expectEqual(false, parsed.clusters[1].check);
+        try std.testing.expectEqual(false, parsed.clusters[2].check);
+    }
+    // The flag is a bool, not a truthy string — strict JSON stage 1.
+    try expectParseError(error.UnexpectedToken,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"check":"on"}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+}
+
+test "config: health interval parses, defaults to inter, rejects zero" {
+    // Explicit value resolves; absent means the HAProxy-inter default.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,
+            \\   "health_interval_ms":250}}
+        );
+        try std.testing.expectEqual(@as(u32, 250), parsed.health_interval_ms);
+    }
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(constants.health_interval_ms_default, parsed.health_interval_ms);
+    }
+    // Zero would probe in a tight loop; the cluster flag is the switch.
+    try expectParseError(error.TimeoutZero,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,
+        \\   "health_interval_ms":0}}
+    );
+    try expectParseError(error.TimeoutOverLimit,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1,
+        \\   "health_interval_ms":3600001}}
     );
 }
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -57,11 +57,12 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// deepest CQ the kernel allows (`completion_queue_entries`,
 /// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
-/// parked-upstream, admin and access-log reservations carved out first,
-/// this caps at `(57344 - 24) / (conn_ops_max + 1) = 11464` —
-/// comptime-derived below (the 24 is the fixed ops: two per config and
+/// parked-upstream, admin, access-log and health-probe reservations
+/// carved out first, this caps at
+/// `(57344 - 27) / (conn_ops_max + 1) = 11463` —
+/// comptime-derived below (the 27 is the fixed ops: two per config and
 /// admin listener [18], the admin client's op budget [3], the access log's
-/// in-flight sink write [1], the signal
+/// in-flight sink write [1], the health prober's op budget [3], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
@@ -72,8 +73,8 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// every admitted connection can be mid-exchange at once. A conn ceiling
 /// above the upstream ceiling is therefore capacity that cannot be served
 /// — slots that admit connections the pool has no upstream for — and one
-/// below it is a pool that can never be drawn down. `11464` is the
-/// largest N with `N * (conn_ops_max + 1) <= 57320`, which keeps both
+/// below it is a pool that can never be drawn down. `11463` is the
+/// largest N with `N * (conn_ops_max + 1) <= 57317`, which keeps both
 /// ceilings clear of a round 10k: what §1 asks for, c10k reachable on
 /// either axis rather than a shape tuned for it.
 ///
@@ -84,7 +85,7 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// The pair is still a policy choice made on the operator's behalf;
 /// IMPLEMENTATION_NOTES.md ("Open questions" — pool ceilings) holds the
 /// standing question of handing it to them instead.
-pub const conn_slots_max: u32 = 11464;
+pub const conn_slots_max: u32 = 11463;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -234,6 +235,31 @@ pub const clusters_min: u16 = 1;
 /// Upper bound on endpoints in one cluster.
 pub const endpoints_per_cluster_max: u16 = 64;
 
+/// Worst-case simultaneously armed ring ops for the §7 health prober:
+/// three. One probe is in flight at a time — {connect, probe deadline}
+/// co-armed while dialing — and settling a verdict or draining adds one
+/// cancel to whichever op is still armed ({connect, deadline,
+/// connect_cancel} at the peak; a drain teardown cancels serially, never
+/// both cancels at once). Reserved in the fd and ring budgets below
+/// unconditionally, the same rule as `admin_conn_ops_max`: the ceiling
+/// is a comptime constant, so it must cover the worst case even when no
+/// cluster sets `check`.
+pub const health_probe_ops_max: u32 = 3;
+
+/// Consecutive failed probes that eject an endpoint from balancing (§7).
+/// HAProxy's `fall` default: three misses is an outage, one is a blip.
+pub const health_probe_fall: u8 = 3;
+
+/// Consecutive successful probes that restore an ejected endpoint (§7).
+/// HAProxy's `rise` default: recovery must prove itself twice.
+pub const health_probe_rise: u8 = 2;
+
+/// Default `timeouts.health_interval_ms`: the pause between health-probe
+/// sweeps when the config omits it (§7). HAProxy's `inter` default. The
+/// probe's own connect budget is `timeouts.connect_ms` — a probe is a
+/// dial try, so it runs under the dial's deadline, not its own.
+pub const health_interval_ms_default: u32 = 2_000;
+
 /// Upper bound on routes in one listener's path-routing table (§7). Config
 /// data, not a runtime pool: routes are immutable arena slices, and the
 /// request-time match is a bounded linear scan over at most this many.
@@ -341,11 +367,12 @@ pub const access_log_line_bytes_max: u32 = blk: {
 /// draining listener holds its armed accept — or the accept-retry backoff
 /// timer — plus the async cancel that reaps it), `admin_conn_ops_max` ops
 /// per admin client (its send/deadline/teardown peak), the access log's one
-/// in-flight sink write, the single async
-/// wakeup op for signals, and the server's one drain-deadline timer. Closed
-/// form so it can be evaluated on the *effective* pool sizes too (XevIo's
-/// per-deployment CQ), not only the ceilings; the admin and access-log
-/// reservations are fixed — always covered even when a config leaves either
+/// in-flight sink write, `health_probe_ops_max` ops for the single
+/// in-flight health probe (§7), the single async wakeup op for signals, and
+/// the server's one drain-deadline timer. Closed form so it can be
+/// evaluated on the *effective* pool sizes too (XevIo's per-deployment CQ),
+/// not only the ceilings; the admin, access-log and health-probe
+/// reservations are fixed — always covered even when a config leaves them
 /// off; `in_flight_ops_max` is it at the ceilings.
 pub fn inFlightOps(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(conn_slots <= conn_slots_max);
@@ -353,7 +380,8 @@ pub fn inFlightOps(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(listeners <= listeners_max);
     return conn_slots * conn_ops_max + upstream_slots +
         2 * (listeners + admin_listeners) +
-        admin_conns * admin_conn_ops_max + access_log_ops_max + 1 + 1;
+        admin_conns * admin_conn_ops_max + access_log_ops_max +
+        health_probe_ops_max + 1 + 1;
 }
 pub const in_flight_ops_max: u32 =
     inFlightOps(conn_slots_max, upstream_slots_max, listeners_max);
@@ -448,15 +476,16 @@ pub const completion_queue_entries: u32 =
 /// per admitted connection (client plus the exchange's upstream) + the one
 /// transient just-accepted fd an admission decision is pending on + one
 /// socket per in-flight admin scrape + one socket per parked upstream,
-/// which belongs to no connection. Closed form so `ensureFdBudget` can
-/// check the *effective* size against RLIMIT_NOFILE; the admin reservation
-/// is fixed; `fds_max` is it at the ceilings.
+/// which belongs to no connection + the one socket the in-flight health
+/// probe may hold while dialing (§7). Closed form so `ensureFdBudget` can
+/// check the *effective* size against RLIMIT_NOFILE; the admin and
+/// health-probe reservations are fixed; `fds_max` is it at the ceilings.
 pub fn fdsRequired(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(conn_slots <= conn_slots_max);
     assert(upstream_slots <= upstream_slots_max);
     assert(listeners <= listeners_max);
     return 3 + 1 + 1 + (listeners + admin_listeners) +
-        2 * conn_slots + 1 + admin_conns + upstream_slots;
+        2 * conn_slots + 1 + admin_conns + upstream_slots + 1;
 }
 pub const fds_max: u32 =
     fdsRequired(conn_slots_max, upstream_slots_max, listeners_max);
@@ -487,19 +516,20 @@ pub const relay_buffers_default: u32 = conn_slots_default;
 /// deployment needs one upstream slot per busy conn slot (see
 /// `conn_slots_max`), because the out-of-box shape is bounded by the
 /// stock 4096 `RLIMIT_NOFILE` rather than by admission: matching 1386
-/// would put the default at 4167 fds, over that line, for capacity an
-/// unconfigured proxy is not there to serve. 1314 is the largest value
+/// would put the default at 4168 fds, over that line, for capacity an
+/// unconfigured proxy is not there to serve. 1313 is the largest value
 /// that still clears that line — `fdsRequired(conn_slots_default, x, 1)`
-/// is `2781 + x`, and that must stay strictly under 4096 (the out-of-box
-/// budget stays *under* the stock limit, not flush against it), so
-/// `4096 - 2781 - 1 = 1314` — the default leans as far toward
+/// is `2782 + x` (the health probe's reserved fd included), and that must
+/// stay strictly under 4096 (the out-of-box budget stays *under* the
+/// stock limit, not flush against it), so `4096 - 2782 - 1 = 1313` — the
+/// default leans as far toward
 /// `conn_slots_default` as the stock fd budget allows. An L4
 /// deployment never leases from this pool at all — an L4 dial reads its
 /// `leased_counts` for the P2C draw and holds no slot. A deployment that
 /// means to fill its conn pool raises both together in `limits` — which
 /// is what the ceilings exist to permit and what the c10k benchmark
 /// configuration does.
-pub const upstream_slots_default: u32 = 1314;
+pub const upstream_slots_default: u32 = 1313;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -569,7 +599,8 @@ comptime {
     assert(conn_slots_max == @divFloor(
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * (@as(u32, listeners_max) + admin_listeners) -
-            admin_conns * admin_conn_ops_max - access_log_ops_max - 1 - 1,
+            admin_conns * admin_conn_ops_max - access_log_ops_max -
+            health_probe_ops_max - 1 - 1,
         conn_ops_max + 1,
     ));
     assert(admin_listeners >= 1);
@@ -591,6 +622,15 @@ comptime {
     assert(access_log_path_bytes_max >= 16);
     assert(access_log_method_bytes_max >= 7); // "OPTIONS", the longest standard method.
     assert(cluster_name_bytes_max >= 1);
+    // The health prober's reservations and thresholds (§7): the op budget
+    // covers dial + deadline + one cancel, a threshold of zero would eject
+    // or restore on no evidence, and the default probe interval is a legal
+    // configured timeout.
+    assert(health_probe_ops_max >= 1);
+    assert(health_probe_fall >= 1);
+    assert(health_probe_rise >= 1);
+    assert(health_interval_ms_default >= 1);
+    assert(health_interval_ms_default <= timeout_ms_max);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool
@@ -736,7 +776,7 @@ test "budgets: c10k ceiling fd count needs a raised NOFILE" {
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 34408), fds_max);
+    try std.testing.expectEqual(@as(u32, 34406), fds_max);
     try std.testing.expect(fds_max <= 65536);
     // The out-of-box side of this is pinned by "the default deployment is
     // lean" below, not restated here.
@@ -765,7 +805,8 @@ test "budgets: conn slots sit at the completion-queue ceiling" {
     try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
     const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
         2 * (@as(u32, listeners_max) + admin_listeners) +
-        admin_conns * admin_conn_ops_max + access_log_ops_max + 1 + 1;
+        admin_conns * admin_conn_ops_max + access_log_ops_max +
+        health_probe_ops_max + 1 + 1;
     try std.testing.expect(one_more > @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
 }
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -99,6 +99,26 @@ pub const Counters = struct {
     upstream_replayed: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
+    /// §7 active health probes dispatched — one per checked endpoint per
+    /// sweep. Not in the gate identity: a probe is the prober's own dial,
+    /// never an accepted connection.
+    health_probes_sent: Value = Value.init(0),
+    /// Probes that failed: refused, unreachable, timed out under the
+    /// connect budget, or kernel pressure on our side (§7). The pressure
+    /// case also lands in `kernel_pressure_connect`, same as a data-path
+    /// dial.
+    health_probes_failed: Value = Value.init(0),
+    /// Endpoints ejected from balancing after `health_probe_fall`
+    /// consecutive failed probes (§7). Their parked connections are
+    /// closed at the transition (§5, `health_parked_closed`).
+    health_endpoint_down: Value = Value.init(0),
+    /// Ejected endpoints restored to balancing after `health_probe_rise`
+    /// consecutive successful probes (§7).
+    health_endpoint_up: Value = Value.init(0),
+    /// Parked upstream connections closed because their endpoint was
+    /// ejected (§5): a parked socket to a dead origin is a stale replay
+    /// waiting to be spent.
+    health_parked_closed: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path). The total; `kernel_pressure_by_op` below
@@ -207,12 +227,21 @@ pub const Counters = struct {
         /// counters already carry the history. This is what keeps an
         /// `other_cause` diagnosable instead of merely counted.
         kernel_pressure_last_errno: u32,
+        /// Endpoints under §7 active checks — static per config (the
+        /// sum of `endpoints` over every `check` cluster). The capacity
+        /// the unhealthy level below is read against.
+        health_endpoints_checked: u32,
+        /// Checked endpoints currently ejected from balancing (§7). A
+        /// level, not a counter: `health_endpoint_down`/`_up` carry the
+        /// history; a scrape wants how many are out *now*.
+        health_endpoints_unhealthy: u32,
 
         /// The invariant every producer owes: a level never exceeds its
         /// own capacity, and the two upstream levels share one.
         pub fn valid(gauges: *const Gauges) bool {
             if (gauges.conn_slots_in_use > gauges.conn_slots_capacity) return false;
             if (gauges.relay_buffers_in_use > gauges.relay_buffers_capacity) return false;
+            if (gauges.health_endpoints_unhealthy > gauges.health_endpoints_checked) return false;
             const upstream_in_use = @as(u64, gauges.upstream_slots_leased) +
                 gauges.upstream_slots_parked;
             return upstream_in_use <= gauges.upstream_slots_capacity;
@@ -424,6 +453,12 @@ pub const Counters = struct {
         // Every §7 replay rides a checkout: only a reused connection's
         // early failure is blamed on staleness.
         assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));
+        // A probe can only fail if it was sent; an ejection needs at least
+        // one failed probe; a restore needs a prior ejection (endpoints
+        // start healthy, §7).
+        assert(counters.get("health_probes_failed") <= counters.get("health_probes_sent"));
+        assert(counters.get("health_endpoint_down") <= counters.get("health_probes_failed"));
+        assert(counters.get("health_endpoint_up") <= counters.get("health_endpoint_down"));
         // The op split partitions the total exactly: a witness that
         // incremented one without the other would make the split lie about
         // where the pressure is, which is the only thing it exists to say.
@@ -463,6 +498,8 @@ const test_gauges: Counters.Gauges = .{
     .upstream_slots_parked = 11,
     .upstream_slots_capacity = 16,
     .kernel_pressure_last_errno = 105, // ENOBUFS on Linux
+    .health_endpoints_checked = 4,
+    .health_endpoints_unhealthy = 1,
 };
 
 test "counters: render emits Prometheus exposition for every field" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -465,7 +465,11 @@ pub fn Proxy(comptime IoType: type) type {
             // beats a fresh dial. A close that slipped through while it
             // was parked surfaces as a failure on first use — absorbed by
             // the §7 free replay (`upstreamFailed`).
-            const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
+            const pick = server.balancer.pick(
+                conn.cluster_index,
+                &server.upstreams.leased_counts,
+                &server.health.healthy,
+            );
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
@@ -1563,7 +1567,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.directions = .{ .{}, .{} };
             // A fresh pick and a fresh dial — never another checkout (§7):
             // the endpoint's whole idle list may be stale the same way.
-            const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
+            const pick = server.balancer.pick(
+                conn.cluster_index,
+                &server.upstreams.leased_counts,
+                &server.health.healthy,
+            );
             dialUpstream(server, conn, pick);
         }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -246,9 +246,11 @@ const HttpOrigin = struct {
     /// Close the second accepted connection immediately: the replayed
     /// try fails too, pinning the one-replay budget (§7).
     close_second_at_accept: bool = false,
-    /// Two connections: the second accept serves the §7 replay's fresh
-    /// dial. Tests that must prove reuse assert `accepted_count == 1`.
-    conns: [2]OConn = .{ .{}, .{} },
+    /// The second accept serves the §7 replay's fresh dial, and a
+    /// `check` scenario's probes each accept-and-vanish too — hence four
+    /// slots, not two. Tests that must prove reuse assert
+    /// `accepted_count == 1`.
+    conns: [4]OConn = .{ .{}, .{}, .{}, .{} },
     accepted_count: u32 = 0,
     requests_served: u32 = 0,
 
@@ -440,6 +442,7 @@ const Http1Bed = struct {
     client: HttpClient,
     client2: HttpClient,
     drain_timer_completion: SimIo.Completion,
+    origin_stop_completion: SimIo.Completion,
 
     const idle_timeout_ms: u32 = 1000;
     /// Deliberately 20× tighter than the idle timeout so a test can witness
@@ -505,6 +508,12 @@ const Http1Bed = struct {
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
         access_log: bool = false,
+        /// §7 active health checks on the one cluster; off by default so
+        /// existing scenarios see no probe traffic.
+        check: bool = false,
+        /// Probe pacing for `check` scenarios — tight, so fall/rise fit
+        /// inside a short virtual run.
+        health_interval_ms: u32 = 40,
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -518,7 +527,7 @@ const Http1Bed = struct {
         }
         try bed.sim_io.init(arena, .{ .seed = options.seed, .adversary = adversary });
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -535,6 +544,7 @@ const Http1Bed = struct {
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
             .access_log_sink = if (options.access_log) .stdout else null,
+            .health_interval_ms = options.health_interval_ms,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -559,6 +569,7 @@ const Http1Bed = struct {
         bed.client = .{ .send_delay_ms = options.send_delay_ms };
         bed.client2 = .{};
         bed.drain_timer_completion = .{};
+        bed.origin_stop_completion = .{};
     }
 
     /// A sweep-observation scenario cannot let the client drive the drain
@@ -577,6 +588,24 @@ const Http1Bed = struct {
     fn onDrainTimer(bed: *Http1Bed, result: Io.TimerError!void) void {
         result catch unreachable; // Nothing cancels the test drain timer.
         bed.server.beginDrain();
+    }
+
+    /// Stop the origin's listener mid-run at a chosen instant — how a
+    /// health scenario turns a serving origin into a refusing one while
+    /// probes are in flight (§7).
+    fn armOriginStopTimer(bed: *Http1Bed, delay_ms: u32) void {
+        bed.sim_io.timerStart(
+            &bed.origin_stop_completion,
+            @as(u64, delay_ms) * std.time.ns_per_ms,
+            Http1Bed,
+            bed,
+            onOriginStopTimer,
+        );
+    }
+
+    fn onOriginStopTimer(bed: *Http1Bed, result: Io.TimerError!void) void {
+        result catch unreachable; // Nothing cancels the origin-stop timer.
+        bed.origin.stopListening();
     }
 
     fn tearDown(bed: *Http1Bed) void {
@@ -2355,6 +2384,35 @@ test "l7: the idle sweep reaps a parked upstream past its deadline" {
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_idle_reaped"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_reused"));
+    try bed.expectDrained();
+}
+
+test "l7: ejecting an endpoint closes its parked connections" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 55,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .check = true,
+        .health_interval_ms = 40,
+    });
+    defer bed.tearDown();
+
+    // The exchange parks its upstream; then the origin stops listening,
+    // the probes start missing, and the third miss ejects the endpoint —
+    // which must close the parked connection on the spot (§5), long
+    // before the idle sweep (interval 500ms here) would have reaped it.
+    // The client must not drain (that reaps parked instantly), so a
+    // timer drains after the ejection has had time to land.
+    bed.client.drain_on_finish = false;
+    bed.armOriginStopTimer(25);
+    bed.armDrainTimer(300);
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_parked_closed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_idle_reaped"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.unhealthy_count);
     try bed.expectDrained();
 }
 

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -1,0 +1,487 @@
+//! Active TCP health checks (DESIGN.md §7, HAProxy's `check` model): one
+//! prober per server sweeps every endpoint of every `check` cluster,
+//! dialing each in turn under the `connect_ms` budget — a SYN/ACK is a
+//! pass, anything else (refused, unreachable, timed out, kernel
+//! pressure) is a fail. `health_probe_fall` consecutive fails eject an
+//! endpoint from balancing and close its parked pooled connections (the
+//! §5 obligation: a parked socket to a dead origin is a stale replay
+//! waiting to be spent); `health_probe_rise` consecutive passes restore
+//! it. Endpoints start healthy — probing demotes, never gates startup —
+//! and an unchecked endpoint is permanently healthy, so the balancer
+//! applies the mask unconditionally (§7 fail-open lives there, not
+//! here).
+//!
+//! One probe is in flight at a time, which is what keeps the prober's
+//! reservation closed-form (`health_probe_ops_max` ring ops, one fd,
+//! §8): sweeps serialize endpoint-by-endpoint, and the interval paces
+//! sweep-end to sweep-start. Cancels are serialized too — one cancel op,
+//! spent on whichever armed op must die next — so the armed set never
+//! exceeds the budget. The probe socket is closed synchronously in the
+//! connect delivery itself and never stored: the probe wanted the
+//! verdict, not a connection.
+
+const std = @import("std");
+
+const config_module = @import("../config.zig");
+const constants = @import("../constants.zig");
+const Io = @import("../io/io.zig");
+const upstream = @import("upstream.zig");
+
+const assert = std.debug.assert;
+
+pub fn Checker(comptime IoType: type) type {
+    const ServerType = @import("../Server.zig").Server(IoType);
+
+    return struct {
+        server: *ServerType,
+        /// The §7 balancing mask, indexed by `upstream.endpointKey`. All
+        /// true at start; only probed (checked) endpoints ever flip.
+        healthy: [upstream.endpoint_keys_max]bool,
+        /// Consecutive failed probes toward `health_probe_fall`; tracked
+        /// only while the endpoint is healthy, reset by any pass.
+        fail_streaks: [upstream.endpoint_keys_max]u8,
+        /// Consecutive passed probes toward `health_probe_rise`; tracked
+        /// only while the endpoint is ejected, reset by any fail.
+        ok_streaks: [upstream.endpoint_keys_max]u8,
+        /// Endpoints under checks — static after `init` (the sum of
+        /// `endpoints.len` over every `check` cluster); zero leaves the
+        /// prober `.off` forever.
+        checked_count: u32,
+        /// Checked endpoints currently ejected; the gauge level (§8).
+        unhealthy_count: u32,
+        state: State,
+        /// The sweep cursor: the cluster and endpoint the in-flight (or
+        /// next) probe targets. Valid while `.probing`.
+        cursor_cluster: u16,
+        cursor_endpoint: u16,
+        /// The in-flight probe's outcome, decided by whichever of the
+        /// dial or its deadline lands first; applied only once every
+        /// armed op has drained (the §5 release discipline).
+        pending_verdict: Verdict,
+        armed: Armed,
+        /// Ops a cancel was already spent on (never `.cancel` itself):
+        /// what keeps the serialized drain from re-canceling an op whose
+        /// terminal delivery is still in flight.
+        canceled: Armed,
+        op_rest: IoType.Completion,
+        op_connect: IoType.Completion,
+        op_deadline: IoType.Completion,
+        /// The one cancel completion, reused across targets — legal
+        /// because cancels are serialized (`armed.cancel` gates every
+        /// submission).
+        op_cancel: IoType.Completion,
+
+        const Self = @This();
+
+        pub const State = enum(u8) {
+            /// Not started, or no cluster sets `check`: nothing ever arms.
+            off,
+            /// A sweep is running: one probe in flight at the cursor.
+            probing,
+            /// Between sweeps: the rest timer is armed for the interval.
+            resting,
+            /// Drain (§8): canceling whatever is armed, serially.
+            stopping,
+            /// Quiescent; never re-arms.
+            stopped,
+        };
+
+        pub const Verdict = enum(u8) {
+            none,
+            pass,
+            fail,
+        };
+
+        /// One bit per embedded op; the prober is quiescent only when
+        /// clear. At most three are ever set (`health_probe_ops_max`):
+        /// rest never co-arms with the probe ops, and the cancel is
+        /// serialized.
+        pub const Armed = packed struct(u4) {
+            rest: bool = false,
+            connect: bool = false,
+            deadline: bool = false,
+            cancel: bool = false,
+        };
+
+        pub fn init(checker: *Self, server: *ServerType) void {
+            checker.server = server;
+            @memset(&checker.healthy, true);
+            @memset(&checker.fail_streaks, 0);
+            @memset(&checker.ok_streaks, 0);
+            checker.checked_count = 0;
+            checker.unhealthy_count = 0;
+            checker.state = .off;
+            checker.cursor_cluster = 0;
+            checker.cursor_endpoint = 0;
+            checker.pending_verdict = .none;
+            checker.armed = .{};
+            checker.canceled = .{};
+            checker.op_rest = .{};
+            checker.op_connect = .{};
+            checker.op_deadline = .{};
+            checker.op_cancel = .{};
+            const clusters = server.config.clusters;
+            assert(clusters.len >= 1);
+            assert(clusters.len <= constants.clusters_max);
+            for (clusters) |cluster| {
+                if (cluster.check) {
+                    checker.checked_count += @intCast(cluster.endpoints.len);
+                }
+            }
+            assert(checker.checked_count <= upstream.endpoint_keys_max);
+            assert(checker.armedCount() == 0);
+        }
+
+        /// Begin probing, or stay `.off` when no cluster opted in. The
+        /// first sweep runs now rather than an interval from now: a
+        /// fresh process should learn its endpoints' state before the
+        /// first interval elapses.
+        pub fn start(checker: *Self) void {
+            assert(checker.state == .off);
+            assert(checker.armedCount() == 0);
+            if (checker.checked_count == 0) return;
+            checker.startSweep();
+        }
+
+        /// Drain (§8): discard any in-flight probe's verdict and cancel
+        /// the armed ops, serially. `maybeStopAfterDrain` fires once the
+        /// armed set empties.
+        pub fn beginStop(checker: *Self) void {
+            if (checker.state == .stopping or checker.state == .stopped) return;
+            if (checker.state == .off) {
+                assert(checker.armedCount() == 0);
+                checker.state = .stopped;
+                return;
+            }
+            // Live states always hold work: probing keeps probe ops armed,
+            // resting keeps the rest timer armed.
+            assert(checker.armedCount() >= 1);
+            assert(checker.checked_count >= 1);
+            checker.state = .stopping;
+            checker.pending_verdict = .none;
+            checker.continueStop();
+        }
+
+        /// The simulator's leak invariant (§9): a leaked armed op is a
+        /// leak like any other. The probe socket needs no term — it is
+        /// closed inside the connect delivery and never held across
+        /// callbacks.
+        pub fn isQuiescent(checker: *const Self) bool {
+            return checker.armedCount() == 0;
+        }
+
+        pub fn armedCount(checker: *const Self) u32 {
+            return @popCount(@as(u4, @bitCast(checker.armed)));
+        }
+
+        fn startSweep(checker: *Self) void {
+            assert(checker.armedCount() == 0);
+            assert(checker.checked_count >= 1);
+            checker.state = .probing;
+            checker.cursor_cluster = 0;
+            checker.cursor_endpoint = 0;
+            checker.probeNext();
+        }
+
+        /// Advance the cursor to the next checked endpoint and dial it,
+        /// or end the sweep and rest for the interval. Bounded: the walk
+        /// visits each cluster at most once past the cursor.
+        fn probeNext(checker: *Self) void {
+            assert(checker.state == .probing);
+            assert(checker.armedCount() == 0);
+            assert(checker.pending_verdict == .none);
+            const clusters = checker.server.config.clusters;
+            while (checker.cursor_cluster < clusters.len) {
+                const cluster = &clusters[checker.cursor_cluster];
+                if (!cluster.check or checker.cursor_endpoint >= cluster.endpoints.len) {
+                    checker.cursor_cluster += 1;
+                    checker.cursor_endpoint = 0;
+                    continue;
+                }
+                checker.beginProbe(cluster);
+                return;
+            }
+            checker.rest();
+        }
+
+        fn beginProbe(checker: *Self, cluster: *const config_module.Config.Cluster) void {
+            assert(checker.state == .probing);
+            assert(checker.armedCount() == 0);
+            assert(cluster.check);
+            assert(checker.cursor_endpoint < cluster.endpoints.len);
+            assert(checker.pending_verdict == .none);
+            const server = checker.server;
+            server.counters.increment("health_probes_sent");
+            checker.canceled = .{};
+            // The probe runs under the dial's own budget (§7): a probe is
+            // a connect try, and `connect_ms` is the connect budget.
+            checker.armed.deadline = true;
+            server.io.timerStart(
+                &checker.op_deadline,
+                @as(u64, server.config.connect_timeout_ms) * std.time.ns_per_ms,
+                Self,
+                checker,
+                onProbeDeadline,
+            );
+            checker.armed.connect = true;
+            server.io.connect(
+                cluster.endpoints[checker.cursor_endpoint],
+                &checker.op_connect,
+                Self,
+                checker,
+                onProbeConnect,
+            );
+            assert(checker.armedCount() <= constants.health_probe_ops_max);
+        }
+
+        fn onProbeConnect(checker: *Self, result: Io.ConnectError!IoType.Socket) void {
+            assert(checker.armed.connect);
+            checker.armed.connect = false;
+            // A socket that arrived is closed on the spot whatever the
+            // state: the probe wanted the SYN/ACK verdict, not a
+            // connection, and an unstored socket cannot leak (§9).
+            if (result) |socket| {
+                checker.server.io.closeNow(socket);
+            } else |_| {}
+            if (checker.state == .stopping) {
+                checker.continueStop();
+                return;
+            }
+            assert(checker.state == .probing);
+            if (result) |_| {
+                // First outcome wins: a dial landing after its deadline
+                // already failed the probe keeps the fail — a late
+                // answer is no answer (§7).
+                if (checker.pending_verdict == .none) {
+                    checker.pending_verdict = .pass;
+                }
+            } else |err| switch (err) {
+                // The deadline fired first and canceled the dial; the
+                // fail verdict is already pending.
+                error.Canceled => assert(checker.pending_verdict == .fail),
+                else => {
+                    if (checker.pending_verdict == .none) {
+                        checker.pending_verdict = .fail;
+                    }
+                    // Typed refusals are the origin's verdict; only
+                    // kernel pressure on our side is witnessed (§8) —
+                    // the same split the data-path dial makes.
+                    checker.server.witnessKernelPressure(.connect, err);
+                },
+            }
+            if (checker.armed.deadline and !checker.armed.cancel) {
+                checker.armCancelDeadline();
+            }
+            checker.settle();
+        }
+
+        fn onProbeDeadline(checker: *Self, result: Io.TimerError!void) void {
+            assert(checker.armed.deadline);
+            checker.armed.deadline = false;
+            if (checker.state == .stopping) {
+                result catch {};
+                checker.continueStop();
+                return;
+            }
+            assert(checker.state == .probing);
+            if (result) |_| {
+                if (checker.pending_verdict == .none) {
+                    // Fired first: the dial outlived its budget — the
+                    // probe fails and the dial is torn down so even a
+                    // black-holed endpoint reaches a terminal
+                    // completion (§5).
+                    checker.pending_verdict = .fail;
+                    assert(checker.armed.connect);
+                    if (!checker.armed.cancel) {
+                        checker.armCancelConnect();
+                    }
+                }
+                // Otherwise the fire raced its own cancel (a legal §4
+                // race): the outcome is decided, this delivery is op
+                // accounting only.
+            } else |err| {
+                assert(err == error.Canceled);
+                assert(checker.pending_verdict != .none);
+            }
+            checker.settle();
+        }
+
+        fn onCancel(checker: *Self) void {
+            assert(checker.armed.cancel);
+            checker.armed.cancel = false;
+            if (checker.state == .stopping) {
+                checker.continueStop();
+                return;
+            }
+            assert(checker.state == .probing);
+            checker.settle();
+        }
+
+        /// The delivery that empties the armed set applies the verdict
+        /// and moves the sweep along — never earlier, so no completion
+        /// can land on a probe that already advanced (§5).
+        fn settle(checker: *Self) void {
+            assert(checker.state == .probing);
+            if (checker.armedCount() != 0) return;
+            assert(checker.pending_verdict != .none);
+            const verdict = checker.pending_verdict;
+            checker.pending_verdict = .none;
+            if (verdict == .pass) {
+                checker.witnessPass(checker.cursor_cluster, checker.cursor_endpoint);
+            } else {
+                checker.witnessFail(checker.cursor_cluster, checker.cursor_endpoint);
+            }
+            checker.cursor_endpoint += 1;
+            checker.probeNext();
+        }
+
+        fn witnessPass(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
+            const key = upstream.endpointKey(cluster_index, endpoint_index);
+            checker.fail_streaks[key] = 0;
+            if (checker.healthy[key]) {
+                assert(checker.ok_streaks[key] == 0);
+                return;
+            }
+            checker.ok_streaks[key] += 1;
+            assert(checker.ok_streaks[key] <= constants.health_probe_rise);
+            if (checker.ok_streaks[key] < constants.health_probe_rise) return;
+            checker.ok_streaks[key] = 0;
+            checker.healthy[key] = true;
+            assert(checker.unhealthy_count >= 1);
+            checker.unhealthy_count -= 1;
+            checker.server.counters.increment("health_endpoint_up");
+        }
+
+        fn witnessFail(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
+            checker.server.counters.increment("health_probes_failed");
+            const key = upstream.endpointKey(cluster_index, endpoint_index);
+            checker.ok_streaks[key] = 0;
+            // Already ejected: nothing further to count — streaks resume
+            // meaning only once a pass starts a recovery.
+            if (!checker.healthy[key]) return;
+            assert(checker.fail_streaks[key] < constants.health_probe_fall);
+            checker.fail_streaks[key] += 1;
+            if (checker.fail_streaks[key] < constants.health_probe_fall) return;
+            checker.fail_streaks[key] = 0;
+            checker.healthy[key] = false;
+            checker.unhealthy_count += 1;
+            assert(checker.unhealthy_count <= checker.checked_count);
+            checker.server.counters.increment("health_endpoint_down");
+            checker.closeParked(cluster_index, endpoint_index);
+        }
+
+        /// The §5 obligation: ejection closes the endpoint's parked
+        /// pooled connections. Synchronous closes — a parked slot holds
+        /// no armed op (§5), so checkout + close + release is one step,
+        /// the reap discipline `Server.reapParked` set.
+        fn closeParked(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
+            // Only an ejection reaches here: the endpoint was just marked
+            // unhealthy by the caller.
+            assert(!checker.healthy[upstream.endpointKey(cluster_index, endpoint_index)]);
+            const server = checker.server;
+            const capacity = server.upstreams.capacity();
+            var reaped: u32 = 0;
+            while (server.upstreams.checkout(cluster_index, endpoint_index)) |parked| {
+                server.io.closeNow(parked.socket);
+                server.releaseUpstream(parked);
+                server.counters.increment("health_parked_closed");
+                reaped += 1;
+                assert(reaped <= capacity);
+            }
+        }
+
+        fn rest(checker: *Self) void {
+            assert(checker.state == .probing);
+            assert(checker.armedCount() == 0);
+            checker.state = .resting;
+            checker.armed.rest = true;
+            checker.server.io.timerStart(
+                &checker.op_rest,
+                @as(u64, checker.server.config.health_interval_ms) * std.time.ns_per_ms,
+                Self,
+                checker,
+                onRest,
+            );
+        }
+
+        fn onRest(checker: *Self, result: Io.TimerError!void) void {
+            assert(checker.armed.rest);
+            checker.armed.rest = false;
+            if (checker.state == .stopping) {
+                result catch {};
+                checker.continueStop();
+                return;
+            }
+            // The rest timer is canceled only by the drain (§4), which
+            // flips `.stopping` first — a live delivery is always a fire.
+            result catch unreachable;
+            assert(checker.state == .resting);
+            checker.startSweep();
+        }
+
+        fn armCancelDeadline(checker: *Self) void {
+            assert(checker.armed.deadline);
+            assert(!checker.armed.cancel);
+            checker.armed.cancel = true;
+            checker.canceled.deadline = true;
+            checker.server.io.timerCancel(
+                &checker.op_deadline,
+                &checker.op_cancel,
+                Self,
+                checker,
+                onCancel,
+            );
+            assert(checker.armedCount() <= constants.health_probe_ops_max);
+        }
+
+        fn armCancelConnect(checker: *Self) void {
+            assert(checker.armed.connect);
+            assert(!checker.armed.cancel);
+            checker.armed.cancel = true;
+            checker.canceled.connect = true;
+            checker.server.io.connectCancel(
+                &checker.op_connect,
+                &checker.op_cancel,
+                Self,
+                checker,
+                onCancel,
+            );
+            assert(checker.armedCount() <= constants.health_probe_ops_max);
+        }
+
+        /// One cancel at a time toward quiescence: cancel the next armed
+        /// op that has not had a cancel spent on it yet, or — once every
+        /// delivery has drained — stop. An op whose cancel already ran
+        /// but whose own terminal delivery is still in flight is waited
+        /// on, never re-canceled.
+        fn continueStop(checker: *Self) void {
+            assert(checker.state == .stopping);
+            if (checker.armed.cancel) return;
+            if (checker.armed.rest and !checker.canceled.rest) {
+                checker.armed.cancel = true;
+                checker.canceled.rest = true;
+                checker.server.io.timerCancel(
+                    &checker.op_rest,
+                    &checker.op_cancel,
+                    Self,
+                    checker,
+                    onCancel,
+                );
+                assert(checker.armedCount() <= constants.health_probe_ops_max);
+                return;
+            }
+            if (checker.armed.deadline and !checker.canceled.deadline) {
+                checker.armCancelDeadline();
+                return;
+            }
+            if (checker.armed.connect and !checker.canceled.connect) {
+                checker.armCancelConnect();
+                return;
+            }
+            if (checker.armedCount() != 0) return;
+            assert(checker.isQuiescent());
+            checker.state = .stopped;
+            checker.server.maybeStopAfterDrain();
+        }
+    };
+}

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -208,6 +208,12 @@ pub const TestBed = struct {
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it.
         access_log: bool = false,
+        /// §7 active health checks on the one cluster; off by default so
+        /// existing scenarios see no probe traffic.
+        check: bool = false,
+        /// Probe pacing for `check` scenarios — tight, so fall/rise fit
+        /// inside a short virtual run.
+        health_interval_ms: u32 = 20,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -225,7 +231,7 @@ pub const TestBed = struct {
 
         try bed.sim_io.init(arena, options.sim);
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .l4 }};
         bed.config = .{
@@ -239,6 +245,7 @@ pub const TestBed = struct {
             // this bed never routes one.
             .request_timeout_ms = 0,
             .access_log_sink = if (options.access_log) .stdout else null,
+            .health_interval_ms = options.health_interval_ms,
         };
         var server_options = options.server;
         server_options.access_log_buffer_bytes = if (options.access_log)
@@ -870,4 +877,86 @@ test "relay: a connection reaped by the idle deadline is logged as aborted" {
     try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_in\":0,") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_out\":0,") != null);
+}
+
+test "health: probes against a listening origin keep the endpoint healthy" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 71 },
+        .check = true,
+        .health_interval_ms = 50,
+    });
+    defer bed.tearDown();
+
+    // No clients: the prober is the only source of work. The terminate
+    // signal ends the scenario the §8 way, which must leave the prober
+    // quiescent and the pools untouched.
+    bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 120 * std.time.ns_per_ms);
+    try bed.sim_io.run();
+
+    // The immediate first sweep plus at least one interval-paced one,
+    // all passing: no ejection, no counted failure, mask untouched.
+    try std.testing.expect(bed.server.counters.get("health_probes_sent") >= 2);
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_probes_failed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.checked_count);
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.unhealthy_count);
+    try bed.expectDrained();
+}
+
+test "health: consecutive refusals eject the endpoint" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 72 },
+        .origin_listens = false,
+        .check = true,
+        .health_interval_ms = 20,
+    });
+    defer bed.tearDown();
+
+    // Nothing listens at the endpoint: every probe is refused. The third
+    // consecutive miss (constants.health_probe_fall) ejects; later misses
+    // keep counting probes but never re-eject.
+    bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 200 * std.time.ns_per_ms);
+    try bed.sim_io.run();
+
+    try std.testing.expect(bed.server.counters.get("health_probes_failed") >= 3);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_up"));
+    try std.testing.expect(!bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.unhealthy_count);
+    // The level reaches the scrape as a gauge, and the snapshot is valid.
+    const gauges = bed.server.gauges();
+    try std.testing.expectEqual(@as(u32, 1), gauges.health_endpoints_unhealthy);
+    try std.testing.expectEqual(@as(u32, 1), gauges.health_endpoints_checked);
+    try bed.expectDrained();
+}
+
+test "health: rise restores an ejected endpoint after passing probes" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 73 },
+        .check = true,
+        .health_interval_ms = 20,
+    });
+    defer bed.tearDown();
+
+    // Three injected dial faults fail exactly the first three probes —
+    // ejecting the endpoint and witnessing §8 kernel pressure on the
+    // probe path — then the listening origin answers, and the second
+    // consecutive pass (constants.health_probe_rise) restores it.
+    bed.sim_io.injectConnectError(TestBed.originAddress());
+    bed.sim_io.injectConnectError(TestBed.originAddress());
+    bed.sim_io.injectConnectError(TestBed.originAddress());
+    bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 160 * std.time.ns_per_ms);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 3), bed.server.counters.get("health_probes_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_up"));
+    try std.testing.expectEqual(@as(u64, 3), bed.server.counters.get("kernel_pressure_connect"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.unhealthy_count);
+    try bed.expectDrained();
 }

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -44,7 +44,11 @@ pub fn Origin(comptime IoType: type) type {
         context: ?*anyopaque = null,
 
         const Self = @This();
-        pub const conns_max: u8 = 16;
+        /// Sized for the sim's worst case: the client population plus a
+        /// `check` scenario's passing probes, each of which accepts and
+        /// vanishes (§7) but still consumes a slot — conns are tracked
+        /// monotonically, never recycled.
+        pub const conns_max: u8 = 32;
         const buffer_bytes: usize = 128;
 
         pub const Conn = struct {


### PR DESCRIPTION
Closes #122 — active TCP health checks, on HAProxy's `check` model.

A cluster opts in with `"check": true`; the prober then dials each of its
endpoints on a pace, and the balancer stops picking endpoints that keep
refusing. Four slices, one commit each.

## The surface

```json
"clusters": { "origin": { "endpoints": ["10.0.0.1:80", "10.0.0.2:80"], "check": true } },
"timeouts": { "health_interval_ms": 2000 }
```

`health_interval_ms` (HAProxy's `inter`, default 2000) paces sweeps; zero is
rejected, because probing is switched by the cluster flag, never by zeroing
its pace. The probe's dial budget is deliberately not a new knob — a probe is
a connect try, so it runs under `connect_ms`. `fall` (3) and `rise` (2) are
named constants for now.

## How it behaves

- One prober per server, **one probe in flight**, sweeping endpoint by
  endpoint. A SYN/ACK passes; refused, unreachable, timed out, or kernel
  pressure (witnessed §8, same split the data-path dial makes) fails.
- **fall = 3** consecutive misses eject an endpoint from balancing and close
  its parked pooled connections — the obligation §5 already had written down
  for this feature: a parked socket to a dead origin is a stale replay
  waiting to be spent. **rise = 2** consecutive passes restore it.
- Endpoints **start healthy**: probing demotes, it never gates startup.
- The pick **fails open**. A cluster with every endpoint ejected balances as
  if none were — routing nowhere would turn a probe verdict into an outage of
  its own, and a same-port TCP probe cannot know better than the dial it
  stands in for. A single-endpoint cluster is therefore unchanged in every
  case.

## Budgets (§5, §8)

The prober's worst case is reserved unconditionally, the admin plane's rule:
`health_probe_ops_max` = 3 ring ops (dial + deadline + one cancel — cancels
are serialized through a single completion, so never two at once) and one fd.
That re-derives the closed forms: `conn_slots_max` 11464 → 11463 (fixed ops
23 → 26) and `upstream_slots_default` 1314 → 1313, keeping the out-of-box fd
budget strictly under the stock 4096 `RLIMIT_NOFILE`. DESIGN.md §5's table
moves with them. Every arm site asserts the armed set against the reservation.

## Observability

Five counters — `health_probes_sent`/`_failed`, `health_endpoint_down`/`_up`,
`health_parked_closed` — joined to `reconcile`'s inequalities (a fail implies
a probe, an ejection implies a fail, a restore implies an ejection), plus
`health_endpoints_checked`/`_unhealthy` gauges on the scrape.

## Coverage (§9)

Directed seeds cover pass streaks, fall, rise, ejection-closes-parked-conn,
and drain quiescence from every prober state.

For the sim, each cluster draws `check` independently, so ~3/4 of seeds run
the prober's whole lifecycle under the adversary. That alone was not enough:
instrumenting 1024 seeds showed the §5 parked-close firing **zero** times —
most scenarios wind down in tens of virtual milliseconds, and the drain reaps
parked conns before an ejection can. So an eighth of adversarial seeds are now
*outage seeds*: the HTTP origin stops listening at 10–40 ms with probes paced
in single milliseconds. Re-measured after: **56 ejections and 6 parked-close
runs per 1024 seeds**, with fall and rise both reached.

Passing probes accept-and-vanish but still consume origin conn slots
(monotonic, never recycled), so both sim origin tables widen — 16 → 32 (L4)
and 32 → 64 (HTTP) — with the sweep bound derived from the shared interval
floor and comptime-asserted against both capacities.

## Gates

`zig build ci` (4096 seeds) and `zig fmt --check` green, plus an extended
12,288-seed sweep (4097..16384). `tiger-style-reviewer` run on each slice;
its findings (budget doc-number drift, a 70-line function, thin assertion
density, the missing sim coverage) are fixed in the commits they belong to.

## Not in this PR

HTTP health checks (expect a status on a configured path, HAProxy's
`http-check`) are tracked separately in #128 — #122 asks only for the basic
TCP check, which this delivers. A TCP probe proves the port accepts, not that
the application behind it is well; closing that gap rides the same prober
skeleton, but the probe grows send/recv ops after connect — so
`health_probe_ops_max` and the state machine both need revisiting, and the
config flag likely evolves beyond a bool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
