### PR TITLE
log: one JSON access line per exchange and per L4 connection (§8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,34 @@ A minimal config — an L4 listener forwarding to one origin
         "idle_ms": 60000,
         "drain_deadline_ms": 10000,
         "max_lifetime_ms": 0
-    }
+    },
+    "access_log": { "sink": "stdout" }
 }
 ```
 
 The full config format — every field, enum, and numeric bound — is
 described by the JSON Schema shipped as a release asset (also emitted
 locally by `zig build schema`).
+
+### Access log
+
+The optional `access_log` block writes one JSON object per line to
+stdout — one per HTTP exchange (rejects, sheds and timeouts included) and
+one per L4 connection:
+
+```json
+{"time":"2026-07-31T09:14:22.481Z","kind":"http","outcome":"ok","client":"10.1.2.3:52344","method":"GET","host":"api.example.com","path":"/v1/items","status":200,"upstream_reused":true,"upstream_replayed":false,"duration_us":1873,"bytes_in":142,"bytes_out":4096,"cluster":"api","upstream":"10.0.0.7:8080"}
+```
+
+`outcome` is the field `status` cannot give you: an origin answering
+`503` and zoxy shedding a request with `503` are the same three digits
+and opposite events. It reads `ok` (the origin answered), `rejected`,
+`shed`, `timed_out`, `upstream_failed`, `aborted`, or — for L4 — `closed`.
+
+Rotation is the operator's: pipe stdout wherever this process's output
+already goes. Logging never blocks the event loop, so a sink that stalls
+costs dropped lines rather than latency; `zoxy_access_log_dropped` counts
+them exactly.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ locally by `zig build schema`).
 ### Access log
 
 The optional `access_log` block writes one JSON object per line to
-stdout — one per HTTP exchange (rejects, sheds and timeouts included) and
-one per L4 connection:
+stdout — one per HTTP exchange (rejects, `503` sheds and timeouts
+included) and one per L4 connection:
 
 ```json
 {"time":"2026-07-31T09:14:22.481Z","kind":"http","outcome":"ok","client":"10.1.2.3:52344","method":"GET","host":"api.example.com","path":"/v1/items","status":200,"upstream_reused":true,"upstream_replayed":false,"duration_us":1873,"bytes_in":142,"bytes_out":4096,"cluster":"api","upstream":"10.0.0.7:8080"}
@@ -63,6 +63,12 @@ one per L4 connection:
 `503` and zoxy shedding a request with `503` are the same three digits
 and opposite events. It reads `ok` (the origin answered), `rejected`,
 `shed`, `timed_out`, `upstream_failed`, `aborted`, or — for L4 — `closed`.
+
+The unit is an *admitted* connection. A connection refused at the
+accept gate — no conn slot, no relay buffer, or a drain already under
+way — never gets a line; those are counted by `zoxy_shed_conn_slots`,
+`zoxy_shed_relay_buffers` and `zoxy_shed_draining` instead, because at
+that point there is nothing to report from and a shed has to stay cheap.
 
 Rotation is the operator's: pipe stdout wherever this process's output
 already goes. Logging never blocks the event loop, so a sink that stalls

--- a/config/example.json
+++ b/config/example.json
@@ -10,5 +10,6 @@
         "idle_ms": 60000,
         "drain_deadline_ms": 10000,
         "max_lifetime_ms": 0
-    }
+    },
+    "access_log": { "sink": "stdout" }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -756,12 +756,26 @@ origin, not one this proxy can pick for them.
   look fine. Optional — a config `access_log` block names a sink, and
   absent it the whole feature reserves nothing and reads no clock — it
   writes one JSON object per line: one per HTTP exchange (including every
-  reject, shed and verdict) and one per L4 connection, carrying the
+  reject, request-level shed and verdict) and one per L4 connection,
+  carrying the
   client, method, canonical host and path (§7), status, outcome,
   duration, byte counts each way, and the cluster and endpoint that
   served. `outcome` is not derivable from `status` and that is the point:
   an origin's own `503` and this proxy's shed `503` are the same three
   digits and opposite events.
+  **The unit is an admitted connection**, which is what draws the line
+  between the two kinds of shed in the table above. A request-level shed
+  — a `503` for relay buffers or upstream slots — belongs to a connection
+  that holds a slot, so it gets a line like any other answer. An
+  *admission-gate* shed does not: `shed_conn_slots`, `shed_relay_buffers`
+  and `shed_draining` fire on a socket that never got a slot, so there is
+  no capture state to report from, and asking the kernel for a peer
+  address would put a syscall and a render on the one path this section
+  keeps to "at most two direct syscalls" — the path that is hottest
+  exactly when it fires. Their witness stays the counters, which is also
+  the honest one: under a shed storm the log would be the highest-volume
+  thing in the process, so the lines an operator most wanted would be the
+  first the drop rung took.
   **A log line must never stall the data path.** The sink is a pipe the
   operator owns, so it can block for arbitrarily long, and a proxy that
   waited on it would hand every client's latency to whatever reads its

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -307,6 +307,17 @@ unmerged behind it, so the pin moves only after re-audit.
   re-base drains it through the same `isTearingDown` checks.
   libxev cancellation is internally cancel+resubmit and consumes its own
   caller-owned completion, embedded in the slot like every other op.
+- **Three seam ops exist for the access log** (§8) and for nothing else.
+  `logWrite` puts the sink on the ring like every other write, so a log
+  reader that stalls cannot stall the loop. `peerAddress` is asked once
+  per admitted connection rather than at log time, when the socket may
+  already be closed and the fd number reused. `nowWallNs` is a *second*
+  clock: precise and uncached, where `now_ns` is coarse and refreshed once
+  per tick. Both of those properties are wrong for a log — a line needs a
+  date, which a monotonic clock cannot give, and a duration measured
+  against the tick would read 0 µs for every request served inside one
+  completion batch. It costs two vDSO reads per logged request, against
+  `now_ns`'s one per tick, and only when a deployment turns the log on.
 - **Plain ops only.** Multishot accept/recv, buffer rings, `send_zc`,
   `splice` stay behind measurement — the previous iteration never became
   CPU-bound without them, and this one is latency-bound with CPU
@@ -381,7 +392,16 @@ a raised `RLIMIT_NOFILE`:
 | conn slots | 1386 | 11464 | ~1.7 KiB state + 8 KiB head |
 | relay buffers | 1386 | 11464 | 2 × 4 KiB |
 | upstream slots | 1314 | 11464 | ~40 B state + 8 KiB head |
-| **pool memory** | **~33 MiB** | **~284 MiB** | |
+| **pool memory** | **~34 MiB** | **~288 MiB** | |
+
+The access log (§8) adds one fixed reservation beside the pools — two
+staging buffers, 64 KiB together by default — and nothing at all when it
+is off. It is in the printed total, because §5's promise is that the
+total covers everything this process holds for its life, not only what is
+shaped like a pool. Roughly half a kilobyte of the conn-slot state above
+is its per-request capture: the method, host and path a line reports live
+in the head buffer, which the response head renders over (§7), so they
+have to be copied out while they are still there.
 
 The ceilings sit on one completion-queue line — a conn slot costs
 `conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
@@ -730,6 +750,39 @@ origin, not one this proxy can pick for them.
   the admin/metrics listener's Prometheus rendering (`admin.zig`, one
   reserved scrape slot off the shared pools) plus a SIGUSR1 dump through
   the seam's `signal` primitive (§4).
+- **The access log is a shed rung of its own.** Counters say how much and
+  how often; an access log says *which request*, and that is what an
+  operator needs when one client is being served badly and the aggregates
+  look fine. Optional — a config `access_log` block names a sink, and
+  absent it the whole feature reserves nothing and reads no clock — it
+  writes one JSON object per line: one per HTTP exchange (including every
+  reject, shed and verdict) and one per L4 connection, carrying the
+  client, method, canonical host and path (§7), status, outcome,
+  duration, byte counts each way, and the cluster and endpoint that
+  served. `outcome` is not derivable from `status` and that is the point:
+  an origin's own `503` and this proxy's shed `503` are the same three
+  digits and opposite events.
+  **A log line must never stall the data path.** The sink is a pipe the
+  operator owns, so it can block for arbitrarily long, and a proxy that
+  waited on it would hand every client's latency to whatever reads its
+  logs. So the write is a ring op like every other (§4) with at most one
+  in flight — one entry in the ring budget, reserved unconditionally —
+  lines accumulate in a second staging buffer while it is out, the two
+  swap when it lands, and **a line that does not fit is dropped and
+  counted.** That is this section's own rule applied to logging: the
+  newest work gives way at a well-defined point, `access_log_dropped`
+  is the witness, and losing a log line is the right trade against
+  stalling a relay. Flushing is self-clocked rather than timer-driven — a
+  record with no write in flight starts one at once — so a quiet proxy's
+  line leaves immediately and a busy one batches a whole write's worth.
+  A sink write that *fails* (a closed pipe) marks the sink broken rather
+  than retrying: what reaches that point is not transient, since the ring
+  already absorbed every would-block. The drain (below) does not stop the
+  loop until the sink is quiet, because the lines describing a shutdown
+  are the ones most likely to be read. The record's per-line width is
+  closed-form in `src/constants.zig` like every other limit, which is why
+  the head-buffer captures it needs — method, host, path — are bounded and
+  truncation is marked rather than silent.
 - **File descriptors are pre-budgeted, not shed.** The fd count is
   closed-form — listeners + connection slots + upstream slots + ring,
   async and signal fds — evaluated on the *effective* config
@@ -881,6 +934,7 @@ src/
   shed.zig            // exhaustion ladder: decisions + static responses
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
   admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
+  access_log.zig      // JSON access log: double-buffered sink, drop rung (§8)
 sim/                  // simulator harness + invariants
 bench/                // micro benches (poop) + loopback harness (zrk), §9
 ```

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -122,6 +122,13 @@ fn deriveAdversary(random: std.Random, clean: bool) SimIo.Adversary {
         // sites on both dial paths were unreachable under every seed
         // until this fate existed (issue #106, kind B).
         .connect_pressure_percent = random.uintAtMost(u8, 5),
+        // A sink that has fallen behind (§8). Most seeds keep it instant;
+        // some stall it past a whole scenario, which is what fills the
+        // staging buffers and makes the drop rung reachable at all.
+        .log_write_stall_ns = if (random.uintLessThan(u8, 4) == 0)
+            random.uintAtMost(u64, 200_000_000)
+        else
+            0,
     };
 }
 
@@ -168,6 +175,11 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
             10 + random.uintAtMost(u32, 90)
         else
             0,
+        // Three seeds in four run with the access log on, so the sink,
+        // its staging swap, and the per-request captures all take the
+        // schedule fuzz; the fourth leaves it off, which is the shape
+        // that must reserve nothing and read no clock (§5, §8).
+        .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
     };
 }
 
@@ -207,14 +219,30 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
     // §8 rungs; clean seeds keep ample pools so golden outcomes
     // never meet a shed.
     const force_exhaustion = !harness.clean and random.uintLessThan(u8, 4) == 0;
+    // Adversarial seeds size the staging buffers at the floor — one
+    // worst-case line each — so the buffer swap runs constantly and every
+    // line meets a nearly-full buffer, against the default's hundred-line
+    // headroom where the swap fires once a scenario. The *drop* rung
+    // itself stays out of reach here: a scenario emits a handful of lines
+    // and filling even the floor takes dozens, so it is pinned by a
+    // directed test (`access_log_test.zig`) rather than left to a seed
+    // that cannot generate the volume.
+    const access_log_buffer_bytes: u32 = if (harness.config.access_log_sink == null)
+        0
+    else if (harness.clean)
+        zoxy.constants.access_log_buffer_bytes_default
+    else
+        zoxy.constants.access_log_buffer_bytes_min;
     const options: ServerSim.InitOptions = if (force_exhaustion)
         .{
             .conn_slots = 1 + random.uintLessThan(u32, 2),
             .relay_buffers = 1,
             .upstream_slots = 1,
+            .access_log_buffer_bytes = access_log_buffer_bytes,
         }
     else
         .{
+            .access_log_buffer_bytes = access_log_buffer_bytes,
             // Clean seeds size every pool so its §8 pressure
             // watermark (ceil of 3/4 capacity: 9 of 12) sits above
             // the whole client population (6): a golden outcome must
@@ -338,12 +366,119 @@ pub fn verify(harness: *Harness) !void {
     if (!harness.io.sockets.isFullyReleased()) return error.SocketLeak;
     // §7: no malformed byte may ever reach an origin.
     if (harness.origin_http.violations != 0) return error.OriginSawMalformedBytes;
+    try harness.verifyAccessLog();
     for (harness.clients[0..harness.l4_count]) |*client| {
         try client.verifyIntegrity();
     }
     for (harness.l7_clients[0..harness.l7_count]) |*client| {
         try client.verify();
     }
+}
+
+/// The §8 access log's invariants (§9). The sink is a virtual file the
+/// harness can read back, so what an operator would have seen is checkable
+/// rather than merely believed: the bytes are whole lines, there are
+/// exactly as many of them as the counter claims, each is shaped like the
+/// documented record, and — when nothing was dropped — every outcome the
+/// data path counted has a line to go with it.
+///
+/// Structural rather than a full JSON parse: `parseFromSlice` allocates,
+/// and the simulator does not. The escaping that a parse would catch is
+/// pinned by `access_log.zig`'s own tests, against inputs far more hostile
+/// than the scripts here send.
+fn verifyAccessLog(harness: *Harness) !void {
+    const counters = &harness.server.counters;
+    const sink = harness.io.sinkBytes();
+    if (harness.io.sink_overflow_bytes != 0) return error.AccessLogSinkOverflowed;
+    // The sink never fails in the sweep, so every accepted line must have
+    // reached it; a failure here would silently weaken every check below.
+    if (counters.get("access_log_write_failed") != 0) return error.AccessLogWriteFailed;
+
+    if (harness.config.access_log_sink == null) {
+        // Off means off: no bytes, and no counter moved (§5).
+        if (sink.len != 0) return error.AccessLogWroteWhileOff;
+        if (counters.get("access_log_lines") != 0) return error.AccessLogCountedWhileOff;
+        if (counters.get("access_log_dropped") != 0) return error.AccessLogCountedWhileOff;
+        return;
+    }
+
+    // The drain does not stop the loop until the sink is quiet (§8), so
+    // the last byte written is the last byte of a line — never half of one.
+    if (sink.len != 0 and sink[sink.len - 1] != '\n') return error.AccessLogTruncatedLine;
+    var lines = std.mem.splitScalar(u8, sink, '\n');
+    var line_count: u64 = 0;
+    while (lines.next()) |line| {
+        if (line.len == 0) continue; // The tail after the final newline.
+        line_count += 1;
+        try verifyAccessLogLine(line);
+    }
+    if (line_count != counters.get("access_log_lines")) return error.AccessLogLineCountDiverged;
+
+    // Nothing was dropped, so every outcome the data path counted owes a
+    // line — plus one per L4 connection and per request that ended without
+    // a verdict, which is why this is an inequality.
+    if (counters.get("access_log_dropped") == 0) {
+        if (counters.get("access_log_lines") < l7OutcomeTotal(counters)) {
+            return error.AccessLogMissedAnOutcome;
+        }
+    }
+}
+
+/// Every L7 outcome that answers a client, summed. Each one runs through
+/// `respond` or `finishExchange`, and both emit a line.
+fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
+    const answered = [_][]const u8{
+        "l7_responses",
+        "l7_bad_request",
+        "l7_uri_too_long",
+        "l7_headers_too_large",
+        "l7_not_implemented",
+        "l7_no_route",
+        "l7_filtered",
+        "l7_shed_relay_buffers",
+        "l7_shed_upstream_slots",
+        "l7_bad_gateway",
+        "l7_gateway_timeout",
+    };
+    var total: u64 = 0;
+    inline for (answered) |name| {
+        total += counters.get(name);
+    }
+    return total;
+}
+
+/// One line's shape: a JSON object carrying every key the record defines,
+/// in the order `renderLine` writes them.
+fn verifyAccessLogLine(line: []const u8) !void {
+    assert(line.len >= 1);
+    if (line[0] != '{') return error.AccessLogLineNotAnObject;
+    if (line[line.len - 1] != '}') return error.AccessLogLineNotAnObject;
+    const required = [_][]const u8{
+        "\"time\":\"",
+        "\"kind\":\"",
+        "\"outcome\":\"",
+        "\"client\":\"",
+        "\"duration_us\":",
+        "\"bytes_in\":",
+        "\"bytes_out\":",
+        "\"cluster\":",
+        "\"upstream\":",
+    };
+    var searched: usize = 0;
+    for (required) |key| {
+        // Searched forward from the previous key, so the order is checked
+        // too: a renderer that emitted the right keys in a shuffled order
+        // would still break a consumer reading them positionally.
+        const at = std.mem.indexOfPos(u8, line, searched, key) orelse
+            return error.AccessLogLineMissingKey;
+        searched = at + key.len;
+    }
+    // An HTTP line carries the request fields; an L4 line must not, or a
+    // consumer keying off `kind` finds a status for a connection that
+    // never had one.
+    const is_http = std.mem.indexOf(u8, line, "\"kind\":\"http\"") != null;
+    const has_status = std.mem.indexOf(u8, line, "\"status\":") != null;
+    if (is_http != has_status) return error.AccessLogLineWrongShape;
 }
 
 /// Both clients' ended hook: type-erased because the client files cannot

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -12,6 +12,7 @@
 
 const std = @import("std");
 
+const access_log_module = @import("access_log.zig");
 const admin_module = @import("admin.zig");
 const Balancer = @import("balancer.zig").Balancer;
 const config_module = @import("config.zig");
@@ -86,10 +87,16 @@ pub fn Server(comptime IoType: type) type {
         /// reserved scrape slot off the shared pools, budgeted separately
         /// (`constants.admin_*`). Off unless a bind is set before `start`.
         admin: admin_module.Admin(IoType),
+        /// The access log (§8): one JSON line per exchange and per L4
+        /// connection, off unless the config names a sink. It holds one
+        /// ring op and two staging buffers, both reserved unconditionally
+        /// in the budgets and allocated only when it is on.
+        access_log: AccessLogType,
 
         const Self = @This();
 
         pub const ConnType = conn_module.Conn(IoType);
+        pub const AccessLogType = access_log_module.AccessLog(IoType);
         const Proxy = proxy.Proxy(IoType);
 
         /// Pool sizes are injectable so tests and the simulator can force
@@ -157,6 +164,8 @@ pub fn Server(comptime IoType: type) type {
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
             server.admin.init(server, config.admin_bind);
+            server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
+            try server.access_log.reserve(arena);
         }
 
         /// Override the admin/metrics bind before `start` — the simulator
@@ -249,6 +258,11 @@ pub fn Server(comptime IoType: type) type {
             // An in-flight scrape holds no pool slot but does hold an armed
             // op and the admin fd; the loop must not stop until it drains.
             if (!server.admin.isQuiescent()) return;
+            // Nor until the access log has flushed: the lines describing
+            // the drain are the ones an operator is most likely to be
+            // reading, and stopping the loop over an armed sink write
+            // would lose exactly those (§8).
+            if (!server.access_log.isQuiescent()) return;
             assert(server.relay_buffers.isFullyReleased());
             // beginDrain reaped every parked slot synchronously and no
             // conn is left to lease one, so the pool must be empty.
@@ -310,7 +324,8 @@ pub fn Server(comptime IoType: type) type {
             return server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
-                server.admin.isQuiescent();
+                server.admin.isQuiescent() and
+                server.access_log.isQuiescent();
         }
 
         pub fn activeCount(server: *const Self) u32 {
@@ -555,6 +570,10 @@ pub fn Server(comptime IoType: type) type {
                 buffer,
                 entryState(listener.protocol),
                 listener.cluster_index,
+                listener.protocol,
+                // Asked once, here, and kept: at log time the socket may
+                // already be closed (§8).
+                server.io.peerAddress(client_socket),
             );
             server.io.setNodelay(client_socket) catch |err| {
                 server.witnessKernelPressure(.set_option, err);
@@ -604,8 +623,13 @@ pub fn Server(comptime IoType: type) type {
             // L4 dials hold no Upstream slot, so the load table reflects
             // L7 leases only — the P2C draw still spreads L4 dials by the
             // observed L7 load, and evenly when there is none.
+            const pick = server.balancer.pick(cluster_index, &server.upstreams.leased_counts);
+            // An L4 dial holds no slot to record the endpoint on, so the
+            // access log takes it here — the only place that knows which
+            // origin this connection is being relayed to (§8).
+            conn.log.endpoint_index = pick.endpoint_index;
             server.io.connect(
-                server.balancer.pick(cluster_index, &server.upstreams.leased_counts).address,
+                pick.address,
                 &conn.op_connect.completion,
                 ConnType,
                 conn,
@@ -716,9 +740,88 @@ pub fn Server(comptime IoType: type) type {
             }
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
+            // The last chance to say anything about this connection (§8).
+            // An exchange that reached a verdict already spoke and is
+            // skipped by `emitted`; what is left here is everything that
+            // ended without one — a client that left mid-request, a
+            // truncated body, a drain straggler — and every L4 connection,
+            // whose whole life is the unit being logged.
+            server.logExchange(conn);
             server.releaseConn(conn);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
+        }
+
+        /// Start this connection's access-log clock, if it owes a line and
+        /// has not started one (§8). The L7 path calls it when a request's
+        /// first head byte lands — which is when the request begins, not
+        /// when its head finishes parsing, so a slowloris's line reports
+        /// the whole time it spent dribbling.
+        pub fn beginLogRequest(server: *Self, conn: *ConnType) void {
+            if (server.access_log.sink == null) return;
+            if (conn.log.started_wall_ns != 0) return;
+            conn.log.started_wall_ns = server.io.nowWallNs();
+            assert(conn.log.started_wall_ns != 0);
+        }
+
+        /// Write the access-log line this connection owes, if any (§8).
+        ///
+        /// The caller sets `conn.log.status` and `conn.log.outcome` when it
+        /// knows them; the defaults — status 0, outcome `aborted` — are
+        /// deliberately the answer for the caller that does not, which is
+        /// teardown. That is what lets one function serve both the path
+        /// that decided an outcome and the path that never got one, with
+        /// `emitted` deciding which of the two speaks for an exchange that
+        /// took both.
+        pub fn logExchange(server: *Self, conn: *ConnType) void {
+            if (server.access_log.sink == null) return;
+            if (conn.log.emitted) return;
+            // Nothing was asked of this connection: an L7 slot that idled
+            // out between requests, or one reaped before its first byte.
+            if (conn.log.started_wall_ns == 0) return;
+            conn.log.emitted = true;
+            const now_wall_ns = server.io.nowWallNs();
+            // Both indices are pool/config positions this connection has
+            // carried since routing; a stale one would name another
+            // operator's backend in the line, so they are checked here
+            // rather than left to Zig's bounds check to turn into a panic.
+            assert(conn.cluster_index < server.config.clusters.len);
+            const cluster = server.config.clusters[conn.cluster_index];
+            if (conn.log.endpoint_index != conn_module.LogState.endpoint_none) {
+                assert(conn.log.endpoint_index < cluster.endpoints.len);
+            }
+            const entry: access_log_module.Record = .{
+                .kind = switch (conn.protocol) {
+                    .l4 => .l4,
+                    .http => .http,
+                },
+                .outcome = conn.log.outcome,
+                .started_wall_ns = conn.log.started_wall_ns,
+                // Saturating: the wall clock can step backwards under NTP,
+                // and a duration that wrapped to eighteen quintillion
+                // microseconds would be read as a stall that never happened.
+                .duration_ns = now_wall_ns -| conn.log.started_wall_ns,
+                .client = conn.client_address,
+                .upstream = if (conn.log.endpoint_index == conn_module.LogState.endpoint_none)
+                    null
+                else
+                    cluster.endpoints[conn.log.endpoint_index],
+                .cluster = cluster.name,
+                .bytes_in = conn.log.bytes_in,
+                .bytes_out = conn.log.bytes_out,
+                .method = conn.log.methodSlice(),
+                .host = conn.log.hostSlice(),
+                .path = conn.log.pathSlice(),
+                .status = conn.log.status,
+                .upstream_reused = conn.l7.upstream_was_reused,
+                .upstream_replayed = conn.l7.replay_used,
+            };
+            // A duration is never negative once saturated, and a line
+            // always names a start: both are what `renderLine` prints
+            // without checking, so they are checked here.
+            assert(entry.started_wall_ns != 0);
+            assert(entry.duration_ns <= now_wall_ns);
+            server.access_log.record(&entry);
         }
 
         /// §8 kernel-pressure rung: a non-orderly op failure on a live

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -1,0 +1,581 @@
+//! The access log (DESIGN.md §8): one JSON object per line — an HTTP
+//! exchange or an L4 connection — written to the configured sink through
+//! the seam's one ring op. Off unless a config `access_log` block names a
+//! sink, and then it reserves exactly two staging buffers and one ring
+//! entry, both closed-form in `constants.zig` like every other budget.
+//!
+//! **A log line never blocks the loop, and never queues without bound.**
+//! Those two rules are the whole design. The sink is a pipe the operator
+//! owns, so it can stall for arbitrarily long, and a proxy that waits for
+//! it would hand every client's latency to whatever is reading its logs.
+//! So the write is a ring op with at most one in flight, lines accumulate
+//! in the *other* buffer while it is out, the buffers swap when it lands,
+//! and a line that does not fit is dropped and counted. That is §8's
+//! ladder applied to logging: exhaustion sheds the newest work at a
+//! well-defined point with a well-defined answer, and `access_log_dropped`
+//! is the witness. Losing a log line is the correct trade against stalling
+//! a data path; the counter is what keeps it from being a silent one.
+//!
+//! Flushing is self-clocked rather than timer-driven: a record with no
+//! write in flight starts one immediately, so a quiet proxy's line reaches
+//! the sink at once, and a busy one batches everything that arrived during
+//! the previous write into the next. No tick hook, no flush timer, and no
+//! line that can sit in a buffer waiting for company.
+//!
+//! `Record` and `renderLine` sit at file scope, outside the Io-generic
+//! part: the wire format is what an operator's tooling parses, so it is
+//! testable without standing up a backend.
+
+const std = @import("std");
+
+const config_module = @import("config.zig");
+const constants = @import("constants.zig");
+const Io = @import("io/io.zig");
+
+const assert = std.debug.assert;
+
+/// What a line describes. The two data paths answer different questions —
+/// an HTTP line is about one request, an L4 line about one connection —
+/// so `kind` is what tells a consumer which fields to expect.
+pub const Kind = enum(u1) {
+    http,
+    l4,
+};
+
+/// How the thing being logged ended. Deliberately not derivable from
+/// `status`: an origin's own `503` and zoxy's shed `503` are the same
+/// three digits and opposite events, and telling them apart is most of
+/// what an operator reads an access log for.
+pub const Outcome = enum(u8) {
+    /// The origin answered and its whole response reached the client. The
+    /// status is the origin's, whatever it is.
+    ok,
+    /// zoxy refused the request itself (§7): malformed, oversize,
+    /// unroutable, unsupported, or stopped by a filter rule.
+    rejected,
+    /// zoxy ran out of a resource and answered `503` (§8) — a relay buffer
+    /// or an upstream slot the request needed.
+    shed,
+    /// The exchange outlived `timeouts.request_ms` and was answered `504`
+    /// (§8).
+    timed_out,
+    /// The upstream leg failed before any response byte and was answered
+    /// `502` (§7, §8) — a refused dial, a dead origin, an unparseable
+    /// response head.
+    upstream_failed,
+    /// No answer was delivered: the connection was torn down mid-request.
+    /// The client left, the deadline fired with a response already in
+    /// flight, or a drain reaped a straggler.
+    aborted,
+    /// L4 only: both directions drained and the connection closed cleanly.
+    closed,
+};
+
+/// One line's worth of facts. Sliced fields alias the caller's storage and
+/// are read out entirely by `renderLine` before it returns, so a caller may
+/// point them at a connection slot it is about to release.
+///
+/// Past 16 bytes several times over, so it travels by `*const` (TIGER_STYLE)
+/// — and because a record is built in one place and read in another, a
+/// stack copy would be pure cost.
+pub const Record = struct {
+    kind: Kind,
+    outcome: Outcome,
+    /// Wall-clock nanoseconds at which the request — or, for L4, the
+    /// connection — *started*. The start rather than the completion: a
+    /// slow request and a fast one that began at the same moment belong
+    /// next to each other when an operator is reconstructing an incident,
+    /// and `duration_us` already says where each one ended.
+    started_wall_ns: u64,
+    duration_ns: u64,
+    client: std.Io.net.IpAddress,
+    /// The endpoint this request or connection was served by, or null when
+    /// none was ever picked — every reject that fires before routing.
+    upstream: ?std.Io.net.IpAddress,
+    /// The cluster's configured name, empty when routing never chose one.
+    cluster: []const u8,
+    /// Bytes received from the client, and bytes sent to it. Both are
+    /// what crossed the wire on this proxy's client side, so a response
+    /// that failed halfway reports the half that landed.
+    bytes_in: u64,
+    bytes_out: u64,
+    /// The request's method token as the client wrote it, truncated to
+    /// `access_log_method_bytes_max`. Empty on an L4 line, and on an HTTP
+    /// line whose head never parsed.
+    method: []const u8 = &.{},
+    /// The canonical routing host (lowercased, port-stripped, §7), empty
+    /// when the request carried none or it was unusable.
+    host: []const u8 = &.{},
+    /// The canonical path routing matched on (§7) — not the raw target:
+    /// it is the spelling the router and the origin both saw, so a log
+    /// line and a route table cannot disagree about which resource was
+    /// named. Truncated to `access_log_path_bytes_max` with a trailing
+    /// `...`.
+    path: []const u8 = &.{},
+    /// The status the client was sent, or 0 when it was sent none.
+    status: u16 = 0,
+    /// Whether this exchange rode a parked upstream connection (§5) and
+    /// whether it spent the one free stale replay (§7). Both are cheap to
+    /// carry and answer the question a raised latency or an odd 502 asks
+    /// first.
+    upstream_reused: bool = false,
+    upstream_replayed: bool = false,
+};
+
+/// Render `record` as one JSON object plus its newline into `buffer`,
+/// returning the filled prefix. `error.NoSpaceLeft` means exactly one
+/// thing to every caller — this line does not fit what is left — and a
+/// buffer of `constants.access_log_line_bytes_max` can never see it, which
+/// is what makes a drop always mean backpressure (§8) and never arithmetic.
+///
+/// Keys are fixed, not templated: a log format language would be a config
+/// DSL (§1 non-goal), and a fixed schema is what lets a consumer index the
+/// fields without discovering them first.
+pub fn renderLine(record: *const Record, buffer: []u8) error{NoSpaceLeft}![]const u8 {
+    assert(buffer.len >= 1);
+    // The two are captured under caps that make the line bound closed-form
+    // (`constants.access_log_line_bytes_max`); a caller that widened one
+    // without widening the bound would turn every line into a drop.
+    assert(record.path.len <= constants.access_log_path_bytes_max);
+    assert(record.cluster.len <= constants.cluster_name_bytes_max);
+    var writer = std.Io.Writer.fixed(buffer);
+    renderInto(record, &writer) catch return error.NoSpaceLeft;
+    const line = writer.buffered();
+    assert(line.len >= 2);
+    assert(line[0] == '{');
+    assert(line[line.len - 1] == '\n');
+    return line;
+}
+
+/// The fields every line carries, then the HTTP-only ones. Split from
+/// `renderLine` so each stays inside the 70-line limit and so the
+/// "which fields does `kind` imply" question is answered by the code
+/// shape rather than by a comment.
+fn renderInto(record: *const Record, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+    try writer.writeAll("{\"time\":\"");
+    try writeTimestamp(writer, record.started_wall_ns);
+    try writer.print("\",\"kind\":\"{t}\",\"outcome\":\"{t}\"", .{
+        record.kind,
+        record.outcome,
+    });
+    try writer.print(",\"client\":\"{f}\"", .{record.client});
+    if (record.kind == .http) {
+        try renderHttpFields(record, writer);
+    }
+    // Microseconds: milliseconds lose the whole interesting range of a
+    // loopback or LAN hop, and nanoseconds report a precision the clock
+    // behind `duration_ns` does not have. Truncating is the right
+    // direction — a duration is reported as what it *at least* was.
+    try writer.print(
+        ",\"duration_us\":{d}",
+        .{@divFloor(record.duration_ns, std.time.ns_per_us)},
+    );
+    try writer.print(",\"bytes_in\":{d},\"bytes_out\":{d}", .{
+        record.bytes_in,
+        record.bytes_out,
+    });
+    try writer.writeAll(",\"cluster\":");
+    try std.json.Stringify.encodeJsonString(record.cluster, .{}, writer);
+    try writer.writeAll(",\"upstream\":");
+    if (record.upstream) |address| {
+        try writer.print("\"{f}\"", .{address});
+    } else {
+        // Null rather than an empty string: "no endpoint was ever picked"
+        // is a different fact from "the endpoint has no address", and a
+        // consumer should not have to guess which one an empty string is.
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}\n");
+}
+
+fn renderHttpFields(record: *const Record, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+    assert(record.kind == .http);
+    assert(record.method.len <= constants.access_log_method_bytes_max);
+    assert(record.host.len <= constants.host_bytes_max);
+    try writer.writeAll(",\"method\":");
+    try std.json.Stringify.encodeJsonString(record.method, .{}, writer);
+    try writer.writeAll(",\"host\":");
+    try std.json.Stringify.encodeJsonString(record.host, .{}, writer);
+    try writer.writeAll(",\"path\":");
+    try std.json.Stringify.encodeJsonString(record.path, .{}, writer);
+    try writer.print(",\"status\":{d}", .{record.status});
+    try writer.print(",\"upstream_reused\":{},\"upstream_replayed\":{}", .{
+        record.upstream_reused,
+        record.upstream_replayed,
+    });
+}
+
+/// RFC 3339 UTC to the millisecond, the spelling every log pipeline reads
+/// without configuration. Milliseconds because that is the resolution of
+/// the coarse clock the stamp comes from (§4) — printing more digits would
+/// be inventing them.
+fn writeTimestamp(writer: *std.Io.Writer, wall_ns: u64) std.Io.Writer.Error!void {
+    const epoch: std.time.epoch.EpochSeconds = .{
+        .secs = @divFloor(wall_ns, std.time.ns_per_s),
+    };
+    const year_day = epoch.getEpochDay().calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const time_of_day = epoch.getDaySeconds();
+    const millis = @divFloor(wall_ns % std.time.ns_per_s, std.time.ns_per_ms);
+    assert(millis < 1000);
+    assert(month_day.day_index < 31);
+    try writer.print("{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}Z", .{
+        year_day.year,
+        month_day.month.numeric(),
+        month_day.day_index + 1,
+        time_of_day.getHoursIntoDay(),
+        time_of_day.getMinutesIntoHour(),
+        time_of_day.getSecondsIntoMinute(),
+        millis,
+    });
+}
+
+/// Copy `source` into `target` for later logging, truncating with a
+/// trailing `...` rather than dropping it. Returns the filled prefix.
+///
+/// Truncation is marked because an unmarked one is a lie: a path cut at
+/// 256 bytes reads as a request for a resource nobody asked for, and an
+/// operator matching log lines against a route table would chase it. The
+/// marker costs three bytes and makes the cut self-describing.
+pub fn captureTruncated(target: []u8, source: []const u8) []const u8 {
+    const marker = "...";
+    assert(target.len > marker.len);
+    if (source.len <= target.len) {
+        @memcpy(target[0..source.len], source);
+        return target[0..source.len];
+    }
+    const kept = target.len - marker.len;
+    assert(kept >= 1);
+    @memcpy(target[0..kept], source[0..kept]);
+    @memcpy(target[kept..][0..marker.len], marker);
+    return target[0..target.len];
+}
+
+/// The sink: two staging buffers, one in-flight write, and the drop rung.
+/// Generic over the Io backend like the rest of the serving path, so the
+/// simulator drives it and can read back exactly what production would
+/// have written (§9).
+pub fn AccessLog(comptime IoType: type) type {
+    const ServerType = @import("Server.zig").Server(IoType);
+
+    return struct {
+        server: *ServerType,
+        /// Null when no `access_log` block was configured: the whole
+        /// feature is off, `record` returns immediately, and `reserve`
+        /// allocates nothing (§5 — an unconfigured feature reserves
+        /// nothing).
+        sink: ?config_module.Config.AccessLogSink,
+        /// Bytes per staging buffer, from `limits` (§8). Zero exactly when
+        /// the sink is null; the simulator shrinks it to the floor to make
+        /// the drop rung reachable (§9).
+        buffer_bytes: u32,
+        /// Both staging buffers, empty slices while the log is off. The
+        /// one at `staging` accepts appends; the other is either idle or
+        /// has a write in flight over its first `flush_len` bytes.
+        buffers: [constants.access_log_buffers][]u8,
+        staging: u1,
+        staging_len: u32,
+        /// The in-flight window over `buffers[staging ^ 1]`, and how much
+        /// of it the sink has taken (a short write resumes from there).
+        flush_len: u32,
+        flush_sent: u32,
+        writing: bool,
+        /// Set once a sink write fails. A broken sink is not retried: the
+        /// failure that reaches here is a closed pipe or a dead file, not
+        /// a transient — the ring already absorbed every would-block — so
+        /// retrying would spend a syscall per line forever to lose the
+        /// same lines. Every subsequent record counts as dropped, so the
+        /// gap is visible in the metrics the log stopped narrating.
+        broken: bool,
+        completion: IoType.Completion,
+
+        const Self = @This();
+
+        pub fn init(
+            log: *Self,
+            server: *ServerType,
+            sink: ?config_module.Config.AccessLogSink,
+            buffer_bytes: u32,
+        ) void {
+            // One number, two facts: the loader keeps the size at zero
+            // exactly when there is no sink, so neither can be set without
+            // the other (§8).
+            assert((sink == null) == (buffer_bytes == 0));
+            if (sink != null) {
+                assert(buffer_bytes >= constants.access_log_buffer_bytes_min);
+                assert(buffer_bytes <= constants.access_log_buffer_bytes_max);
+            }
+            log.server = server;
+            log.sink = sink;
+            log.buffer_bytes = buffer_bytes;
+            log.buffers = .{ &.{}, &.{} };
+            log.staging = 0;
+            log.staging_len = 0;
+            log.flush_len = 0;
+            log.flush_sent = 0;
+            log.writing = false;
+            log.broken = false;
+            log.completion = .{};
+            assert(log.isQuiescent());
+        }
+
+        /// Reserve the staging buffers, or nothing when the log is off
+        /// (§5). Separate from `init` because it is the one part that
+        /// allocates, and it allocates from the startup arena exactly once.
+        pub fn reserve(log: *Self, arena: std.mem.Allocator) error{OutOfMemory}!void {
+            assert(log.buffers[0].len == 0);
+            assert(log.buffers[1].len == 0);
+            if (log.sink == null) return;
+            for (&log.buffers) |*buffer| {
+                buffer.* = try arena.alloc(u8, log.buffer_bytes);
+            }
+            assert(log.buffers[0].len == log.buffer_bytes);
+            assert(log.buffers[1].len == log.buffer_bytes);
+        }
+
+        /// Append one record, or drop it (§8). The only entry point the
+        /// serving path uses, and it never fails: a caller settling an
+        /// exchange has nothing useful to do with a logging error, so the
+        /// two ways a line can be lost — no room, or a broken sink — are
+        /// counted here rather than returned.
+        pub fn record(log: *Self, entry: *const Record) void {
+            if (log.sink == null) return;
+            if (log.broken) {
+                log.server.counters.increment("access_log_dropped");
+                return;
+            }
+            const buffer = log.buffers[log.staging];
+            assert(log.staging_len <= buffer.len);
+            const line = renderLine(entry, buffer[log.staging_len..]) catch {
+                // The staging buffer is full because the sink has not
+                // drained it yet: the newest line is what gives way (§8),
+                // and the counter is what says so.
+                log.server.counters.increment("access_log_dropped");
+                return;
+            };
+            assert(line.len <= constants.access_log_line_bytes_max);
+            log.staging_len += @intCast(line.len);
+            assert(log.staging_len <= buffer.len);
+            log.server.counters.increment("access_log_lines");
+            log.maybeFlush();
+        }
+
+        /// Start a write if there is something to write and nothing in
+        /// flight. Called after every append and after every completion,
+        /// which is what makes flushing self-clocking: no timer, and no
+        /// line waiting on one.
+        fn maybeFlush(log: *Self) void {
+            assert(log.sink != null);
+            if (log.writing) return;
+            if (log.staging_len == 0) return;
+            assert(!log.broken);
+            // Nothing is in flight, so the other buffer's contents are
+            // spent: swapping makes the lines just written the flush
+            // window and hands their old buffer back for appends.
+            log.flush_len = log.staging_len;
+            log.flush_sent = 0;
+            log.staging ^= 1;
+            log.staging_len = 0;
+            assert(log.flush_len >= 1);
+            log.armWrite();
+        }
+
+        fn armWrite(log: *Self) void {
+            assert(!log.writing);
+            assert(log.flush_sent < log.flush_len);
+            const buffer = log.buffers[log.staging ^ 1];
+            assert(log.flush_len <= buffer.len);
+            log.writing = true;
+            log.server.io.logWrite(
+                buffer[log.flush_sent..log.flush_len],
+                &log.completion,
+                Self,
+                log,
+                onWritten,
+            );
+        }
+
+        fn onWritten(log: *Self, result: Io.LogWriteError!u32) void {
+            assert(log.writing);
+            log.writing = false;
+            const written = result catch {
+                // Deliberately *not* counted as drops: the lines in flight
+                // and the ones behind them were already counted as
+                // `access_log_lines` when they were accepted, and counting
+                // them twice would break the identity the §9 oracle checks
+                // — every loggable event is one line or one drop. This
+                // counter is the witness that some accepted lines never
+                // landed, and that everything after this is a drop.
+                log.server.counters.increment("access_log_write_failed");
+                log.broken = true;
+                log.flush_len = 0;
+                log.flush_sent = 0;
+                log.staging_len = 0;
+                log.server.maybeStopAfterDrain();
+                return;
+            };
+            assert(written >= 1);
+            log.flush_sent += written;
+            assert(log.flush_sent <= log.flush_len);
+            if (log.flush_sent < log.flush_len) {
+                log.armWrite(); // A short write resumes (§6's rule, one sink over).
+                return;
+            }
+            log.flush_len = 0;
+            log.flush_sent = 0;
+            log.maybeFlush();
+            // The drain stops the loop only once the sink is quiet, so the
+            // completion that empties it is the one that has to re-check.
+            log.server.maybeStopAfterDrain();
+        }
+
+        /// Quiescent for the drain-stop gate (§8): nothing in flight and
+        /// nothing waiting. A log the drain stopped short of flushing
+        /// would lose exactly the lines describing the shutdown, which is
+        /// when an operator is most likely to be reading it.
+        pub fn isQuiescent(log: *const Self) bool {
+            return !log.writing and log.staging_len == 0;
+        }
+    };
+}
+
+const testing = std.testing;
+
+/// A record with every field set to something distinguishable, so a test
+/// can assert on one field without the others being coincidentally right.
+fn testRecord() Record {
+    return .{
+        .kind = .http,
+        .outcome = .ok,
+        // 2026-07-31T09:14:22.481Z
+        .started_wall_ns = 1_785_489_262 * std.time.ns_per_s + 481 * std.time.ns_per_ms,
+        .duration_ns = 1_873_000,
+        .client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:52344") catch unreachable,
+        .upstream = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable,
+        .cluster = "api",
+        .bytes_in = 142,
+        .bytes_out = 4096,
+        .method = "GET",
+        .host = "api.example.com",
+        .path = "/v1/items",
+        .status = 200,
+        .upstream_reused = true,
+        .upstream_replayed = false,
+    };
+}
+
+test "access log: an HTTP line carries every field, exactly once" {
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    const entry = testRecord();
+    const line = try renderLine(&entry, &buffer);
+
+    try testing.expectEqualStrings(
+        "{\"time\":\"2026-07-31T09:14:22.481Z\",\"kind\":\"http\",\"outcome\":\"ok\"," ++
+            "\"client\":\"10.1.2.3:52344\",\"method\":\"GET\",\"host\":\"api.example.com\"," ++
+            "\"path\":\"/v1/items\",\"status\":200,\"upstream_reused\":true," ++
+            "\"upstream_replayed\":false,\"duration_us\":1873,\"bytes_in\":142," ++
+            "\"bytes_out\":4096,\"cluster\":\"api\",\"upstream\":\"10.0.0.7:8080\"}\n",
+        line,
+    );
+}
+
+test "access log: an L4 line omits the request fields and names no status" {
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    var entry = testRecord();
+    entry.kind = .l4;
+    entry.outcome = .closed;
+    entry.cluster = "tcp";
+    entry.upstream = try std.Io.net.IpAddress.parseLiteral("10.0.0.7:9000");
+    const line = try renderLine(&entry, &buffer);
+
+    try testing.expectEqualStrings(
+        "{\"time\":\"2026-07-31T09:14:22.481Z\",\"kind\":\"l4\",\"outcome\":\"closed\"," ++
+            "\"client\":\"10.1.2.3:52344\",\"duration_us\":1873,\"bytes_in\":142," ++
+            "\"bytes_out\":4096,\"cluster\":\"tcp\",\"upstream\":\"10.0.0.7:9000\"}\n",
+        line,
+    );
+    // The HTTP-only keys are absent, not empty: a consumer keying off
+    // `kind` must not find a `status` on an L4 line at all.
+    try testing.expect(std.mem.indexOf(u8, line, "status") == null);
+    try testing.expect(std.mem.indexOf(u8, line, "method") == null);
+}
+
+test "access log: every line is valid JSON, including hostile paths" {
+    // A percent-decoded canonical path may legally contain a quote, a
+    // backslash, or a control byte (§7 decodes unreserved escapes and
+    // rejects only the structure-changing ones), and each has to survive
+    // as a JSON string rather than as a broken line the consumer drops.
+    const paths = [_][]const u8{
+        "/v1/items",
+        "/a\"b",
+        "/a\\b",
+        "/a\x01b",
+        "/\x00",
+        "/emoji-\u{1F600}",
+    };
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    for (paths) |path| {
+        var entry = testRecord();
+        entry.path = path;
+        entry.host = "h\"ost";
+        entry.cluster = "cl\\uster";
+        const line = try renderLine(&entry, &buffer);
+
+        const parsed = try std.json.parseFromSlice(
+            std.json.Value,
+            testing.allocator,
+            line,
+            .{},
+        );
+        defer parsed.deinit();
+        try testing.expectEqualStrings(path, parsed.value.object.get("path").?.string);
+        try testing.expectEqualStrings("h\"ost", parsed.value.object.get("host").?.string);
+    }
+}
+
+test "access log: the line bound holds at every field's maximum" {
+    // `access_log_line_bytes_max` is what lets `record` treat NoSpaceLeft
+    // as backpressure rather than arithmetic (§8), so it must survive the
+    // widest line the caps allow: full-width IPv6 on both ends, a path and
+    // a host of nothing but 6-byte escapes, and every number saturated.
+    var path: [constants.access_log_path_bytes_max]u8 = undefined;
+    @memset(&path, '\x01');
+    var host: [constants.host_bytes_max]u8 = undefined;
+    @memset(&host, '\x01');
+    var method: [constants.access_log_method_bytes_max]u8 = undefined;
+    @memset(&method, '\x01');
+    var cluster: [constants.cluster_name_bytes_max]u8 = undefined;
+    @memset(&cluster, 'c');
+
+    const entry: Record = .{
+        .kind = .http,
+        .outcome = .upstream_failed,
+        .started_wall_ns = std.math.maxInt(u32) * std.time.ns_per_s,
+        .duration_ns = std.math.maxInt(u64),
+        .client = try .parseLiteral("[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535"),
+        .upstream = try .parseLiteral("[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535"),
+        .cluster = &cluster,
+        .bytes_in = std.math.maxInt(u64),
+        .bytes_out = std.math.maxInt(u64),
+        .method = &method,
+        .host = &host,
+        .path = &path,
+        .status = 999,
+        .upstream_reused = true,
+        .upstream_replayed = true,
+    };
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    const line = try renderLine(&entry, &buffer);
+    try testing.expect(line.len <= constants.access_log_line_bytes_max);
+}
+
+test "access log: a truncated capture says so" {
+    var target: [16]u8 = undefined;
+    // Short enough to fit: copied whole, no marker.
+    try testing.expectEqualStrings("/short", captureTruncated(&target, "/short"));
+    // Exactly the cap: still whole — the marker is for what was cut, and
+    // nothing was.
+    try testing.expectEqualStrings("/0123456789abcde", captureTruncated(&target, "/0123456789abcde"));
+    // One byte over: the prefix survives and the cut is visible.
+    try testing.expectEqualStrings("/0123456789ab...", captureTruncated(&target, "/0123456789abcdef"));
+}

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -1,0 +1,283 @@
+//! Directed access-log scenarios over SimIo (§9). The sink is a state
+//! machine with a rung of its own — two staging buffers, one in-flight
+//! write, and a drop when the buffers fill — and its rung is not one a
+//! simulator *scenario* can reach: filling even the smallest legal buffer
+//! takes dozens of lines, where a scenario emits a handful. So the sweep
+//! covers the ordinary paths under schedule fuzz and these tests pin the
+//! edges: the drop, the broken sink, the short-write resume, and the drain
+//! that must not stop the loop over an unflushed line.
+//!
+//! Records are handed to `AccessLog.record` directly. The serving path's
+//! job is to *build* them, which the sweep and `http_proxy_test.zig` both
+//! exercise; what is under test here is what the sink does with one.
+
+const std = @import("std");
+
+const access_log = @import("access_log.zig");
+const config_module = @import("config.zig");
+const constants = @import("constants.zig");
+const router = @import("http/router.zig");
+const Server = @import("Server.zig").Server;
+const SimIo = @import("io/SimIo.zig");
+
+const assert = std.debug.assert;
+const testing = std.testing;
+
+const ServerSim = Server(SimIo);
+
+fn bindAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:8080") catch unreachable;
+}
+fn originAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
+}
+
+const Harness = struct {
+    arena_state: std.heap.ArenaAllocator,
+    sim_io: SimIo,
+    endpoints: [1]std.Io.net.IpAddress,
+    clusters: [1]config_module.Config.Cluster,
+    routes: [1]router.Route,
+    listeners: [1]config_module.Config.Listener,
+    config: config_module.Config,
+    server: ServerSim,
+
+    /// `buffer_bytes` of zero is how a config leaves the log off; anything
+    /// else turns it on at that staging size. No listeners are started:
+    /// the sink is the whole subject, and an armed accept would keep the
+    /// loop from ever returning.
+    fn setUp(
+        harness: *Harness,
+        gpa: std.mem.Allocator,
+        buffer_bytes: u32,
+        stall_ns: u64,
+    ) !void {
+        harness.arena_state = std.heap.ArenaAllocator.init(gpa);
+        errdefer harness.arena_state.deinit();
+        const arena = harness.arena_state.allocator();
+
+        try harness.sim_io.init(arena, .{
+            .seed = 1,
+            .adversary = .{ .partial_io = false, .log_write_stall_ns = stall_ns },
+        });
+        harness.endpoints = .{originAddress()};
+        harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
+        harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
+        harness.listeners = .{.{
+            .bind_address = bindAddress(),
+            .routes = &harness.routes,
+            .protocol = .http,
+        }};
+        harness.config = .{
+            .listeners = &harness.listeners,
+            .clusters = &harness.clusters,
+            .connect_timeout_ms = 50,
+            .idle_timeout_ms = 1000,
+            .drain_deadline_ms = 1000,
+            .max_lifetime_ms = 0,
+            .request_timeout_ms = 0,
+            .access_log_sink = if (buffer_bytes == 0) null else .stdout,
+        };
+        try harness.server.init(arena, &harness.sim_io, &harness.config, .{
+            .conn_slots = 4,
+            .relay_buffers = 2,
+            .access_log_buffer_bytes = buffer_bytes,
+        });
+    }
+
+    fn tearDown(harness: *Harness) void {
+        harness.arena_state.deinit();
+    }
+
+    fn counter(harness: *const Harness, comptime name: []const u8) u64 {
+        return harness.server.counters.get(name);
+    }
+
+    /// Deliver everything pending — the sink's writes and nothing else,
+    /// since no listener is armed.
+    fn drainSink(harness: *Harness) !void {
+        try harness.sim_io.run();
+    }
+
+    fn emit(harness: *Harness, index: u32) void {
+        var entry = sampleRecord();
+        entry.bytes_in = index; // Distinguishable per line, for order checks.
+        harness.server.access_log.record(&entry);
+    }
+};
+
+fn sampleRecord() access_log.Record {
+    return .{
+        .kind = .http,
+        .outcome = .ok,
+        .started_wall_ns = 1_785_489_262 * std.time.ns_per_s,
+        .duration_ns = 1000,
+        .client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:52344") catch unreachable,
+        .upstream = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable,
+        .cluster = "origin",
+        .bytes_in = 0,
+        .bytes_out = 7,
+        .method = "GET",
+        .host = "example.com",
+        .path = "/v1/items",
+        .status = 200,
+    };
+}
+
+fn lineCount(sink: []const u8) u64 {
+    return std.mem.count(u8, sink, "\n");
+}
+
+test "access log: a burst past the staging buffers drops, and says how much" {
+    // The §8 rung. The sink is stalled for the whole burst, so both
+    // buffers fill and there is nowhere for the rest to go — which must
+    // cost lines, never a stalled caller.
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 1_000_000_000);
+    defer harness.tearDown();
+
+    const burst: u32 = 512;
+    var index: u32 = 0;
+    while (index < burst) : (index += 1) {
+        harness.emit(index);
+    }
+
+    // Every record is one line or one drop — no third outcome, which is
+    // what lets an operator read `dropped` as "this is how incomplete".
+    try testing.expectEqual(
+        @as(u64, burst),
+        harness.counter("access_log_lines") + harness.counter("access_log_dropped"),
+    );
+    try testing.expect(harness.counter("access_log_dropped") > 0);
+    try testing.expect(harness.counter("access_log_lines") > 0);
+    // Backpressure, not a broken sink: nothing failed, the writes are
+    // simply still out.
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_write_failed"));
+    try testing.expect(!harness.server.access_log.isQuiescent());
+
+    // What was accepted still reaches the sink once it drains, whole.
+    try harness.drainSink();
+    const sink = harness.sim_io.sinkBytes();
+    try testing.expectEqual(harness.counter("access_log_lines"), lineCount(sink));
+    try testing.expectEqual(@as(u8, '\n'), sink[sink.len - 1]);
+    try testing.expect(harness.server.access_log.isQuiescent());
+}
+
+test "access log: lines reach the sink in order, across the buffer swap" {
+    // The swap is what lets appends continue during a write, and getting
+    // it backwards would reorder or duplicate whole buffers rather than
+    // lose a byte — a failure no line-count check would notice.
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 1_000_000);
+    defer harness.tearDown();
+
+    const count: u32 = 12;
+    var index: u32 = 0;
+    while (index < count) : (index += 1) {
+        harness.emit(index);
+        // Interleave delivery with appends so a write is in flight for
+        // some of them and not for others — both sides of `maybeFlush`.
+        try harness.drainSink();
+    }
+    try harness.drainSink();
+
+    try testing.expectEqual(@as(u64, count), harness.counter("access_log_lines"));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+
+    // `bytes_in` carries each record's index, so the sink must read back
+    // as 0, 1, 2, … with nothing missing and nothing repeated.
+    var lines = std.mem.splitScalar(u8, harness.sim_io.sinkBytes(), '\n');
+    var expected: u32 = 0;
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        var needle_buffer: [32]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&needle_buffer, "\"bytes_in\":{d},", .{expected});
+        try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+        expected += 1;
+    }
+    try testing.expectEqual(count, expected);
+}
+
+test "access log: a failed sink write stops the log and is witnessed once" {
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 0);
+    defer harness.tearDown();
+
+    harness.sim_io.injectLogWriteError();
+    harness.emit(0);
+    try harness.drainSink();
+
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_write_failed"));
+    try testing.expect(harness.server.access_log.broken);
+    // The sink is quiet — a broken log must not hold the drain open.
+    try testing.expect(harness.server.access_log.isQuiescent());
+    const written_before = harness.sim_io.sinkBytes().len;
+
+    // Everything after is a drop, and nothing more is ever written: the
+    // failure is a closed pipe, not a transient, so retrying would spend a
+    // syscall per line to lose the same lines.
+    harness.emit(1);
+    harness.emit(2);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 2), harness.counter("access_log_dropped"));
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_write_failed"));
+    try testing.expectEqual(written_before, harness.sim_io.sinkBytes().len);
+}
+
+test "access log: a short write resumes rather than losing its tail" {
+    // The sink takes one byte at a time, so a single line needs as many
+    // completions as it has bytes — the resume path, driven to its limit.
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 0);
+    defer harness.tearDown();
+    harness.sim_io.adversary.partial_io = true;
+
+    harness.emit(0);
+    harness.emit(1);
+    try harness.drainSink();
+
+    try testing.expectEqual(@as(u64, 2), harness.counter("access_log_lines"));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+    const sink = harness.sim_io.sinkBytes();
+    try testing.expectEqual(@as(u64, 2), lineCount(sink));
+    try testing.expectEqual(@as(u8, '\n'), sink[sink.len - 1]);
+}
+
+test "access log: off reserves nothing, writes nothing, counts nothing" {
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, 0, 0);
+    defer harness.tearDown();
+
+    try testing.expect(harness.server.access_log.sink == null);
+    try testing.expectEqual(@as(usize, 0), harness.server.access_log.buffers[0].len);
+    try testing.expectEqual(@as(usize, 0), harness.server.access_log.buffers[1].len);
+
+    harness.emit(0);
+    try harness.drainSink();
+
+    try testing.expectEqual(@as(usize, 0), harness.sim_io.sinkBytes().len);
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_lines"));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+    // Quiescent by construction, so a disabled log can never hold a drain.
+    try testing.expect(harness.server.access_log.isQuiescent());
+}
+
+test "access log: an unflushed line keeps the drain from stopping the loop" {
+    // The drain's whole point is that admitted work finishes (§8), and the
+    // lines describing a shutdown are the ones most likely to be read.
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 1_000_000);
+    defer harness.tearDown();
+
+    harness.emit(0);
+    try testing.expect(!harness.server.access_log.isQuiescent());
+    // Every pool is empty, so the sink is the only thing left holding the
+    // drain-stop gate — which is exactly the condition being tested.
+    try testing.expect(harness.server.conns.isFullyReleased());
+    try testing.expect(!harness.server.isIdle());
+
+    try harness.drainSink();
+    try testing.expect(harness.server.access_log.isQuiescent());
+    try testing.expect(harness.server.isIdle());
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -52,6 +52,19 @@ pub const Config = struct {
     /// or null when no `admin` block is configured — the plane stays off.
     /// A static IP:port literal like every other bind (hostnames rejected).
     admin_bind: ?std.Io.net.IpAddress = null,
+    /// Where access-log lines go (§8), or null when no `access_log` block
+    /// is configured — the log stays off and reserves nothing.
+    access_log_sink: ?AccessLogSink = null,
+
+    /// Where the access log writes (§8). An enum with one arm today
+    /// because there is one sink: the process's own stdout, inherited
+    /// rather than opened, so the log costs no file descriptor and carries
+    /// no rotation story of its own — an operator pipes it wherever they
+    /// already send this process's output. Named rather than made a bare
+    /// boolean so a second sink is a new arm, not a new field.
+    pub const AccessLogSink = enum(u1) {
+        stdout,
+    };
 
     pub const Limits = struct {
         conn_slots: u32 = constants.conn_slots_default,
@@ -64,6 +77,14 @@ pub const Config = struct {
         /// headroom at the cost of a lower feasible conn-slot count. A value
         /// whose ring would exceed the compiled one is rejected at load.
         cq_fill_eighths: u32 = constants.cq_fill_eighths_default,
+        /// Bytes per access-log staging buffer, of which there are two
+        /// (§8). Larger buys more tolerance for a sink that has stalled,
+        /// at a fixed memory cost; smaller drops sooner. **Zero exactly
+        /// when the log is off**, which is how `accessLogBytes` reads
+        /// "reserves nothing" off this one number rather than needing the
+        /// sink beside it. Unlike the pool sizes it may be raised as well
+        /// as lowered: it is plain memory, not a share of a budgeted ring.
+        access_log_buffer_bytes: u32 = 0,
     };
 
     pub const Listener = struct {
@@ -118,6 +139,8 @@ pub const ValidationError = error{
     ClustersEmpty,
     ClustersOverLimit,
     ClusterNameDuplicate,
+    ClusterNameEmpty,
+    ClusterNameTooLong,
     ClusterPickUnknown,
     ListenerClusterOrRoutes,
     ListenerL4Routes,
@@ -153,7 +176,10 @@ pub const ValidationError = error{
     LimitUpstreamSlotsOutOfRange,
     LimitCqFillOutOfRange,
     LimitConnSlotsOverCqFill,
+    LimitAccessLogBufferOutOfRange,
+    LimitAccessLogBufferWithoutSink,
     AdminBindInvalid,
+    AccessLogSinkUnknown,
 };
 
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
@@ -171,7 +197,12 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     const clusters = try resolveClusters(arena, &parsed.clusters);
     const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     try validateTimeouts(&parsed.timeouts);
-    const limits = try resolveLimits(&parsed.limits, @intCast(listeners.len));
+    const access_log_sink = try resolveAccessLogSink(parsed.access_log);
+    const limits = try resolveLimits(
+        &parsed.limits,
+        @intCast(listeners.len),
+        access_log_sink != null,
+    );
     const admin_bind = try resolveAdminBind(parsed.admin);
 
     assert(listeners.len >= 1);
@@ -186,7 +217,20 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .request_timeout_ms = parsed.timeouts.request_ms,
         .limits = limits,
         .admin_bind = admin_bind,
+        .access_log_sink = access_log_sink,
     };
+}
+
+/// Resolve the optional access log (§8): absent means off — no staging
+/// buffers reserved, no lines emitted. A present block names its sink from
+/// a closed set, so an unknown value fails at load rather than silently
+/// logging somewhere the operator did not ask for.
+fn resolveAccessLogSink(
+    access_log_json: ?AccessLogJson,
+) ValidationError!?Config.AccessLogSink {
+    const access_log = access_log_json orelse return null;
+    return std.meta.stringToEnum(Config.AccessLogSink, access_log.sink) orelse
+        error.AccessLogSinkUnknown;
 }
 
 /// Resolve the optional admin/metrics listener (§8):
@@ -203,7 +247,11 @@ fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddres
 /// relay-buffer count derives from the effective conn slots (a buffer
 /// beyond the slot count could never be acquired); a *specified* count
 /// above them is a contradiction and fails loudly.
-fn resolveLimits(limits_json: *const LimitsJson, listeners_count: u32) ValidationError!Config.Limits {
+fn resolveLimits(
+    limits_json: *const LimitsJson,
+    listeners_count: u32,
+    access_log_on: bool,
+) ValidationError!Config.Limits {
     assert(listeners_count >= 1);
     // Omitted limits default to the lean out-of-box sizes, not the
     // compiled ceilings (§5): a small footprint unless the operator opts
@@ -237,13 +285,40 @@ fn resolveLimits(limits_json: *const LimitsJson, listeners_count: u32) Validatio
     if (!constants.cqFillFits(conn_slots, upstream_slots, listeners_count, cq_fill_eighths)) {
         return error.LimitConnSlotsOverCqFill;
     }
+    // Zero exactly when the log is off, so the one number says both how
+    // big the staging buffers are and whether there are any (§8). A
+    // deployment that sized the buffers but never named a sink has asked
+    // for something contradictory, and is told so rather than quietly
+    // getting no log.
+    const access_log_buffer_bytes = try resolveAccessLogBuffer(
+        limits_json.access_log_buffer_bytes,
+        access_log_on,
+    );
     assert(relay_buffers <= conn_slots);
     return .{
         .conn_slots = conn_slots,
         .relay_buffers = relay_buffers,
         .upstream_slots = upstream_slots,
         .cq_fill_eighths = cq_fill_eighths,
+        .access_log_buffer_bytes = access_log_buffer_bytes,
     };
+}
+
+fn resolveAccessLogBuffer(
+    requested: ?u32,
+    access_log_on: bool,
+) ValidationError!u32 {
+    if (!access_log_on) {
+        if (requested != null) return error.LimitAccessLogBufferWithoutSink;
+        return 0;
+    }
+    const bytes = requested orelse constants.access_log_buffer_bytes_default;
+    if (bytes < constants.access_log_buffer_bytes_min or
+        bytes > constants.access_log_buffer_bytes_max)
+    {
+        return error.LimitAccessLogBufferOutOfRange;
+    }
+    return bytes;
 }
 
 // The strict parser binds JSON to these `*Json` DTOs. Each carries the
@@ -264,6 +339,8 @@ pub const ConfigJson = struct {
     /// Optional admin/metrics listener (§8); absent
     /// leaves the plane off.
     admin: ?AdminJson = null,
+    /// Optional access log (§8); absent leaves it off.
+    access_log: ?AccessLogJson = null,
 
     pub const schema_doc =
         "Startup config for the zoxy L4/L7 proxy. Encodes structure, enums, " ++
@@ -280,6 +357,23 @@ pub const ConfigJson = struct {
         .timeouts = .{ .desc = "Connection lifecycle deadlines (milliseconds)." },
         .limits = .{ .desc = "Optional pool sizes and the CQ-fill headroom knob; absent fields take the lean defaults." },
         .admin = .{ .desc = "Optional admin/metrics listener; absent leaves it off." },
+        .access_log = .{ .desc = "Optional per-request/per-connection JSON access log; absent leaves it off." },
+    };
+};
+
+pub const AccessLogJson = struct {
+    sink: []const u8,
+
+    pub const schema_doc =
+        "Optional access log. When present, zoxy writes one JSON object per " ++
+        "line for every HTTP exchange and every L4 connection; absent leaves " ++
+        "it off and reserves nothing. Lines are dropped, and counted, rather " ++
+        "than allowed to block the event loop when the sink cannot keep up.";
+    pub const schema_fields = .{
+        .sink = .{
+            .desc = "Where lines are written. `stdout` is the process's own standard output.",
+            .enum_type = Config.AccessLogSink,
+        },
     };
 };
 
@@ -299,6 +393,7 @@ pub const LimitsJson = struct {
     relay_buffers: ?u32 = null,
     upstream_slots: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
+    access_log_buffer_bytes: ?u32 = null,
 
     pub const schema_doc =
         "Optional pool sizes and the CQ-fill headroom knob; absent fields " ++
@@ -326,6 +421,13 @@ pub const LimitsJson = struct {
                 "but lowers the feasible connection-slot ceiling.",
             .minimum = constants.cq_fill_eighths_min,
             .maximum = constants.cq_fill_eighths_max,
+        },
+        .access_log_buffer_bytes = .{
+            .desc = "Bytes per access-log staging buffer, of which there are two; " ++
+                "larger tolerates a slower sink before lines are dropped. " ++
+                "Only valid alongside an `access_log` block.",
+            .minimum = constants.access_log_buffer_bytes_min,
+            .maximum = constants.access_log_buffer_bytes_max,
         },
     };
 };
@@ -665,7 +767,7 @@ pub const dto_types = .{
     ConfigJson,  ListenerJson,    RouteJson,    FilterJson,
     MatchJson,   HeaderMatchJson, ActionJson,   HeaderEditJson,
     RewriteJson, ClusterJson,     TimeoutsJson, LimitsJson,
-    AdminJson,
+    AdminJson,   AccessLogJson,
 };
 
 comptime {
@@ -690,6 +792,15 @@ fn resolveClusters(
             if (std.mem.eql(u8, previous.name, entry.name)) {
                 return error.ClusterNameDuplicate;
             }
+        }
+        // A name is an identifier an operator writes and the access log
+        // echoes (§8): bounding it is what keeps a log line's width a
+        // function of `constants.zig` rather than of the config file.
+        if (entry.name.len == 0) {
+            return error.ClusterNameEmpty;
+        }
+        if (entry.name.len > constants.cluster_name_bytes_max) {
+            return error.ClusterNameTooLong;
         }
         clusters[index] = .{
             .name = entry.name,
@@ -1845,4 +1956,113 @@ fn fuzzParse(context: void, smith: *std.testing.Smith) !void {
             }
         }
     } else |_| {}
+}
+
+test "config: the access-log block resolves a sink, absent leaves it off" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}],";
+
+    // Absent: the log stays off and reserves nothing. The buffer size is
+    // zero exactly then, which is how `accessLogBytes` reads "off" off one
+    // number instead of needing the sink beside it (§5, §8).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(), head ++ tail ++ "}");
+        try std.testing.expect(parsed.access_log_sink == null);
+        try std.testing.expectEqual(@as(u32, 0), parsed.limits.access_log_buffer_bytes);
+    }
+    // Present: the sink resolves and the staging buffers take the default.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}}",
+        );
+        try std.testing.expectEqual(Config.AccessLogSink.stdout, parsed.access_log_sink.?);
+        try std.testing.expectEqual(
+            constants.access_log_buffer_bytes_default,
+            parsed.limits.access_log_buffer_bytes,
+        );
+    }
+    // A sized buffer alongside a sink resolves verbatim.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}," ++
+                "\"limits\":{\"access_log_buffer_bytes\":65536}}",
+        );
+        try std.testing.expectEqual(@as(u32, 65536), parsed.limits.access_log_buffer_bytes);
+    }
+
+    // The sink vocabulary is closed: an unnamed one fails at load rather
+    // than silently logging somewhere the operator did not ask for.
+    try expectParseError(
+        error.AccessLogSinkUnknown,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"syslog\"}}",
+    );
+    // The block is strict like every other: `sink` required, extras rejected.
+    try expectParseError(error.MissingField, head ++ tail ++ ",\"access_log\":{}}");
+    try expectParseError(
+        error.UnknownField,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\",\"path\":\"/tmp/x\"}}",
+    );
+    // A buffer below one worst-case line would drop lines it had room for,
+    // which is the one thing a drop must never mean; above the ceiling is
+    // memory nobody asked to reserve.
+    try expectParseError(
+        error.LimitAccessLogBufferOutOfRange,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}," ++
+            "\"limits\":{\"access_log_buffer_bytes\":16}}",
+    );
+    try expectParseError(
+        error.LimitAccessLogBufferOutOfRange,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}," ++
+            "\"limits\":{\"access_log_buffer_bytes\":99999999}}",
+    );
+    // Sizing buffers for a log that was never turned on is a contradiction,
+    // and is told so rather than quietly getting no log.
+    try expectParseError(
+        error.LimitAccessLogBufferWithoutSink,
+        head ++ tail ++ ",\"limits\":{\"access_log_buffer_bytes\":65536}}",
+    );
+}
+
+test "config: a cluster name is bounded, because the access log echoes it" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"";
+    const long_name = "n" ** (constants.cluster_name_bytes_max + 1);
+    const at_limit = "n" ** constants.cluster_name_bytes_max;
+
+    // At the cap it resolves; one byte over fails. Without the bound a log
+    // line's width would be a function of the config file rather than of
+    // constants.zig (§8).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ at_limit ++ "\"}],\"clusters\":{\"" ++ at_limit ++
+                "\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+                "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}",
+        );
+        try std.testing.expectEqual(@as(usize, constants.cluster_name_bytes_max), parsed.clusters[0].name.len);
+    }
+    try expectParseError(
+        error.ClusterNameTooLong,
+        head ++ long_name ++ "\"}],\"clusters\":{\"" ++ long_name ++
+            "\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}",
+    );
+    // An empty name names nothing and would render as `"cluster":""`.
+    try expectParseError(
+        error.ClusterNameEmpty,
+        head ++ "\"}],\"clusters\":{\"\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}",
+    );
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -57,10 +57,11 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// deepest CQ the kernel allows (`completion_queue_entries`,
 /// IORING_SETUP_CQSIZE) against the 4096 SQ, so at the largest fill a
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
-/// parked-upstream and admin reservations carved out first, this caps at
-/// `(57344 - 23) / (conn_ops_max + 1) = 11464` —
-/// comptime-derived below (the 23 is the fixed ops: two per config and
-/// admin listener [18], the admin client's op budget [3], the signal
+/// parked-upstream, admin and access-log reservations carved out first,
+/// this caps at `(57344 - 24) / (conn_ops_max + 1) = 11464` —
+/// comptime-derived below (the 24 is the fixed ops: two per config and
+/// admin listener [18], the admin client's op budget [3], the access log's
+/// in-flight sink write [1], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
@@ -72,7 +73,7 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// above the upstream ceiling is therefore capacity that cannot be served
 /// — slots that admit connections the pool has no upstream for — and one
 /// below it is a pool that can never be drawn down. `11464` is the
-/// largest N with `N * (conn_ops_max + 1) <= 57321`, which keeps both
+/// largest N with `N * (conn_ops_max + 1) <= 57320`, which keeps both
 /// ceilings clear of a round 10k: what §1 asks for, c10k reachable on
 /// either axis rather than a shape tuned for it.
 ///
@@ -220,6 +221,11 @@ pub const config_bytes_max: u32 = 256 * 1024;
 /// Upper bound on configured clusters.
 pub const clusters_max: u16 = 16;
 
+/// Upper bound on a cluster's name. Names are identifiers an operator
+/// writes and the access log echoes (§8), so the bound is what keeps a
+/// log line's width closed-form rather than a function of the config file.
+pub const cluster_name_bytes_max: u16 = 64;
+
 /// Lower bound on configured clusters: a config with no cluster can route
 /// nowhere, so the loader rejects an empty map and the config JSON Schema
 /// emits it as `minProperties`.
@@ -253,6 +259,80 @@ pub const header_edits_max: u16 = 16;
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
 
+// -- the access log (§8) --
+//
+// One JSON line per L7 exchange and per L4 connection, written to the
+// configured sink through the seam's one ring op. The bounds below are what
+// make that a closed-form cost: two staging buffers of a fixed size, a line
+// that cannot exceed a fixed width, and per-record captures that cannot
+// exceed a fixed share of a connection slot.
+
+/// Bytes per access-log staging buffer when the config does not say; there
+/// are two (`access_log_buffers`), so the default reservation is twice
+/// this. Two rather than one because a write is a ring op: while it is in
+/// flight its bytes must not move, and the lines still arriving need
+/// somewhere to go. One buffer accepts appends while the other is being
+/// written, and they swap when it drains — no memmove, and no window where
+/// a line has nowhere to land except the drop counter.
+///
+/// 32 KiB holds ~130 typical lines, which at any plausible request rate is
+/// far more than one sink write takes to complete. A burst that outruns it
+/// drops lines and counts them (§8's ladder: exhaustion sheds the newest
+/// work), because the alternative — waiting for the sink — would make an
+/// operator's log pipe able to stall the data path.
+pub const access_log_buffer_bytes_default: u32 = 32 * 1024;
+/// The ceiling and floor `limits.access_log_buffer_bytes` may name. The
+/// floor is one line: a buffer that could not hold the widest single line
+/// would drop every wide one regardless of backpressure, which is the one
+/// thing the drop counter must never mean. The simulator sizes down to it
+/// to force the drop rung, the same way it sizes the pools down to force
+/// theirs (§9).
+pub const access_log_buffer_bytes_min: u32 = access_log_line_bytes_max;
+pub const access_log_buffer_bytes_max: u32 = 1024 * 1024;
+pub const access_log_buffers: u32 = 2;
+
+/// Worst-case simultaneously armed ring ops for the access log: one. The
+/// sink has a single write in flight at a time by construction — the second
+/// staging buffer is what absorbs everything that arrives meanwhile — so it
+/// costs exactly one entry in the §8 ring budget, reserved unconditionally
+/// like the admin plane's so the compiled ceiling covers a config that
+/// enables it.
+pub const access_log_ops_max: u32 = 1;
+
+/// Raw bytes of a request's canonical path kept for its log line. The path
+/// lives in the connection's head buffer, which the response head renders
+/// over (§7 buffer rotation), so what the log reports has to be copied out
+/// while it is still there. A longer path is truncated with a trailing
+/// `...` rather than dropped: the prefix is what identifies the resource.
+pub const access_log_path_bytes_max: u16 = 256;
+
+/// Raw bytes of a request method token kept for its log line. Standard
+/// methods are at most 7 bytes; the bound covers extension tokens (§7)
+/// without letting one widen a log line without limit.
+pub const access_log_method_bytes_max: u8 = 24;
+
+/// Upper bound on one rendered access-log line, including its newline
+/// (§5: the caller sizes a fixed buffer to it, so a line never has to be
+/// dropped for want of room in an *empty* buffer). Derived from the field
+/// caps rather than chosen, so raising one of them cannot silently make
+/// the bound a lie. The `6 *` on the two text fields is JSON's worst case:
+/// a control byte escapes to `\u00XX`, and a percent-decoded path may
+/// legitimately contain one.
+pub const access_log_line_bytes_max: u32 = blk: {
+    // Every key, brace, comma, quote, and the trailing newline, with slack
+    // for a field or two more before the bound has to be re-derived.
+    const scaffolding = 320;
+    const timestamp = 30; // "2026-07-31T09:14:22.481Z"
+    // "[" + 39 bytes of IPv6 + "]:" + 5 port digits, quoted.
+    const address = 48;
+    const number = 20; // a u64 at its widest
+    const addresses = 2; // client and upstream
+    const numbers = 4; // duration, bytes in, bytes out, status
+    break :blk scaffolding + timestamp + addresses * address + numbers * number +
+        @as(u32, access_log_method_bytes_max) + @as(u32, cluster_name_bytes_max) +
+        6 * @as(u32, host_bytes_max) + 6 * @as(u32, access_log_path_bytes_max);
+};
+
 /// Worst-case in-flight ring ops (§8: the ring is pre-budgeted, not shed):
 /// every connection slot at its op peak (L7 slots hold armed ops with or
 /// without a relay buffer, so the term is per slot, not per buffer), one
@@ -260,19 +340,20 @@ pub const timeout_ms_max: u32 = 3_600_000;
 /// keep-alive slice), two ops per listener — configured *and* admin — (a
 /// draining listener holds its armed accept — or the accept-retry backoff
 /// timer — plus the async cancel that reaps it), `admin_conn_ops_max` ops
-/// per admin client (its send/deadline/teardown peak), the single async
+/// per admin client (its send/deadline/teardown peak), the access log's one
+/// in-flight sink write, the single async
 /// wakeup op for signals, and the server's one drain-deadline timer. Closed
 /// form so it can be evaluated on the *effective* pool sizes too (XevIo's
-/// per-deployment CQ), not only the ceilings; the admin reservation is
-/// fixed — always covered even when a config leaves the plane unbound;
-/// `in_flight_ops_max` is it at the ceilings.
+/// per-deployment CQ), not only the ceilings; the admin and access-log
+/// reservations are fixed — always covered even when a config leaves either
+/// off; `in_flight_ops_max` is it at the ceilings.
 pub fn inFlightOps(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(conn_slots <= conn_slots_max);
     assert(upstream_slots <= upstream_slots_max);
     assert(listeners <= listeners_max);
     return conn_slots * conn_ops_max + upstream_slots +
         2 * (listeners + admin_listeners) +
-        admin_conns * admin_conn_ops_max + 1 + 1;
+        admin_conns * admin_conn_ops_max + access_log_ops_max + 1 + 1;
 }
 pub const in_flight_ops_max: u32 =
     inFlightOps(conn_slots_max, upstream_slots_max, listeners_max);
@@ -488,7 +569,7 @@ comptime {
     assert(conn_slots_max == @divFloor(
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * (@as(u32, listeners_max) + admin_listeners) -
-            admin_conns * admin_conn_ops_max - 1 - 1,
+            admin_conns * admin_conn_ops_max - access_log_ops_max - 1 - 1,
         conn_ops_max + 1,
     ));
     assert(admin_listeners >= 1);
@@ -496,6 +577,20 @@ comptime {
     assert(admin_conn_ops_max >= 1);
     assert(admin_scrape_deadline_ms >= 1);
     assert(admin_drain_scratch_bytes >= 1);
+    // A staging buffer that could not hold the widest line would drop
+    // lines it had room for — the bound exists precisely so a drop always
+    // means backpressure, never arithmetic. The floor is that bound, so
+    // no config can name a buffer that breaks it.
+    assert(access_log_buffer_bytes_min >= access_log_line_bytes_max);
+    assert(access_log_buffer_bytes_default >= access_log_buffer_bytes_min);
+    assert(access_log_buffer_bytes_default <= access_log_buffer_bytes_max);
+    // Two buffers exactly: the swap is what lets appends continue during
+    // a write, and a third would be a queue nobody drains.
+    assert(access_log_buffers == 2);
+    assert(access_log_ops_max >= 1);
+    assert(access_log_path_bytes_max >= 16);
+    assert(access_log_method_bytes_max >= 7); // "OPTIONS", the longest standard method.
+    assert(cluster_name_bytes_max >= 1);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool
@@ -522,7 +617,24 @@ pub const PoolSizes = struct {
     relay_buffer_pair_bytes: u64,
     upstream_slots: u32,
     upstream_bytes: u64,
+    /// The access log's staging buffers (§8), or zero when the config
+    /// leaves the log off. Not a pool — it is one fixed reservation, not a
+    /// per-connection unit — but it is startup arena memory this process
+    /// holds for its life, and §5's promise is that the printed total
+    /// covers all of that. `accessLogBytes` is the closed form.
+    access_log_bytes: u64,
 };
+
+/// What the access log reserves: nothing when it is off, both staging
+/// buffers at the effective size when it is on (§8). `buffer_bytes` is
+/// zero exactly when the log is off, so one argument carries both facts
+/// and they cannot be passed inconsistently.
+pub fn accessLogBytes(buffer_bytes: u32) u64 {
+    if (buffer_bytes == 0) return 0;
+    assert(buffer_bytes >= access_log_buffer_bytes_min);
+    assert(buffer_bytes <= access_log_buffer_bytes_max);
+    return @as(u64, access_log_buffers) * buffer_bytes;
+}
 
 /// By pointer: `PoolSizes` is past the 16-byte threshold TIGER_STYLE sets
 /// for by-value arguments, and a stack copy of the budget buys nothing.
@@ -536,9 +648,18 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     assert(sizes.conn_bytes > 0);
     assert(sizes.relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
     assert(sizes.upstream_bytes >= head_bytes_max);
+    // Either the log is off and costs nothing, or it holds exactly its two
+    // buffers at a size the loader validated — never some third number.
+    assert(sizes.access_log_bytes % access_log_buffers == 0);
+    assert(sizes.access_log_bytes == 0 or
+        sizes.access_log_bytes >=
+            @as(u64, access_log_buffers) * access_log_buffer_bytes_min);
+    assert(sizes.access_log_bytes <=
+        @as(u64, access_log_buffers) * access_log_buffer_bytes_max);
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
-        @as(u64, sizes.upstream_slots) * sizes.upstream_bytes;
+        @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
+        sizes.access_log_bytes;
     assert(total > 0);
     return total;
 }
@@ -568,10 +689,14 @@ test "budgets: memory total matches the closed form" {
     const conn_bytes: u64 = 10240;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
     const upstream_bytes: u64 = head_bytes_max + 64;
-    // At the ceilings and at a shrunken (config-limits) shape alike.
+    // At the ceilings and at a shrunken (config-limits) shape alike, with
+    // the access log on at the ceiling and off below it — the term is a
+    // fixed reservation, so it must move the total by exactly its own size
+    // and by nothing else.
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
-        @as(u64, upstream_slots_max) * upstream_bytes;
+        @as(u64, upstream_slots_max) * upstream_bytes +
+        accessLogBytes(access_log_buffer_bytes_default);
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
@@ -579,6 +704,7 @@ test "budgets: memory total matches the closed form" {
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = upstream_slots_max,
         .upstream_bytes = upstream_bytes,
+        .access_log_bytes = accessLogBytes(access_log_buffer_bytes_default),
     }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
@@ -588,7 +714,20 @@ test "budgets: memory total matches the closed form" {
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = 8,
         .upstream_bytes = upstream_bytes,
+        .access_log_bytes = accessLogBytes(0),
     }));
+    // An unconfigured access log reserves nothing (§5), and a configured
+    // one reserves both buffers at whatever size it was given — the term
+    // tracks `limits`, not the compiled default.
+    try std.testing.expectEqual(@as(u64, 0), accessLogBytes(0));
+    try std.testing.expectEqual(
+        @as(u64, access_log_buffers) * access_log_buffer_bytes_default,
+        accessLogBytes(access_log_buffer_bytes_default),
+    );
+    try std.testing.expectEqual(
+        @as(u64, access_log_buffers) * access_log_buffer_bytes_min,
+        accessLogBytes(access_log_buffer_bytes_min),
+    );
 }
 
 test "budgets: c10k ceiling fd count needs a raised NOFILE" {
@@ -626,7 +765,7 @@ test "budgets: conn slots sit at the completion-queue ceiling" {
     try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
     const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
         2 * (@as(u32, listeners_max) + admin_listeners) +
-        admin_conns * admin_conn_ops_max + 1 + 1;
+        admin_conns * admin_conn_ops_max + access_log_ops_max + 1 + 1;
     try std.testing.expect(one_more > @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
 }
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -145,6 +145,26 @@ pub const Counters = struct {
     /// Admin scrapes reaped by the scrape deadline before completing — a
     /// stalled or slowloris client freed from the single reserved slot (§8).
     admin_reaped: Value = Value.init(0),
+    /// Access-log lines rendered and accepted into a staging buffer (§8),
+    /// and lines dropped because there was no room for them or the sink
+    /// had already failed. Every loggable outcome increments exactly one
+    /// of the two, so their sum is how many exchanges and connections the
+    /// log had to describe — the identity the simulator checks.
+    ///
+    /// A drop is backpressure, not a bug: the sink is a pipe an operator
+    /// owns, and §8's answer to a resource running out is to shed the
+    /// newest work rather than to block. A nonzero `access_log_dropped`
+    /// says the log is incomplete and by how much; a rising one says the
+    /// sink cannot keep up with the request rate.
+    access_log_lines: Value = Value.init(0),
+    access_log_dropped: Value = Value.init(0),
+    /// Sink writes that failed (§8). At most one is ever recorded: the
+    /// first failure marks the sink broken, because what reaches here is a
+    /// closed pipe or a dead file rather than a transient — the ring
+    /// already absorbed every would-block. Nonzero therefore means two
+    /// things at once: some already-accepted lines never reached the sink,
+    /// and every line since has been counted as dropped.
+    access_log_write_failed: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -33,6 +33,7 @@
 
 const std = @import("std");
 
+const access_log = @import("../access_log.zig");
 const Balancer = @import("../balancer.zig").Balancer;
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
@@ -151,6 +152,15 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(received >= 1);
+            // A request begins with its first byte, and only with a byte:
+            // started here rather than before the unwrap above, because
+            // the read that ends an *idle* kept-alive connection completes
+            // in this same callback with EOF, and starting a request there
+            // would owe the log a line for a request nobody made. Nor at
+            // the parse: a slowloris that dribbles for the whole head-read
+            // deadline must report the time it spent doing it (§8).
+            server.beginLogRequest(conn);
+            conn.log.bytes_in += received;
             fillHead(conn, received);
             parseAndDispatch(server, conn);
         }
@@ -359,6 +369,10 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.request_framing = framingFromParsed(request.framing);
             conn.l7.request_head_len = request.head_len;
             conn.l7.client_keep_alive = request.keep_alive;
+            // Copied out now because the head buffer is not the log's to
+            // read later: the response head renders over it (§7 buffer
+            // rotation), and by the exchange's settle these bytes are gone.
+            conn.log.captureMethod(request.method_token);
         }
 
         /// Start this exchange's §8 deadline, if the deployment set one.
@@ -379,6 +393,26 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.request_deadline_ns > now_ns);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.rebaseDeadline(conn);
+        }
+
+        /// Record what this request asked for, before any rung can reject
+        /// it (§8): every reject, shed and verdict below reports the same
+        /// spelling the router matched on, and the head buffer these bytes
+        /// live in is gone by the time the line is written (§7 rotation).
+        ///
+        /// `path` is the canonical view when there is one and the raw
+        /// target when there is not — the 400 case, where no canonical
+        /// spelling exists and the raw one is both the honest answer and
+        /// the useful one, since a 400 line is read to find out what was
+        /// actually asked for.
+        fn captureTarget(conn: *ConnType, host: ?[]const u8, path: []const u8) void {
+            assert(conn.state == .l7_reading_head);
+            assert(path.len >= 1);
+            conn.log.capturePath(path);
+            if (host) |canonical| {
+                assert(canonical.len >= 1);
+                conn.log.captureHost(canonical);
+            }
         }
 
         /// Policy gate, then the exchange's admission: tunnels and
@@ -405,8 +439,10 @@ pub fn Proxy(comptime IoType: type) type {
             var scratch: [constants.head_bytes_max]u8 = undefined;
             var host_scratch: [constants.host_bytes_max]u8 = undefined;
             const keys = requestKeys(request, &scratch, &host_scratch) catch {
+                captureTarget(conn, null, request.target);
                 return respond(server, conn, 400, "l7_bad_request");
             };
+            captureTarget(conn, keys.host, keys.views.match);
             // §7 filters run before routing: a policy reject stops the
             // request whether or not it would have routed.
             if (filter.firstReject(conn.filters, .{
@@ -432,6 +468,11 @@ pub fn Proxy(comptime IoType: type) type {
             const pick = server.balancer.pick(conn.cluster_index, &server.upstreams.leased_counts);
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
+                // Recorded once the slot is actually held, never at the
+                // pick: a request shed for want of a slot contacted no
+                // origin, and a line claiming one would send an operator
+                // looking at a backend that never saw the request (§8).
+                conn.log.endpoint_index = pick.endpoint_index;
                 conn.upstream = parked;
                 conn.upstream_socket = parked.socket;
                 parked.head_len = 0;
@@ -459,6 +500,10 @@ pub fn Proxy(comptime IoType: type) type {
             conn.upstream = server.acquireUpstream(conn.cluster_index, pick.endpoint_index) orelse {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
+            // The slot is held, so this try really is going to this
+            // endpoint — whether or not the dial ends up succeeding. A
+            // replay overwrites it, naming the endpoint that served (§7).
+            conn.log.endpoint_index = pick.endpoint_index;
             conn.state = .l7_dialing;
             // The head-read/idle timer is already armed; re-base it to the
             // tighter per-try connect budget so a hung origin fires the §8
@@ -802,6 +847,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
 
             pub fn afterFeed(conn: *ConnType, received: u32, fr: pump.FeedResult) void {
+                // Body bytes this request owns, counted where framing said
+                // which they were: a pipelined tail belongs to the *next*
+                // request, so it must not land on this one's line (§8).
+                conn.log.bytes_in += fr.consumed;
                 if (fr.consumed < received) {
                     // Bytes past the body are a pipelined next request; the
                     // connection will close after this exchange (§2 note).
@@ -1035,6 +1084,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.response_leg = .sending_head;
             // Committed to answering: no verdict may intervene from here (§7).
             conn.l7.response_started = true;
+            // The origin's own status, and `ok` whatever it is: `outcome`
+            // exists precisely so an origin's 503 and this proxy's shed
+            // 503 do not read as the same event (§8).
+            conn.log.status = response.status;
+            conn.log.outcome = .ok;
             armClientWrite(server, conn, conn.head[0..head_write_len], .response_excess);
         }
 
@@ -1094,6 +1148,7 @@ pub fn Proxy(comptime IoType: type) type {
             };
             assert(sent >= 1);
             assert(sent <= write.pending.len);
+            conn.log.bytes_out += sent;
             write.pending = write.pending[sent..];
             if (write.pending.len > 0) {
                 resumeClientWrite(server, conn); // Short send resumes (§6).
@@ -1117,8 +1172,19 @@ pub fn Proxy(comptime IoType: type) type {
                     assert(conn.l7.response_leg == .sending_body_excess);
                     afterResponseExcess(server, conn);
                 },
-                .lingering_close => beginLingeringClose(server, conn),
-                .next_request => resumeAfterStaticResponse(server, conn),
+                // A static answer is fully delivered. Log it here rather
+                // than where the verdict was decided, so the byte count
+                // includes the answer, and before either continuation runs
+                // — the keep path resets what the line reports, and the
+                // close path hands the connection to a drain (§8).
+                .lingering_close => {
+                    server.logExchange(conn);
+                    beginLingeringClose(server, conn);
+                },
+                .next_request => {
+                    server.logExchange(conn);
+                    resumeAfterStaticResponse(server, conn);
+                },
             }
         }
 
@@ -1185,6 +1251,14 @@ pub fn Proxy(comptime IoType: type) type {
                 return feedFraming(&conn.l7.response_framing, chunk);
             }
 
+            /// Response body bytes that reached the client. The head and
+            /// any coalesced excess are counted by the client-write
+            /// channel; between them every byte this proxy sends the
+            /// client is counted exactly once (§8).
+            pub fn afterSend(conn: *ConnType, sent: u32) void {
+                conn.log.bytes_out += sent;
+            }
+
             pub fn framingDone(conn: *ConnType) bool {
                 return framingDoneOf(&conn.l7.response_framing);
             }
@@ -1239,6 +1313,10 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_started);
             conn.l7.response_leg = .done;
             server.counters.increment("l7_responses");
+            // The whole response reached the client: the line goes out
+            // now, before the turnaround below clears what it reports.
+            assert(conn.log.outcome == .ok);
+            server.logExchange(conn);
 
             const request_complete = conn.l7.request_leg == .done;
             if (conn.l7.upstream_reusable and request_complete and !server.draining) {
@@ -1328,8 +1406,14 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.client_write.pending.len == 0);
+            // The exchange that just ended has spoken for itself, so its
+            // accounting resets with the rest of the per-request state
+            // (§8). The captures are left in place: their lengths are what
+            // gate every read, and this zeroes those.
+            assert(conn.log.emitted or conn.log.started_wall_ns == 0);
             conn.head_len = 0;
             conn.l7 = .{};
+            conn.log.reset();
             conn.directions = .{ .{}, .{} };
             conn.state = .l7_reading_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
@@ -1554,6 +1638,37 @@ pub fn Proxy(comptime IoType: type) type {
             return conn.head_len == conn.l7.request_head_len;
         }
 
+        /// Everything a static response no longer needs, returned before
+        /// the answer goes out rather than at teardown (§5, §8).
+        ///
+        /// The relay buffer: the response and its lingering drain
+        /// read/write only conn.head, so a reject or 503 storm holding
+        /// buffers for the whole drain window would pin the L4 admissions
+        /// those buffers gate. The upstream slot: a still-attached one — a
+        /// failed dial with no socket, an oversize-after-edit reject, a
+        /// malformed body — would otherwise ride the same window. Both
+        /// data ops are free at every caller, so nothing is armed on the
+        /// upstream socket and the close is synchronous, like `detach`.
+        fn releaseForStaticResponse(server: *ServerType, conn: *ConnType) void {
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            if (conn.relay_buffer) |buffer| {
+                server.releaseRelayBuffer(buffer);
+                conn.relay_buffer = null;
+            }
+            if (conn.upstream) |leased| {
+                if (conn.upstream_socket) |socket| {
+                    server.io.closeNow(socket);
+                }
+                server.releaseUpstream(leased);
+                conn.upstream = null;
+                conn.upstream_socket = null;
+            }
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            assert(conn.upstream_socket == null);
+        }
+
         /// Answer a comptime static error response, then keep the
         /// connection or close it (§8). Legal from head reading (rejects),
         /// dialing (502), and the exchange (upstream failures) — every
@@ -1570,27 +1685,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
-            // The static response and its lingering drain read/write only
-            // conn.head, never a relay buffer; free any held one now so a
-            // reject or 503 storm cannot pin buffers — and the L4 admissions
-            // they gate — for the whole drain window (§5, §8).
-            if (conn.relay_buffer) |buffer| {
-                server.releaseRelayBuffer(buffer);
-                conn.relay_buffer = null;
-            }
-            // A still-attached upstream (a failed dial with no socket, an
-            // oversize-after-edit reject, a malformed body) closes and frees
-            // its slot now instead of riding the whole lingering drain (§5).
-            // Both data ops are free (asserted above), so nothing is armed on
-            // the upstream socket and the close is synchronous, like detach.
-            if (conn.upstream) |leased| {
-                if (conn.upstream_socket) |socket| {
-                    server.io.closeNow(socket);
-                }
-                server.releaseUpstream(leased);
-                conn.upstream = null;
-                conn.upstream_socket = null;
-            }
+            releaseForStaticResponse(server, conn);
             // A rung committed to an answer: retire the §8 request deadline
             // so it cannot expire the connection out from under the write
             // that delivers it (`clearRequestDeadline` owns the rule).
@@ -1603,6 +1698,11 @@ pub fn Proxy(comptime IoType: type) type {
             ServerType.clearRequestDeadline(conn);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment(counter);
+            // What the line will say, recorded here where the verdict is
+            // made; it is written once the response is on the wire, so the
+            // byte count includes the answer itself (§8).
+            conn.log.status = status;
+            conn.log.outcome = comptime outcomeOfCounter(counter);
             // §8's "then keep or close per pressure". Closing is not free:
             // it costs the client a fresh handshake and this proxy a fresh
             // accept, conn slot and admission — which is how a shed storm
@@ -1630,6 +1730,36 @@ pub fn Proxy(comptime IoType: type) type {
             } else {
                 armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
             }
+        }
+
+        /// The access-log outcome a `respond` rung reports (§8), keyed off
+        /// the counter it already names so the two cannot drift: a rung
+        /// that grows a counter must place it here or fail to compile.
+        ///
+        /// The split is the one an operator acts on, not the one HTTP's
+        /// status classes make. `503` covers both a resource wall and,
+        /// from an origin, a perfectly ordinary answer; `502` and `504`
+        /// each name a distinct failure of the upstream leg; everything
+        /// else in the list is this proxy refusing the request on its own
+        /// terms. Reading those apart from the status alone is impossible,
+        /// which is why `outcome` exists at all.
+        fn outcomeOfCounter(comptime counter: []const u8) access_log.Outcome {
+            const rejects = [_][]const u8{
+                "l7_bad_request",
+                "l7_uri_too_long",
+                "l7_headers_too_large",
+                "l7_not_implemented",
+                "l7_no_route",
+                "l7_filtered",
+            };
+            for (rejects) |name| {
+                if (std.mem.eql(u8, counter, name)) return .rejected;
+            }
+            if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
+            if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
+            if (std.mem.eql(u8, counter, "l7_bad_gateway")) return .upstream_failed;
+            if (std.mem.eql(u8, counter, "l7_gateway_timeout")) return .timed_out;
+            @compileError("static-response counter with no access-log outcome: " ++ counter);
         }
 
         /// The static response is out and the stream is still synchronized:

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -48,6 +48,12 @@ const HttpClient = struct {
     /// The last client begins the drain; a scenario that wants to watch
     /// the idle sweep instead arms a drain timer and clears this.
     drain_on_finish: bool = true,
+    /// Close from the client side once the response is in, rather than
+    /// waiting for the proxy to close. This is what an ordinary keep-alive
+    /// client does — curl, a browser, any pooled HTTP client — and it is
+    /// the only way to reach the read that ends an *idle* kept-alive
+    /// connection, which no `Connection: close` scenario can.
+    close_after_response: bool = false,
     sent_len: u32 = 0,
     send_in_flight: bool = false,
     /// Twice the proxy's head buffer: a response that fills that buffer and
@@ -162,32 +168,51 @@ const HttpClient = struct {
         client.received_len += received;
         assert(client.received_len <= client.receive_buffer.len);
         client.maybeSendSecond();
+        if (client.maybeCloseAfterResponse()) return;
         client.armRecv();
     }
 
-    /// Sequential keep-alive: once the first response is complete (its
-    /// content-length body fully received), send the queued second
-    /// request on the same connection.
-    fn maybeSendSecond(client: *HttpClient) void {
-        const queued = client.second_request orelse return;
+    /// Whether the first response has fully arrived — head plus whatever
+    /// body its framing declared.
+    fn firstResponseComplete(client: *const HttpClient) bool {
         var storage: parser.HeaderStorage = undefined;
         const first = parser.parseResponseHead(
             client.receive_buffer[0..client.received_len],
             false,
             &storage,
             .get,
-        ) catch return; // Incomplete head: keep reading.
+        ) catch return false; // Incomplete head: keep reading.
         const body_len: u32 = switch (first.framing) {
             .content_length => |length| @intCast(length),
             else => 0,
         };
-        if (client.received_len < first.head_len + body_len) {
-            return;
-        }
+        return client.received_len >= first.head_len + body_len;
+    }
+
+    /// Sequential keep-alive: once the first response is complete, send
+    /// the queued second request on the same connection.
+    fn maybeSendSecond(client: *HttpClient) void {
+        const queued = client.second_request orelse return;
+        if (!firstResponseComplete(client)) return;
         client.second_request = null;
         client.request = queued;
         client.sent_len = 0;
         client.armSend();
+    }
+
+    /// Hang up from this end once the exchange is done, leaving the proxy
+    /// to observe the close on a connection it was keeping alive. Returns
+    /// whether the client is finished, so the caller does not re-arm a
+    /// read on a socket that is gone.
+    fn maybeCloseAfterResponse(client: *HttpClient) bool {
+        if (!client.close_after_response) return false;
+        if (client.second_request != null) return false;
+        if (!firstResponseComplete(client)) return false;
+        // The connection ended cleanly; that this end sent the FIN rather
+        // than received one is not a distinction any caller draws.
+        client.outcome = .fin;
+        client.finish();
+        return true;
     }
 
     fn response(client: *const HttpClient) []const u8 {
@@ -476,6 +501,10 @@ const Http1Bed = struct {
         /// scenarios are unfiltered. A test supplies compiled rules to
         /// drive the filter reject/edit paths.
         filters: []const filter.Rule = &.{},
+        /// Turn the §8 access log on. Off by default so every existing
+        /// scenario keeps paying nothing for it; a test that turns it on
+        /// reads the emitted lines straight out of SimIo's virtual sink.
+        access_log: bool = false,
     };
 
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
@@ -505,11 +534,16 @@ const Http1Bed = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
+            .access_log_sink = if (options.access_log) .stdout else null,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
             .relay_buffers = options.relay_buffers,
             .upstream_slots = options.upstream_slots,
+            .access_log_buffer_bytes = if (options.access_log)
+                constants.access_log_buffer_bytes_default
+            else
+                0,
         });
         try bed.server.start();
         bed.origin = .{
@@ -2625,4 +2659,206 @@ test "l7: the replay path allocates nothing after init" {
     strict_bed.client2.request = second_request;
     try strict_bed.exchange(first_request);
     try strict_bed.expectDrained();
+}
+
+/// The single line the §8 access log wrote during a scenario. Fails rather
+/// than returning null when there is not exactly one: a test asserting on
+/// "the" line must not silently read the first of several.
+fn onlyAccessLogLine(bed: *const Http1Bed) ![]const u8 {
+    const sink = bed.sim_io.sinkBytes();
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, sink, "\n"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("access_log_lines"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("access_log_dropped"));
+    return std.mem.trimEnd(u8, sink, "\n");
+}
+
+/// The one access-log line containing `needle`, for scenarios that emit
+/// several. Fails when it is not exactly one, so a needle that matched
+/// every line — or none — is a test bug rather than a passing assertion.
+fn accessLogLineFor(bed: *const Http1Bed, needle: []const u8) ![]const u8 {
+    var found: ?[]const u8 = null;
+    var lines = std.mem.splitScalar(u8, bed.sim_io.sinkBytes(), '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        if (std.mem.indexOf(u8, line, needle) == null) continue;
+        try std.testing.expect(found == null);
+        found = line;
+    }
+    return found orelse error.NoSuchAccessLogLine;
+}
+
+test "l7: a proxied GET writes one access-log line naming the origin's status" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 6,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello",
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    const request = "GET /path?q=1 HTTP/1.1\r\nHost: Origin.Example:8080\r\nConnection: close\r\n\r\n";
+    try bed.exchange(request);
+    try bed.expectDrained();
+
+    const line = try onlyAccessLogLine(&bed);
+    // The line names what the *client* asked and what the *origin*
+    // answered: the canonical routing path (query split off, §7), the
+    // canonical host (lowercased and port-stripped, §7), and the origin's
+    // own status under outcome `ok`.
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"kind\":\"http\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"method\":\"GET\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"path\":\"/path\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"host\":\"origin.example\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"status\":200") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"cluster\":\"origin\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"upstream\":\"127.0.0.1:9000\"") != null);
+    // Byte counts are what crossed this proxy's client side: the whole
+    // request head in, the rendered response head plus its body out.
+    var expected: [64]u8 = undefined;
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        line,
+        try std.fmt.bufPrint(&expected, "\"bytes_in\":{d}", .{request.len}),
+    ) != null);
+    const relayed = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello";
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        line,
+        try std.fmt.bufPrint(&expected, "\"bytes_out\":{d}", .{relayed.len}),
+    ) != null);
+}
+
+test "l7: a shed and an origin 503 are the same status and different outcomes" {
+    // The whole reason `outcome` exists beside `status` (§8): read off the
+    // three digits alone, a resource wall and an origin's own answer are
+    // indistinguishable, and they call for opposite responses.
+    //
+    // The single upstream slot goes to a client the origin never answers,
+    // so the second client's request meets the wall — the same technique
+    // the shed-persistence test uses.
+    var shed_bed: Http1Bed = undefined;
+    try shed_bed.setUp(std.testing.allocator, .{
+        .seed = 11,
+        .upstream_slots = 1,
+        .origin_mute = true,
+        .access_log = true,
+    });
+    defer shed_bed.tearDown();
+    shed_bed.client.drain_on_finish = false;
+    shed_bed.client2.send_delay_ms = 100;
+    shed_bed.client2.request = "GET /shed HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    shed_bed.client2.start(&shed_bed.sim_io, &shed_bed.server, Http1Bed.bindAddress());
+    try shed_bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
+    try shed_bed.expectDrained();
+
+    const shed_line = try accessLogLineFor(&shed_bed, "\"path\":\"/shed\"");
+    try std.testing.expect(std.mem.indexOf(u8, shed_line, "\"status\":503") != null);
+    try std.testing.expect(std.mem.indexOf(u8, shed_line, "\"outcome\":\"shed\"") != null);
+    // No endpoint was ever leased, so the line names none.
+    try std.testing.expect(std.mem.indexOf(u8, shed_line, "\"upstream\":null") != null);
+    // The held request met the deadline against a mute origin and was
+    // answered 504 — a third 5xx that `status` alone cannot tell from
+    // either of the two above, and that names the endpoint it was waiting
+    // on, which is the one an operator would go and look at.
+    const held_line = try accessLogLineFor(&shed_bed, "\"path\":\"/held\"");
+    try std.testing.expect(std.mem.indexOf(u8, held_line, "\"status\":504") != null);
+    try std.testing.expect(std.mem.indexOf(u8, held_line, "\"outcome\":\"timed_out\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, held_line, "\"upstream\":\"127.0.0.1:9000\"") != null);
+
+    var origin_bed: Http1Bed = undefined;
+    try origin_bed.setUp(std.testing.allocator, .{
+        .seed = 11,
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .access_log = true,
+    });
+    defer origin_bed.tearDown();
+    try origin_bed.exchange("GET /path HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n");
+    try origin_bed.expectDrained();
+
+    const origin_line = try onlyAccessLogLine(&origin_bed);
+    try std.testing.expect(std.mem.indexOf(u8, origin_line, "\"status\":503") != null);
+    try std.testing.expect(std.mem.indexOf(u8, origin_line, "\"outcome\":\"ok\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, origin_line, "\"upstream\":\"127.0.0.1:9000\"") != null);
+}
+
+test "l7: a reject logs the target the client actually sent" {
+    // A path that will not canonicalize has no §7 spelling to report, and
+    // an empty field would tell an operator investigating a 400 nothing at
+    // all — so the raw target is what the line carries.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 12, .access_log = true });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /a%2Fb HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n");
+    try bed.expectDrained();
+
+    const line = try onlyAccessLogLine(&bed);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"status\":400") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"rejected\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"path\":\"/a%2Fb\"") != null);
+}
+
+test "l7: each request on a kept-alive connection gets its own line" {
+    // The turnaround resets the per-request accounting (§8), so two
+    // requests over one connection must produce two lines with their own
+    // paths and their own byte counts — not one line, and not a running
+    // total carried across.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 13,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    const second_request = "GET /second HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n";
+    bed.client.next = &bed.client2;
+    bed.client2.request = second_request;
+    try bed.exchange("GET /first HTTP/1.1\r\nHost: a\r\n\r\n");
+    try bed.expectDrained();
+
+    const sink = bed.sim_io.sinkBytes();
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("access_log_lines"));
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, sink, "\n"));
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, sink, "\n"), '\n');
+    const first = lines.next().?;
+    const second = lines.next().?;
+    try std.testing.expect(lines.next() == null);
+    try std.testing.expect(std.mem.indexOf(u8, first, "\"path\":\"/first\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, second, "\"path\":\"/second\"") != null);
+    // The second request's counts are its own, not the pair's.
+    var expected: [64]u8 = undefined;
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        second,
+        try std.fmt.bufPrint(&expected, "\"bytes_in\":{d},", .{second_request.len}),
+    ) != null);
+}
+
+test "l7: an idle kept-alive connection closing owes no line" {
+    // The read that ends an idle kept-alive connection completes in the
+    // same callback as the read that starts a request, and for a while
+    // this proxy could not tell them apart: every keep-alive client got a
+    // second, empty line reading `aborted` with no method, no path and no
+    // status — one phantom request per real one. A request begins with a
+    // *byte*, and a connection the client simply closed made none.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 14,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    // No `Connection: close`: the proxy keeps the connection, the client
+    // reads its response and then closes, and that close must be silent.
+    bed.client.close_after_response = true;
+    try bed.exchange("GET /kept HTTP/1.1\r\nHost: a\r\n\r\n");
+    try bed.expectDrained();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("access_log_lines"));
+    const line = try onlyAccessLogLine(&bed);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"path\":\"/kept\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") != null);
 }

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -50,6 +50,24 @@ const never_ns: u64 = std.math.maxInt(u64);
 const peer_none: u16 = std.math.maxInt(u16);
 /// Ports the simulator hands out for port-zero binds.
 const ephemeral_port_base: u16 = 40_000;
+/// The virtual access-log sink (§8): every byte the server writes lands
+/// here for the harness to read back and check (§9). Sized so no scenario
+/// in the sweep can fill it — `sink_overflow_bytes` is asserted zero by the
+/// harness, so a scenario that ever did would fail rather than silently
+/// hand the oracle a truncated log.
+const sink_bytes_max: u32 = 1024 * 1024;
+/// Where the simulated wall clock starts: 2020-01-01T00:00:00Z. Fixed, so
+/// a seed's log lines are byte-identical across runs — the determinism the
+/// §9 trace-hash check demands, extended to the one output that carries a
+/// date. Virtual time advances it exactly as it advances `nowNs`.
+const wall_clock_base_ns: u64 = 1_577_836_800 * std.time.ns_per_s;
+/// The address block simulated clients dial from (RFC 5737 TEST-NET-2), so
+/// a log line read out of the sink is recognizably the simulator's.
+const client_ip_bytes: [4]u8 = .{ 198, 51, 100, 1 };
+/// The first ephemeral port a simulated client connects from; each new
+/// virtual pair takes the next one, so every client in a run is
+/// distinguishable in the access log by address alone.
+const client_port_base: u16 = 50_000;
 
 sockets: Pool(SocketEntry),
 listeners: []ListenerEntry,
@@ -87,6 +105,22 @@ blackholed_count: u8,
 /// connect to a matching address fails with `error.Unexpected`.
 connect_error_addresses: [connect_error_addresses_max]std.Io.net.IpAddress,
 connect_error_count: u8,
+/// The virtual access-log sink (§8): what the server wrote, in order, for
+/// the §9 oracle to parse back. Arena-allocated at init like every other
+/// simulator buffer.
+sink: []u8,
+sink_len: u32,
+/// Bytes the sink could not hold. Not a model of anything production does
+/// — the real sink is a pipe with its own backpressure, which the server's
+/// own staging buffer already answers by dropping — but a loud way for the
+/// harness to notice its oracle was handed a truncated log.
+sink_overflow_bytes: u32,
+/// Pending one-shot sink failures (`injectLogWriteError`): the write path
+/// a real broken pipe takes, which a virtual sink would otherwise never
+/// exercise (§9) — the same argument `pending_set_option_errors` makes.
+pending_log_write_errors: u8,
+/// The ephemeral port the next simulated client connects from.
+next_client_port: u16,
 
 const blackholed_addresses_max: u8 = 4;
 const connect_error_addresses_max: u8 = 4;
@@ -116,6 +150,14 @@ pub const Adversary = struct {
     /// the origin's verdict, this is our own exhaustion, and the two
     /// want opposite responses upstream.
     connect_pressure_percent: u8 = 0,
+    /// How long a sink write takes to complete (§8 access log). Zero is an
+    /// instant sink, where lines never accumulate and the drop rung is
+    /// unreachable; a stall is a reader that has fallen behind, which is
+    /// the condition the two staging buffers and the drop counter exist
+    /// for. A scenario that stalls the sink long enough overflows the
+    /// staging buffer and must still serve every request unaffected —
+    /// which is the property being tested.
+    log_write_stall_ns: u64 = 0,
     batch_max: u32 = constants.loop_completions_per_tick_max,
 };
 
@@ -154,6 +196,7 @@ const Op = union(enum) {
     recv: struct { socket: Socket, buffer: []u8 },
     send: struct { socket: Socket, bytes: []const u8 },
     close: struct { socket: Socket },
+    log_write: struct { bytes: []const u8 },
     timer: struct { fire_at_ns: u64, canceled: bool },
     timer_cancel: struct { target: *Completion },
     connect_cancel: struct { target: *Completion },
@@ -167,6 +210,7 @@ const Result = union(enum) {
     recv: Io.RecvError!u32,
     send: Io.SendError!u32,
     close: void,
+    log_write: Io.LogWriteError!u32,
     timer: Io.TimerError!void,
     timer_cancel: void,
     connect_cancel: void,
@@ -218,6 +262,13 @@ const SocketEntry = struct {
     pool_next: u32,
     generation: u32,
     peer: u16,
+    /// What `peerAddress` reports for this socket (§8 access log): the
+    /// dialed address on a client socket, the synthesized client address
+    /// on the accepted one. Held per entry rather than derived from the
+    /// peer index because an accepted socket outlives nothing here — but
+    /// its peer may close first, and the log still has to name who
+    /// connected.
+    peer_address: std.Io.net.IpAddress,
     fin_received: bool,
     read_shutdown: bool,
     write_shutdown: bool,
@@ -312,6 +363,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
 
     io.listeners = try arena.alloc(ListenerEntry, listeners_max);
     io.pending = try arena.alloc(*Completion, pending_ops_max);
+    io.sink = try arena.alloc(u8, sink_bytes_max);
     try io.sockets.init(arena, sockets_max);
     io.listeners_count = 0;
     io.pending_count = 0;
@@ -332,6 +384,10 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.blackholed_count = 0;
     io.connect_error_addresses = undefined;
     io.connect_error_count = 0;
+    io.sink_len = 0;
+    io.sink_overflow_bytes = 0;
+    io.pending_log_write_errors = 0;
+    io.next_client_port = client_port_base;
     assert(io.sockets.isFullyReleased());
 }
 
@@ -526,6 +582,59 @@ pub fn close(
         .callback = erasedVoid(Userdata, .close, callback),
     };
     io.enqueue(completion);
+}
+
+/// The access-log sink as a ring op (§8), so the simulator sees exactly
+/// what production does: a write that may complete short, at a moment the
+/// scheduler picks, while the server keeps serving. `partialLen` fragments
+/// it like any other write, which is what exercises the sink's resume.
+pub fn logWrite(
+    io: *SimIo,
+    bytes: []const u8,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.LogWriteError!u32) void,
+) void {
+    assert(completion.state == .dead);
+    assert(bytes.len >= 1);
+    completion.* = .{
+        .op = .{ .log_write = .{ .bytes = bytes } },
+        .ready_at_ns = io.now_ns_value + io.adversary.log_write_stall_ns,
+        .userdata = userdata,
+        .callback = erasedResult(Userdata, .log_write, callback),
+    };
+    io.enqueue(completion);
+}
+
+/// Who is on the other end (§8 access log). Virtual sockets have no
+/// kernel to ask, so the address was assigned when the pair was created —
+/// deterministically, so a seed's log lines are reproducible.
+pub fn peerAddress(io: *SimIo, socket: Socket) std.Io.net.IpAddress {
+    return io.socketEntry(socket).peer_address;
+}
+
+/// The simulated wall clock (§8): the fixed epoch base plus however far
+/// virtual time has advanced. Derived from `now_ns_value` rather than
+/// tracked separately so the two clocks can never disagree about how much
+/// time a scenario took.
+pub fn nowWallNs(io: *const SimIo) u64 {
+    assert(io.now_ns_value >= clock_start_ns);
+    return wall_clock_base_ns + (io.now_ns_value - clock_start_ns);
+}
+
+/// Targeted scenario control: the next `logWrite` fails, driving the
+/// broken-sink path (§8) a virtual sink would never reach on its own —
+/// the same argument `injectSetOptionError` makes for socket options.
+pub fn injectLogWriteError(io: *SimIo) void {
+    assert(io.pending_log_write_errors < std.math.maxInt(u8));
+    io.pending_log_write_errors += 1;
+}
+
+/// Everything the server wrote to the sink, for the §9 oracle.
+pub fn sinkBytes(io: *const SimIo) []const u8 {
+    assert(io.sink_len <= io.sink.len);
+    return io.sink[0..io.sink_len];
 }
 
 pub fn timerStart(
@@ -904,6 +1013,13 @@ fn opReady(io: *SimIo, completion: *Completion) bool {
             break :ready io.peerEntry(entry).inbox.freeSpace() > 0;
         },
         .close, .timer_cancel, .connect_cancel => true,
+        // A sink that takes its time is the whole point of the staging
+        // buffers (§8): while this write is out, lines pile up in the
+        // other one, and the drop rung fires when they overflow it. With
+        // `log_write_stall_ns` at zero the sink is instant and the rung is
+        // unreachable — which is exactly how it stayed invisible before
+        // the knob existed.
+        .log_write => io.now_ns_value >= completion.ready_at_ns,
         .timer => |op| op.canceled or io.now_ns_value >= op.fire_at_ns,
     };
 }
@@ -933,6 +1049,7 @@ fn deliverOne(io: *SimIo, completion: *Completion) void {
         },
         .recv => |op| .{ .recv = io.finishRecv(op.socket, op.buffer) },
         .send => |op| .{ .send = io.finishSend(op.socket, op.bytes) },
+        .log_write => |op| .{ .log_write = io.finishLogWrite(op.bytes) },
         .close => |op| close: {
             io.closeEntry(op.socket);
             break :close .{ .close = {} };
@@ -1008,6 +1125,20 @@ fn finishConnect(
     initSocketEntry(server_entry, io.adversary.inbox_bytes);
     client_entry.peer = @intCast(io.sockets.indexOf(server_entry));
     server_entry.peer = @intCast(io.sockets.indexOf(client_entry));
+    // Each end names the other, the way a kernel's socket pair does: the
+    // dialer's peer is what it dialed, the accepted socket's peer is the
+    // client that reached it. Ports climb so every simulated client is
+    // distinguishable in the access log; the wrap keeps that bounded
+    // rather than overflowing on a long-lived fuzz run.
+    client_entry.peer_address = address;
+    server_entry.peer_address = .{ .ip4 = .{
+        .bytes = client_ip_bytes,
+        .port = io.next_client_port,
+    } };
+    io.next_client_port = if (io.next_client_port == std.math.maxInt(u16))
+        client_port_base
+    else
+        io.next_client_port + 1;
     listener.accept_queue[listener.accept_queue_len] = io.socketHandle(server_entry);
     listener.accept_queue_len += 1;
     return io.socketHandle(client_entry);
@@ -1073,6 +1204,34 @@ fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
     return n;
 }
 
+/// Append to the virtual sink, short-writing like any other op (§9). The
+/// overflow branch is not a modeled behavior — it is the harness's tripwire
+/// for a scenario that outgrew `sink_bytes_max`, counted rather than
+/// asserted here so the failure is reported by the oracle that noticed the
+/// log was incomplete, not by a panic inside the backend.
+fn finishLogWrite(io: *SimIo, bytes: []const u8) Io.LogWriteError!u32 {
+    assert(bytes.len >= 1);
+    if (io.pending_log_write_errors > 0) {
+        io.pending_log_write_errors -= 1;
+        return error.Unexpected;
+    }
+    const free: u32 = @intCast(io.sink.len - io.sink_len);
+    const wanted: u32 = @min(@as(u32, @intCast(bytes.len)), free);
+    if (wanted == 0) {
+        io.sink_overflow_bytes += @intCast(bytes.len);
+        // A sink with no room still has to make progress, or the server's
+        // staging buffer never drains and the run deadlocks on a pending
+        // flush. Report the whole write as accepted and count what was lost.
+        return @intCast(bytes.len);
+    }
+    const n = io.partialLen(wanted);
+    @memcpy(io.sink[io.sink_len..][0..n], bytes[0..n]);
+    io.sink_len += n;
+    assert(io.sink_len <= io.sink.len);
+    assert(n >= 1);
+    return n;
+}
+
 fn deliverDueSignals(io: *SimIo) void {
     if (io.signal_callback == null) return;
     var index: u8 = 0;
@@ -1093,7 +1252,7 @@ fn earliestWakeNs(io: *const SimIo) u64 {
     var earliest: u64 = never_ns;
     for (io.pending[0..io.pending_count]) |completion| {
         const wake = switch (completion.op) {
-            .connect => completion.ready_at_ns,
+            .connect, .log_write => completion.ready_at_ns,
             .timer => |op| op.fire_at_ns,
             else => never_ns,
         };
@@ -1228,6 +1387,10 @@ fn initSocketEntry(entry: *SocketEntry, inbox_capacity: u32) void {
     entry.inbox.head = 0;
     entry.inbox.count = 0;
     entry.inbox.capacity = inbox_capacity;
+    // Overwritten by `finishConnect` for both ends of every pair it makes;
+    // the placeholder keeps a socket that somehow skipped that from
+    // reporting another connection's peer out of a recycled slot.
+    entry.peer_address = .{ .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 } };
 }
 
 fn closeEntry(io: *SimIo, socket: Socket) void {
@@ -1264,6 +1427,7 @@ fn traceMix(io: *SimIo, completion: *const Completion, result: *const Result) vo
         .close => 6000,
         .timer_cancel => 7000,
         .connect_cancel => 8000,
+        .log_write => |r| if (r) |n| 9000 + @as(u64, n) else |err| 10000 + @intFromError(err),
     };
     io.mix(detail);
 }

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -21,16 +21,23 @@ const linux = std.os.linux;
 
 const XevIo = @This();
 
-/// kqueue (macOS, local bench runs) dispatches `.close` ops to a thread
-/// pool — io_uring closes inside the ring, so Linux never spawns a thread.
-/// Pool threads only perform the blocking syscall; completion callbacks
-/// still run on the loop thread, so the single-threaded discipline holds.
-const close_needs_thread_pool = xev.backend == .kqueue;
+/// kqueue (macOS, local bench runs) dispatches `.close` ops — and the
+/// access log's file writes — to a thread pool; io_uring performs both
+/// inside the ring, so Linux never spawns a thread. Pool threads only
+/// perform the blocking syscall; completion callbacks still run on the
+/// loop thread, so the single-threaded discipline holds.
+const needs_thread_pool = xev.backend == .kqueue;
+
+/// The access-log sink (§8): the process's own stdout, inherited, never
+/// opened here. Config names the sink by enum and this is the only value
+/// it can name today, so the fd budget is unchanged — stdout is already
+/// one of the three stdio descriptors `fdsRequired` reserves.
+const log_sink_fd: posix.fd_t = 1;
 
 loop: xev.Loop,
 timer: xev.Timer,
 notifier: xev.Async,
-thread_pool: if (close_needs_thread_pool) xev.ThreadPool else void,
+thread_pool: if (needs_thread_pool) xev.ThreadPool else void,
 notifier_completion: xev.Completion,
 signal_mask: std.atomic.Value(u8),
 signal_callback: ?*const fn (?*anyopaque, Io.Signal) void,
@@ -64,16 +71,16 @@ const ListenerEntry = struct {
 /// deployment (`constants.completionQueueDepthFor` of the effective config,
 /// §8) — the io_uring backend sizes its ring to it; other backends ignore it.
 pub fn init(io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
-    if (comptime close_needs_thread_pool) {
+    if (comptime needs_thread_pool) {
         io.thread_pool = xev.ThreadPool.init(.{});
     }
-    errdefer if (comptime close_needs_thread_pool) {
+    errdefer if (comptime needs_thread_pool) {
         io.thread_pool.shutdown();
         io.thread_pool.deinit();
     };
     io.loop = try initLoop(
         cq_entries,
-        if (comptime close_needs_thread_pool) &io.thread_pool else null,
+        if (comptime needs_thread_pool) &io.thread_pool else null,
     );
     errdefer io.loop.deinit();
     io.notifier = try xev.Async.init();
@@ -162,7 +169,7 @@ pub fn deinit(io: *XevIo) void {
     io.timer.deinit();
     io.notifier.deinit();
     io.loop.deinit();
-    if (comptime close_needs_thread_pool) {
+    if (comptime needs_thread_pool) {
         io.thread_pool.shutdown();
         io.thread_pool.deinit();
     }
@@ -462,6 +469,65 @@ pub fn send(
     }).adapter);
 }
 
+/// Write one batch of access-log bytes to the sink (§8). A ring op, not a
+/// direct `write`: the sink is whatever the operator pointed stdout at, and
+/// a pipe whose reader has stalled would block the whole loop for as long
+/// as it stays stalled — the one thing this proxy must never do. Through
+/// the ring the kernel punts a would-block write to its own worker and the
+/// loop keeps serving; the caller's staging buffer absorbs the interval and
+/// drops when it cannot (§8's ladder, applied to logging).
+///
+/// `xev.File` rather than `xev.TCP`: the io_uring backend submits `send`
+/// for a TCP write, which a non-socket fd answers with ENOTSOCK.
+pub fn logWrite(
+    io: *XevIo,
+    bytes: []const u8,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.LogWriteError!u32) void,
+) void {
+    assert(bytes.len >= 1);
+    const file = xev.File.initFd(log_sink_fd);
+    file.write(&io.loop, completion, .{ .slice = bytes }, Userdata, userdata, (struct {
+        fn adapter(
+            context: ?*Userdata,
+            loop: *xev.Loop,
+            write_completion: *xev.Completion,
+            file_inner: xev.File,
+            write_buffer: xev.WriteBuffer,
+            result: xev.WriteError!usize,
+        ) xev.CallbackAction {
+            const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+            // The sink's failures are not §8 kernel pressure and must not be
+            // witnessed as it, but a classified cause left over from an
+            // earlier op would be read as this one's — clear it, the same
+            // honest reset `setNodelay` performs when it has no completion
+            // to classify from.
+            io_inner.recordPressure(write_completion);
+            _ = file_inner;
+            _ = write_buffer;
+            callback(context.?, if (result) |n|
+                @as(u32, @intCast(n))
+            else |_|
+                error.Unexpected);
+            return .disarm;
+        }
+    }).adapter);
+}
+
+/// Who is on the other end of an accepted socket (§8 access log). A
+/// `getpeername` rather than the sockaddr libxev's accept op fills:
+/// that field is a bare `posix.sockaddr`, 16 bytes, so the kernel
+/// truncates every IPv6 peer into it. One syscall per admitted connection
+/// — against the accept's ring op, the `setNodelay` setsockopt, and the
+/// dial that follows it, an unmeasurable addition on a path that runs once
+/// per connection, never per request.
+pub fn peerAddress(io: *XevIo, socket: Socket) std.Io.net.IpAddress {
+    _ = io;
+    return addressOf(@intFromEnum(socket), posix.system.getpeername);
+}
+
 pub fn close(
     io: *XevIo,
     socket: Socket,
@@ -705,6 +771,39 @@ pub fn nowNs(io: *XevIo) u64 {
         @as(u64, @intCast(cached.nsec));
 }
 
+/// Wall-clock nanoseconds since the Unix epoch, for the access log (§8) —
+/// both a line's timestamp and, read again at the end, its duration.
+///
+/// A second clock beside `nowNs`, deliberately, and on the opposite side of
+/// both of that one's trade-offs. It is *precise*, not coarse: `nowNs`
+/// feeds second-scale deadlines where a millisecond granule is free, while
+/// a duration quantized to the coarse granule would report 0 µs for every
+/// request a loopback or LAN hop actually serves. And it is *not* cached
+/// per tick: a cached read would give every request in one completion batch
+/// the same start and end, which is the same failure a second time.
+///
+/// The cost is bounded by being rare — two vDSO reads per *logged request*,
+/// against `nowNs`'s one per tick — and it is paid only when an operator
+/// turned the log on. Deriving durations from a wall clock does mean an NTP
+/// step lands in whichever line spans it; the saturating subtraction at the
+/// call site keeps that a wrong number rather than a wrapped one.
+pub fn nowWallNs(io: *XevIo) u64 {
+    _ = io;
+    var ts: linux.timespec = undefined;
+    // The read stands on its own line, never inside the assert: an
+    // assertion argument is not the place for the syscall the function
+    // exists to make. CLOCK_REALTIME with a valid pointer has no failure
+    // mode on a running kernel — EFAULT and EINVAL are both unreachable
+    // from here — so the result is an invariant, asserted rather than
+    // absorbed into a zero stamp that would date every line to 1970 and
+    // report a fifty-year duration. Same shape as `shutdown` and `closeFd`.
+    const rc = linux.clock_gettime(linux.CLOCK.REALTIME, &ts);
+    assert(posix.errno(rc) == .SUCCESS);
+    assert(ts.sec >= 0);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s +
+        @as(u64, @intCast(ts.nsec));
+}
+
 pub fn run(io: *XevIo) Io.RunError!void {
     // anyerror: CompletionQueueOvercommitted exists only on io_uring.
     io.loop.run(.until_done) catch |err| switch (@as(anyerror, err)) {
@@ -830,17 +929,64 @@ fn listenerEntryConst(io: *const XevIo, listener: Listener) *const ListenerEntry
 /// both address families (IPv4/IPv6 share the family/port prefix). Public
 /// for the raw-libxev smoke test, which lives under src/io/ too.
 pub fn boundPort(fd: posix.socket_t) error{Unexpected}!u16 {
-    var bound: posix.sockaddr.in6 = undefined;
-    var bound_len: posix.socklen_t = @sizeOf(posix.sockaddr.in6);
-    const rc = posix.system.getsockname(fd, @ptrCast(&bound), &bound_len);
-    if (posix.errno(rc) != .SUCCESS) {
+    const port = addressOf(fd, posix.system.getsockname).getPort();
+    // Both failure modes land here as zero: a getsockname that did not
+    // succeed, and a socket that is somehow still unbound. Neither is a
+    // port a listener may serve on, and the caller's answer to both is
+    // the same — refuse to start.
+    if (port == 0) {
         return error.Unexpected;
     }
-    // sockaddr.in and sockaddr.in6 share the family/port prefix layout.
-    const family_port: *const posix.sockaddr.in = @ptrCast(&bound);
-    assert(family_port.family == posix.AF.INET or family_port.family == posix.AF.INET6);
-    return std.mem.bigToNative(u16, family_port.port);
+    return port;
 }
+
+/// What a socket reports for one end of its address pair, decoded into the
+/// seam's address type. `getter` is `getsockname` or `getpeername`; the two
+/// differ only in which end they name, and sharing the decode is what keeps
+/// the family fork written once.
+///
+/// A failure yields `address_unknown` rather than an error: the only caller
+/// that can fail meaningfully is `boundPort` (which reads the zero port
+/// back as one), and the other — the access log — asks about a peer that
+/// may already have reset, where "unknown" is the honest answer and there
+/// is nothing an access-log line could do with an error anyway.
+fn addressOf(fd: posix.socket_t, comptime getter: anytype) std.Io.net.IpAddress {
+    var storage: posix.sockaddr.in6 = undefined;
+    var length: posix.socklen_t = @sizeOf(posix.sockaddr.in6);
+    const rc = getter(fd, @ptrCast(&storage), &length);
+    if (posix.errno(rc) != .SUCCESS) {
+        return address_unknown;
+    }
+    // sockaddr.in and sockaddr.in6 share the family/port prefix layout.
+    const family_port: *const posix.sockaddr.in = @ptrCast(&storage);
+    const port = std.mem.bigToNative(u16, family_port.port);
+    if (family_port.family == posix.AF.INET) {
+        assert(length >= @sizeOf(posix.sockaddr.in));
+        return .{ .ip4 = .{
+            .bytes = @bitCast(family_port.addr),
+            .port = port,
+        } };
+    }
+    assert(family_port.family == posix.AF.INET6);
+    assert(length >= @sizeOf(posix.sockaddr.in6));
+    // `fromIp6` unwraps an IPv4-mapped address back to the IPv4 one it
+    // is, so a client reaching a dual-stack listener is logged as the
+    // address it dialed from rather than as `::ffff:a.b.c.d`. The scope
+    // is dropped: it names a local interface, not the peer.
+    return .fromIp6(.{
+        .port = port,
+        .bytes = storage.addr,
+        .flow = storage.flowinfo,
+        .interface = .none,
+    });
+}
+
+/// The answer when a socket cannot name an end of its pair. Distinguishable
+/// in a log line — no real peer connects from port 0 — without needing an
+/// optional at every consumer.
+const address_unknown: std.Io.net.IpAddress = .{
+    .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 },
+};
 
 fn closeFd(fd: posix.socket_t) void {
     const rc = posix.system.close(fd);

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -19,13 +19,16 @@
 //!   recv(io, socket, buffer, c, U, u, cb(u, RecvError!u32))
 //!   send(io, socket, bytes, c, U, u, cb(u, SendError!u32))
 //!   close(io, socket, c, U, u, cb(u))
+//!   logWrite(io, bytes, c, U, u, cb(u, LogWriteError!u32))   (§8 access log)
 //!   timerStart(io, c, delay_ns, U, u, cb(u, TimerError!void))
 //!   timerCancel(io, timer_c, cancel_c, U, u, cb(u))     (the one legal cancel)
 //!   signalWait(io, U, u, cb(u, Signal))                 (persistent waiter)
 //!   setNodelay / setLingerRst (io, socket) SetOptionError!void   (sync)
 //!   shutdown(io, socket, how) void                      (sync control op)
 //!   closeNow(io, socket) void                           (sync; un-admitted sheds)
+//!   peerAddress(io, socket) IpAddress                   (sync; who connected)
 //!   nowNs(io) u64                                       (per-tick clock, §4)
+//!   nowWallNs(io) u64                                   (epoch clock, §8 log)
 //!   run(io) RunError!void, stop(io) void
 
 const std = @import("std");
@@ -90,6 +93,16 @@ pub const SendError = error{
 pub const TimerError = error{
     /// The one legal cancel: teardown (§4).
     Canceled,
+};
+
+/// The access-log sink's only failure (§8). One error rather than a set,
+/// because there is exactly one response to any of them: the sink is
+/// declared broken, the failure is counted, and further lines are dropped.
+/// An operator's log pipe closing (EPIPE) and a full disk are the same
+/// event to a proxy whose job is not to log — a distinction nobody could
+/// act on differently from inside the loop.
+pub const LogWriteError = error{
+    Unexpected,
 };
 
 pub const SetOptionError = error{
@@ -157,6 +170,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "recv",
             "send",
             "close",
+            "logWrite",
             "timerStart",
             "timerCancel",
             "signalWait",
@@ -164,8 +178,10 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "setLingerRst",
             "shutdown",
             "closeNow",
+            "peerAddress",
             "lastPressure",
             "nowNs",
+            "nowWallNs",
             "run",
             "stop",
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -225,6 +225,7 @@ fn printBudgets(
         limits.upstream_slots,
         @intCast(config.listeners.len),
     );
+    const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
     const memory_total = constants.memoryBytesTotal(&.{
         .conn_slots = limits.conn_slots,
         .conn_bytes = @sizeOf(ServerXev.ConnType),
@@ -232,17 +233,18 @@ fn printBudgets(
         .relay_buffer_pair_bytes = @sizeOf(zoxy.RelayBuffer),
         .upstream_slots = limits.upstream_slots,
         .upstream_bytes = @sizeOf(UpstreamType),
+        .access_log_bytes = access_log_bytes,
     });
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;
     try writer.print(
         \\zoxy budgets (closed-form, DESIGN.md §5/§8):
-        \\  memory  pools {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
-        \\          + upstream slots {d} x {d} B
+        \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
+        \\          + upstream slots {d} x {d} B + access log {d} KiB
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
         \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
-        \\  config  {d} listener(s), {d} cluster(s)
+        \\  config  {d} listener(s), {d} cluster(s), access log {s}
         \\
     , .{
         memory_total / 1024,
@@ -252,12 +254,14 @@ fn printBudgets(
         @sizeOf(zoxy.RelayBuffer),
         limits.upstream_slots,
         @sizeOf(UpstreamType),
+        access_log_bytes / 1024,
         fds_required,
         constants.ring_entries,
         cq_entries,
         in_flight,
         config.listeners.len,
         config.clusters.len,
+        if (config.access_log_sink) |sink| @tagName(sink) else "off",
     });
     try writer.flush();
 }
@@ -271,6 +275,21 @@ fn installSignalHandlers() void {
     std.posix.sigaction(.TERM, &action, null);
     std.posix.sigaction(.INT, &action, null);
     std.posix.sigaction(.USR1, &action, null);
+    // A proxy must not die because something downstream of it went away.
+    // The access log writes to a pipe the operator owns (§8), and a `write`
+    // to a pipe with no reader raises SIGPIPE, whose default action is to
+    // terminate — an operator closing `zoxy config.json | jq` would take
+    // the data path with it. Ignoring it turns that into the EPIPE the
+    // sink already handles by declaring itself broken. Socket sends are
+    // covered too: io_uring sets MSG_NOSIGNAL for them, but a proxy
+    // relying on that for its liveness is relying on a detail of a
+    // dependency's submission path.
+    const ignore = std.posix.Sigaction{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(.PIPE, &ignore, null);
 }
 
 /// Async-signal-safe: delegates to the seam's atomic-mask + eventfd wake

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -8,6 +8,8 @@
 
 const std = @import("std");
 
+const access_log = @import("../access_log.zig");
+const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const parser = @import("../http/parser.zig");
 const router = @import("../http/router.zig");
@@ -122,6 +124,101 @@ pub const ClientWrite = struct {
     };
 };
 
+/// What an access-log line needs that is not still on the connection when
+/// the line is written (DESIGN.md §8). The head buffer is the reason this
+/// exists: it holds the request head only until the response head renders
+/// over it (§7 buffer rotation), so a line emitted at settle time would
+/// find the method, host and path it is supposed to report already gone.
+/// Each is therefore copied out — bounded, truncation marked — while it is
+/// still there.
+///
+/// One instance per connection, covering one *request* on the L7 path
+/// (`reset` runs at every keep-alive turnaround) and the whole connection
+/// on the L4 path, which has no smaller unit. The arrays are deliberately
+/// not cleared by `reset`: the lengths beside them gate every read, so
+/// clearing 500-odd bytes per request would be work for an invariant that
+/// already holds — the same argument `Conn.head` makes.
+pub const LogState = struct {
+    /// Wall-clock nanoseconds at which this request — or, on L4, this
+    /// connection — began. Zero means nothing is in flight, which is what
+    /// keeps an idle keep-alive connection reaped by its deadline from
+    /// emitting a line about a request nobody made; it is also why nothing
+    /// sets it while the log is off, so a disabled log reads no clock.
+    ///
+    /// Wall-clock rather than the monotonic deadline clock because a line
+    /// needs both a date and a duration, and one precise read at each end
+    /// answers both — where `Io.now_ns` is coarse and cached per tick (§4),
+    /// which would report 0 µs for every request served inside one batch.
+    started_wall_ns: u64 = 0,
+    /// Bytes read from the client and written to it, for this request.
+    bytes_in: u64 = 0,
+    bytes_out: u64 = 0,
+    /// The endpoint the balancer picked (§7), or `endpoint_none` before
+    /// one was — every reject that fires ahead of routing.
+    endpoint_index: u16 = endpoint_none,
+    /// The status this request was answered with; 0 until one is decided.
+    status: u16 = 0,
+    outcome: access_log.Outcome = .aborted,
+    /// Set once this request's line has been written, so the teardown
+    /// fallback cannot emit a second one for an exchange that already
+    /// reported its own outcome.
+    emitted: bool = false,
+    method_len: u8 = 0,
+    host_len: u16 = 0,
+    path_len: u16 = 0,
+    method: [constants.access_log_method_bytes_max]u8 = undefined,
+    host: [constants.host_bytes_max]u8 = undefined,
+    path: [constants.access_log_path_bytes_max]u8 = undefined,
+
+    /// No endpoint has been picked. `maxInt` rather than a separate flag:
+    /// the pool's own ceiling is asserted below `maxInt(u16)`, so the
+    /// sentinel can never collide with a real index.
+    pub const endpoint_none: u16 = std.math.maxInt(u16);
+
+    comptime {
+        assert(constants.endpoints_per_cluster_max < endpoint_none);
+    }
+
+    /// Start a fresh request's accounting. Only the scalars: the three
+    /// captures are read through their lengths, which this zeroes.
+    pub fn reset(state: *LogState) void {
+        state.started_wall_ns = 0;
+        state.bytes_in = 0;
+        state.bytes_out = 0;
+        state.endpoint_index = endpoint_none;
+        state.status = 0;
+        state.outcome = .aborted;
+        state.emitted = false;
+        state.method_len = 0;
+        state.host_len = 0;
+        state.path_len = 0;
+    }
+
+    pub fn methodSlice(state: *const LogState) []const u8 {
+        return state.method[0..state.method_len];
+    }
+
+    pub fn hostSlice(state: *const LogState) []const u8 {
+        return state.host[0..state.host_len];
+    }
+
+    pub fn pathSlice(state: *const LogState) []const u8 {
+        return state.path[0..state.path_len];
+    }
+
+    pub fn captureMethod(state: *LogState, token: []const u8) void {
+        state.method_len = @intCast(access_log.captureTruncated(&state.method, token).len);
+    }
+
+    pub fn captureHost(state: *LogState, host: []const u8) void {
+        state.host_len = @intCast(access_log.captureTruncated(&state.host, host).len);
+    }
+
+    pub fn capturePath(state: *LogState, path: []const u8) void {
+        state.path_len = @intCast(access_log.captureTruncated(&state.path, path).len);
+    }
+};
+
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
@@ -183,6 +280,20 @@ pub fn Conn(comptime IoType: type) type {
         upstream: ?*UpstreamType,
         /// L7 exchange bookkeeping (§7); reset per exchange.
         l7: L7State,
+        /// What this connection speaks (§6, §7). Read only by the access
+        /// log, at teardown, to decide which kind of line a connection
+        /// owes — an unanswered HTTP request, or the L4 connection itself.
+        /// `startProtocol` used to argue that a stored protocol would be
+        /// state with no reader; the log is that reader.
+        protocol: config_module.Config.Listener.Protocol,
+        /// Who connected, read once at admission through the seam (§8).
+        /// Kept rather than asked for at log time: by then the socket may
+        /// already be closed, and `getpeername` on a closed fd names
+        /// whoever inherited the number.
+        client_address: std.Io.net.IpAddress,
+        /// Access-log capture (§8); per request on the L7 path, per
+        /// connection on the L4 one.
+        log: LogState,
 
         op_data_client_to_upstream: Op,
         op_data_upstream_to_client: Op,
@@ -399,6 +510,8 @@ pub fn Conn(comptime IoType: type) type {
             buffer: ?*relay.RelayBuffer,
             state: State,
             cluster_index: u16,
+            protocol: config_module.Config.Listener.Protocol,
+            client_address: std.Io.net.IpAddress,
         ) void {
             assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;
@@ -419,6 +532,20 @@ pub fn Conn(comptime IoType: type) type {
             conn.filters = &.{};
             conn.upstream = null;
             conn.l7 = .{};
+            conn.protocol = protocol;
+            conn.client_address = client_address;
+            // The field defaults are `reset`'s values; a recycled slot
+            // needs both the scalars and the (unread) capture arrays, and
+            // this sets them in one write.
+            conn.log = .{};
+            // An L4 connection is its own log unit and starts here; an L7
+            // one starts a request only when its first head byte lands, so
+            // an idle keep-alive connection that is reaped without ever
+            // being asked anything owes no line. Both are gated on the log
+            // being on, so a deployment without one reads no clock here.
+            if (protocol == .l4 and server.access_log.sink != null) {
+                conn.log.started_wall_ns = server.io.nowWallNs();
+            }
             conn.op_data_client_to_upstream = .{};
             conn.op_data_upstream_to_client = .{};
             conn.op_connect = .{};
@@ -431,6 +558,8 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.client_write.pending.len == 0);
             assert(conn.upstream == null);
             assert(conn.l7.request_leg == .idle);
+            assert(!conn.log.emitted);
+            assert(conn.log.bytes_in == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -28,6 +28,7 @@
 //!   beforeRecv(conn) / beforeSend(conn)   pre-arm bookkeeping (flags, phase)
 //!   onRecvEntry(conn)                     post-await recv invariant re-checks
 //!   afterFeed(conn, received, fr)         e.g. pipelined-tail detection
+//!   afterSend(conn, sent)                 e.g. access-log byte accounting
 //!   onSendEntry(server, conn) bool        divert a settled verdict; true = handled
 //!   recvBuffer(conn) []u8                 where a read lands
 //!   transformIn(conn, chunk) ?[]const u8  read bytes → framed bytes
@@ -310,6 +311,10 @@ pub fn Pump(
             const sent = result catch |err| return Policy.onSendError(server, conn, err);
             assert(sent >= 1);
             creditSend(conn, sent);
+            // What actually left on the wire, whether or not framing
+            // counts in the same units (the transform seam above): the
+            // access log reports bytes moved, not bytes framed.
+            if (@hasDecl(Policy, "afterSend")) Policy.afterSend(conn, sent);
             // "Anything left to write?" rather than "is the framed debt
             // settled?" — the same question for a plain policy, whose
             // `sendSlice` empties exactly when the debt does, and the only

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -687,7 +687,15 @@ const Harness = struct {
         // through both in spirit.
         bed.server.counters.increment("accepted");
         bed.server.counters.increment("admitted");
-        conn.prepare(&bed.server, bed.proxy_client_socket, buffer, .connecting, 0);
+        conn.prepare(
+            &bed.server,
+            bed.proxy_client_socket,
+            buffer,
+            .connecting,
+            0,
+            .l4,
+            bed.server.io.peerAddress(bed.proxy_client_socket),
+        );
         conn.upstream_socket = bed.proxy_upstream_socket;
         conn.state = .relaying;
         bed.conn = conn;

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -96,6 +96,28 @@ pub fn Relay(comptime IoType: type) type {
                     return .{ .consumed = @intCast(chunk.len), .done = false, .malformed = false };
                 }
 
+                /// The access log's byte counts for an L4 connection (§8),
+                /// taken on the client side of the proxy in both
+                /// directions: what arrived from the client is counted as
+                /// it is received, what leaves for the client as it is
+                /// sent. Counting each direction on its client-facing half
+                /// is what makes `bytes_in`/`bytes_out` mean the same
+                /// thing here as they do on an HTTP line — bytes that
+                /// crossed the wire to and from the client — rather than
+                /// bytes the origin happened to see.
+                pub fn afterFeed(conn: *ConnType, received: u32, fr: pump.FeedResult) void {
+                    _ = received;
+                    if (direction == .client_to_upstream) {
+                        conn.log.bytes_in += fr.consumed;
+                    }
+                }
+
+                pub fn afterSend(conn: *ConnType, sent: u32) void {
+                    if (direction == .upstream_to_client) {
+                        conn.log.bytes_out += sent;
+                    }
+                }
+
                 /// A FIN never arrives through here (relay has no length to
                 /// count down); the loop only leaves on EOF or teardown.
                 pub fn framingDone(conn: *ConnType) bool {
@@ -156,6 +178,12 @@ pub fn Relay(comptime IoType: type) type {
             assert(conn.state == .relaying);
             if (conn.directions[0].phase == .finished) {
                 if (conn.directions[1].phase == .finished) {
+                    // The one L4 ending that is not a failure: both peers
+                    // said goodbye. Every other way this connection can end
+                    // — a reset, a deadline, a drain straggler — leaves the
+                    // access log's default `aborted` in place (§8), so the
+                    // line distinguishes a completed relay from a cut one.
+                    conn.log.outcome = .closed;
                     server.beginTeardown(conn);
                 }
             }

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,6 +4,7 @@
 
 const std = @import("std");
 
+pub const access_log = @import("access_log.zig");
 pub const balancer = @import("balancer.zig");
 pub const config = @import("config.zig");
 pub const config_schema = @import("config_schema.zig");
@@ -32,6 +33,7 @@ pub const testing = struct {
 };
 
 test {
+    _ = access_log;
     _ = balancer;
     _ = config;
     _ = config_schema;
@@ -57,5 +59,6 @@ test {
     _ = @import("server_test.zig");
     _ = @import("http_proxy_test.zig");
     _ = @import("admin_test.zig");
+    _ = @import("access_log_test.zig");
     _ = @import("zero_alloc_test.zig");
 }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const constants = @import("constants.zig");
 const router = @import("http/router.zig");
 const Io = @import("io/io.zig");
 const Server = @import("Server.zig").Server;
@@ -204,6 +205,9 @@ pub const TestBed = struct {
         max_lifetime_ms: u32 = 0,
         connect_timeout_ms: u32 = 50,
         drain_deadline_ms: u32 = 1000,
+        /// Turn the §8 access log on. Off by default so every existing
+        /// scenario keeps paying nothing for it.
+        access_log: bool = false,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -234,8 +238,14 @@ pub const TestBed = struct {
             // L4 only: the §8 request deadline is an L7 exchange bound and
             // this bed never routes one.
             .request_timeout_ms = 0,
+            .access_log_sink = if (options.access_log) .stdout else null,
         };
-        try bed.server.init(arena, &bed.sim_io, &bed.config, options.server);
+        var server_options = options.server;
+        server_options.access_log_buffer_bytes = if (options.access_log)
+            constants.access_log_buffer_bytes_default
+        else
+            0;
+        try bed.server.init(arena, &bed.sim_io, &bed.config, server_options);
         try bed.server.start();
 
         bed.scenario = .{
@@ -787,4 +797,77 @@ test "teardown: a drain racing its own upstream dial peaks at four armed ops" {
         try std.testing.expectEqual(@as(u8, 4), bed.server.armed_ops_peak);
         try bed.expectDrained();
     }
+}
+
+test "relay: a completed L4 connection writes one line counting both directions" {
+    // The L4 half of the §8 access log. A connection, not a request, is
+    // the unit here — there is no smaller one — so the line covers the
+    // whole relay: who connected, which origin served, how long it lasted,
+    // and how many bytes crossed each way.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 3, .adversary = .{ .partial_io = true } },
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, true);
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    const sink = bed.sim_io.sinkBytes();
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("access_log_lines"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("access_log_dropped"));
+    const line = std.mem.trimEnd(u8, sink, "\n");
+
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"kind\":\"l4\"") != null);
+    // Both peers said goodbye, which is the one L4 ending that is not a
+    // cut — every other way out leaves `aborted`.
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"closed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"cluster\":\"origin\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"upstream\":\"127.0.0.1:9000\"") != null);
+    // The echo scenario sends the token up and reads it back down, so both
+    // counts are exactly its length — and they are *separate* counts, which
+    // a single total would have hidden.
+    var expected: [64]u8 = undefined;
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        line,
+        try std.fmt.bufPrint(&expected, "\"bytes_in\":{d},", .{echo_token.len}),
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        line,
+        try std.fmt.bufPrint(&expected, "\"bytes_out\":{d},", .{echo_token.len}),
+    ) != null);
+    // The HTTP-only fields are absent on an L4 line, not empty.
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"status\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"path\"") == null);
+}
+
+test "relay: a connection reaped by the idle deadline is logged as aborted" {
+    // The negative space of the test above: a relay that never reached a
+    // clean two-way close must not read as one. `aborted` is the default
+    // precisely so every path that forgets to say otherwise says this.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 4 },
+        .idle_timeout_ms = 20,
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    // `exchange = false`: the client connects and then says nothing, so
+    // the idle deadline is what ends it.
+    bed.startClients(1, false);
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("access_log_lines"));
+    const line = std.mem.trimEnd(u8, bed.sim_io.sinkBytes(), "\n");
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"kind\":\"l4\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_in\":0,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_out\":0,") != null);
 }

--- a/src/zero_alloc_test.zig
+++ b/src/zero_alloc_test.zig
@@ -17,6 +17,12 @@ test "zero-alloc gate: the serving path allocates nothing after init" {
             .seed = 7,
             .adversary = .{ .partial_io = true, .connect_delay_ns_max = 1_000_000 },
         },
+        // The §8 access log renders and writes on the serving path, so it
+        // has to be inside this gate rather than beside it: the two
+        // staging buffers come out of the startup arena and everything
+        // after — the render, the swap, the sink write — must ask for
+        // nothing. A log left off here would leave that unproven.
+        .access_log = true,
     });
     defer bed.tearDown();
 
@@ -37,6 +43,12 @@ test "zero-alloc gate: the serving path allocates nothing after init" {
             .seed = 7,
             .adversary = .{ .partial_io = true, .connect_delay_ns_max = 1_000_000 },
         },
+        // The §8 access log renders and writes on the serving path, so it
+        // has to be inside this gate rather than beside it: the two
+        // staging buffers come out of the startup arena and everything
+        // after — the render, the swap, the sink write — must ask for
+        // nothing. A log left off here would leave that unproven.
+        .access_log = true,
     });
     defer strict_bed.tearDown();
     strict_bed.startClients(2, true);


### PR DESCRIPTION
Closes #124.

Counters say how much and how often; they cannot say *which request*, which is what an operator needs when one client is served badly and the aggregates look fine. This adds an optional access log — a config `access_log` block names a sink, and absent it the feature reserves nothing, reads no clock and emits nothing.

```json
{"time":"2026-07-31T12:08:01.595Z","kind":"http","outcome":"ok","client":"127.0.0.1:58530","method":"GET","host":"example.com","path":"/missing","status":404,"upstream_reused":true,"upstream_replayed":false,"duration_us":83,"bytes_in":87,"bytes_out":284,"cluster":"origin","upstream":"127.0.0.1:9000"}
{"time":"2026-07-31T12:08:01.601Z","kind":"l4","outcome":"closed","client":"127.0.0.1:59278","duration_us":128,"bytes_in":78,"bytes_out":249,"cluster":"origin","upstream":"127.0.0.1:9000"}
```

`outcome` sits beside `status` because it is not derivable from it: an origin answering `503` and this proxy shedding a request with `503` are the same three digits and opposite events.

## A log line must never stall the data path

The sink is a pipe the operator owns, so it can block for arbitrarily long, and a proxy that waited on it would hand every client's latency to whatever reads its logs. So the write is a **ring op** like every other (§4) with at most one in flight — one entry in the ring budget, reserved unconditionally — lines accumulate in a second staging buffer while it is out, the two swap when it lands, and **a line that does not fit is dropped and counted**. That is §8's own ladder applied to logging, with `access_log_dropped` as the witness that keeps it from being silent.

Flushing is self-clocked rather than timer-driven, so a quiet proxy's line leaves at once and a busy one batches a whole write's worth. The drain does not stop the loop until the sink is quiet, because the lines describing a shutdown are the ones most likely to be read.

## Scope of what gets a line

The unit is an **admitted** connection. Request-level sheds (`503` for relay buffers or upstream slots) get a line; admission-gate sheds — `shed_conn_slots`, `shed_relay_buffers`, `shed_draining` — do not, because at that point there is no slot to report from and a shed has to stay at "at most two direct syscalls". Their witness stays the counters. The second commit records that boundary in §8 and the README.

## Seam and budgets

Three seam ops serve this and nothing else: `logWrite`, `peerAddress` (asked at admission, since at log time the socket may already be closed and its fd number reused), and `nowWallNs` — a second clock, precise and uncached where `now_ns` is coarse and per-tick, because a line needs a date a monotonic clock cannot give and a duration measured against the tick reads 0 µs for every request served inside one completion batch.

Budgets stay closed-form:

- **ring** gains one fixed op; the c10k conn-slot ceiling is **unchanged at 11464** (57320/5 still floors there)
- **memory** gains the staging buffers as a term — default footprint ~33 → ~34 MiB, ceiling ~284 → ~288 MiB, since `Conn` grew ~600 B for the per-request captures (method/host/path must be copied out before the response head renders over the head buffer, §7). §5's table is updated.
- **fds** do not move: stdout is already one of the three stdio descriptors `fdsRequired` reserves.

Cluster names gained a 64-byte bound for the same reason the captures are bounded — a log line's width has to be a function of `constants.zig`, not of the config file. **This is the one way an existing config could newly be rejected.**

`limits.access_log_buffer_bytes` sizes the staging buffers; it is also the seam the simulator and tests use to force the drop rung, exactly as the pool sizes force theirs.

## Gates

- **Directed tests** (`src/access_log_test.zig`) pin the drop, broken-sink, short-write and drain-quiescence edges — filling even the smallest legal buffer takes dozens of lines where a sim scenario emits a handful, so these cannot live in the sweep.
- **Simulation**: the log is on for three seeds in four; the oracle checks the sink holds whole lines, exactly as many as the counter claims, each shaped like the record, and never fewer than the outcomes the data path counted. A `log_write_stall_ns` adversary knob models a sink that has fallen behind.
- **Zero-alloc gate** now runs with the log on, so the render, the swap and the sink write are inside it rather than beside it.
- `zig build ci` and `zig fmt --check` green; `tiger-style-reviewer` returned *ready to commit*.

## What the simulator did not catch

A live smoke test against nginx over real io_uring found that starting the request clock before unwrapping the head read meant the EOF closing an **idle** kept-alive connection began a request nobody made — every keep-alive client got a phantom second line. The 4096-seed sweep passed with that bug, because spurious lines only inflate the oracle's `>=` invariant. A request begins with a byte; `http_proxy_test.zig` now pins it, and the test client learned to hang up the way curl does, which is the only way to reach that read.

## Deferred

A file sink (`{"sink": "file", "path": ...}`) is deliberately out of scope: it costs an fd and raises rotation, which config-reload-as-a-non-goal makes awkward. Worth its own issue if a deployment needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)