### PR TITLE
health: HTTP checks, and fall/rise as config (§5, §7, §9)

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -3,7 +3,10 @@
         { "bind": "127.0.0.1:8080", "cluster": "origin", "protocol": "l4" }
     ],
     "clusters": {
-        "origin": { "endpoints": ["127.0.0.1:9000"], "check": true }
+        "origin": {
+            "endpoints": ["127.0.0.1:9000"],
+            "check": { "type": "tcp", "fall": 3, "rise": 2 }
+        }
     },
     "timeouts": {
         "connect_ms": 5000,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -658,23 +658,39 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   for strict rotation. Cluster endpoints are static socket addresses
   resolved once at config load, never on the loop (dynamic DNS is a
   non-goal, §1).
-- **Active TCP health checks** are per-cluster opt-in (`check` —
+- **Active health checks** are per-cluster opt-in (a `check` block —
   HAProxy's model) so a request is not routed to an endpoint known to be
-  down. One prober per server sweeps every checked endpoint with a
-  single probe in flight, budgeted like the admin plane (§8:
-  `health_probe_ops_max` ring ops and one fd, reserved unconditionally);
-  each probe is a dial under the `connect_ms` budget, and sweeps pace
-  sweep-end to sweep-start on `timeouts.health_interval_ms`. A SYN/ACK
-  passes; refused, unreachable, timed out, or kernel pressure (witnessed
-  §8) fails. `health_probe_fall` (3) consecutive misses eject the
-  endpoint from balancing and close its parked pooled connections (§5);
-  `health_probe_rise` (2) passes restore it. Endpoints start healthy —
-  probing demotes, never gates startup — and the pick **fails open**: a
-  cluster with every endpoint ejected balances as if none were, because
-  routing nowhere would turn a probe verdict into an outage of its own,
-  and a same-port TCP probe cannot know better than the dial it stands
-  in for. The check is TCP-level: it proves the port accepts, not that
-  the application behind it is well. Circuit breakers, outlier ejection,
+  down:
+
+  ```json
+  "api": { "endpoints": ["10.0.0.1:80"],
+           "check": { "type": "http", "path": "/health",
+                      "expect_status": 200, "fall": 3, "rise": 2 } }
+  ```
+
+  One prober per server sweeps every checked endpoint with a **single
+  probe in flight**, budgeted like the admin plane (§8:
+  `health_probe_ops_max` ring ops and one fd, reserved unconditionally).
+  Sweeps pace sweep-end to sweep-start on `timeouts.health_interval_ms`;
+  one probe is bounded by the check's `timeout_ms`, which defaults to
+  `connect_ms`.
+
+  What a probe proves is the operator's choice. A **`tcp`** check dials:
+  a SYN/ACK passes, and refused, unreachable, timed out or kernel
+  pressure (witnessed §8) fails. It proves the port accepts, which an
+  origin that is listening but answering 500s also does. An **`http`**
+  check therefore sends `GET <path>` and requires the configured status,
+  reading the response with the data path's own head parser (§7) — so a
+  probe accepts exactly the heads this proxy would forward. Its legs run
+  in sequence, dial then send then recv, which is why the op budget is
+  the same for both kinds.
+
+  `fall` consecutive misses eject the endpoint from balancing and close
+  its parked pooled connections (§5); `rise` consecutive passes restore
+  it. Endpoints start healthy — probing demotes, it never gates startup
+  — and the pick **fails open**: a cluster with every endpoint ejected
+  balances as if none were, because routing nowhere would turn a probe
+  verdict into an outage of its own. Circuit breakers, outlier ejection,
   retry budgets stay *deferred* — the previous iteration proved them
   buildable in this architecture; simplicity says they wait for a
   demonstrated need.

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -245,6 +245,21 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     };
 }
 
+/// Which check the http cluster runs, if any. An outage seed always
+/// takes the dial check: its origin stops listening, so a request check
+/// would only ever reach the same refused dial by a longer route.
+fn checkHttpDraw(
+    checked: bool,
+    outage: bool,
+    random: std.Random,
+    tcp_check: Check,
+    http_check: Check,
+) ?Check {
+    if (!checked) return null;
+    if (outage) return tcp_check;
+    return if (random.boolean()) http_check else tcp_check;
+}
+
 /// The §7 health-check shape of one scenario: which clusters probe, how
 /// fast, and whether the HTTP origin dies mid-run.
 const HealthDraw = struct {
@@ -294,12 +309,7 @@ fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDr
         // The L4 origin echoes bytes rather than speaking HTTP, so only
         // the dial check is meaningful against it.
         .check_l4 = if (!outage and random.boolean()) tcp_check else null,
-        .check_http = if (!checked_http)
-            null
-        else if (!outage and random.boolean())
-            http_check
-        else
-            tcp_check,
+        .check_http = checkHttpDraw(checked_http, outage, random, tcp_check, http_check),
         .interval_ms = if (outage)
             5 + random.uintAtMost(u32, 10)
         else

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -276,9 +276,30 @@ fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDr
         .fall = 1 + random.uintAtMost(u8, 3),
         .rise = 1 + random.uintAtMost(u8, 2),
     };
+    // Half the checked http clusters probe with a real request instead of
+    // a dial, so the send and recv legs — and the shutdown that ends one
+    // when a deadline or a drain lands mid-leg — take the schedule fuzz.
+    // A quarter of those expect a status the origin never sends, which is
+    // the only way to reach the wrong-status ejection: every other
+    // failure here is a transport failure, and a check that could not
+    // tell those apart would be the whole point missed.
+    var http_check = tcp_check;
+    http_check.kind = .http;
+    http_check.http = .{
+        .path = "/health",
+        .expect_status = if (random.uintLessThan(u8, 4) == 0) 599 else 200,
+    };
+    const checked_http = outage or random.boolean();
     const draw: HealthDraw = .{
+        // The L4 origin echoes bytes rather than speaking HTTP, so only
+        // the dial check is meaningful against it.
         .check_l4 = if (!outage and random.boolean()) tcp_check else null,
-        .check_http = if (outage or random.boolean()) tcp_check else null,
+        .check_http = if (!checked_http)
+            null
+        else if (!outage and random.boolean())
+            http_check
+        else
+            tcp_check,
         .interval_ms = if (outage)
             5 + random.uintAtMost(u32, 10)
         else

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -203,7 +203,8 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     // a single-endpoint topology's routing unchanged whatever the
     // verdicts, so the L7 golden oracles hold on clean seeds (where
     // probes always pass) and prefix-legality holds under the adversary.
-    const health = deriveHealthChecks(harness.clean, random);
+    const connect_timeout_ms: u32 = 20 + random.uintAtMost(u32, 40);
+    const health = deriveHealthChecks(harness.clean, random, connect_timeout_ms);
     harness.http_origin_stop_at_ns = health.http_origin_stop_at_ns;
     harness.clusters = .{
         .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick_l4, .check = health.check_l4 },
@@ -215,7 +216,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.config = .{
         .listeners = &harness.listener_configs,
         .clusters = &harness.clusters,
-        .connect_timeout_ms = 20 + random.uintAtMost(u32, 40),
+        .connect_timeout_ms = connect_timeout_ms,
         .idle_timeout_ms = 30 + random.uintAtMost(u32, 70),
         .drain_deadline_ms = 100,
         // A third of seeds arm the max-lifetime cap (§6). The range
@@ -247,11 +248,13 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
 /// The §7 health-check shape of one scenario: which clusters probe, how
 /// fast, and whether the HTTP origin dies mid-run.
 const HealthDraw = struct {
-    check_l4: bool,
-    check_http: bool,
+    check_l4: ?Check,
+    check_http: ?Check,
     interval_ms: u32,
     http_origin_stop_at_ns: u64,
 };
+
+const Check = zoxy.config.Config.Cluster.Check;
 
 /// An eighth of adversarial seeds are outage seeds: the HTTP origin
 /// stops listening while clients are still live and parked connections
@@ -263,11 +266,19 @@ const HealthDraw = struct {
 /// conn table, while the stopped HTTP origin refuses its probes and a
 /// refused probe consumes no origin conn. Everyone else paces from the
 /// `health_interval_floor_ms` the origin-capacity bound is derived at.
-fn deriveHealthChecks(clean: bool, random: std.Random) HealthDraw {
+fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDraw {
+    assert(timeout_ms >= 1);
     const outage = !clean and random.uintLessThan(u8, 8) == 0;
+    // Thresholds draw around their defaults so a configured fall/rise —
+    // not only the compiled one — decides ejections under the fuzz.
+    const tcp_check: Check = .{
+        .timeout_ms = timeout_ms,
+        .fall = 1 + random.uintAtMost(u8, 3),
+        .rise = 1 + random.uintAtMost(u8, 2),
+    };
     const draw: HealthDraw = .{
-        .check_l4 = !outage and random.boolean(),
-        .check_http = outage or random.boolean(),
+        .check_l4 = if (!outage and random.boolean()) tcp_check else null,
+        .check_http = if (outage or random.boolean()) tcp_check else null,
         .interval_ms = if (outage)
             5 + random.uintAtMost(u32, 10)
         else
@@ -279,7 +290,7 @@ fn deriveHealthChecks(clean: bool, random: std.Random) HealthDraw {
     };
     // An outage always probes the cluster it exists to eject, and the
     // instant always precedes the scenario-end backstop.
-    assert(draw.http_origin_stop_at_ns == 0 or draw.check_http);
+    assert(draw.http_origin_stop_at_ns == 0 or draw.check_http != null);
     assert(draw.http_origin_stop_at_ns < scenario_end_ns);
     assert(draw.interval_ms >= 1);
     return draw;

--- a/src/config.zig
+++ b/src/config.zig
@@ -127,18 +127,59 @@ pub const Config = struct {
         /// (predictable spread, cache warming, pure-L4 clusters whose
         /// load p2c cannot see).
         pick: Pick = .p2c,
-        /// §7 active TCP health checks for every endpoint in this
-        /// cluster: the server's prober dials each endpoint every
-        /// `health_interval_ms`, and the balancer skips endpoints that
-        /// failed `constants.health_probe_fall` consecutive probes until
-        /// `constants.health_probe_rise` successes restore them. The
-        /// JSON field is optional and defaults off — probing is opt-in
-        /// per cluster.
-        check: bool = false,
+        /// §7 active health checks for every endpoint in this cluster,
+        /// or null when the cluster is unprobed — probing is opt-in per
+        /// cluster, so absent means the balancer never skips anything
+        /// here and the prober never dials it.
+        check: ?Check = null,
 
         pub const Pick = enum(u1) {
             rr,
             p2c,
+        };
+
+        /// One cluster's resolved check policy (§7). Every field is
+        /// settled at load: the thresholds, the per-probe budget, and —
+        /// for an HTTP check — the exact request to send and the status
+        /// that passes. Nothing here is decided on the loop.
+        pub const Check = struct {
+            /// What a probe proves. `tcp` proves the port accepts;
+            /// `http` proves the application answered a chosen path with
+            /// a chosen status, which a SYN/ACK cannot.
+            kind: Kind = .tcp,
+            /// Consecutive failures that eject, successes that restore.
+            fall: u8 = constants.health_probe_fall_default,
+            rise: u8 = constants.health_probe_rise_default,
+            /// Budget for one whole probe — the dial for a `tcp` check,
+            /// and dial + request + response for an `http` one. Defaults
+            /// to `connect_timeout_ms`: a probe is at least a dial, and
+            /// an operator who has tuned that has said what a
+            /// too-slow origin looks like.
+            timeout_ms: u32,
+            /// The rest is meaningful only when `kind == .http`, and the
+            /// loader rejects it otherwise rather than leaving dead
+            /// fields to be misread.
+            http: ?Http = null,
+
+            pub const Kind = enum(u1) {
+                tcp,
+                http,
+            };
+
+            pub const Http = struct {
+                /// Canonical origin-form path, validated at load exactly
+                /// like a route prefix — the probe sends it verbatim.
+                path: []const u8,
+                /// `Host` value. Null means the endpoint's own literal,
+                /// which is what a non-vhosted origin expects; a name
+                /// here is what makes a vhosted origin probeable.
+                host: ?[]const u8 = null,
+                /// The one status that passes. A single value, not a
+                /// class: an endpoint that answers 200 today and 302
+                /// tomorrow has changed its meaning, and a check that
+                /// shrugged at that would be reporting the wrong thing.
+                expect_status: u16 = 200,
+            };
         };
     };
 };
@@ -157,6 +198,15 @@ pub const ValidationError = error{
     ClusterNameEmpty,
     ClusterNameTooLong,
     ClusterPickUnknown,
+    ClusterCheckTypeUnknown,
+    ClusterCheckThresholdOutOfRange,
+    ClusterCheckTimeoutOutOfRange,
+    ClusterCheckHttpFieldOnTcp,
+    ClusterCheckPathMissing,
+    ClusterCheckPathTooLong,
+    ClusterCheckPathNotCanonical,
+    ClusterCheckHostInvalid,
+    ClusterCheckStatusInvalid,
     ListenerClusterOrRoutes,
     ListenerL4Routes,
     RoutesEmpty,
@@ -209,9 +259,12 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .ignore_unknown_fields = false,
     });
 
-    const clusters = try resolveClusters(arena, &parsed.clusters);
-    const listeners = try resolveListeners(arena, parsed.listeners, clusters);
+    // Timeouts first: a cluster's check budget defaults to the connect
+    // timeout, so that value must already be known to be in range before
+    // any check inherits it.
     try validateTimeouts(&parsed.timeouts);
+    const clusters = try resolveClusters(arena, &parsed.clusters, parsed.timeouts.connect_ms);
+    const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     const access_log_sink = try resolveAccessLogSink(parsed.access_log);
     const limits = try resolveLimits(
         &parsed.limits,
@@ -609,11 +662,11 @@ pub const ClusterJson = struct {
     /// Optional §7 pick policy; absent means `p2c` (the design's
     /// trajectory), `rr` opts back into strict rotation.
     pick: []const u8 = "p2c",
-    /// Optional §7 active TCP health checks; absent means off, so a
-    /// config that never heard of probing keeps its exact behavior.
-    check: bool = false,
+    /// Optional §7 active health checks; absent means off, so an
+    /// unprobed cluster reserves nothing and is never skipped.
+    check: ?CheckJson = null,
 
-    pub const schema_doc = "One upstream cluster: its endpoints and pick policy.";
+    pub const schema_doc = "One upstream cluster: its endpoints, pick policy and health checks.";
     pub const schema_fields = .{
         .endpoints = .{
             .desc = "IP:port endpoint literals (port must be non-zero).",
@@ -625,7 +678,61 @@ pub const ClusterJson = struct {
             .enum_type = Config.Cluster.Pick,
         },
         .check = .{
-            .desc = "Active TCP health checks for every endpoint in this cluster (default off).",
+            .desc = "Active health checks for every endpoint in this cluster; absent leaves them off.",
+        },
+    };
+};
+
+/// One cluster's health-check block (§7). `type` picks what a probe
+/// proves; the `http` fields are rejected under `tcp` rather than
+/// ignored, so a config cannot quietly describe a check it is not
+/// running.
+pub const CheckJson = struct {
+    type: []const u8 = "tcp",
+    /// Thresholds, HAProxy's `fall`/`rise`.
+    fall: u8 = constants.health_probe_fall_default,
+    rise: u8 = constants.health_probe_rise_default,
+    /// Budget for one whole probe; absent means `timeouts.connect_ms`.
+    timeout_ms: ?u32 = null,
+    /// Required for `http`, rejected for `tcp`.
+    path: ?[]const u8 = null,
+    /// `Host` for an `http` probe; absent sends the endpoint literal.
+    host: ?[]const u8 = null,
+    expect_status: u16 = 200,
+
+    pub const schema_doc = "Active health checks for a cluster's endpoints.";
+    pub const schema_fields = .{
+        .type = .{
+            .desc = "What a probe proves: tcp (the port accepts) or http (a path answered the expected status).",
+            .enum_type = Config.Cluster.Check.Kind,
+        },
+        .fall = .{
+            .desc = "Consecutive failed probes that eject an endpoint from balancing.",
+            .minimum = 1,
+            .maximum = constants.health_probe_threshold_max,
+        },
+        .rise = .{
+            .desc = "Consecutive successful probes that restore an ejected endpoint.",
+            .minimum = 1,
+            .maximum = constants.health_probe_threshold_max,
+        },
+        .timeout_ms = .{
+            .desc = "Budget for one whole probe; absent uses timeouts.connect_ms.",
+            .minimum = 1,
+            .maximum = constants.timeout_ms_max,
+        },
+        .path = .{
+            .desc = "Canonical origin-form path an http probe requests; required for http, rejected for tcp.",
+            .min_length = 1,
+        },
+        .host = .{
+            .desc = "Host header an http probe sends; absent sends the endpoint's own IP:port literal.",
+            .min_length = 1,
+        },
+        .expect_status = .{
+            .desc = "The one response status an http probe accepts as healthy.",
+            .minimum = 100,
+            .maximum = 599,
         },
     };
 };
@@ -798,7 +905,7 @@ pub const dto_types = .{
     ConfigJson,  ListenerJson,    RouteJson,    FilterJson,
     MatchJson,   HeaderMatchJson, ActionJson,   HeaderEditJson,
     RewriteJson, ClusterJson,     TimeoutsJson, LimitsJson,
-    AdminJson,   AccessLogJson,
+    AdminJson,   AccessLogJson,   CheckJson,
 };
 
 comptime {
@@ -808,7 +915,9 @@ comptime {
 fn resolveClusters(
     arena: std.mem.Allocator,
     clusters_json: *const ClustersJson,
+    connect_timeout_ms: u32,
 ) ParseError![]const Config.Cluster {
+    assert(connect_timeout_ms >= 1);
     if (clusters_json.seen_count < constants.clusters_min) {
         return error.ClustersEmpty;
     }
@@ -837,7 +946,7 @@ fn resolveClusters(
             .name = entry.name,
             .endpoints = try resolveEndpoints(arena, entry.cluster.endpoints),
             .pick = try pickOf(entry.cluster.pick),
-            .check = entry.cluster.check,
+            .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
         };
     }
     assert(clusters.len == count);
@@ -1277,6 +1386,82 @@ fn validateRoutePrefix(prefix: []const u8) ParseError!void {
     }
 }
 
+/// Resolve one cluster's §7 check block. Absent leaves the cluster
+/// unprobed. Every limit gets its own error (§5), and the `http` fields
+/// are rejected under `tcp` rather than ignored: a config that names a
+/// path for a check that will never request it is describing something
+/// the process is not doing, which is exactly the negative space this
+/// loader exists to refuse.
+fn resolveCheck(
+    check_json: ?CheckJson,
+    connect_timeout_ms: u32,
+) ParseError!?Config.Cluster.Check {
+    assert(connect_timeout_ms >= 1);
+    const check = check_json orelse return null;
+    const kind = std.meta.stringToEnum(Config.Cluster.Check.Kind, check.type) orelse
+        return error.ClusterCheckTypeUnknown;
+    if (check.fall < 1 or check.fall > constants.health_probe_threshold_max) {
+        return error.ClusterCheckThresholdOutOfRange;
+    }
+    if (check.rise < 1 or check.rise > constants.health_probe_threshold_max) {
+        return error.ClusterCheckThresholdOutOfRange;
+    }
+    const timeout_ms = check.timeout_ms orelse connect_timeout_ms;
+    if (timeout_ms < 1 or timeout_ms > constants.timeout_ms_max) {
+        return error.ClusterCheckTimeoutOutOfRange;
+    }
+    const http = switch (kind) {
+        .tcp => blk: {
+            // A TCP probe sends nothing and reads nothing, so every
+            // HTTP-shaped field here would be inert.
+            if (check.path != null or check.host != null) {
+                return error.ClusterCheckHttpFieldOnTcp;
+            }
+            break :blk null;
+        },
+        .http => try resolveHttpCheck(&check),
+    };
+    return .{
+        .kind = kind,
+        .fall = check.fall,
+        .rise = check.rise,
+        .timeout_ms = timeout_ms,
+        .http = http,
+    };
+}
+
+/// The `http` half: a canonical path (validated exactly as a route
+/// prefix is, so the probe sends bytes the origin's own router will
+/// recognize), a bounded Host, and a status in the real range.
+fn resolveHttpCheck(check: *const CheckJson) ParseError!Config.Cluster.Check.Http {
+    const path = check.path orelse return error.ClusterCheckPathMissing;
+    if (path.len > constants.health_check_path_bytes_max) {
+        return error.ClusterCheckPathTooLong;
+    }
+    validateRoutePrefix(path) catch return error.ClusterCheckPathNotCanonical;
+    if (check.host) |host| {
+        if (host.len == 0 or host.len > constants.health_check_host_bytes_max) {
+            return error.ClusterCheckHostInvalid;
+        }
+        // The value is rendered into a request head, so it must not be
+        // able to inject one: no CR, LF, or NUL, the same rule the §7
+        // filter header values obey.
+        for (host) |byte| {
+            if (byte == '\r' or byte == '\n' or byte == 0) {
+                return error.ClusterCheckHostInvalid;
+            }
+        }
+    }
+    if (check.expect_status < 100 or check.expect_status > 599) {
+        return error.ClusterCheckStatusInvalid;
+    }
+    return .{
+        .path = path,
+        .host = check.host,
+        .expect_status = check.expect_status,
+    };
+}
+
 /// The closed pick-policy vocabulary; anything else is its own error so
 /// a typo ("pc2") fails loudly instead of silently balancing as p2c.
 fn pickOf(literal: []const u8) error{ClusterPickUnknown}!Config.Cluster.Pick {
@@ -1361,7 +1546,14 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
     try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].getPort());
-    try std.testing.expectEqual(true, parsed.clusters[0].check);
+    // The example's tcp check resolves with its thresholds, and its
+    // omitted budget inherits the connect timeout.
+    const example_check = parsed.clusters[0].check.?;
+    try std.testing.expectEqual(Config.Cluster.Check.Kind.tcp, example_check.kind);
+    try std.testing.expectEqual(@as(u8, 3), example_check.fall);
+    try std.testing.expectEqual(@as(u8, 2), example_check.rise);
+    try std.testing.expectEqual(@as(u32, 5000), example_check.timeout_ms);
+    try std.testing.expectEqual(@as(?Config.Cluster.Check.Http, null), example_check.http);
     try std.testing.expectEqual(@as(u32, 5000), parsed.connect_timeout_ms);
     try std.testing.expectEqual(@as(u32, 60000), parsed.idle_timeout_ms);
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
@@ -1713,28 +1905,119 @@ test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
     );
 }
 
-test "config: cluster check flag parses, defaults off, rejects non-bool" {
-    // Explicit true and false both resolve; absent defaults off (§7:
-    // probing is opt-in per cluster).
+test "config: a check block resolves its kind, thresholds and budget" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
+        \\     "check":{"type":"tcp","fall":5,"rise":1,"timeout_ms":250}},
+        \\   "b":{"endpoints":["127.0.0.1:3"],"check":{"type":"tcp"}},
+        \\   "c":{"endpoints":["127.0.0.1:4"]}},
+        \\ "timeouts":{"connect_ms":7,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    const tuned = parsed.clusters[0].check.?;
+    try std.testing.expectEqual(@as(u8, 5), tuned.fall);
+    try std.testing.expectEqual(@as(u8, 1), tuned.rise);
+    try std.testing.expectEqual(@as(u32, 250), tuned.timeout_ms);
+    // Omitted thresholds take the compiled defaults, and an omitted
+    // budget inherits the connect timeout rather than inventing one.
+    const defaulted = parsed.clusters[1].check.?;
+    try std.testing.expectEqual(constants.health_probe_fall_default, defaulted.fall);
+    try std.testing.expectEqual(constants.health_probe_rise_default, defaulted.rise);
+    try std.testing.expectEqual(@as(u32, 7), defaulted.timeout_ms);
+    // Absent means unprobed — the cluster the balancer never skips.
+    try std.testing.expectEqual(@as(?Config.Cluster.Check, null), parsed.clusters[2].check);
+}
+
+test "config: an http check resolves its request and expected status" {
     {
         var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena_state.deinit();
         const parsed = try parse(arena_state.allocator(),
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
-            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"check":true},
-            \\   "b":{"endpoints":["127.0.0.1:3"],"check":false},
-            \\   "c":{"endpoints":["127.0.0.1:4"]}},
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
+            \\     "check":{"type":"http","path":"/healthz","host":"api.example",
+            \\       "expect_status":204}}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
         );
-        try std.testing.expectEqual(true, parsed.clusters[0].check);
-        try std.testing.expectEqual(false, parsed.clusters[1].check);
-        try std.testing.expectEqual(false, parsed.clusters[2].check);
+        const check = parsed.clusters[0].check.?;
+        try std.testing.expectEqual(Config.Cluster.Check.Kind.http, check.kind);
+        const http = check.http.?;
+        try std.testing.expectEqualStrings("/healthz", http.path);
+        try std.testing.expectEqualStrings("api.example", http.host.?);
+        try std.testing.expectEqual(@as(u16, 204), http.expect_status);
     }
-    // The flag is a bool, not a truthy string — strict JSON stage 1.
-    try expectParseError(error.UnexpectedToken,
+    // Host is optional: absent means the endpoint's own literal (§7).
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
+            \\     "check":{"type":"http","path":"/health"}}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        const http = parsed.clusters[0].check.?.http.?;
+        try std.testing.expectEqual(@as(?[]const u8, null), http.host);
+        try std.testing.expectEqual(@as(u16, 200), http.expect_status);
+    }
+}
+
+test "config: a check block rejects every shape it cannot run" {
+    const head =
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
-        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"check":"on"}},
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"check":
+    ;
+    const tail =
+        \\}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    ;
+    // A typo in the vocabulary must not silently probe as tcp.
+    try expectParseError(error.ClusterCheckTypeUnknown, head ++ "{\"type\":\"htp\"}" ++ tail);
+    // Thresholds are counts of probes: zero would eject or restore on no
+    // evidence at all, and the ceiling keeps the u8 streaks from wrapping.
+    try expectParseError(error.ClusterCheckThresholdOutOfRange, head ++ "{\"fall\":0}" ++ tail);
+    try expectParseError(error.ClusterCheckThresholdOutOfRange, head ++ "{\"rise\":0}" ++ tail);
+    try expectParseError(error.ClusterCheckThresholdOutOfRange, head ++ "{\"fall\":65}" ++ tail);
+    // A zero budget would expire before the dial was submitted.
+    try expectParseError(error.ClusterCheckTimeoutOutOfRange, head ++ "{\"timeout_ms\":0}" ++ tail);
+    // An http check with nothing to request is not a check.
+    try expectParseError(error.ClusterCheckPathMissing, head ++ "{\"type\":\"http\"}" ++ tail);
+    // A path a tcp probe would never send is a config describing
+    // something the process is not doing.
+    try expectParseError(
+        error.ClusterCheckHttpFieldOnTcp,
+        head ++ "{\"type\":\"tcp\",\"path\":\"/health\"}" ++ tail,
+    );
+    // The probe sends the path verbatim, so it must already be canonical
+    // — the same rule a route prefix obeys (§7).
+    try expectParseError(
+        error.ClusterCheckPathNotCanonical,
+        head ++ "{\"type\":\"http\",\"path\":\"health\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterCheckPathNotCanonical,
+        head ++ "{\"type\":\"http\",\"path\":\"/a/../b\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterCheckPathNotCanonical,
+        head ++ "{\"type\":\"http\",\"path\":\"/health?x=1\"}" ++ tail,
+    );
+    // A Host is rendered into a request head, so it may not carry the
+    // bytes that would end one.
+    try expectParseError(
+        error.ClusterCheckHostInvalid,
+        head ++ "{\"type\":\"http\",\"path\":\"/h\",\"host\":\"a\\r\\nX: y\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterCheckHostInvalid,
+        head ++ "{\"type\":\"http\",\"path\":\"/h\",\"host\":\"\"}" ++ tail,
+    );
+    // A status outside the real range can never match a response.
+    try expectParseError(
+        error.ClusterCheckStatusInvalid,
+        head ++ "{\"type\":\"http\",\"path\":\"/h\",\"expect_status\":99}" ++ tail,
     );
 }
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -246,19 +246,42 @@ pub const endpoints_per_cluster_max: u16 = 64;
 /// cluster sets `check`.
 pub const health_probe_ops_max: u32 = 3;
 
-/// Consecutive failed probes that eject an endpoint from balancing (§7).
+/// Default consecutive failed probes that eject an endpoint from
+/// balancing (§7), when a cluster's `check` block omits `fall`.
 /// HAProxy's `fall` default: three misses is an outage, one is a blip.
-pub const health_probe_fall: u8 = 3;
+pub const health_probe_fall_default: u8 = 3;
 
-/// Consecutive successful probes that restore an ejected endpoint (§7).
+/// Default consecutive successful probes that restore an ejected
+/// endpoint (§7), when a cluster's `check` block omits `rise`.
 /// HAProxy's `rise` default: recovery must prove itself twice.
-pub const health_probe_rise: u8 = 2;
+pub const health_probe_rise_default: u8 = 2;
+
+/// Upper bound on a configured `fall`/`rise`. The streak counters are
+/// `u8`, so this is what keeps them from wrapping; it is also far past
+/// any useful tuning — a threshold in the dozens means the *interval* is
+/// the wrong knob, since detection latency is `fall × interval`.
+pub const health_probe_threshold_max: u8 = 64;
 
 /// Default `timeouts.health_interval_ms`: the pause between health-probe
-/// sweeps when the config omits it (§7). HAProxy's `inter` default. The
-/// probe's own connect budget is `timeouts.connect_ms` — a probe is a
-/// dial try, so it runs under the dial's deadline, not its own.
+/// sweeps when the config omits it (§7). HAProxy's `inter` default. What
+/// bounds a single probe is the check's own `timeout_ms`, which defaults
+/// to `timeouts.connect_ms`.
 pub const health_interval_ms_default: u32 = 2_000;
+
+/// Upper bound on a configured HTTP-check request path (§7). The probe
+/// renders one request into a fixed buffer, so the path it may carry is
+/// bounded like every other config string; a health endpoint's path is a
+/// handful of bytes in practice.
+pub const health_check_path_bytes_max: u16 = 256;
+
+/// Upper bound on a configured HTTP-check `Host` value (§7). Same bound
+/// as a routing host, and for the same reason — it is a DNS name.
+pub const health_check_host_bytes_max: u16 = host_bytes_max;
+
+/// The probe's rendered request buffer (§7): request line + Host +
+/// the two fixed headers, all bounded by the two limits above.
+pub const health_check_request_bytes_max: u32 =
+    64 + health_check_path_bytes_max + health_check_host_bytes_max;
 
 /// Upper bound on routes in one listener's path-routing table (§7). Config
 /// data, not a runtime pool: routes are immutable arena slices, and the
@@ -627,10 +650,21 @@ comptime {
     // or restore on no evidence, and the default probe interval is a legal
     // configured timeout.
     assert(health_probe_ops_max >= 1);
-    assert(health_probe_fall >= 1);
-    assert(health_probe_rise >= 1);
+    assert(health_probe_fall_default >= 1);
+    assert(health_probe_rise_default >= 1);
+    assert(health_probe_fall_default <= health_probe_threshold_max);
+    assert(health_probe_rise_default <= health_probe_threshold_max);
     assert(health_interval_ms_default >= 1);
     assert(health_interval_ms_default <= timeout_ms_max);
+    // The rendered probe request must fit its buffer whatever a config
+    // names, which is what makes the render infallible (§5).
+    assert(health_check_path_bytes_max >= 1);
+    assert(health_check_host_bytes_max >= 1);
+    assert(health_check_request_bytes_max >
+        @as(u32, health_check_path_bytes_max) + health_check_host_bytes_max);
+    // A probe response is parsed by the same head parser the data path
+    // uses, so its buffer may never exceed what that parser accepts.
+    assert(health_check_request_bytes_max <= head_bytes_max);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -250,7 +250,11 @@ const HttpOrigin = struct {
     /// `check` scenario's probes each accept-and-vanish too — hence four
     /// slots, not two. Tests that must prove reuse assert
     /// `accepted_count == 1`.
-    conns: [4]OConn = .{ .{}, .{}, .{}, .{} },
+    /// Client-driven dials (fresh, replay, post-ejection) plus one per
+    /// http health probe, which accepts and hangs up but still consumes a
+    /// slot — conns are tracked monotonically, never recycled. Tests that
+    /// must prove reuse assert `accepted_count == 1` regardless.
+    conns: [16]OConn = @splat(.{}),
     accepted_count: u32 = 0,
     requests_served: u32 = 0,
 
@@ -2405,7 +2409,7 @@ test "l7: ejecting an endpoint closes its parked connections" {
     // timer drains after the ejection has had time to land.
     bed.client.drain_on_finish = false;
     bed.armOriginStopTimer(25);
-    bed.armDrainTimer(300);
+    bed.armDrainTimer(220);
     try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
@@ -2919,4 +2923,98 @@ test "l7: an idle kept-alive connection closing owes no line" {
     const line = try onlyAccessLogLine(&bed);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"path\":\"/kept\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") != null);
+}
+
+test "health: an http probe passes on the expected status" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 61,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .check = .{
+            .kind = .http,
+            .timeout_ms = Http1Bed.connect_timeout_ms,
+            .http = .{ .path = "/health" },
+        },
+        .health_interval_ms = 30,
+    });
+    defer bed.tearDown();
+
+    // No client at all: the prober is the only traffic. Each probe dials,
+    // sends its GET, reads the 200 and hangs up, so the endpoint stays
+    // healthy and nothing is ever ejected.
+    bed.armDrainTimer(110);
+    try bed.sim_io.run();
+
+    // The count is the load-bearing assertion, not just "some probes
+    // ran": a probe that reaches its verdict and then idles until its
+    // budget expires still passes and still reports healthy, so only the
+    // *rate* catches it. At a 30ms interval inside a 110ms run a probe
+    // that settles immediately gets three sweeps away; one that waits out
+    // the 50ms budget manages two. That gap is the regression this pins —
+    // it was a real bug, found because this assertion was `>= 2`.
+    try std.testing.expect(bed.server.counters.get("health_probes_sent") >= 3);
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_probes_failed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    // The origin saw real requests — an http probe that never sent one
+    // would pass this test on a TCP accept alone.
+    try std.testing.expect(bed.origin.accepted_count >= 2);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
+        "GET /health HTTP/1.1\r\n",
+    ) != null);
+    try bed.expectDrained();
+}
+
+test "health: an http probe fails on a status it was not promised" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 62,
+        // The origin is listening and answering — a TCP check would call
+        // this endpoint healthy. Only reading the status can tell.
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .check = .{
+            .kind = .http,
+            .timeout_ms = Http1Bed.connect_timeout_ms,
+            .http = .{ .path = "/health" },
+        },
+        .health_interval_ms = 30,
+    });
+    defer bed.tearDown();
+
+    bed.armDrainTimer(130);
+    try bed.sim_io.run();
+
+    try std.testing.expect(bed.server.counters.get("health_probes_failed") >= 3);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(!bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.unhealthy_count);
+    try bed.expectDrained();
+}
+
+test "health: an http probe fails when the origin never answers" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 63,
+        // Reads the request in full and says nothing: the recv leg is
+        // armed with no answer coming, so only the probe's own budget
+        // ends it — and a data op is never canceled (§5), so the
+        // deadline must shut the socket down to force its completion.
+        .origin_mute = true,
+        .check = .{
+            .kind = .http,
+            .timeout_ms = 30,
+            .http = .{ .path = "/health" },
+        },
+        .health_interval_ms = 30,
+    });
+    defer bed.tearDown();
+
+    bed.armDrainTimer(220);
+    try bed.sim_io.run();
+
+    try std.testing.expect(bed.server.counters.get("health_probes_failed") >= 3);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try bed.expectDrained();
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -508,9 +508,9 @@ const Http1Bed = struct {
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
         access_log: bool = false,
-        /// §7 active health checks on the one cluster; off by default so
+        /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
-        check: bool = false,
+        check: ?config_module.Config.Cluster.Check = null,
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 40,
@@ -2392,7 +2392,7 @@ test "l7: ejecting an endpoint closes its parked connections" {
     try bed.setUp(std.testing.allocator, .{
         .seed = 55,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
-        .check = true,
+        .check = .{ .timeout_ms = Http1Bed.connect_timeout_ms },
         .health_interval_ms = 40,
     });
     defer bed.tearDown();

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -124,7 +124,7 @@ pub fn Checker(comptime IoType: type) type {
             assert(clusters.len >= 1);
             assert(clusters.len <= constants.clusters_max);
             for (clusters) |cluster| {
-                if (cluster.check) {
+                if (cluster.check != null) {
                     checker.checked_count += @intCast(cluster.endpoints.len);
                 }
             }
@@ -193,7 +193,7 @@ pub fn Checker(comptime IoType: type) type {
             const clusters = checker.server.config.clusters;
             while (checker.cursor_cluster < clusters.len) {
                 const cluster = &clusters[checker.cursor_cluster];
-                if (!cluster.check or checker.cursor_endpoint >= cluster.endpoints.len) {
+                if (cluster.check == null or checker.cursor_endpoint >= cluster.endpoints.len) {
                     checker.cursor_cluster += 1;
                     checker.cursor_endpoint = 0;
                     continue;
@@ -204,21 +204,34 @@ pub fn Checker(comptime IoType: type) type {
             checker.rest();
         }
 
+        /// The cluster's resolved check policy. Only a checked cluster is
+        /// ever probed, so the option is settled by the walk in
+        /// `probeNext` before anything here reads it.
+        fn checkOf(checker: *const Self, cluster_index: u16) *const config_module.Config.Cluster.Check {
+            assert(cluster_index < checker.server.config.clusters.len);
+            const check = &checker.server.config.clusters[cluster_index].check;
+            assert(check.* != null);
+            return &check.*.?;
+        }
+
         fn beginProbe(checker: *Self, cluster: *const config_module.Config.Cluster) void {
             assert(checker.state == .probing);
             assert(checker.armedCount() == 0);
-            assert(cluster.check);
+            assert(cluster.check != null);
             assert(checker.cursor_endpoint < cluster.endpoints.len);
             assert(checker.pending_verdict == .none);
             const server = checker.server;
+            const check = &cluster.check.?;
             server.counters.increment("health_probes_sent");
             checker.canceled = .{};
-            // The probe runs under the dial's own budget (§7): a probe is
-            // a connect try, and `connect_ms` is the connect budget.
+            // One budget covers the whole probe (§7) — the dial alone for
+            // a tcp check, dial + request + response for an http one —
+            // because what an operator cares about is how long an
+            // endpoint may take to prove itself, not which leg was slow.
             checker.armed.deadline = true;
             server.io.timerStart(
                 &checker.op_deadline,
-                @as(u64, server.config.connect_timeout_ms) * std.time.ns_per_ms,
+                @as(u64, check.timeout_ms) * std.time.ns_per_ms,
                 Self,
                 checker,
                 onProbeDeadline,
@@ -336,6 +349,8 @@ pub fn Checker(comptime IoType: type) type {
         }
 
         fn witnessPass(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
+            const rise = checker.checkOf(cluster_index).rise;
+            assert(rise >= 1);
             const key = upstream.endpointKey(cluster_index, endpoint_index);
             checker.fail_streaks[key] = 0;
             if (checker.healthy[key]) {
@@ -343,8 +358,8 @@ pub fn Checker(comptime IoType: type) type {
                 return;
             }
             checker.ok_streaks[key] += 1;
-            assert(checker.ok_streaks[key] <= constants.health_probe_rise);
-            if (checker.ok_streaks[key] < constants.health_probe_rise) return;
+            assert(checker.ok_streaks[key] <= rise);
+            if (checker.ok_streaks[key] < rise) return;
             checker.ok_streaks[key] = 0;
             checker.healthy[key] = true;
             assert(checker.unhealthy_count >= 1);
@@ -353,15 +368,17 @@ pub fn Checker(comptime IoType: type) type {
         }
 
         fn witnessFail(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
+            const fall = checker.checkOf(cluster_index).fall;
+            assert(fall >= 1);
             checker.server.counters.increment("health_probes_failed");
             const key = upstream.endpointKey(cluster_index, endpoint_index);
             checker.ok_streaks[key] = 0;
             // Already ejected: nothing further to count — streaks resume
             // meaning only once a pass starts a recovery.
             if (!checker.healthy[key]) return;
-            assert(checker.fail_streaks[key] < constants.health_probe_fall);
+            assert(checker.fail_streaks[key] < fall);
             checker.fail_streaks[key] += 1;
-            if (checker.fail_streaks[key] < constants.health_probe_fall) return;
+            if (checker.fail_streaks[key] < fall) return;
             checker.fail_streaks[key] = 0;
             checker.healthy[key] = false;
             checker.unhealthy_count += 1;

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -1,24 +1,35 @@
-//! Active TCP health checks (DESIGN.md §7, HAProxy's `check` model): one
-//! prober per server sweeps every endpoint of every `check` cluster,
-//! dialing each in turn under the `connect_ms` budget — a SYN/ACK is a
-//! pass, anything else (refused, unreachable, timed out, kernel
-//! pressure) is a fail. `health_probe_fall` consecutive fails eject an
-//! endpoint from balancing and close its parked pooled connections (the
-//! §5 obligation: a parked socket to a dead origin is a stale replay
-//! waiting to be spent); `health_probe_rise` consecutive passes restore
-//! it. Endpoints start healthy — probing demotes, never gates startup —
-//! and an unchecked endpoint is permanently healthy, so the balancer
-//! applies the mask unconditionally (§7 fail-open lives there, not
-//! here).
+//! Active health checks (DESIGN.md §7, HAProxy's `check` model): one
+//! prober per server sweeps every endpoint of every checked cluster,
+//! probing each in turn under the check's own `timeout_ms`. What a probe
+//! proves is the cluster's choice: a `tcp` check dials and takes the
+//! SYN/ACK as its answer, while an `http` check goes on to send a
+//! request and require the configured status — the difference between
+//! knowing the port accepts and knowing the application answered.
+//! Anything else (refused, unreachable, timed out, a wrong status, a
+//! head that will not parse, kernel pressure) is a fail. `fall`
+//! consecutive fails eject an endpoint from balancing and close its
+//! parked pooled connections (the §5 obligation: a parked socket to a
+//! dead origin is a stale replay waiting to be spent); `rise`
+//! consecutive passes restore it. Endpoints start healthy — probing
+//! demotes, never gates startup — and an unchecked endpoint is
+//! permanently healthy, so the balancer applies the mask unconditionally
+//! (§7 fail-open lives there, not here).
 //!
-//! One probe is in flight at a time, which is what keeps the prober's
-//! reservation closed-form (`health_probe_ops_max` ring ops, one fd,
-//! §8): sweeps serialize endpoint-by-endpoint, and the interval paces
-//! sweep-end to sweep-start. Cancels are serialized too — one cancel op,
-//! spent on whichever armed op must die next — so the armed set never
-//! exceeds the budget. The probe socket is closed synchronously in the
-//! connect delivery itself and never stored: the probe wanted the
-//! verdict, not a connection.
+//! One probe is in flight at a time, and its legs run in sequence — dial,
+//! then send, then recv — which is what keeps the prober's reservation
+//! closed-form whichever kind is configured (`health_probe_ops_max` ring
+//! ops, one fd, §8): the peak is one leg, the deadline, and at most one
+//! cancel. Sweeps serialize endpoint-by-endpoint and the interval paces
+//! sweep-end to sweep-start.
+//!
+//! Ending a probe early depends on which leg is armed, because data ops
+//! are never canceled (§4, §5). A dial takes the one legal cancel; a
+//! send or recv is ended by shutting the socket down, which makes it
+//! complete. So a `tcp` probe's socket is closed inside the dial's own
+//! delivery and never stored — it wanted the verdict, not a connection —
+//! while an `http` probe holds its socket across the data legs and
+//! closes it once every armed op has drained, the same
+//! release-when-quiescent rule `continueTeardown` follows.
 
 const std = @import("std");
 
@@ -393,6 +404,11 @@ pub fn Checker(comptime IoType: type) type {
             }
             assert(checker.state == .probing);
             const sent = result catch |err| {
+                // Never a cancel: data ops are ended by the shutdown in
+                // `endArmedLeg`, never by one (§4, §5). A Canceled here
+                // would mean some path reached for a cancel op that this
+                // design says does not exist for a data leg.
+                assert(err != error.Canceled);
                 // The origin hung up on the request, or the deadline shut
                 // this socket down. Either way the probe has its answer.
                 if (checker.pending_verdict == .none) {
@@ -444,6 +460,7 @@ pub fn Checker(comptime IoType: type) type {
             }
             assert(checker.state == .probing);
             const received = result catch |err| {
+                assert(err != error.Canceled); // Same rule as the send leg.
                 // EOF or reset before a whole head arrived: an origin
                 // that hangs up mid-status has not answered the check.
                 if (checker.pending_verdict == .none) {
@@ -537,11 +554,19 @@ pub fn Checker(comptime IoType: type) type {
         /// it complete. Both are idempotent here, because a deadline and
         /// a drain can each reach this for the same probe.
         fn endArmedLeg(checker: *Self) void {
+            // Only ever called with a leg outstanding: a deadline fires
+            // against the leg it was armed beside, and the drain ladder
+            // reaches here only under its own armed guard.
+            assert(checker.armed.connect or checker.armed.send or checker.armed.recv);
+            assert(checker.state == .probing or checker.state == .stopping);
             if (checker.armed.connect and !checker.armed.cancel and !checker.canceled.connect) {
                 checker.armCancelConnect();
                 return;
             }
             if ((checker.armed.send or checker.armed.recv) and !checker.probe_shutdown) {
+                // A data leg exists only for an http probe, which is the
+                // only kind that holds a socket to shut down.
+                assert(checker.probe_socket != null);
                 checker.probe_shutdown = true;
                 checker.server.io.shutdown(checker.probe_socket.?, .both);
             }
@@ -553,6 +578,7 @@ pub fn Checker(comptime IoType: type) type {
         /// against this fd (§5).
         fn closeProbeSocket(checker: *Self) void {
             assert(checker.armedCount() == 0);
+            assert(checker.state == .probing or checker.state == .stopping);
             if (checker.probe_socket) |socket| {
                 checker.server.io.closeNow(socket);
                 checker.probe_socket = null;
@@ -741,8 +767,10 @@ pub fn Checker(comptime IoType: type) type {
             // makes it complete, and its delivery re-enters here. It
             // therefore does not `return` — the shutdown consumes no
             // completion to wait on, so the armed check below is what
-            // decides whether anything is still outstanding.
-            if ((checker.armed.send or checker.armed.recv) and !checker.probe_shutdown) {
+            // decides whether anything is still outstanding. The guard
+            // lives inside `endArmedLeg`, which is idempotent, so this
+            // states only that a leg is what it is being called for.
+            if (checker.armed.send or checker.armed.recv) {
                 checker.endArmedLeg();
             }
             if (checker.armedCount() != 0) return;

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -25,6 +25,7 @@ const std = @import("std");
 const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const Io = @import("../io/io.zig");
+const parser = @import("../http/parser.zig");
 const upstream = @import("upstream.zig");
 
 const assert = std.debug.assert;
@@ -55,9 +56,27 @@ pub fn Checker(comptime IoType: type) type {
         cursor_cluster: u16,
         cursor_endpoint: u16,
         /// The in-flight probe's outcome, decided by whichever of the
-        /// dial or its deadline lands first; applied only once every
-        /// armed op has drained (the §5 release discipline).
+        /// dial, its data legs, or its deadline lands first; applied only
+        /// once every armed op has drained (the §5 release discipline).
         pending_verdict: Verdict,
+        /// The http probe's socket, held across its send and recv legs.
+        /// Null for a tcp probe, which closes inline in the dial's own
+        /// delivery — it wanted the SYN/ACK, not a connection.
+        probe_socket: ?IoType.Socket,
+        /// Whether this probe's socket has been shut down already. Data
+        /// ops are never canceled (§4/§5): a deadline or a drain that
+        /// must end an armed send or recv shuts the socket down instead,
+        /// which makes the op complete — and must do so exactly once.
+        probe_shutdown: bool,
+        /// The rendered request, and how much of it has gone out.
+        request: [constants.health_check_request_bytes_max]u8,
+        request_len: u32,
+        request_sent: u32,
+        /// The response head as it accumulates. Sized to what the data
+        /// path's own parser accepts, so a head this proxy would forward
+        /// is never one the probe rejects for being too big.
+        response: [constants.head_bytes_max]u8,
+        response_len: u32,
         armed: Armed,
         /// Ops a cancel was already spent on (never `.cancel` itself):
         /// what keeps the serialized drain from re-canceling an op whose
@@ -65,6 +84,11 @@ pub fn Checker(comptime IoType: type) type {
         canceled: Armed,
         op_rest: IoType.Completion,
         op_connect: IoType.Completion,
+        /// The http probe's two data legs. They never co-arm — the
+        /// request goes out in full before a byte is read — so one
+        /// completion each is the whole story.
+        op_send: IoType.Completion,
+        op_recv: IoType.Completion,
         op_deadline: IoType.Completion,
         /// The one cancel completion, reused across targets — legal
         /// because cancels are serialized (`armed.cancel` gates every
@@ -94,13 +118,18 @@ pub fn Checker(comptime IoType: type) type {
 
         /// One bit per embedded op; the prober is quiescent only when
         /// clear. At most three are ever set (`health_probe_ops_max`):
-        /// rest never co-arms with the probe ops, and the cancel is
-        /// serialized.
-        pub const Armed = packed struct(u4) {
+        /// rest never co-arms with a probe, the probe's own legs run one
+        /// at a time (dial, then send, then recv), and the cancel is
+        /// serialized — so the peak is one leg + the deadline + one
+        /// cancel however far an http probe gets.
+        pub const Armed = packed struct(u8) {
             rest: bool = false,
             connect: bool = false,
+            send: bool = false,
+            recv: bool = false,
             deadline: bool = false,
             cancel: bool = false,
+            _pad: u2 = 0,
         };
 
         pub fn init(checker: *Self, server: *ServerType) void {
@@ -114,10 +143,17 @@ pub fn Checker(comptime IoType: type) type {
             checker.cursor_cluster = 0;
             checker.cursor_endpoint = 0;
             checker.pending_verdict = .none;
+            checker.probe_socket = null;
+            checker.probe_shutdown = false;
+            checker.request_len = 0;
+            checker.request_sent = 0;
+            checker.response_len = 0;
             checker.armed = .{};
             checker.canceled = .{};
             checker.op_rest = .{};
             checker.op_connect = .{};
+            checker.op_send = .{};
+            checker.op_recv = .{};
             checker.op_deadline = .{};
             checker.op_cancel = .{};
             const clusters = server.config.clusters;
@@ -171,7 +207,7 @@ pub fn Checker(comptime IoType: type) type {
         }
 
         pub fn armedCount(checker: *const Self) u32 {
-            return @popCount(@as(u4, @bitCast(checker.armed)));
+            return @popCount(@as(u8, @bitCast(checker.armed)));
         }
 
         fn startSweep(checker: *Self) void {
@@ -250,10 +286,23 @@ pub fn Checker(comptime IoType: type) type {
         fn onProbeConnect(checker: *Self, result: Io.ConnectError!IoType.Socket) void {
             assert(checker.armed.connect);
             checker.armed.connect = false;
-            // A socket that arrived is closed on the spot whatever the
-            // state: the probe wanted the SYN/ACK verdict, not a
-            // connection, and an unstored socket cannot leak (§9).
+            const http_check = checker.state == .probing and
+                checker.pending_verdict == .none and
+                checker.checkOf(checker.cursor_cluster).kind == .http;
             if (result) |socket| {
+                if (http_check) {
+                    // The http probe's dial is the beginning of the
+                    // probe, not its verdict: the socket is stored and
+                    // carries the request and response legs.
+                    checker.probe_socket = socket;
+                    checker.beginRequest(socket);
+                    checker.settle();
+                    return;
+                }
+                // A tcp probe wanted the SYN/ACK, not a connection — and
+                // a socket that was never stored cannot leak (§9). The
+                // same holds for a dial that lands after its own verdict
+                // or into a drain: there is nothing left to send it.
                 checker.server.io.closeNow(socket);
             } else |_| {}
             if (checker.state == .stopping) {
@@ -282,10 +331,165 @@ pub fn Checker(comptime IoType: type) type {
                     checker.server.witnessKernelPressure(.connect, err);
                 },
             }
-            if (checker.armed.deadline and !checker.armed.cancel) {
-                checker.armCancelDeadline();
+            checker.settle();
+        }
+
+        /// Render this probe's request and start writing it. The render
+        /// cannot fail: `health_check_request_bytes_max` is derived from
+        /// the path and Host bounds the loader already enforced (§5).
+        fn beginRequest(checker: *Self, socket: IoType.Socket) void {
+            assert(checker.state == .probing);
+            assert(!checker.armed.send);
+            assert(!checker.armed.recv);
+            const check = checker.checkOf(checker.cursor_cluster);
+            assert(check.kind == .http);
+            const http = check.http.?;
+            const cluster = &checker.server.config.clusters[checker.cursor_cluster];
+            const endpoint = cluster.endpoints[checker.cursor_endpoint];
+            // `Connection: close` because the probe never reuses this
+            // socket: it asks one question and hangs up, which also frees
+            // the origin from parking a connection nobody will return to.
+            const rendered = if (http.host) |host|
+                std.fmt.bufPrint(
+                    &checker.request,
+                    "GET {s} HTTP/1.1\r\nHost: {s}\r\nConnection: close\r\n\r\n",
+                    .{ http.path, host },
+                ) catch unreachable
+            else
+                std.fmt.bufPrint(
+                    &checker.request,
+                    "GET {s} HTTP/1.1\r\nHost: {f}\r\nConnection: close\r\n\r\n",
+                    .{ http.path, endpoint },
+                ) catch unreachable;
+            checker.request_len = @intCast(rendered.len);
+            checker.request_sent = 0;
+            checker.response_len = 0;
+            assert(checker.request_len >= 1);
+            checker.armSend(socket);
+        }
+
+        fn armSend(checker: *Self, socket: IoType.Socket) void {
+            assert(checker.state == .probing);
+            assert(!checker.armed.send);
+            assert(checker.request_sent < checker.request_len);
+            checker.armed.send = true;
+            checker.server.io.send(
+                socket,
+                checker.request[checker.request_sent..checker.request_len],
+                &checker.op_send,
+                Self,
+                checker,
+                onProbeSend,
+            );
+            assert(checker.armedCount() <= constants.health_probe_ops_max);
+        }
+
+        fn onProbeSend(checker: *Self, result: Io.SendError!u32) void {
+            assert(checker.armed.send);
+            checker.armed.send = false;
+            if (checker.state == .stopping) {
+                checker.continueStop();
+                return;
+            }
+            assert(checker.state == .probing);
+            const sent = result catch |err| {
+                // The origin hung up on the request, or the deadline shut
+                // this socket down. Either way the probe has its answer.
+                if (checker.pending_verdict == .none) {
+                    checker.pending_verdict = .fail;
+                    checker.server.witnessKernelPressure(.send, err);
+                }
+                checker.settle();
+                return;
+            };
+            checker.request_sent += sent;
+            assert(checker.request_sent <= checker.request_len);
+            // A verdict already reached (the deadline fired and shut this
+            // socket down) ends the probe here: arming another leg would
+            // only spend an op to be told what is already known.
+            if (checker.pending_verdict == .none) {
+                const socket = checker.probe_socket.?;
+                if (checker.request_sent < checker.request_len) {
+                    // A short write is ordinary (§6): resume where it left off.
+                    checker.armSend(socket);
+                } else {
+                    checker.armRecv(socket);
+                }
             }
             checker.settle();
+        }
+
+        fn armRecv(checker: *Self, socket: IoType.Socket) void {
+            assert(checker.state == .probing);
+            assert(!checker.armed.recv);
+            assert(checker.response_len < checker.response.len);
+            checker.armed.recv = true;
+            checker.server.io.recv(
+                socket,
+                checker.response[checker.response_len..],
+                &checker.op_recv,
+                Self,
+                checker,
+                onProbeRecv,
+            );
+            assert(checker.armedCount() <= constants.health_probe_ops_max);
+        }
+
+        fn onProbeRecv(checker: *Self, result: Io.RecvError!u32) void {
+            assert(checker.armed.recv);
+            checker.armed.recv = false;
+            if (checker.state == .stopping) {
+                checker.continueStop();
+                return;
+            }
+            assert(checker.state == .probing);
+            const received = result catch |err| {
+                // EOF or reset before a whole head arrived: an origin
+                // that hangs up mid-status has not answered the check.
+                if (checker.pending_verdict == .none) {
+                    checker.pending_verdict = .fail;
+                    checker.server.witnessKernelPressure(.recv, err);
+                }
+                checker.settle();
+                return;
+            };
+            checker.response_len += received;
+            assert(checker.response_len <= checker.response.len);
+            if (checker.pending_verdict == .none) {
+                checker.judgeResponse();
+            }
+            if (checker.pending_verdict == .none) {
+                // The head is still arriving. A full buffer with no head
+                // in it is the §7 oversize-head verdict, not a shortfall.
+                if (checker.response_len == checker.response.len) {
+                    checker.pending_verdict = .fail;
+                } else {
+                    checker.armRecv(checker.probe_socket.?);
+                }
+            }
+            checker.settle();
+        }
+
+        /// Judge what has arrived so far, leaving the verdict `.none`
+        /// while the head is merely incomplete. The head parser is the
+        /// data path's own (§7), so a probe accepts exactly the responses
+        /// this proxy would forward — and nothing it would reject.
+        fn judgeResponse(checker: *Self) void {
+            assert(checker.state == .probing);
+            assert(checker.pending_verdict == .none);
+            const expect_status = checker.checkOf(checker.cursor_cluster).http.?.expect_status;
+            var storage: parser.HeaderStorage = undefined;
+            const head = parser.parseResponseHead(
+                checker.response[0..checker.response_len],
+                false,
+                &storage,
+                .get,
+            ) catch |err| {
+                if (err == error.Incomplete) return;
+                checker.pending_verdict = .fail;
+                return;
+            };
+            checker.pending_verdict = if (head.status == expect_status) .pass else .fail;
         }
 
         fn onProbeDeadline(checker: *Self, result: Io.TimerError!void) void {
@@ -299,15 +503,12 @@ pub fn Checker(comptime IoType: type) type {
             assert(checker.state == .probing);
             if (result) |_| {
                 if (checker.pending_verdict == .none) {
-                    // Fired first: the dial outlived its budget — the
-                    // probe fails and the dial is torn down so even a
-                    // black-holed endpoint reaches a terminal
-                    // completion (§5).
+                    // Fired first: the probe outlived its budget. It
+                    // fails, and whatever leg is armed is forced to a
+                    // terminal completion so even a black-holed endpoint
+                    // or a mute origin releases the prober (§5).
                     checker.pending_verdict = .fail;
-                    assert(checker.armed.connect);
-                    if (!checker.armed.cancel) {
-                        checker.armCancelConnect();
-                    }
+                    checker.endArmedLeg();
                 }
                 // Otherwise the fire raced its own cancel (a legal §4
                 // race): the outcome is decided, this delivery is op
@@ -330,13 +531,54 @@ pub fn Checker(comptime IoType: type) type {
             checker.settle();
         }
 
+        /// End whichever leg is armed, by the only means each allows: a
+        /// dial takes the one legal cancel (§4), while a send or recv is
+        /// never canceled (§5) — shutting the socket down is what makes
+        /// it complete. Both are idempotent here, because a deadline and
+        /// a drain can each reach this for the same probe.
+        fn endArmedLeg(checker: *Self) void {
+            if (checker.armed.connect and !checker.armed.cancel and !checker.canceled.connect) {
+                checker.armCancelConnect();
+                return;
+            }
+            if ((checker.armed.send or checker.armed.recv) and !checker.probe_shutdown) {
+                checker.probe_shutdown = true;
+                checker.server.io.shutdown(checker.probe_socket.?, .both);
+            }
+        }
+
+        /// The probe's socket, once no op can reference it. Closing is
+        /// synchronous for the same reason `continueTeardown`'s is: by
+        /// here the armed set is empty, so nothing is left to deliver
+        /// against this fd (§5).
+        fn closeProbeSocket(checker: *Self) void {
+            assert(checker.armedCount() == 0);
+            if (checker.probe_socket) |socket| {
+                checker.server.io.closeNow(socket);
+                checker.probe_socket = null;
+            }
+            checker.probe_shutdown = false;
+        }
+
         /// The delivery that empties the armed set applies the verdict
         /// and moves the sweep along — never earlier, so no completion
         /// can land on a probe that already advanced (§5).
         fn settle(checker: *Self) void {
             assert(checker.state == .probing);
+            // A decided probe has no use for its budget. Cancelling here
+            // rather than at each verdict site is what makes every leg —
+            // dial, send, recv — advance the sweep the moment it knows,
+            // instead of idling until the deadline fires: an http probe
+            // that answered in a microsecond must not hold the prober
+            // for the whole `timeout_ms`.
+            if (checker.pending_verdict != .none and
+                checker.armed.deadline and !checker.armed.cancel)
+            {
+                checker.armCancelDeadline();
+            }
             if (checker.armedCount() != 0) return;
             assert(checker.pending_verdict != .none);
+            checker.closeProbeSocket();
             const verdict = checker.pending_verdict;
             checker.pending_verdict = .none;
             if (verdict == .pass) {
@@ -495,8 +737,19 @@ pub fn Checker(comptime IoType: type) type {
                 checker.armCancelConnect();
                 return;
             }
+            // A data leg takes no cancel op at all (§5): the shutdown
+            // makes it complete, and its delivery re-enters here. It
+            // therefore does not `return` — the shutdown consumes no
+            // completion to wait on, so the armed check below is what
+            // decides whether anything is still outstanding.
+            if ((checker.armed.send or checker.armed.recv) and !checker.probe_shutdown) {
+                checker.endArmedLeg();
+            }
             if (checker.armedCount() != 0) return;
             assert(checker.isQuiescent());
+            // Nothing can reference the probe's fd once every op has
+            // drained, which is what makes closing it here safe (§5).
+            checker.closeProbeSocket();
             checker.state = .stopped;
             checker.server.maybeStopAfterDrain();
         }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -208,9 +208,9 @@ pub const TestBed = struct {
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it.
         access_log: bool = false,
-        /// §7 active health checks on the one cluster; off by default so
+        /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
-        check: bool = false,
+        check: ?config_module.Config.Cluster.Check = null,
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 20,
@@ -883,7 +883,7 @@ test "health: probes against a listening origin keep the endpoint healthy" {
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .sim = .{ .seed = 71 },
-        .check = true,
+        .check = .{ .timeout_ms = 50 },
         .health_interval_ms = 50,
     });
     defer bed.tearDown();
@@ -910,7 +910,7 @@ test "health: consecutive refusals eject the endpoint" {
     try bed.setUp(std.testing.allocator, .{
         .sim = .{ .seed = 72 },
         .origin_listens = false,
-        .check = true,
+        .check = .{ .timeout_ms = 50 },
         .health_interval_ms = 20,
     });
     defer bed.tearDown();
@@ -937,7 +937,7 @@ test "health: rise restores an ejected endpoint after passing probes" {
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .sim = .{ .seed = 73 },
-        .check = true,
+        .check = .{ .timeout_ms = 50 },
         .health_interval_ms = 20,
     });
     defer bed.tearDown();


### PR DESCRIPTION
Closes #128.

A TCP check proves the port accepts. An origin that is listening but
answering 500s — wedged before its router, a dependency down, a
half-finished deploy — passes every one of them. This adds the check that
asks a question and reads the answer, and makes HAProxy's `fall`/`rise`
an operator's to tune rather than a compiled constant.

```json
"api": {
  "endpoints": ["10.0.0.1:80"],
  "check": { "type": "http", "path": "/health", "expect_status": 200,
             "fall": 3, "rise": 2, "timeout_ms": 1000 }
}
```

## The config surface breaks, deliberately

`"check": true` becomes `"check": { ... }`. Carrying both spellings would
have cost a custom `jsonParse` plus a special case in the schema emitter,
to describe a shape nobody would write twice — and the bool shipped a day
ago in #127, used only by `config/example.json`. DESIGN.md's own rule
against dormant mechanisms ("every later change has to stay compatible
with a mechanism that may never exist") reads the same for config.

`timeout_ms` bounds one whole probe and defaults to `timeouts.connect_ms`
— which is why timeouts now resolve *before* clusters: a check can only
inherit a value already known to be in range. The `http` fields are
rejected under `type: tcp` rather than ignored; a config naming a path
for a probe that will never send one describes something the process is
not doing.

## The op budget does not move

`health_probe_ops_max` stays 3 and no new fd is reserved, because a
probe's legs are **sequential** — dial, then send, then recv — so the
armed peak is still one leg + the deadline + at most one cancel. What
changes is socket lifetime: an http probe holds its socket across
callbacks and closes it once every op has drained, the same
release-when-quiescent rule `continueTeardown` follows.

Ending a probe early splits by leg, because **data ops are never
cancelled** (§4/§5): a dial takes the one legal cancel, while a send or
recv is ended by *shutting the socket down*, which makes it complete.
`endArmedLeg` owns that choice and is idempotent, since a deadline and a
drain can each reach it for the same probe.

Responses are judged by the data path's own `parseResponseHead`, so a
probe accepts exactly the heads this proxy would forward; a head that
overruns the buffer fails the probe rather than being read forever.

## A bug the sweep would not have caught

The data legs reached their verdict but never cancelled the deadline, so
every http probe idled until its whole `timeout_ms` elapsed. A *passing*
check still reported healthy — the verdict was already `.pass` when the
timer fired — so nothing about correctness looked wrong; only the probe
**rate** revealed it. The first version of the passing test asserted
`>= 2` probes, which a broken 30 ms cycle still satisfies. It now pins
`>= 3`, and I verified both http tests fail with the fix reverted.

That is the `>=`-oracle failure mode from #129's notes, hit again in the
same shape.

## Coverage

Directed: probe passes on the expected status (asserting nginx-style
origins saw a real `GET /health`), fails on a status it was not promised,
fails when the origin reads the request and never answers (the deadline
must shut the socket down to end an armed recv).

Sim: half of checked http clusters probe over http, so the send/recv legs
and the mid-leg shutdown take the schedule fuzz. Reaching the
*wrong-status* verdict needed a trick — every other failure is a
transport failure, which the existing origin already produces — so a
quarter of those seeds expect a status the origin never sends. Measured
over 1024 seeds (each run twice): 452 runs probe over http, 1150 probes
sent / 380 failed, **24 of the 100 impossible-status runs reach an
ejection through the mismatch branch**, and 250 of the 352 expecting 200
finish with no failure at all.

## Live verification

`zig build ci` (4096 seeds) and `zig fmt --check` green; tiger-style
review run and its findings fixed (a doc comment that had gone stale
within one commit, missing pre/postconditions on the new teardown
helpers, negative-space asserts that the data legs never see `Canceled`).

Then the real binary against nginx, since none of the http legs had ever
touched io_uring:

- nginx's access log shows real `GET /health HTTP/1.1` → `200`, at the
  correct rate (5 probes in ~2 s at 500 ms pacing — a broken cycle gives 2).
- `/health` switched to `503` by an nginx reload, **port still open**:
  ejected after exactly 3 failures, ~1.6 s later, while `curl` to `/` on
  the same port still returned 200. A TCP check calls that endpoint
  healthy; this is the entire point of the feature.
- restored ~0.8 s after `/health` went back to 200 — exactly `rise` = 2.
- SIGTERM with a probe's **recv leg armed** against a mute origin and a
  60 s budget: exited in the same second, so the shutdown really did end
  the data op rather than waiting out the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)