### PR TITLE
lb: max_inflight — cap the work one endpoint may be asked to carry (§7, §8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ is chosen. Up to 16 clusters, 64 endpoints each.
 
 | `pick` | behavior |
 |---|---|
-| `p2c` *(default)* | two uniform candidates; the one with fewer requests in flight wins |
+| `p2c` *(default)* | two uniform candidates; the one carrying less in-flight work wins — HTTP requests and L4 connections both count |
 | `rr` | strict rotation — predictable spread, useful for cache warming |
 | `hash` | the same client always reaches the same endpoint |
 
@@ -184,6 +184,35 @@ budget of `timeouts.connect_ms` unless `timeout_ms` overrides it.
 
 If *every* endpoint in a cluster is ejected, zoxy fails open and uses them
 all — routing nowhere would turn a probe verdict into an outage of its own.
+
+### Protecting a backend from overload
+
+`max_inflight` caps the concurrent work zoxy will ask of **one endpoint**.
+It is the per-server unit, so a three-endpoint cluster with a cap of 100
+admits up to 300 — the same shape as HAProxy's `server ... maxconn`.
+
+```json
+"api": {
+    "endpoints": ["10.0.0.1:8080", "10.0.0.2:8080"],
+    "max_inflight": 100
+}
+```
+
+An endpoint at its cap is skipped, so requests keep flowing while any
+endpoint has room. Only when *every* endpoint is full does zoxy refuse: an
+HTTP request is answered `503` and an L4 connection is closed, since a byte
+relay has no way to say "try later". Absent, a cluster is uncapped.
+
+This is the one limit that fails **closed**, and the difference from health
+checks is deliberate: an ejected cluster means *we do not know whether these
+work*, so trying is better than refusing — while a capped one means *we know
+they are full*, and sending more is precisely what the cap exists to prevent.
+
+Both protocols count against the same figure: an in-flight HTTP request and
+a live L4 connection are each one unit of work the backend is carrying.
+`zoxy_l7_shed_endpoint_inflight` and `zoxy_l4_shed_endpoint_inflight` count
+refusals — kept apart from `zoxy_l7_shed_upstream_slots`, which means zoxy
+ran out of its own slots and wants a wider pool rather than a busier backend.
 
 ### Filters
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -660,6 +660,18 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   for strict rotation, `hash` for stickiness. Cluster endpoints are
   static socket addresses resolved once at config load, never on the
   loop (dynamic DNS is a non-goal, §1).
+- **A pick chooses among the endpoints that are both healthy and under
+  capacity**, in that order, and the two filters differ in what an empty
+  result means. Health fails **open**: a cluster with every endpoint
+  ejected balances as if none were. `max_inflight` (§8) fails **closed**:
+  every endpoint at its cap refuses the request rather than dialing one.
+  The asymmetry is the point — an ejection says *we do not know whether
+  these work*, so trying beats refusing, while a cap says *we know they
+  are full*, and the whole reason it exists is to not send more. Capacity
+  is judged over whatever health left, so a cluster that fails open still
+  respects its caps. The in-flight total both this and `p2c` read counts
+  L7 leases and live L4 connections alike, which is what lets an L4-only
+  deployment be protected and load-balanced at all.
 - **`hash` is rendezvous hashing, and it is stateless because it has to
   be.** Client-to-backend stickiness is normally a *table* — the proxy
   records which server a client went to. That mechanism cannot work

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -747,16 +747,25 @@ the loop thread.
 | relay buffers (L4) | accept admission | close immediately |
 | relay buffers (L7) | request admission on a kept-alive conn | static `503` from the head buffer, then keep or close per pressure |
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7), then keep or close per pressure / close (L4) |
+| **origin capacity** — every endpoint at its `max_inflight` | endpoint pick | static `503` (L7) / close (L4) |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
-Every rung but one sheds on a *resource* running out. That is a real gap
-and it was measured, not theorised: at c10k the upstream pool's ceiling
-was the only thing saying no, and once it was given enough headroom to
-stop firing (§5), nothing bounded an overloaded exchange at all —
-latency grew until the *client* gave up, and this proxy went on spending
-CPU answering requests whose callers had left. The numbers are in
-IMPLEMENTATION_NOTES.md.
+Most rungs shed on a *resource of this proxy's* running out. That was
+once every rung, and it was a real gap — measured, not theorised: at
+c10k the upstream pool's ceiling was the only thing saying no, and once
+it was given enough headroom to stop firing (§5), nothing bounded an
+overloaded exchange at all — latency grew until the *client* gave up,
+and this proxy went on spending CPU answering requests whose callers had
+left. The numbers are in IMPLEMENTATION_NOTES.md.
+
+Two rungs answer on something else. One is **time** (below). The other
+is the **origin's** capacity rather than this proxy's: `max_inflight`
+caps the work one endpoint may carry, counted across both protocols
+(§7), and refuses past it. The distinction is the point — running out of
+upstream slots says *widen the pool*, while a capped endpoint says *the
+backend is full*, and the two have their own counters so an operator
+cannot read one as the other.
 
 The rung that answers on **time** rather than on exhaustion is the
 request deadline, and `timeouts.request_ms` is what arms it: an absolute

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -654,7 +654,9 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   replay is spent before its try begins (no loop) and always dials
   fresh — the endpoint's whole idle list may be stale the same way. The
   endpoint pick is per-cluster config: `p2c` (two uniform candidates
-  from a fixed-seed PRNG, the lower leased count wins) by default, `rr`
+  from a fixed-seed PRNG, the lower **in-flight total** wins — L7 leases
+  and live L4 connections summed, since both are work the origin is
+  carrying) by default, `rr`
   for strict rotation, `hash` for stickiness. Cluster endpoints are
   static socket addresses resolved once at config load, never on the
   loop (dynamic DNS is a non-goal, §1).

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -213,8 +213,20 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     const health = deriveHealthChecks(harness.clean, random, connect_timeout_ms);
     harness.http_origin_stop_at_ns = health.http_origin_stop_at_ns;
     harness.clusters = .{
-        .{ .name = "origin-l4", .endpoints = &harness.endpoints_l4, .pick = pick_l4, .check = health.check_l4 },
-        .{ .name = "origin-http", .endpoints = &harness.endpoints_http, .pick = pick_http, .check = health.check_http },
+        .{
+            .name = "origin-l4",
+            .endpoints = &harness.endpoints_l4,
+            .pick = pick_l4,
+            .check = health.check_l4,
+            .max_inflight = deriveMaxInflight(harness.clean, random),
+        },
+        .{
+            .name = "origin-http",
+            .endpoints = &harness.endpoints_http,
+            .pick = pick_http,
+            .check = health.check_http,
+            .max_inflight = deriveMaxInflight(harness.clean, random),
+        },
     };
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
@@ -249,6 +261,26 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
         .health_interval_ms = health.interval_ms,
     };
+}
+
+/// The §8 per-endpoint cap for one cluster, or null for uncapped.
+///
+/// Only adversarial seeds cap, and the reason is the oracle rather than
+/// the mechanism: a refusal is a `503` an L7 script did not ask for and a
+/// close an L4 client did not expect, both of which a clean seed's golden
+/// outcomes forbid. Under the adversary they are ordinary fates — the
+/// prefix oracles already tolerate a cut, and a cap-shed `503` is the
+/// same shape as the pool-exhaustion one those seeds already produce.
+///
+/// The value is drawn *below* the client population on purpose. A cap
+/// the scenario cannot reach exercises the comparison and nothing else;
+/// at one or two against up to six clients, both refusal paths run
+/// against real contention, and every seed still crosses back under the
+/// cap as connections finish — so the recovery side runs too.
+fn deriveMaxInflight(clean: bool, random: std.Random) ?u32 {
+    if (clean) return null;
+    if (random.uintLessThan(u8, 3) != 0) return null;
+    return 1 + random.uintAtMost(u32, 1);
 }
 
 /// Which check the http cluster runs, if any. An outage seed always

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -659,13 +659,27 @@ pub fn Server(comptime IoType: type) type {
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
             assert(conn.state == .connecting);
-            conn.arm(&conn.op_connect, "connect");
             const pick = server.balancer.pick(
                 cluster_index,
                 &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
-            );
+            ) orelse {
+                // Every endpoint is at its §8 cap. An L4 listener has no
+                // way to say so — it relays bytes, and there is no
+                // protocol to answer in — so the ladder's L4 answer
+                // applies: close. Counted outside the gate identity,
+                // because this connection was admitted before an endpoint
+                // was ever picked (§8).
+                server.counters.increment("l4_shed_endpoint_inflight");
+                // Nothing was armed for this dial yet — the arm below is
+                // the first — so teardown here cancels only the deadline
+                // admission left running (§5).
+                assert(!conn.armed.connect);
+                server.beginTeardown(conn);
+                return;
+            };
+            conn.arm(&conn.op_connect, "connect");
             // An L4 dial holds no slot to record the endpoint on, so the
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -42,6 +42,17 @@ pub fn Server(comptime IoType: type) type {
         /// The shared upstream connection pool (§3, §5): leased per L7
         /// exchange today; parking joins with keep-alive.
         upstreams: upstream_module.UpstreamPool(IoType),
+        /// Live L4 relayed connections per endpoint (§7), the other half
+        /// of `upstream_module.Load`. The pool cannot hold this: an L4
+        /// connection leases no upstream slot, so it is the server —
+        /// which owns the conn slots such a connection *does* hold —
+        /// that counts them. Charged at the dial, released with the conn
+        /// slot, so the two move together.
+        ///
+        /// `u16` for the same reason `leased_counts` is: one charge per
+        /// live conn slot bounds every entry by `conn_slots_max`, which
+        /// `constants` asserts fits (`conn_slots_max - 1 <= maxInt(u16)`).
+        l4_inflight: [upstream_module.endpoint_keys_max]u16,
         listeners: []ListenerState,
         listeners_count: u16,
         /// The load-balancing policy: resolves a cluster to the endpoint to
@@ -156,6 +167,7 @@ pub fn Server(comptime IoType: type) type {
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
             try server.upstreams.init(arena, options.upstream_slots);
+            @memset(&server.l4_inflight, 0);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
             server.listeners_count = @intCast(config.listeners.len);
             server.balancer.init(config);
@@ -331,11 +343,24 @@ pub fn Server(comptime IoType: type) type {
             server.ensureUpstreamSweep();
         }
 
+        /// Every L4 endpoint charge has been released (§7). A scan, not a
+        /// running total: a second counter would be one more thing that
+        /// can disagree with the table it summarises, and this is asked
+        /// only at the idle checks, never on the serving path.
+        pub fn l4Released(server: *const Self) bool {
+            for (server.l4_inflight) |count| {
+                if (count != 0) return false;
+            }
+            return true;
+        }
+
         /// The simulator's leak invariant (§9). The admin conn holds no
         /// pool slot, but a leaked armed op or an open admin fd is a leak
-        /// all the same, so its quiescence is part of "idle".
+        /// all the same, so its quiescence is part of "idle" — and so is
+        /// an endpoint left carrying a charge for a connection that ended.
         pub fn isIdle(server: *const Self) bool {
-            return server.conns.isFullyReleased() and
+            return server.l4Released() and
+                server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
                 server.admin.isQuiescent() and
@@ -635,12 +660,9 @@ pub fn Server(comptime IoType: type) type {
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
             assert(conn.state == .connecting);
             conn.arm(&conn.op_connect, "connect");
-            // L4 dials hold no Upstream slot, so the load table reflects
-            // L7 leases only — the P2C draw still spreads L4 dials by the
-            // observed L7 load, and evenly when there is none.
             const pick = server.balancer.pick(
                 cluster_index,
-                &server.upstreams.leased_counts,
+                &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
             );
@@ -648,6 +670,7 @@ pub fn Server(comptime IoType: type) type {
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
             conn.log.endpoint_index = pick.endpoint_index;
+            server.chargeL4(conn, cluster_index, pick.endpoint_index);
             server.io.connect(
                 pick.address,
                 &conn.op_connect.completion,
@@ -758,8 +781,13 @@ pub fn Server(comptime IoType: type) type {
                 server.releaseUpstream(leased);
                 conn.upstream = null;
             }
+            // The L4 endpoint charge rides the same rule: the socket that
+            // made this connection work against an origin is closed just
+            // above, so the origin is no longer carrying it (§7).
+            server.releaseL4(conn);
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
+            assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
             // The last chance to say anything about this connection (§8).
             // An exchange that reached a verdict already spoke and is
             // skipped by `emitted`; what is left here is everything that
@@ -1010,6 +1038,47 @@ pub fn Server(comptime IoType: type) type {
             assert(leased.endpoint_index == endpoint_index);
             server.updateUpstreamPressure();
             return leased;
+        }
+
+        /// The per-endpoint in-flight view both policies read (§7): the
+        /// pool's L7 leases beside the server's L4 charges. Built at the
+        /// read rather than stored, so it cannot drift from either
+        /// writer.
+        pub fn endpointLoad(server: *const Self) upstream_module.Load {
+            return .{
+                .l7 = &server.upstreams.leased_counts,
+                .l4 = &server.l4_inflight,
+            };
+        }
+
+        /// The L4 counterpart of `acquireUpstream`: a dial about to go
+        /// out counts against its endpoint. The endpoint is recorded on
+        /// the connection so the release cannot guess, and so a slot
+        /// that never dialed releases nothing.
+        fn chargeL4(server: *Self, conn: *ConnType, cluster_index: u16, endpoint_index: u16) void {
+            assert(conn.protocol == .l4);
+            assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
+            const key = upstream_module.endpointKey(cluster_index, endpoint_index);
+            server.l4_inflight[key] += 1;
+            // Every charge is held by a live conn slot, so one endpoint's
+            // count can never pass the conn pool's own size — the same
+            // shape `leased_counts` asserts against the upstream pool, and
+            // a far tighter canary for a missed release than the type's
+            // ceiling would be.
+            assert(server.l4_inflight[key] <= server.conns.capacity());
+            conn.charged_cluster = cluster_index;
+            conn.charged_endpoint = endpoint_index;
+        }
+
+        /// The release side, from the one place every L4 teardown passes
+        /// through. Idempotent by the sentinel: a connection shed before
+        /// its dial, or torn down twice, has nothing charged.
+        fn releaseL4(server: *Self, conn: *ConnType) void {
+            if (conn.charged_endpoint == conn_module.LogState.endpoint_none) return;
+            const key = upstream_module.endpointKey(conn.charged_cluster, conn.charged_endpoint);
+            assert(server.l4_inflight[key] >= 1);
+            server.l4_inflight[key] -= 1;
+            conn.charged_endpoint = conn_module.LogState.endpoint_none;
         }
 
         pub fn releaseUpstream(

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -181,19 +181,29 @@ pub const Balancer = struct {
         load: *const upstream.Load,
         healthy: *const [upstream.endpoint_keys_max]bool,
         client_address: *const std.Io.net.IpAddress,
-    ) Pick {
+    ) ?Pick {
         assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
         assert(cluster.endpoints.len >= 1);
         assert(cluster.endpoints.len <= constants.endpoints_per_cluster_max);
-        if (cluster.endpoints.len == 1) {
-            // Neither a rotation nor a draw: single-endpoint clusters
-            // stay branch-cheap and policy state is untouched. The mask
-            // is moot too — one endpoint ejected is the fail-open case.
+        if (cluster.endpoints.len == 1 and cluster.max_inflight == null) {
+            // Neither a rotation nor a draw: uncapped single-endpoint
+            // clusters stay branch-cheap and policy state is untouched.
+            // The mask is moot too — one endpoint ejected is the
+            // fail-open case. A cap has to be read, so it takes the
+            // general path below.
             return .{ .address = cluster.endpoints[0], .endpoint_index = 0 };
         }
         var eligible: [constants.endpoints_per_cluster_max]u16 = undefined;
-        const count = eligibleEndpoints(cluster_index, cluster, healthy, &eligible);
+        const count = eligibleEndpoints(cluster_index, cluster, load, healthy, &eligible);
+        if (count == 0) {
+            // Every endpoint is at its §8 cap. Unlike the health mask
+            // this does *not* fail open: an ejected cluster means "we do
+            // not know, try anyway", while a capped one means "we know
+            // they are full", and dialing anyway is the exact thing the
+            // cap exists to stop.
+            return null;
+        }
         const chosen = switch (cluster.pick) {
             .rr => balancer.pickRoundRobin(cluster_index, eligible[0..count]),
             .p2c => balancer.pickPowerOfTwo(cluster_index, eligible[0..count], load),
@@ -206,18 +216,28 @@ pub const Balancer = struct {
         };
     }
 
-    /// The §7-eligible endpoints: the healthy ones — or, the fail-open
-    /// rule, every endpoint when the whole cluster is ejected. Dialing a
-    /// maybe-dead endpoint reports the outage the way it always did;
-    /// routing nowhere would turn a probe verdict into an outage of its
-    /// own, and a same-port TCP probe cannot know better than the dial.
+    /// The endpoints a pick may choose between, in two passes.
+    ///
+    /// First §7 health: the healthy ones — or, the fail-open rule, every
+    /// endpoint when the whole cluster is ejected. Dialing a maybe-dead
+    /// endpoint reports the outage the way it always did; routing
+    /// nowhere would turn a probe verdict into an outage of its own, and
+    /// a same-port TCP probe cannot know better than the dial.
+    ///
+    /// Then §8 capacity, over whatever survived: an endpoint already
+    /// carrying its `max_inflight` is dropped. This pass **may return
+    /// zero**, and that is the difference from the health pass — the
+    /// caller sheds rather than dialing. The order matters too: capacity
+    /// is judged over the endpoints health would have used, so a cluster
+    /// that fails open still respects its caps.
     fn eligibleEndpoints(
         cluster_index: u16,
         cluster: *const config_module.Config.Cluster,
+        load: *const upstream.Load,
         healthy: *const [upstream.endpoint_keys_max]bool,
         eligible: *[constants.endpoints_per_cluster_max]u16,
     ) u16 {
-        assert(cluster.endpoints.len >= 2); // pick() short-circuited 1.
+        assert(cluster.endpoints.len >= 1);
         var count: u16 = 0;
         for (0..cluster.endpoints.len) |endpoint_index| {
             const index: u16 = @intCast(endpoint_index);
@@ -233,6 +253,17 @@ pub const Balancer = struct {
             count = @intCast(cluster.endpoints.len);
         }
         assert(count >= 1);
+        if (cluster.max_inflight) |cap| {
+            assert(cap >= 1);
+            var under: u16 = 0;
+            for (eligible[0..count]) |index| {
+                if (load.inFlight(upstream.endpointKey(cluster_index, index)) < cap) {
+                    eligible[under] = index;
+                    under += 1;
+                }
+            }
+            count = under;
+        }
         assert(count <= cluster.endpoints.len);
         return count;
     }
@@ -425,7 +456,7 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     counts[upstream.endpointKey(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
         try std.testing.expectEqual(trio[want_index], picked.address);
     }
@@ -446,7 +477,7 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
         try std.testing.expectEqual(solo, picked.address);
         try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
     }
@@ -474,7 +505,7 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     counts[upstream.endpointKey(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -498,7 +529,7 @@ test "balancer: p2c spreads across endpoints under equal load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 300) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
         hits[picked.endpoint_index] += 1;
     }
     for (hits) |hit_count| {
@@ -526,8 +557,8 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index,
-            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index,
+            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
+            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
         );
     }
 }
@@ -552,7 +583,7 @@ test "balancer: rr rotates over the healthy endpoints only" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -579,7 +610,7 @@ test "balancer: p2c never picks an ejected endpoint" {
     counts[upstream.endpointKey(0, 2)] = 50;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -604,7 +635,7 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
         try std.testing.expectEqual(@as(u16, 1), picked.endpoint_index);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
@@ -632,7 +663,7 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -655,7 +686,7 @@ test "balancer: policies keep independent state across clusters" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 1, 0 };
     for (expected) |want_index| {
-        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index);
+        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index);
         _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client);
     }
 }
@@ -691,10 +722,10 @@ test "balancer: hash sends one client to one endpoint, every time" {
 
     const counts = [_]u16{0} ** test_counts_len;
     const client = testAddress("203.0.113.9:51000");
-    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).endpoint_index;
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client);
+        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
         try std.testing.expectEqual(first, again.endpoint_index);
         try std.testing.expectEqual(endpoints[first], again.address);
     }
@@ -704,7 +735,7 @@ test "balancer: hash sends one client to one endpoint, every time" {
     loaded[upstream.endpointKey(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client).endpoint_index,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client).?.endpoint_index,
     );
 }
 
@@ -742,7 +773,7 @@ test "balancer: hash spreads distinct clients across every endpoint" {
     var hits = [_]u32{0} ** 8;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index] += 1;
     }
     // Rendezvous gives each client an independent uniform choice, so the
     // spread is a balls-in-bins one: loose bounds, but every endpoint must
@@ -774,7 +805,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var before: [clients]u16 = undefined;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index;
+        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index;
     }
 
     const ejected: u16 = 3;
@@ -784,7 +815,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var moved: u32 = 0;
     index = 0;
     while (index < clients) : (index += 1) {
-        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index)).endpoint_index;
+        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index)).?.endpoint_index;
         try std.testing.expect(after != ejected);
         if (before[index] == ejected) {
             moved += 1;
@@ -805,7 +836,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     while (index < clients) : (index += 1) {
         try std.testing.expectEqual(
             before[index],
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index,
         );
     }
 }
@@ -848,8 +879,8 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     var index: u16 = 0;
     while (index < 1000) : (index += 1) {
         const client = testClientAt(index);
-        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client);
-        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client);
+        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
+        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
         // The *address* must match; the index deliberately need not, the
         // lists being permutations of each other.
         try std.testing.expectEqual(left_pick.address, right_pick.address);
@@ -872,8 +903,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     const first = testAddress("[2001:db8:1:2:aaaa:bbbb:cccc:dddd]:51000");
     const rotated = testAddress("[2001:db8:1:2:1111:2222:3333:4444]:52000");
     try std.testing.expectEqual(
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).endpoint_index,
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated).endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).?.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated).?.endpoint_index,
     );
 
     // A different /64 is a different client and must be free to land
@@ -884,8 +915,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     while (prefix < 64) : (prefix += 1) {
         var other = first;
         other.ip6.bytes[7] = @intCast(prefix);
-        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other).endpoint_index !=
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).endpoint_index)
+        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other).?.endpoint_index !=
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).?.endpoint_index)
         {
             differs = true;
             break;
@@ -956,8 +987,8 @@ test "balancer: a fully ejected hash cluster still answers, deterministically" {
         // Fail-open restores the full set, so the answer is the same one
         // the healthy cluster gives.
         try std.testing.expectEqual(
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).endpoint_index,
-            balancer.pick(0, &testLoad(&counts), &none_healthy, &client).endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &none_healthy, &client).?.endpoint_index,
         );
     }
 }
@@ -999,7 +1030,7 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
     const load: upstream.Load = .{ .l7 = &l7_idle, .l4 = &l4 };
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client).endpoint_index != 1);
+        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index != 1);
     }
 }
 
@@ -1031,7 +1062,126 @@ test "balancer: p2c compares the sum of both protocols" {
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 0),
-            balancer.pick(0, &load, &test_healthy_all, &test_client).endpoint_index,
+            balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index,
         );
     }
+}
+
+test "balancer: a capped endpoint is skipped while another has room" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 2 },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Endpoint 0 is at its cap, endpoint 1 is not. Rotation must land on
+    // 1 every time — a cap narrows the eligible set, it does not shed
+    // while any endpoint can still take work.
+    var l7 = [_]u16{0} ** test_counts_len;
+    l7[upstream.endpointKey(0, 0)] = 2;
+    const load = testLoad(&l7);
+    var round: u32 = 0;
+    while (round < 8) : (round += 1) {
+        try std.testing.expectEqual(
+            @as(u16, 1),
+            balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index,
+        );
+    }
+}
+
+test "balancer: a fully capped cluster refuses rather than failing open" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .p2c, .max_inflight = 3 },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Both endpoints at capacity: no pick. This is the deliberate
+    // difference from the health mask, which fails *open* — an ejected
+    // cluster means "we do not know", a capped one means "we know they
+    // are full", and dialing anyway is what the cap exists to stop.
+    var l7 = [_]u16{0} ** test_counts_len;
+    l7[upstream.endpointKey(0, 0)] = 3;
+    l7[upstream.endpointKey(0, 1)] = 3;
+    try std.testing.expectEqual(
+        @as(?Balancer.Pick, null),
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client),
+    );
+    // One request completes on endpoint 1 and the cluster serves again.
+    l7[upstream.endpointKey(0, 1)] = 2;
+    try std.testing.expectEqual(
+        @as(u16, 1),
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client).?.endpoint_index,
+    );
+}
+
+test "balancer: the cap counts both protocols, and covers one endpoint" {
+    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
+    const one = [_]std.Io.net.IpAddress{solo};
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "one", .endpoints = &one, .max_inflight = 4 },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // A single-endpoint cluster takes the fast path when uncapped; with
+    // a cap it must not, or the one endpoint could never be protected.
+    // Three L7 requests and one L4 connection is four: at the cap.
+    var l7 = [_]u16{0} ** test_counts_len;
+    var l4 = [_]u16{0} ** test_counts_len;
+    l7[upstream.endpointKey(0, 0)] = 3;
+    l4[upstream.endpointKey(0, 0)] = 1;
+    const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
+    try std.testing.expectEqual(
+        @as(?Balancer.Pick, null),
+        balancer.pick(0, &load, &test_healthy_all, &test_client),
+    );
+    // Reading either table alone would leave room and dial anyway.
+    try std.testing.expect(l7[upstream.endpointKey(0, 0)] < 4);
+    try std.testing.expect(l4[upstream.endpointKey(0, 0)] < 4);
+}
+
+test "balancer: capacity is judged over the endpoints health left" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 1 },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Endpoint 0 is ejected, so health leaves only endpoint 1 — which is
+    // at its cap. The cap runs second and refuses: a cluster whose only
+    // healthy endpoint is full must not be handed the request anyway.
+    var healthy = test_healthy_all;
+    healthy[upstream.endpointKey(0, 0)] = false;
+    var l7 = [_]u16{0} ** test_counts_len;
+    l7[upstream.endpointKey(0, 1)] = 1;
+    try std.testing.expectEqual(
+        @as(?Balancer.Pick, null),
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client),
+    );
+    // And when health fails open — every endpoint ejected — the caps
+    // still apply to the whole set rather than being bypassed with it.
+    healthy[upstream.endpointKey(0, 1)] = false;
+    l7[upstream.endpointKey(0, 0)] = 1;
+    try std.testing.expectEqual(
+        @as(?Balancer.Pick, null),
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client),
+    );
 }

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -4,10 +4,11 @@
 //! Three policies, selected per cluster in the config (§5 parse-once):
 //! `rr` rotates a per-cluster cursor, `p2c` draws two distinct candidates
 //! uniformly and leases the calmer one, `hash` sends a given client to a
-//! given endpoint every time. P2C's load is the upstream pool's
-//! per-endpoint leased count, passed in by the caller — the balancer owns
-//! the draw, the pool owns the truth. A single-endpoint cluster
-//! short-circuits every policy without touching its state.
+//! given endpoint every time. P2C's load is the per-endpoint in-flight
+//! total across both protocols — the pool's L7 leases plus the server's
+//! live L4 connections — passed in by the caller as a view: the balancer
+//! owns the draw, the pool and the server own the truth. A single-endpoint
+//! cluster short-circuits every policy without touching its state.
 //!
 //! **Why `hash` is stateless, and why that is not merely a simplification.**
 //! Stickiness is usually a *table*: HAProxy records client → server as
@@ -168,16 +169,16 @@ pub const Balancer = struct {
     };
 
     /// Choose the endpoint to dial for `cluster_index` under the
-    /// cluster's configured policy. `leased_counts` is the pool's
-    /// per-endpoint load table (indexed by `upstream.endpointKey`),
-    /// consulted by p2c and ignored by rr; `healthy` is the §7 health
-    /// mask (same index) — the prober owns that truth the way the pool
-    /// owns the load. Bounded work, no allocation, and a validated
-    /// config guarantees at least one endpoint.
+    /// cluster's configured policy. `load` is the per-endpoint in-flight
+    /// view (indexed by `upstream.endpointKey`), consulted by p2c and
+    /// ignored by rr; `healthy` is the §7 health mask (same index) — the
+    /// prober owns that truth the way the pool and the server own the
+    /// load. Bounded work, no allocation, and a validated config
+    /// guarantees at least one endpoint.
     pub fn pick(
         balancer: *Balancer,
         cluster_index: u16,
-        leased_counts: *const [upstream.endpoint_keys_max]u16,
+        load: *const upstream.Load,
         healthy: *const [upstream.endpoint_keys_max]bool,
         client_address: *const std.Io.net.IpAddress,
     ) Pick {
@@ -195,7 +196,7 @@ pub const Balancer = struct {
         const count = eligibleEndpoints(cluster_index, cluster, healthy, &eligible);
         const chosen = switch (cluster.pick) {
             .rr => balancer.pickRoundRobin(cluster_index, eligible[0..count]),
-            .p2c => balancer.pickPowerOfTwo(cluster_index, eligible[0..count], leased_counts),
+            .p2c => balancer.pickPowerOfTwo(cluster_index, eligible[0..count], load),
             .hash => balancer.pickHash(cluster_index, eligible[0..count], client_address),
         };
         assert(chosen < cluster.endpoints.len);
@@ -254,14 +255,14 @@ pub const Balancer = struct {
     }
 
     /// P2C over the eligible set: two distinct uniform candidates, the
-    /// lower leased count wins, a tie goes to the first. A mask narrowed
+    /// lower in-flight total wins, a tie goes to the first. A mask narrowed
     /// to one endpoint skips the draw the way a one-endpoint cluster
     /// does — no candidates to compare, no PRNG state spent.
     fn pickPowerOfTwo(
         balancer: *Balancer,
         cluster_index: u16,
         eligible: []const u16,
-        leased_counts: *const [upstream.endpoint_keys_max]u16,
+        load: *const upstream.Load,
     ) u16 {
         assert(balancer.config.clusters[cluster_index].pick == .p2c);
         assert(eligible.len >= 1);
@@ -279,8 +280,12 @@ pub const Balancer = struct {
         assert(second_slot < eligible.len);
         const first = eligible[first_slot];
         const second = eligible[second_slot];
-        const first_load = leased_counts[upstream.endpointKey(cluster_index, first)];
-        const second_load = leased_counts[upstream.endpointKey(cluster_index, second)];
+        // Both protocols count here (§7): an L4 dial holds no upstream
+        // slot, so before this view the draw on a pure-L4 cluster read a
+        // table of zeros and spread uniformly while presenting as
+        // load-aware.
+        const first_load = load.inFlight(upstream.endpointKey(cluster_index, first));
+        const second_load = load.inFlight(upstream.endpointKey(cluster_index, second));
         return if (second_load < first_load) second else first;
     }
 
@@ -373,6 +378,15 @@ const test_counts_len = upstream.endpoint_keys_max;
 /// exactly what `Checker.init` hands a server whose clusters never check.
 const test_healthy_all = [_]bool{true} ** upstream.endpoint_keys_max;
 
+/// The L4 half of the load view, all zero: what a pure-L7 test sees.
+const test_l4_idle = [_]u16{0} ** upstream.endpoint_keys_max;
+
+/// A load view over an L7 lease table, for the tests that only vary
+/// that half. The pair-of-tables shape is what production passes.
+fn testLoad(l7: *const [upstream.endpoint_keys_max]u16) upstream.Load {
+    return .{ .l7 = l7, .l4 = &test_l4_idle };
+}
+
 /// The client address `rr`/`p2c` scenarios pass and ignore; only `.hash`
 /// reads it.
 const test_client = std.Io.net.IpAddress.parseLiteral("198.51.100.7:40000") catch unreachable;
@@ -411,7 +425,7 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     counts[upstream.endpointKey(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &counts, &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
         try std.testing.expectEqual(want_index, picked.endpoint_index);
         try std.testing.expectEqual(trio[want_index], picked.address);
     }
@@ -432,7 +446,7 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &counts, &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
         try std.testing.expectEqual(solo, picked.address);
         try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
     }
@@ -460,7 +474,7 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     counts[upstream.endpointKey(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &counts, &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -484,7 +498,7 @@ test "balancer: p2c spreads across endpoints under equal load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 300) : (round += 1) {
-        const picked = balancer.pick(0, &counts, &test_healthy_all, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client);
         hits[picked.endpoint_index] += 1;
     }
     for (hits) |hit_count| {
@@ -512,8 +526,8 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            left.pick(0, &counts, &test_healthy_all, &test_client).endpoint_index,
-            right.pick(0, &counts, &test_healthy_all, &test_client).endpoint_index,
+            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index,
+            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index,
         );
     }
 }
@@ -538,7 +552,7 @@ test "balancer: rr rotates over the healthy endpoints only" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &counts, &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -565,7 +579,7 @@ test "balancer: p2c never picks an ejected endpoint" {
     counts[upstream.endpointKey(0, 2)] = 50;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &counts, &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -590,7 +604,7 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &counts, &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
         try std.testing.expectEqual(@as(u16, 1), picked.endpoint_index);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
@@ -618,7 +632,7 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &counts, &healthy, &test_client);
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client);
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -641,8 +655,8 @@ test "balancer: policies keep independent state across clusters" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 1, 0 };
     for (expected) |want_index| {
-        try std.testing.expectEqual(want_index, balancer.pick(0, &counts, &test_healthy_all, &test_client).endpoint_index);
-        _ = balancer.pick(1, &counts, &test_healthy_all, &test_client);
+        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).endpoint_index);
+        _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client);
     }
 }
 
@@ -677,10 +691,10 @@ test "balancer: hash sends one client to one endpoint, every time" {
 
     const counts = [_]u16{0} ** test_counts_len;
     const client = testAddress("203.0.113.9:51000");
-    const first = balancer.pick(0, &counts, &test_healthy_all, &client).endpoint_index;
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).endpoint_index;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const again = balancer.pick(0, &counts, &test_healthy_all, &client);
+        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client);
         try std.testing.expectEqual(first, again.endpoint_index);
         try std.testing.expectEqual(endpoints[first], again.address);
     }
@@ -690,7 +704,7 @@ test "balancer: hash sends one client to one endpoint, every time" {
     loaded[upstream.endpointKey(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &loaded, &test_healthy_all, &client).endpoint_index,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client).endpoint_index,
     );
 }
 
@@ -709,7 +723,7 @@ test "balancer: hash spends no PRNG state and needs none" {
     const counts = [_]u16{0} ** test_counts_len;
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
-        _ = balancer.pick(0, &counts, &test_healthy_all, &testClientAt(index));
+        _ = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index));
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
 }
@@ -728,7 +742,7 @@ test "balancer: hash spreads distinct clients across every endpoint" {
     var hits = [_]u32{0} ** 8;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &counts, &test_healthy_all, &testClientAt(index)).endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index] += 1;
     }
     // Rendezvous gives each client an independent uniform choice, so the
     // spread is a balls-in-bins one: loose bounds, but every endpoint must
@@ -760,7 +774,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var before: [clients]u16 = undefined;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        before[index] = balancer.pick(0, &counts, &test_healthy_all, &testClientAt(index)).endpoint_index;
+        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index;
     }
 
     const ejected: u16 = 3;
@@ -770,7 +784,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var moved: u32 = 0;
     index = 0;
     while (index < clients) : (index += 1) {
-        const after = balancer.pick(0, &counts, &healthy, &testClientAt(index)).endpoint_index;
+        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index)).endpoint_index;
         try std.testing.expect(after != ejected);
         if (before[index] == ejected) {
             moved += 1;
@@ -791,7 +805,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     while (index < clients) : (index += 1) {
         try std.testing.expectEqual(
             before[index],
-            balancer.pick(0, &counts, &test_healthy_all, &testClientAt(index)).endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).endpoint_index,
         );
     }
 }
@@ -834,8 +848,8 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     var index: u16 = 0;
     while (index < 1000) : (index += 1) {
         const client = testClientAt(index);
-        const left_pick = left.pick(0, &counts, &test_healthy_all, &client);
-        const right_pick = right.pick(0, &counts, &test_healthy_all, &client);
+        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client);
+        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client);
         // The *address* must match; the index deliberately need not, the
         // lists being permutations of each other.
         try std.testing.expectEqual(left_pick.address, right_pick.address);
@@ -858,8 +872,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     const first = testAddress("[2001:db8:1:2:aaaa:bbbb:cccc:dddd]:51000");
     const rotated = testAddress("[2001:db8:1:2:1111:2222:3333:4444]:52000");
     try std.testing.expectEqual(
-        balancer.pick(0, &counts, &test_healthy_all, &first).endpoint_index,
-        balancer.pick(0, &counts, &test_healthy_all, &rotated).endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated).endpoint_index,
     );
 
     // A different /64 is a different client and must be free to land
@@ -870,8 +884,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     while (prefix < 64) : (prefix += 1) {
         var other = first;
         other.ip6.bytes[7] = @intCast(prefix);
-        if (balancer.pick(0, &counts, &test_healthy_all, &other).endpoint_index !=
-            balancer.pick(0, &counts, &test_healthy_all, &first).endpoint_index)
+        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other).endpoint_index !=
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).endpoint_index)
         {
             differs = true;
             break;
@@ -942,8 +956,8 @@ test "balancer: a fully ejected hash cluster still answers, deterministically" {
         // Fail-open restores the full set, so the answer is the same one
         // the healthy cluster gives.
         try std.testing.expectEqual(
-            balancer.pick(0, &counts, &test_healthy_all, &client).endpoint_index,
-            balancer.pick(0, &counts, &none_healthy, &client).endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &none_healthy, &client).endpoint_index,
         );
     }
 }
@@ -959,4 +973,65 @@ fn sourceKeyOf(comptime literal: []const u8) u64 {
 fn endpointIdOf(comptime literal: []const u8) u64 {
     const address = testAddress(literal);
     return endpointId(&address);
+}
+
+test "balancer: p2c weighs L4 connections, not only L7 leases" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // A pure-L4 cluster: the lease table stays empty for its whole life,
+    // so before the load view this draw compared zero against zero and
+    // spread uniformly while presenting as load-aware. Endpoint 1 is
+    // drowning in relayed connections; any pair containing it also
+    // contains a calmer endpoint, so it must never win.
+    const l7_idle = [_]u16{0} ** test_counts_len;
+    var l4 = [_]u16{0} ** test_counts_len;
+    l4[upstream.endpointKey(0, 1)] = 100;
+    const load: upstream.Load = .{ .l7 = &l7_idle, .l4 = &l4 };
+    var round: u32 = 0;
+    while (round < 200) : (round += 1) {
+        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client).endpoint_index != 1);
+    }
+}
+
+test "balancer: p2c compares the sum of both protocols" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer: Balancer = undefined;
+    balancer.init(&config);
+
+    // Endpoint 0 carries 5 requests and no connections; endpoint 1
+    // carries 1 request and 9 connections. Reading either table alone
+    // picks the wrong one — only the total (5 against 10) is the load
+    // the origin actually feels.
+    var l7 = [_]u16{0} ** test_counts_len;
+    var l4 = [_]u16{0} ** test_counts_len;
+    l7[upstream.endpointKey(0, 0)] = 5;
+    l7[upstream.endpointKey(0, 1)] = 1;
+    l4[upstream.endpointKey(0, 1)] = 9;
+    const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
+    try std.testing.expectEqual(@as(u32, 5), load.inFlight(upstream.endpointKey(0, 0)));
+    try std.testing.expectEqual(@as(u32, 10), load.inFlight(upstream.endpointKey(0, 1)));
+    var round: u32 = 0;
+    while (round < 100) : (round += 1) {
+        try std.testing.expectEqual(
+            @as(u16, 0),
+            balancer.pick(0, &load, &test_healthy_all, &test_client).endpoint_index,
+        );
+    }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -132,6 +132,14 @@ pub const Config = struct {
         /// cluster, so absent means the balancer never skips anything
         /// here and the prober never dials it.
         check: ?Check = null,
+        /// The §8 concurrency cap protecting each of this cluster's
+        /// endpoints, or null for uncapped. **Per endpoint, not per
+        /// cluster**: it is a statement about what one origin can carry,
+        /// the same unit HAProxy's `server ... maxconn` names, so a
+        /// cluster's total admitted work is this times its endpoint
+        /// count. Counted against the endpoint's in-flight total —
+        /// L7 requests and live L4 connections alike (§7).
+        max_inflight: ?u32 = null,
 
         /// What a `hash` cluster keys its endpoint choice on (§7). Read
         /// only when `pick == .hash`; the loader rejects a `hash` block
@@ -229,6 +237,7 @@ pub const ValidationError = error{
     ClusterCheckPathNotCanonical,
     ClusterCheckHostInvalid,
     ClusterCheckStatusInvalid,
+    ClusterMaxInflightOutOfRange,
     ClusterHashKeyUnknown,
     ClusterHashWithoutHashPick,
     ListenerClusterOrRoutes,
@@ -689,6 +698,8 @@ pub const ClusterJson = struct {
     /// Optional §7 active health checks; absent means off, so an
     /// unprobed cluster reserves nothing and is never skipped.
     check: ?CheckJson = null,
+    /// Optional §8 per-endpoint concurrency cap; absent means uncapped.
+    max_inflight: ?u32 = null,
     /// Optional §7 hash-policy detail; only valid beside `"pick": "hash"`,
     /// and absent there means the default key.
     hash: ?ClusterHashJson = null,
@@ -711,6 +722,11 @@ pub const ClusterJson = struct {
         },
         .hash = .{
             .desc = "Hash-policy detail; only valid alongside \"pick\": \"hash\".",
+        },
+        .max_inflight = .{
+            .desc = "Cap on concurrent in-flight work per endpoint; absent leaves the cluster uncapped.",
+            .minimum = 1,
+            .maximum = constants.endpoint_inflight_max,
         },
     };
 };
@@ -999,6 +1015,7 @@ fn resolveClusters(
             .pick = pick,
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
             .hash_key = try hashKeyOf(pick, entry.cluster.hash),
+            .max_inflight = try resolveMaxInflight(entry.cluster.max_inflight),
         };
     }
     assert(clusters.len == count);
@@ -1512,6 +1529,20 @@ fn resolveHttpCheck(check: *const CheckJson) ParseError!Config.Cluster.Check.Htt
         .host = check.host,
         .expect_status = check.expect_status,
     };
+}
+
+/// Resolve the §8 per-endpoint concurrency cap. Absent leaves the
+/// cluster uncapped; zero would refuse every request to an endpoint that
+/// is doing nothing, and a value at or above the largest representable
+/// in-flight total could never refuse anything — both are far more
+/// likely a mistake than an intent, and "uncapped" already has a
+/// spelling.
+fn resolveMaxInflight(max_inflight: ?u32) ParseError!?u32 {
+    const cap = max_inflight orelse return null;
+    if (cap < 1 or cap > constants.endpoint_inflight_max) {
+        return error.ClusterMaxInflightOutOfRange;
+    }
+    return cap;
 }
 
 /// The closed pick-policy vocabulary; anything else is its own error so
@@ -2592,4 +2623,51 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
         error.UnknownField,
         head ++ endpoints ++ ",\"pick\":\"hash\",\"hash\":{\"key\":\"source_ip\",\"mask\":24}" ++ tail,
     );
+}
+
+test "config: max_inflight resolves, defaults to uncapped, rejects the useless" {
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"max_inflight":64},
+            \\   "b":{"endpoints":["127.0.0.1:3"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(@as(?u32, 64), parsed.clusters[0].max_inflight);
+        // Absent is uncapped, which is the only spelling of "no limit".
+        try std.testing.expectEqual(@as(?u32, null), parsed.clusters[1].max_inflight);
+    }
+    // Zero would refuse every request to an idle endpoint, and a value
+    // past the largest representable load could never refuse one —
+    // both are typos rather than intents (§8).
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"max_inflight":
+    ;
+    const tail =
+        \\}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    ;
+    try expectParseError(error.ClusterMaxInflightOutOfRange, head ++ "0" ++ tail);
+    try expectParseError(error.ClusterMaxInflightOutOfRange, head ++ "4294967295" ++ tail);
+    // The ceiling itself is legal, and deliberately so: it is reachable
+    // only if every conn and upstream slot in the process piles onto one
+    // endpoint, which is a real (if extreme) shape rather than a no-op.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        var buffer: [512]u8 = undefined;
+        const json = try std.fmt.bufPrint(
+            &buffer,
+            "{s}{d}{s}",
+            .{ head, constants.endpoint_inflight_max, tail },
+        );
+        const parsed = try parse(arena_state.allocator(), json);
+        try std.testing.expectEqual(
+            @as(?u32, constants.endpoint_inflight_max),
+            parsed.clusters[0].max_inflight,
+        );
+    }
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -235,6 +235,15 @@ pub const clusters_min: u16 = 1;
 /// Upper bound on endpoints in one cluster.
 pub const endpoints_per_cluster_max: u16 = 64;
 
+/// The largest in-flight total one endpoint can ever carry (§7), and so
+/// the ceiling a configured `max_inflight` is validated against: one L7
+/// lease per upstream slot plus one L4 charge per conn slot, since a
+/// connection of either kind holds exactly one of those. A cap at or
+/// above this can never refuse anything, so the loader rejects it rather
+/// than letting a typo'd figure read as "unlimited" — which is what
+/// omitting the field already says, unambiguously.
+pub const endpoint_inflight_max: u32 = conn_slots_max + upstream_slots_max;
+
 /// Worst-case simultaneously armed ring ops for the §7 health prober:
 /// three. One probe is in flight at a time — {connect, probe deadline}
 /// co-armed while dialing — and settling a verdict or draining adds one
@@ -585,6 +594,14 @@ comptime {
     assert(clusters_min >= 1);
     assert(clusters_max >= clusters_min);
     assert(endpoints_per_cluster_max >= 1);
+    // The §8 cap ceiling is the largest load one endpoint can carry: one
+    // L7 lease per upstream slot plus one L4 charge per conn slot, since
+    // a connection of either kind holds exactly one. Asserted rather than
+    // merely written that way, so a change to either pool ceiling cannot
+    // silently leave a cap validated against a total nothing can reach.
+    assert(endpoint_inflight_max == conn_slots_max + upstream_slots_max);
+    assert(endpoint_inflight_max >= conn_slots_max);
+    assert(endpoint_inflight_max >= upstream_slots_max);
     assert(routes_max >= 1);
     assert(filters_per_listener_max >= 1);
     assert(actions_per_filter_max >= 1);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -70,6 +70,12 @@ pub const Counters = struct {
     /// and the ratio to `accepted` is the churn signal.
     l7_shed_relay_buffers: Value = Value.init(0),
     l7_shed_upstream_slots: Value = Value.init(0),
+    /// §8 requests answered 503 because every endpoint of their cluster
+    /// was already carrying its configured `max_inflight`. Distinct from
+    /// `l7_shed_upstream_slots` on purpose: that one says this proxy ran
+    /// out of slots, this one says the origins were protected — opposite
+    /// diagnoses, and an operator widening the wrong limit fixes neither.
+    l7_shed_endpoint_inflight: Value = Value.init(0),
     /// Upstream leg failed before any response byte reached the client:
     /// answered 502 (§7, §8). A spent-replay second failure lands here
     /// too — the one free §7 replay never loops.
@@ -185,6 +191,14 @@ pub const Counters = struct {
     /// things at once: some already-accepted lines never reached the sink,
     /// and every line since has been counted as dropped.
     access_log_write_failed: Value = Value.init(0),
+    /// §8 L4 connections closed because every endpoint of their cluster
+    /// was already carrying its configured `max_inflight`. An L4 listener
+    /// has no way to say "try later", so the ladder's L4 answer applies:
+    /// close. Deliberately **not** `shed_`-prefixed — the connection was
+    /// admitted before an endpoint could be picked, so it counts in the
+    /// flow identity as an ordinary completion, and folding it into the
+    /// admission-gate sum would make that identity false.
+    l4_shed_endpoint_inflight: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -467,7 +467,7 @@ pub fn Proxy(comptime IoType: type) type {
             // the §7 free replay (`upstreamFailed`).
             const pick = server.balancer.pick(
                 conn.cluster_index,
-                &server.upstreams.leased_counts,
+                &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
             );
@@ -1570,7 +1570,7 @@ pub fn Proxy(comptime IoType: type) type {
             // the endpoint's whole idle list may be stale the same way.
             const pick = server.balancer.pick(
                 conn.cluster_index,
-                &server.upstreams.leased_counts,
+                &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
             );

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -460,7 +460,23 @@ pub fn Proxy(comptime IoType: type) type {
             conn.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
             };
+            beginUpstream(server, conn, request, &keys.views);
+        }
 
+        /// Route resolved and a relay buffer held: choose an endpoint and
+        /// get onto it, by reuse when the pool has one parked and by a
+        /// fresh dial otherwise. Split from `routeRequest` because the
+        /// two halves answer different questions — *where does this
+        /// request go* and *how does it get there* — and the first was
+        /// already at the length limit.
+        fn beginUpstream(
+            server: *ServerType,
+            conn: *ConnType,
+            request: *const parser.RequestHead,
+            views: *const TargetViews,
+        ) void {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.relay_buffer != null);
             // The §3 reuse win: a parked connection to the picked endpoint
             // beats a fresh dial. A close that slipped through while it
             // was parked surfaces as a failure on first use — absorbed by
@@ -470,7 +486,14 @@ pub fn Proxy(comptime IoType: type) type {
                 &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
-            );
+            ) orelse {
+                // Every endpoint of this cluster is at its §8 cap. The
+                // reuse path is capped too, deliberately: checking out a
+                // parked connection starts a request the origin has to
+                // serve, which is the thing being bounded — the saved
+                // handshake does not make it free.
+                return respond(server, conn, 503, "l7_shed_endpoint_inflight");
+            };
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
@@ -488,7 +511,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // the hot one — skips the re-parse the dial path needs,
                 // and hands over the canonical target it already built
                 // rather than having it decoded and collapsed again.
-                renderRequestAndStartLegs(server, conn, request, &keys.views);
+                renderRequestAndStartLegs(server, conn, request, views);
                 return;
             }
             dialUpstream(server, conn, pick);
@@ -1573,7 +1596,12 @@ pub fn Proxy(comptime IoType: type) type {
                 &server.endpointLoad(),
                 &server.health.healthy,
                 &conn.client_address,
-            );
+            ) orelse {
+                // The replay is a fresh try against the same cluster, so
+                // it meets the same cap. Its budget is already spent, so
+                // this answers rather than replaying again (§7).
+                return respond(server, conn, 503, "l7_shed_endpoint_inflight");
+            };
             dialUpstream(server, conn, pick);
         }
 
@@ -1767,6 +1795,11 @@ pub fn Proxy(comptime IoType: type) type {
             }
             if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
+            // A capped endpoint is a shed like any other from the
+            // client's side: the request was refused to protect the
+            // origin, and the line should read the same as the rungs
+            // that refuse to protect this proxy (§8).
+            if (std.mem.eql(u8, counter, "l7_shed_endpoint_inflight")) return .shed;
             if (std.mem.eql(u8, counter, "l7_bad_gateway")) return .upstream_failed;
             if (std.mem.eql(u8, counter, "l7_gateway_timeout")) return .timed_out;
             @compileError("static-response counter with no access-log outcome: " ++ counter);

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -515,6 +515,9 @@ const Http1Bed = struct {
         /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
         check: ?config_module.Config.Cluster.Check = null,
+        /// §8 per-endpoint concurrency cap; null leaves the cluster
+        /// uncapped, which is what every pre-existing scenario wants.
+        max_inflight: ?u32 = null,
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 40,
@@ -531,7 +534,7 @@ const Http1Bed = struct {
         }
         try bed.sim_io.init(arena, .{ .seed = options.seed, .adversary = adversary });
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -3017,4 +3020,37 @@ test "health: an http probe fails when the origin never answers" {
     try std.testing.expect(bed.server.counters.get("health_probes_failed") >= 3);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
     try bed.expectDrained();
+}
+
+test "l7: a request past the endpoint cap is answered 503, not sent" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 71,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        // One in flight per endpoint, and this bed has exactly one
+        // endpoint: the second concurrent request has nowhere under
+        // capacity to go.
+        .max_inflight = 1,
+        // The origin reads the first request and never answers, so that
+        // request stays in flight while the second arrives.
+        .origin_mute = true,
+        .request_timeout_ms = 400,
+    });
+    defer bed.tearDown();
+
+    bed.client.request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    bed.client2.request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    bed.client2.send_delay_ms = 40;
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.sim_io.run();
+
+    // The second client is refused to protect the origin — and the
+    // origin must never have seen it: exactly one connection accepted.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_shed_endpoint_inflight"));
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
+    try std.testing.expect(std.mem.startsWith(u8, bed.client2.response(), "HTTP/1.1 503"));
+    // The pool never ran out — that is a different rung with a different
+    // fix, and confusing the two is what the separate counter prevents.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_upstream_slots"));
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -278,6 +278,19 @@ pub fn Conn(comptime IoType: type) type {
         /// teardown alongside the conn slot (§5). Null outside exchanges
         /// and on the whole L4 path.
         upstream: ?*UpstreamType,
+        /// The endpoint this L4 connection is charged against in the
+        /// server's per-endpoint in-flight table (§7), or `endpoint_none`
+        /// when it is charged against none — every L7 connection, and
+        /// every L4 one shed before it dialed. Separate from
+        /// `log.endpoint_index`, which the access log still needs after
+        /// the charge is released; this one is the release's own
+        /// bookkeeping, and clearing it is what makes the release
+        /// exactly-once.
+        charged_endpoint: u16,
+        /// The cluster half of that key. `cluster_index` cannot serve:
+        /// the L7 path overwrites it per request at routing, so a key
+        /// built from it at teardown need not be the key charged.
+        charged_cluster: u16,
         /// L7 exchange bookkeeping (§7); reset per exchange.
         l7: L7State,
         /// What this connection speaks (§6, §7). Read only by the access
@@ -531,6 +544,8 @@ pub fn Conn(comptime IoType: type) type {
             conn.routes = &.{};
             conn.filters = &.{};
             conn.upstream = null;
+            conn.charged_endpoint = LogState.endpoint_none;
+            conn.charged_cluster = 0;
             conn.l7 = .{};
             conn.protocol = protocol;
             conn.client_address = client_address;

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -225,6 +225,37 @@ pub fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
     return @as(u32, cluster_index) * constants.endpoints_per_cluster_max + endpoint_index;
 }
 
+/// How much work an endpoint is carrying right now, across both
+/// protocols (§7). Two tables rather than one running total, because
+/// each has its own provable bound and its own single writer: the pool
+/// owns `l7` (leases, `leased_counts`) and the server owns `l4` (live
+/// relayed connections, which hold no pool slot at all). A shared
+/// counter would have to give up `leased_counts <= slot_pool.slots.len`,
+/// since L4 connections outnumber the upstream pool whenever
+/// `conn_slots` exceeds `upstream_slots` — a legal config.
+///
+/// A view, not storage: it borrows both tables so the sum is computed
+/// where it is read and can never drift from either writer.
+///
+/// The two count different things — an L7 lease is one in-flight
+/// *request*, an L4 charge is one live *connection* — and the sum is
+/// deliberate: both are work the origin is doing right now, which is
+/// what a load comparison and a capacity limit are about. A cluster
+/// reached by both an `l4` and an `http` listener is representable, and
+/// there the total is that mixed unit.
+pub const Load = struct {
+    l7: *const [endpoint_keys_max]u16,
+    l4: *const [endpoint_keys_max]u16,
+
+    /// Total in-flight work against one endpoint. `u32` because the two
+    /// ceilings sum past a `u16`'s range in principle, even though no
+    /// single deployment reaches both at once.
+    pub fn inFlight(load: *const Load, key: u32) u32 {
+        assert(key < endpoint_keys_max);
+        return @as(u32, load.l7[key]) + load.l4[key];
+    }
+};
+
 // Tests drive the pool through a socket-free fake Io: the pool never
 // touches the socket, it only stores it for the owner.
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -221,6 +221,9 @@ pub const TestBed = struct {
         /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
         check: ?config_module.Config.Cluster.Check = null,
+        /// §8 per-endpoint concurrency cap; null leaves the cluster
+        /// uncapped, which is what every pre-existing scenario wants.
+        max_inflight: ?u32 = null,
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 20,
@@ -241,7 +244,7 @@ pub const TestBed = struct {
 
         try bed.sim_io.init(arena, options.sim);
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .l4 }};
         bed.config = .{
@@ -1014,5 +1017,34 @@ test "relay: a refused dial releases the endpoint charge it took" {
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
     try std.testing.expect(bed.server.l4Released());
+    try bed.expectDrained();
+}
+
+test "relay: an L4 connection past the endpoint cap is closed, not dialed" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 21 },
+        // One in flight per endpoint against this bed's single endpoint.
+        .max_inflight = 1,
+        // Silent clients hold their charge until the idle deadline, so
+        // the second one certainly meets a full endpoint rather than
+        // racing the first one's completion.
+        .idle_timeout_ms = 60,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(2, false);
+    try bed.sim_io.run();
+
+    // Exactly one was refused, and the origin only ever saw the other:
+    // an L4 listener cannot say "try later", so the ladder's L4 answer
+    // is a close (§8).
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_shed_endpoint_inflight"));
+    try std.testing.expectEqual(@as(u8, 1), bed.scenario.origin.conns_count);
+    // Both were admitted and both completed: the refusal happens after
+    // admission, so it must not disturb the gate identity (§8, §9).
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("admitted"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("completed"));
+    try std.testing.expect(bed.server.reconcile());
     try bed.expectDrained();
 }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -16,6 +16,7 @@ const Io = @import("io/io.zig");
 const Server = @import("Server.zig").Server;
 const SimIo = @import("io/SimIo.zig");
 const origin_mod = @import("testing/origin.zig");
+const upstream_module = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
 
@@ -35,6 +36,15 @@ pub const Scenario = struct {
     /// test); the shared Origin fires on_accept on every accept, so the
     /// hook makes this one-shot.
     pending_racer: ?*Client = null,
+    /// The §7 L4 charge against endpoint 0 sampled the moment the origin
+    /// accepted, so a test can prove the count *rises* — "it drained to
+    /// zero" is satisfied just as well by never counting at all.
+    l4_sample: u16 = 0,
+
+    fn sampleL4Charge(context: ?*anyopaque) void {
+        const scenario: *Scenario = @ptrCast(@alignCast(context.?));
+        scenario.l4_sample = scenario.server.l4_inflight[upstream_module.endpointKey(0, 0)];
+    }
 
     fn clientEnded(scenario: *Scenario) void {
         scenario.ended_count += 1;
@@ -958,5 +968,51 @@ test "health: rise restores an ejected endpoint after passing probes" {
     try std.testing.expectEqual(@as(u64, 3), bed.server.counters.get("kernel_pressure_connect"));
     try std.testing.expect(bed.server.health.healthy[0]);
     try std.testing.expectEqual(@as(u32, 0), bed.server.health.unhealthy_count);
+    try bed.expectDrained();
+}
+
+test "relay: an L4 connection charges its endpoint, and gives it back" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 12 } });
+    defer bed.tearDown();
+
+    // Sampled inside the origin's accept, which can only happen while the
+    // dial that charged the endpoint is still live: the count must be up
+    // by then. Without this the drain check below passes on a charge that
+    // never happened.
+    bed.scenario.origin.on_accept = Scenario.sampleL4Charge;
+    bed.scenario.origin.context = &bed.scenario;
+
+    bed.startClients(1, true);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u16, 1), bed.scenario.l4_sample);
+    try std.testing.expectEqual(Client.Outcome.eof, bed.scenario.clients[0].outcome);
+    // And back to zero afterwards — `expectDrained` asks the server, whose
+    // idle check now covers the charge table for every scenario in this
+    // file and every sim seed (§9).
+    try std.testing.expectEqual(
+        @as(u16, 0),
+        bed.server.l4_inflight[upstream_module.endpointKey(0, 0)],
+    );
+    try bed.expectDrained();
+}
+
+test "relay: a refused dial releases the endpoint charge it took" {
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 13 },
+        // Nothing listens: the dial is charged at `armConnect` and then
+        // refused, so the release rides a teardown that never relayed a
+        // byte — the path where an unbalanced charge would hide.
+        .origin_listens = false,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, true);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expect(bed.server.l4Released());
     try bed.expectDrained();
 }


### PR DESCRIPTION
First round of #123, per the [plan on that issue](https://github.com/zoxy-io/zoxy/issues/123#issuecomment-5145311030).

Until now the only thing that could say no on an origin's behalf was the
global upstream pool ceiling. §8 named the gap itself — *"Every rung but
one sheds on a resource running out"* — and an origin being overloaded is
not a zoxy resource running out, so nothing caught it.

```json
"api": { "endpoints": ["10.0.0.1:80", "10.0.0.2:80"], "max_inflight": 100 }
```

Per **endpoint**, not per cluster: the unit that matches a server's
capacity, and the one HAProxy's `server ... maxconn` names.

## Scope

Only one of the four examples in the linked HAProxy post protects a
backend — `maxconn`. The other three throttle abusive *clients* via stick
tables and 429s, which is a different feature with per-source state and an
eviction policy, and belongs in its own issue rather than folded in here.

Concurrency rather than requests/second, because it bounds what the origin
is *actually doing* (Little's law), needs no time-window bookkeeping, and
does not keep piling work on an origin that has merely become slow.

## Two commits

**1. The accounting — and a bug fix that fell out of it.**
`upstream.Load` pairs the pool's `leased_counts` (L7 in-flight requests)
with a new server-owned `l4_inflight` table (live L4 connections) and sums
them where load is read. Two tables rather than one shared counter:
`leased_counts <= slot_pool.slots.len` is a real invariant, and an L4
connection holds no pool slot, so with `conn_slots` above `upstream_slots`
— a legal config — a shared counter could only keep that bound by giving
it up.

`armConnect` carried this comment: *"the load table reflects L7 leases only
— the P2C draw still spreads L4 dials by the observed L7 load"*. On a
pure-L4 cluster that table is all zeros, so **p2c was comparing zero against
zero and spreading uniformly while presenting as load-aware.** It now weighs
both protocols. One test covers a pure-L4 cluster; another sets up a case
where reading either table alone picks the wrong endpoint and only the sum
picks the right one.

Charges are taken at the dial and released in `continueTeardown` beside the
relay buffer and upstream slot, exactly-once via a dedicated
`Conn.charged_endpoint` sentinel — separate from `log.endpoint_index`, which
the access log still needs after the charge is gone.

**2. The cap.** The pick runs two passes: health first (unchanged, fails
**open**), then capacity over whatever health left (may return zero, fails
**closed**). That asymmetry is the design — an ejected cluster means *we do
not know, try anyway*; a capped one means *we know they are full* — so the
ordering is asserted and tested from both directions, including the case
where health fails fully open and the caps still apply to the restored set.
A single-endpoint cluster leaves its fast path when capped, or the one
endpoint it has could never be protected.

Refusal reuses each protocol's existing answer: static `503` for L7, close
for L4. Neither counter takes the `shed_` prefix — both connections were
admitted before an endpoint could be picked, so folding them into
`accepted == admitted + shedTotal()` would make the gate identity false —
and they stay distinct from `l7_shed_upstream_slots`, which means *widen the
pool* where these mean *the backend is full*.

The reuse path is capped too: checking out a parked connection starts a
request the origin must serve, and the saved handshake does not make it free.

## Coverage

Six directed tests, **all six verified to fail with the cap filter
neutered** — the first attempt at that check did not compile and so proved
nothing until it did. Slice 1's charge/release balance is folded into
`isIdle`, so every L4 scenario and every sim seed checks it; since "always
zero" would satisfy that vacuously, a directed test samples the count inside
the origin's accept and was likewise verified to fail without the charge.

`zig build ci` (4096 seeds) and `zig fmt --check` green; tiger-style review
run on both commits and its findings fixed (a missing comptime relation on
the new constant, and `routeRequest` — already at the limit — split once my
branch pushed it to 80 lines).

## Not in this PR

- **Sim coverage of the cap.** The 4096-seed sweep exercises the new
  accounting on every seed, but no cluster there draws a `max_inflight` low
  enough to cross, so the refusal paths are covered by directed tests only.
  Worth adding with the instrumented-sweep method used in #127/#130, where
  the counter is measured rather than assumed.
- **A live smoke run.** The cap has only ever refused anything under SimIo.
- **Queueing.** HAProxy queues over-cap requests; §8's stance is shed-fast
  and never queue unboundedly. A bounded queue is representable but adds a
  waiting state, a queue timeout, and fairness questions — ship the shed,
  measure, then decide.
- **Client-side rate limiting** — separate issue, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)