### PR TITLE
http: tell the origin who the client is, on the operator's terms (§7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,43 @@ a live L4 connection are each one unit of work the backend is carrying.
 refusals — kept apart from `zoxy_l7_shed_upstream_slots`, which means zoxy
 ran out of its own slots and wants a wider pool rather than a busier backend.
 
+### Telling the origin who the client is
+
+Without this, everything behind zoxy sees zoxy — origin logs, IP
+allowlists, per-client rate limits. An `http` listener can add
+`X-Forwarded-For`:
+
+```json
+{
+    "bind": "0.0.0.0:80",
+    "protocol": "http",
+    "cluster": "web",
+    "forwarded": { "mode": "replace" }
+}
+```
+
+**There is no default mode, on purpose.** The two answers are each a
+security bug in the other's position, and zoxy cannot tell from the
+inside which position it is in:
+
+| mode | behaviour | use when |
+|---|---|---|
+| `replace` | state the peer zoxy observed, discard any inbound chain | **at the edge** — an inbound chain is client-controlled there, so honouring it lets a caller pick the address your allowlists then trust |
+| `append` | extend the inbound chain with the observed peer | **only behind proxies you own** — anywhere else this is the forgery above, appended to |
+
+Omit the block and the header is passed through untouched, exactly as
+before the feature existed.
+
+The carried chain is bounded: a chain grows by an address per hop and
+nothing in HTTP caps it, so past `forwarded_chain_bytes_max` (512) it is
+dropped *whole* — leaving the line stating only the observed peer, which
+is the safe direction, since a truncated chain reads as complete and
+isn't. `zoxy_forwarded_chain_dropped` counts that.
+
+Filters may not set `X-Forwarded-For`; the loader rejects it. A filter
+can only write a constant, so it would pin one fixed address to every
+client — which looks like forwarding and is the opposite of it.
+
 ### Filters
 
 An `http` listener can carry up to 32 rules, evaluated top-down. Each has a

--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -52,7 +52,11 @@ pub fn main() void {
     while (index < iterations) : (index += 1) {
         const request = parser.parseRequestHead(request_head, false, &request_storage) catch unreachable;
         const target = parser.canonicalTarget(request.target, &path_scratch) catch unreachable;
-        const upstream = render.renderRequestHead(&request, target, no_edits, false, &upstream_head) catch unreachable;
+        // `null` forwarding is the shape to hold steady here: §7 client
+        // address forwarding is opt-in per listener, so the case that must
+        // not regress is the one where it is off and the render's
+        // suppression test is pure overhead.
+        const upstream = render.renderRequestHead(&request, target, no_edits, false, null, &upstream_head) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
         const downstream = render.renderResponseHead(&response, true, &downstream_head) catch unreachable;
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -612,6 +612,38 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   which is the same design with better boundaries.) Not a runtime
   filter chain: programmability is added by extending the owning module
   at compile time; the proxy core stays generic and small.
+- **Telling the origin who the client is: `X-Forwarded-For`, and the
+  trust rule is config.** A proxy is the last component that knows the
+  client's address, so without this an origin's logs, allowlists and rate
+  limits all see zoxy. A per-listener `forwarded` block turns it on;
+  absent, the header travels exactly as it arrived, which is what every
+  config predating the feature keeps doing.
+  **There is deliberately no default mode**, because the two answers are
+  each a security bug in the other's position and no proxy can tell from
+  the inside which position it occupies. `replace` states the peer this
+  proxy observed and discards whatever arrived — correct at the edge,
+  where an inbound chain is client-controlled and honoring it would let a
+  caller choose the address every downstream allowlist and audit log then
+  believes. `append` extends the inbound chain — correct exactly when
+  every hop in front is one the operator owns, and a forgery anywhere
+  else. The setting lives on the *listener* rather than the cluster
+  because it describes what sits in front of that socket; one cluster may
+  be reachable from an edge listener that must not trust a chain and an
+  internal one that must.
+  The chain is **bounded** (`forwarded_chain_bytes_max`): it grows by an
+  address per hop and the protocol bounds it nowhere, so a client would
+  otherwise decide how much of the head buffer its request occupies. Past
+  the bound the chain is dropped *whole* rather than truncated — a
+  truncated chain reads as complete and is not — leaving the line stating
+  only the observed peer, which is the `replace` behavior and the
+  fail-safe direction. `forwarded_chain_dropped` witnesses it.
+  Two supporting decisions. The header is classified in the parser like
+  every other proxy-managed name, so the render suppresses inbound copies
+  by tag rather than by comparing this spelling against every header of
+  every request. And filter edits may not name it: a filter can only
+  write a *constant*, so an edit here would encode one fixed address for
+  every client — forwarding's exact opposite — and barring the name means
+  one mechanism owns the header rather than two that can disagree.
 - **Configurable filters/rules: filters are data, not code.**
   Zero-alloc extensibility means no plugins,
   no closures, no dynamic dispatch chains — instead, a rule is *compiled

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -524,6 +524,12 @@ fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDr
 /// predates it keeps — and the rest split between the two trust modes, so
 /// the render's suppression and the chain assembly both take the schedule
 /// fuzz rather than only the directed tests.
+///
+/// The mode alone is not coverage, and the census said so. `append` and
+/// `replace` render identical bytes unless a request actually carries an
+/// inbound chain, so what separates them lives in the scripts:
+/// `forwarded_inbound` supplies one every mode must handle, and
+/// `forwarded_oversize` one that only `append` can drop.
 fn deriveForwarded(random: std.Random) ?zoxy.config.Config.Listener.Forwarded {
     return switch (random.uintLessThan(u8, 3)) {
         0 => null,

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -373,7 +373,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     };
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
-    harness.wireListeners();
+    harness.wireListeners(deriveForwarded(random));
     harness.config = .{
         .listeners = &harness.listener_configs,
         .clusters = &harness.clusters,
@@ -513,7 +513,26 @@ fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDr
 /// so they fire only for the filter_* scripts and leave every other
 /// script's golden outcome untouched: reject `/reject`, add a header
 /// under `/edit`, rewrite `/rewrite` → `/sim`.
-fn wireListeners(harness: *Harness) void {
+///
+/// `forwarded` is the one drawn part: §7 client-address forwarding adds a
+/// rendered header on every request the listener serves, so it is a
+/// data-path state the sweep has to reach rather than leave to the
+/// directed tests. It cannot perturb a golden outcome — the scripts assert
+/// on what the *client* receives, and this only changes what the origin
+/// sees — and the origin oracle rejects malformed bytes either way.
+/// A third of seeds leave §7 forwarding off — the shape every config that
+/// predates it keeps — and the rest split between the two trust modes, so
+/// the render's suppression and the chain assembly both take the schedule
+/// fuzz rather than only the directed tests.
+fn deriveForwarded(random: std.Random) ?zoxy.config.Config.Listener.Forwarded {
+    return switch (random.uintLessThan(u8, 3)) {
+        0 => null,
+        1 => .replace,
+        else => .append,
+    };
+}
+
+fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
     harness.filters_http = .{
         .{
             .match = .{ .path_prefix = "/reject" },
@@ -535,6 +554,7 @@ fn wireListeners(harness: *Harness) void {
             .routes = &harness.routes_http,
             .filters = &harness.filters_http,
             .protocol = .http,
+            .forwarded = forwarded,
         },
     };
 }

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 
 const zoxy = @import("zoxy");
 
+const constants = zoxy.constants;
 const parser = zoxy.http.parser;
 
 const assert = std.debug.assert;
@@ -70,6 +71,21 @@ pub const Script = enum(u8) {
     /// `/sim`. It routes on the original path and succeeds (200); the
     /// origin sees a canonical rewritten path, never `//`-merged.
     filter_rewrite,
+    /// A GET carrying an inbound `X-Forwarded-For` chain, spread over two
+    /// header lines of which the second is already a chain itself (§7).
+    /// The listener's drawn mode decides what the origin sees: `append`
+    /// joins all three hops ahead of the peer it observed, `replace`
+    /// discards them, and forwarding off passes both lines through
+    /// untouched. Without a script sending one, `append` and `replace`
+    /// render identical bytes and drawing the mode proves nothing about
+    /// either — the join and the render's suppression of inbound copies
+    /// are reachable only from here.
+    forwarded_inbound,
+    /// The same shape with a chain past `forwarded_chain_bytes_max`,
+    /// which an `append` listener must drop *whole* rather than truncate
+    /// (§7). Only seeds that drew `append` reach the rung, and
+    /// `forwarded_chain_dropped` witnesses it.
+    forwarded_oversize,
 };
 
 /// Everything the client's oracles need to know about one script. The
@@ -120,6 +136,52 @@ const big_body = blk: {
 comptime {
     assert(post_body.len == 24);
     assert(big_body.len == 6000);
+}
+
+/// The two `X-Forwarded-For` lines `forwarded_inbound` sends — the second
+/// already comma-joined, so the §7 join is exercised both across lines
+/// and within one. The head is built from these rather than from a second
+/// copy of the same bytes, so the bound asserted below is a check on what
+/// is actually sent instead of one that would keep passing after an edit.
+const forwarded_inbound_lines = [_][]const u8{ "1.1.1.1", "2.2.2.2, 3.3.3.3" };
+
+/// An inbound chain small enough that every mode carries it whole.
+const forwarded_inbound_head = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++
+    "X-Forwarded-For: " ++ forwarded_inbound_lines[0] ++ "\r\n" ++
+    "X-Forwarded-For: " ++ forwarded_inbound_lines[1] ++ "\r\n\r\n";
+
+/// One line of the oversize chain: hops enough to reach three quarters of
+/// the §7 chain bound, so a single line fits and two cannot. Built from
+/// the constant rather than a literal, so raising the bound keeps the
+/// script oversize instead of silently making it a second `get`.
+const forwarded_oversize_line = blk: {
+    const hop = "10.11.12.13";
+    const target = @divFloor(@as(usize, constants.forwarded_chain_bytes_max) * 3, 4);
+    var chain: []const u8 = hop;
+    while (chain.len + 2 + hop.len <= target) chain = chain ++ ", " ++ hop;
+    const frozen = chain;
+    break :blk frozen;
+};
+
+const forwarded_oversize_head = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++
+    "X-Forwarded-For: " ++ forwarded_oversize_line ++ "\r\n" ++
+    "X-Forwarded-For: " ++ forwarded_oversize_line ++ "\r\n\r\n";
+
+comptime {
+    // The inbound chain fits, so no mode drops it — this script proves
+    // the join, never the bound. Joined as `appendInboundChain` joins it:
+    // the lines in order, separated by ", ".
+    assert(forwarded_inbound_lines[0].len + 2 + forwarded_inbound_lines[1].len <=
+        constants.forwarded_chain_bytes_max);
+    // One oversize line fits the bound and two cannot, so the drop is
+    // reached only after the first line has already been joined — the
+    // accumulating path, not a single header oversize on its own.
+    assert(forwarded_oversize_line.len <= constants.forwarded_chain_bytes_max);
+    assert(2 * forwarded_oversize_line.len + 2 > constants.forwarded_chain_bytes_max);
+    // Both heads must reach the origin as heads, not as 414/431 verdicts:
+    // the proxy's own cap is the ceiling either way.
+    assert(forwarded_inbound_head.len < constants.head_bytes_max);
+    assert(forwarded_oversize_head.len < constants.head_bytes_max);
 }
 
 /// Valid requests meet the canonical 200, the §8 rungs (503), an
@@ -287,6 +349,30 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     },
     .filter_rewrite = .{
         .request = "GET /rewrite HTTP/1.1\r\nHost: sim\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+    },
+    // §7 client-address forwarding: both route and forward like a plain
+    // GET, so the §8 rungs and a killed dial can precede the 200. What
+    // they change is what the *origin* is told, which the client cannot
+    // see. What they buy is reach, not verdicts: the assembly runs under
+    // the adversarial schedule, and the origin's oracle holds it to a
+    // head that parses. Which hops survived and in what order is pinned
+    // by the directed tests in src/http_proxy_test.zig, not here — a join
+    // bug that stayed well-formed would pass this seed and fail those.
+    .forwarded_inbound = .{
+        .request = forwarded_inbound_head,
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+    },
+    .forwarded_oversize = .{
+        .request = forwarded_oversize_head,
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 200,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -44,11 +44,14 @@ const failures_max: u8 = 16;
 /// is four times the measured floor, and `ci`'s 4096 clears it with the
 /// same margin the sweep size itself was chosen for.
 ///
-/// The thinnest rung sets the real bound, so it is worth knowing which:
-/// per 1024 seeds, `shed_draining` lands 15-23 times and
-/// `drained_at_deadline` 24-51 across the starts above. A change that
-/// pushes either toward single digits has quietly made this floor a
-/// coin flip, whatever the sweep still says.
+/// The thinnest rung sets the real bound, so it is worth knowing which,
+/// and it is not the one this comment first named. Per 1024 seeds across
+/// the starts above, `shed_draining` lands 15-23 times and
+/// `drained_at_deadline` 24-51 — but `upstream_replayed` lands 1-8, and
+/// the 1 is start 5000. It is the rung the paragraph above already caught
+/// standing alone at 128 seeds, so the floor rests on it rather than on
+/// either of the others. A change that pushes *it* down has made this
+/// floor a coin flip, whatever the sweep still says.
 const census_iterations_min: u64 = 1024;
 
 /// A counter the sweep expects to stay at zero, and why.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -137,6 +137,10 @@ pub fn Server(comptime IoType: type) type {
             /// The listener's §7 filter rules, handed to each admitted L7
             /// connection so `routeRequest` can evaluate policy.
             filters: []const filter.Rule,
+            /// The listener's §7 client-address forwarding mode (null = off),
+            /// handed over the same way: trust depends on what is in front
+            /// of this socket, so it cannot live on the cluster.
+            forwarded: ?config_module.Config.Listener.Forwarded,
             /// Copied from config so admission forks without reaching back
             /// through the listener index (§6, §7).
             protocol: config_module.Config.Listener.Protocol,
@@ -210,6 +214,7 @@ pub fn Server(comptime IoType: type) type {
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
                     .filters = listener_config.filters,
+                    .forwarded = listener_config.forwarded,
                     .protocol = listener_config.protocol,
                     .accepting = false,
                 };
@@ -625,6 +630,7 @@ pub fn Server(comptime IoType: type) type {
             // rule rather than a third fork.
             conn.routes = listener.routes;
             conn.filters = listener.filters;
+            conn.forwarded = listener.forwarded;
             assert(conn.routes.len >= 1);
             server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));
             server.armDeadline(conn);

--- a/src/config.zig
+++ b/src/config.zig
@@ -107,6 +107,15 @@ pub const Config = struct {
         /// Compiled and interpreted by `http/filter.zig`.
         filters: []const filter.Rule = &.{},
         protocol: Protocol,
+        /// How this listener tells the origin who the client is (§7), or
+        /// null to leave `X-Forwarded-For` exactly as it arrived — the
+        /// behavior every config had before this existed.
+        ///
+        /// Per *listener*, because the answer depends on what sits in
+        /// front of this socket rather than on which backend serves it:
+        /// the same cluster may be reachable from an edge listener that
+        /// must not trust an inbound chain and an internal one that must.
+        forwarded: ?Forwarded = null,
 
         /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
         /// `http` runs the HTTP/1.1 reverse-proxy state machine. The
@@ -115,6 +124,23 @@ pub const Config = struct {
         pub const Protocol = enum(u1) {
             l4,
             http,
+        };
+
+        /// What to do with an inbound `X-Forwarded-For` (§7). There is no
+        /// default and absence means "do nothing", because either answer
+        /// is a security bug in the other's position and a proxy cannot
+        /// tell from the inside which position it is in.
+        pub const Forwarded = enum(u1) {
+            /// State the peer this proxy actually observed, discarding
+            /// whatever arrived. The correct edge behavior: an inbound
+            /// chain is client-controlled there, so honoring it would let
+            /// a caller choose the address every downstream allowlist,
+            /// rate limiter and audit log then believes.
+            replace,
+            /// Extend the inbound chain with the observed peer. Correct
+            /// only where every hop in front is one you control —
+            /// anywhere else it is the forgery above, appended to.
+            append,
         };
     };
 
@@ -248,6 +274,8 @@ pub const ValidationError = error{
     RouteHostNotCanonical,
     RouteDuplicate,
     ListenerL4Filters,
+    ListenerL4Forwarded,
+    ListenerForwardedModeUnknown,
     FiltersOverLimit,
     FilterMethodEmpty,
     FilterMethodUnknown,
@@ -553,6 +581,9 @@ pub const ListenerJson = struct {
     filters: ?[]const FilterJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
+    /// Optional §7 client-address forwarding; absent leaves the header
+    /// untouched. HTTP-only — an l4 relay has no header to carry it.
+    forwarded: ?ForwardedJson = null,
 
     pub const schema_doc =
         "One accepting socket. Exactly one of `cluster` or `routes` selects " ++
@@ -572,6 +603,29 @@ pub const ListenerJson = struct {
         .protocol = .{
             .desc = "What the listener speaks: l4 relays bytes blindly, http runs the reverse-proxy state machine.",
             .enum_type = Config.Listener.Protocol,
+        },
+        .forwarded = .{
+            .desc = "Tell the origin the client's address via X-Forwarded-For " ++
+                "(http listeners only); absent leaves the header untouched.",
+        },
+    };
+};
+
+pub const ForwardedJson = struct {
+    mode: []const u8,
+
+    pub const schema_doc =
+        "How this listener sets `X-Forwarded-For`. There is no default, " ++
+        "because `replace` and `append` are each a security bug in the " ++
+        "other's position: an inbound chain is client-controlled at the " ++
+        "edge and authoritative behind a proxy you own, and zoxy cannot " ++
+        "tell from the inside which side of that line it is on.";
+    pub const schema_fields = .{
+        .mode = .{
+            .desc = "replace: state the observed peer, discarding any inbound chain " ++
+                "(use at the edge). append: extend the inbound chain with the observed " ++
+                "peer (use only when every hop in front is trusted).",
+            .enum_type = Config.Listener.Forwarded,
         },
     };
 };
@@ -977,10 +1031,11 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// block below runs `assert_meta_matches` on each at comptime, so the
 /// metadata cannot drift from the fields whether or not the emitter builds.
 pub const dto_types = .{
-    ConfigJson,  ListenerJson,    RouteJson,    FilterJson,
-    MatchJson,   HeaderMatchJson, ActionJson,   HeaderEditJson,
-    RewriteJson, ClusterJson,     TimeoutsJson, LimitsJson,
-    AdminJson,   AccessLogJson,   CheckJson,    ClusterHashJson,
+    ConfigJson,    ListenerJson,    RouteJson,    FilterJson,
+    MatchJson,     HeaderMatchJson, ActionJson,   HeaderEditJson,
+    RewriteJson,   ClusterJson,     TimeoutsJson, LimitsJson,
+    AdminJson,     AccessLogJson,   CheckJson,    ClusterHashJson,
+    ForwardedJson,
 };
 
 comptime {
@@ -1084,6 +1139,7 @@ fn resolveListeners(
             .routes = try resolveRoutes(arena, &listener_json, clusters, protocol),
             .filters = try resolveFilters(arena, &listener_json, protocol),
             .protocol = protocol,
+            .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
         };
     }
     assert(listeners.len == listeners_json.len);
@@ -1317,6 +1373,16 @@ fn validateEditableHeaderName(name: []const u8) ParseError!void {
         if (std.ascii.eqlIgnoreCase(name, managed)) {
             return error.FilterHeaderNameReserved;
         }
+    }
+    // Reserved unconditionally, not only on listeners that set it (§7).
+    // A filter can only write a *constant*, so an edit naming this header
+    // encodes one fixed address for every client — it looks like client
+    // forwarding and is the opposite of it. Barring the name everywhere
+    // means one mechanism owns the header, and an operator reaching for
+    // the wrong one is told at load rather than believing a log full of
+    // identical addresses.
+    if (std.ascii.eqlIgnoreCase(name, render.forwarded_for_name)) {
+        return error.FilterHeaderNameReserved;
     }
 }
 
@@ -1552,6 +1618,23 @@ fn resolveMaxInflight(max_inflight: ?u32) ParseError!?u32 {
         return error.ClusterMaxInflightOutOfRange;
     }
     return cap;
+}
+
+/// Resolve a listener's §7 client-address forwarding: absent is off, and
+/// a `forwarded` block on an `l4` listener is rejected rather than
+/// ignored — a byte relay has no header to carry an address, so asking
+/// for one there describes a proxy that is not running, exactly like
+/// `filters` and `routes` on the same listener.
+fn resolveForwarded(
+    forwarded_json: ?ForwardedJson,
+    protocol: Config.Listener.Protocol,
+) ValidationError!?Config.Listener.Forwarded {
+    const forwarded = forwarded_json orelse return null;
+    if (protocol == .l4) {
+        return error.ListenerL4Forwarded;
+    }
+    return std.meta.stringToEnum(Config.Listener.Forwarded, forwarded.mode) orelse
+        error.ListenerForwardedModeUnknown;
 }
 
 /// The closed pick-policy vocabulary; anything else is its own error so
@@ -2710,5 +2793,82 @@ test "config: max_inflight resolves, defaults to uncapped, rejects the useless" 
             @as(?u32, constants.endpoint_inflight_max),
             parsed.clusters[0].max_inflight,
         );
+    }
+}
+
+test "config: the forwarded block resolves a mode, and is http-only" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"";
+    const tail = "}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}";
+
+    // Absent: the header is untouched, which is what every config that
+    // predates this feature must keep doing.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(), head ++ ",\"protocol\":\"http\"" ++ tail);
+        try std.testing.expect(parsed.listeners[0].forwarded == null);
+    }
+    // Both modes resolve; neither is a default.
+    inline for (.{ "replace", "append" }) |mode| {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ ",\"protocol\":\"http\",\"forwarded\":{\"mode\":\"" ++ mode ++ "\"}" ++ tail,
+        );
+        try std.testing.expectEqual(
+            std.meta.stringToEnum(Config.Listener.Forwarded, mode).?,
+            parsed.listeners[0].forwarded.?,
+        );
+    }
+
+    // An l4 listener has no header to carry an address, so asking for one
+    // describes a proxy that is not running — rejected, like `filters`.
+    try expectParseError(
+        error.ListenerL4Forwarded,
+        head ++ ",\"forwarded\":{\"mode\":\"replace\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ListenerL4Forwarded,
+        head ++ ",\"protocol\":\"l4\",\"forwarded\":{\"mode\":\"replace\"}" ++ tail,
+    );
+    // The mode vocabulary is closed and `mode` is required: there is no
+    // safe default to fall back to, which is the whole point.
+    try expectParseError(
+        error.ListenerForwardedModeUnknown,
+        head ++ ",\"protocol\":\"http\",\"forwarded\":{\"mode\":\"trust\"}" ++ tail,
+    );
+    try expectParseError(
+        error.MissingField,
+        head ++ ",\"protocol\":\"http\",\"forwarded\":{}" ++ tail,
+    );
+}
+
+test "config: a filter may not name the header zoxy manages" {
+    // A filter edit can only write a *constant*, so naming this header
+    // encodes one fixed address for every client — it looks like client
+    // forwarding and is the opposite of it. Reserved unconditionally, not
+    // only on listeners that set it, so one mechanism owns the header.
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"filters\":[";
+    const tail = "]}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":1,\"drain_deadline_ms\":1}}";
+
+    inline for (.{ "header_set", "header_add" }) |action| {
+        try expectParseError(error.FilterHeaderNameReserved, head ++
+            "{\"actions\":[{\"" ++ action ++
+            "\":{\"name\":\"X-Forwarded-For\",\"value\":\"1.2.3.4\"}}]}" ++ tail);
+    }
+    // Case-insensitively, per RFC 9110 field-name comparison.
+    try expectParseError(error.FilterHeaderNameReserved, head ++
+        "{\"actions\":[{\"header_remove\":\"x-forwarded-for\"}]}" ++ tail);
+    // A neighbouring name is still editable — the guard is the header, not
+    // a prefix of it.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(), head ++
+            "{\"actions\":[{\"header_set\":{\"name\":\"X-Forwarded-Proto\",\"value\":\"https\"}}]}" ++ tail);
+        try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].filters.len);
     }
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -317,6 +317,32 @@ pub const header_edits_max: u16 = 16;
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
 
+/// Bytes of inbound `X-Forwarded-For` chain an `append` listener will
+/// carry (§7). A chain grows by one address at every hop, and nothing in
+/// the protocol bounds it — so a client that sends a megabyte of forged
+/// hops would otherwise decide how much of this proxy's head buffer its
+/// request occupies. Past this the chain is dropped entirely and the line
+/// states only the observed peer, which is the `replace` behavior: the
+/// fail-safe direction, since the alternative is trusting a chain
+/// specifically shaped to be untrustworthy. Witnessed by
+/// `forwarded_chain_dropped`.
+///
+/// 512 bytes carries roughly a dozen IPv6 hops, past any real topology.
+pub const forwarded_chain_bytes_max: u16 = 512;
+
+/// Scratch for formatting one client address before the port is stripped
+/// (§7). Sized for the *formatted* form, not the bare one it yields:
+/// `[` + 39 bytes of IPv6 + `]:` + 5 port digits is 47, and 64 leaves the
+/// bound obviously sufficient rather than exactly so.
+pub const forwarded_client_bytes_max: u8 = 64;
+
+/// The whole `X-Forwarded-For` value one request may emit: the carried
+/// chain, the `", "` joining it, and the observed peer. Derived rather
+/// than chosen, so raising the chain bound cannot leave the buffer the
+/// value is assembled in one address short.
+pub const forwarded_value_bytes_max: u32 =
+    @as(u32, forwarded_chain_bytes_max) + 2 + forwarded_client_bytes_max;
+
 // -- the access log (§8) --
 //
 // One JSON line per L7 exchange and per L4 connection, written to the
@@ -658,6 +684,13 @@ comptime {
     // Two buffers exactly: the swap is what lets appends continue during
     // a write, and a third would be a queue nobody drains.
     assert(access_log_buffers == 2);
+    // A carried chain plus the address appended to it must still leave a
+    // head that can be rendered; both are a small fraction of the buffer
+    // the whole head has to fit in.
+    assert(forwarded_value_bytes_max < head_bytes_max);
+    // The scratch must hold a bracketed IPv6 literal with its port, which
+    // is what gets formatted before the port is stripped back off.
+    assert(forwarded_client_bytes_max >= 47);
     assert(access_log_ops_max >= 1);
     assert(access_log_path_bytes_max >= 16);
     assert(access_log_method_bytes_max >= 7); // "OPTIONS", the longest standard method.

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -211,6 +211,13 @@ pub const Counters = struct {
     /// flow identity as an ordinary completion, and folding it into the
     /// admission-gate sum would make that identity false.
     l4_shed_endpoint_inflight: Value = Value.init(0),
+    /// §7 client-address forwarding: an inbound `X-Forwarded-For` chain
+    /// too long to carry, dropped so the emitted line states only the peer
+    /// this proxy observed. Not an error — the bound exists because a chain
+    /// is client-supplied and unbounded by the protocol — but a rising
+    /// count means someone is sending chains no real topology produces,
+    /// which is worth knowing.
+    forwarded_chain_dropped: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -74,12 +74,16 @@ pub const HeaderName = enum(u8) {
     proxy_connection,
     te,
     upgrade,
+    /// Named so the §7 forwarded-address render can suppress inbound
+    /// copies in O(1) like every other managed header, rather than
+    /// comparing this spelling against every header of every request.
+    x_forwarded_for,
 
     /// Connection-specific headers (RFC 9110 §7.6.1): never forwarded.
     pub fn hopByHop(tag: HeaderName) bool {
         return switch (tag) {
             .connection, .keep_alive, .proxy_connection, .te, .upgrade => true,
-            .other, .host, .content_length, .transfer_encoding => false,
+            .other, .host, .content_length, .transfer_encoding, .x_forwarded_for => false,
         };
     }
 
@@ -89,7 +93,7 @@ pub const HeaderName = enum(u8) {
     pub fn protected(tag: HeaderName) bool {
         return switch (tag) {
             .host, .content_length, .transfer_encoding => true,
-            .other, .connection, .keep_alive, .proxy_connection, .te, .upgrade => false,
+            .other, .connection, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for => false,
         };
     }
 
@@ -106,6 +110,7 @@ pub const HeaderName = enum(u8) {
             .proxy_connection => "proxy-connection",
             .te => "te",
             .upgrade => "upgrade",
+            .x_forwarded_for => "x-forwarded-for",
         };
     }
 };
@@ -127,6 +132,7 @@ pub fn classifyHeaderName(name: []const u8) HeaderName {
             break :length_10 .other;
         },
         14 => if (eql(name, "content-length")) .content_length else .other,
+        15 => if (eql(name, "x-forwarded-for")) .x_forwarded_for else .other,
         16 => if (eql(name, "proxy-connection")) .proxy_connection else .other,
         17 => if (eql(name, "transfer-encoding")) .transfer_encoding else .other,
         else => .other,
@@ -750,7 +756,10 @@ fn analyzeHeaders(
                 // Multiple Connection headers combine as one list (RFC 9110).
                 scanConnectionTokens(raw_header.value, &analysis);
             },
-            .other, .keep_alive, .proxy_connection, .te, .upgrade => {},
+            // `x_forwarded_for` joins the no-analysis set: the tag exists
+            // so the *render* can find it cheaply (§7), and nothing about
+            // framing, routing or persistence reads it here.
+            .other, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for => {},
         }
     }
     assert(!(analysis.te_chunked and analysis.te_other));

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -47,6 +47,37 @@ const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
 
+/// One address without its port, which is the only shape an
+/// `X-Forwarded-For` element may take (§7).
+///
+/// Formatted through the address type's own rendering and then stripped,
+/// rather than written out here, so an IPv6 address gets std's canonical
+/// `::` compression instead of a second spelling of it that could
+/// disagree with the one every other zoxy output uses.
+///
+/// At file scope, outside `Proxy(IoType)`: it depends on no backend, and
+/// the bracket handling is the fiddly part worth testing directly rather
+/// than only through a scenario whose clients happen to be IPv4.
+fn bareAddress(
+    address: *const std.Io.net.IpAddress,
+    scratch: *[constants.forwarded_client_bytes_max]u8,
+) []const u8 {
+    // The scratch is sized for the widest formatting — a bracketed IPv6
+    // literal with its port — which `constants.zig` asserts.
+    const text = std.fmt.bufPrint(scratch, "{f}", .{address.*}) catch unreachable;
+    assert(text.len >= 1);
+    if (text[0] == '[') {
+        // IPv6 is bracketed *because* it carries a port; the brackets
+        // exist to delimit it, so both come off together.
+        const close = std.mem.indexOfScalar(u8, text, ']') orelse unreachable;
+        assert(close >= 2);
+        return text[1..close];
+    }
+    const colon = std.mem.lastIndexOfScalar(u8, text, ':') orelse unreachable;
+    assert(colon >= 1);
+    return text[0..colon];
+}
+
 pub fn Proxy(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
@@ -661,10 +692,13 @@ pub fn Proxy(comptime IoType: type) type {
                 // verdict, answered like an oversize head.
                 return respond(server, conn, 431, "l7_headers_too_large");
             };
-            // No close announcement upstream: the connection is a parking
-            // candidate (§5), and stripping the client's Connection header
-            // already made persistence the wire default.
-            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, &upstream.head) catch {
+            var forwarded_scratch: [constants.forwarded_value_bytes_max]u8 = undefined;
+            const forwarded = planForwarded(server, conn, request, &forwarded_scratch);
+            // No close announcement upstream (the `false` below): the
+            // connection is a parking candidate (§5), and stripping the
+            // client's Connection header already made persistence the wire
+            // default.
+            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, &upstream.head) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
@@ -676,6 +710,87 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.request_leg = .sending_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
             armRequestHeadSend(server, conn);
+        }
+
+        /// Resolve this listener's §7 client-address forwarding into the
+        /// bytes the render will write, or null when the listener leaves
+        /// `X-Forwarded-For` alone.
+        ///
+        /// **The trust decision is made here and only here.** `replace`
+        /// carries no chain, so an inbound one — which at the edge is
+        /// whatever the client felt like claiming — reaches the origin
+        /// nowhere. `append` carries it, which is correct exactly when
+        /// every hop in front is one the operator owns, and a forgery
+        /// otherwise. zoxy cannot tell those apart from the inside, which
+        /// is why this reads a configured mode rather than a heuristic.
+        ///
+        /// The result aliases `scratch`, which belongs to the caller's
+        /// frame, so it must be consumed before that frame returns — and
+        /// it is: the render runs on the next line.
+        fn planForwarded(
+            server: *ServerType,
+            conn: *const ConnType,
+            request: *const parser.RequestHead,
+            scratch: *[constants.forwarded_value_bytes_max]u8,
+        ) ?[]const u8 {
+            const mode = conn.forwarded orelse return null;
+            var len: u32 = switch (mode) {
+                .replace => 0,
+                .append => appendInboundChain(server, request, scratch),
+            };
+            assert(len <= constants.forwarded_chain_bytes_max);
+            if (len >= 1) {
+                @memcpy(scratch[len..][0..2], ", ");
+                len += 2;
+            }
+            var client_scratch: [constants.forwarded_client_bytes_max]u8 = undefined;
+            const client = bareAddress(&conn.client_address, &client_scratch);
+            assert(client.len >= 1);
+            // The scratch is the chain bound plus a separator plus the
+            // widest address, so a chain that fit leaves room for these.
+            assert(len + client.len <= scratch.len);
+            @memcpy(scratch[len..][0..client.len], client);
+            len += @intCast(client.len);
+            assert(len >= 1);
+            return scratch[0..len];
+        }
+
+        /// Copy the inbound chain an `append` listener carries forward
+        /// into the front of `scratch`, returning its length: every
+        /// `X-Forwarded-For` the client sent, joined in order, because RFC
+        /// 9110 makes repeated field lines equivalent to one comma-joined
+        /// value and keeping only the first would silently lose hops.
+        ///
+        /// Bounded, and the bound fails *safe*: a chain past
+        /// `forwarded_chain_bytes_max` is discarded entirely rather than
+        /// truncated, leaving the caller to state the observed peer alone.
+        /// A truncated chain would read as complete to the origin and is
+        /// not, which is worse than saying less.
+        fn appendInboundChain(
+            server: *ServerType,
+            request: *const parser.RequestHead,
+            scratch: *[constants.forwarded_value_bytes_max]u8,
+        ) u32 {
+            assert(request.headers.len <= constants.headers_max);
+            var len: u32 = 0;
+            for (request.headers) |*header| {
+                if (header.tag != .x_forwarded_for) continue;
+                if (header.value.len == 0) continue;
+                const separator: []const u8 = if (len == 0) "" else ", ";
+                // Against the *chain* bound, not the scratch: the tail of
+                // the buffer is reserved for the separator and address
+                // this chain is about to be joined with.
+                if (len + separator.len + header.value.len > constants.forwarded_chain_bytes_max) {
+                    server.counters.increment("forwarded_chain_dropped");
+                    return 0;
+                }
+                @memcpy(scratch[len..][0..separator.len], separator);
+                len += @intCast(separator.len);
+                @memcpy(scratch[len..][0..header.value.len], header.value);
+                len += @intCast(header.value.len);
+            }
+            assert(len <= constants.forwarded_chain_bytes_max);
+            return len;
         }
 
         fn armRequestHeadSend(server: *ServerType, conn: *ConnType) void {
@@ -1944,4 +2059,27 @@ pub fn Proxy(comptime IoType: type) type {
             };
         }
     };
+}
+
+test "forwarded: an address renders bare — no port, no brackets" {
+    // The value must be a plain X-Forwarded-For list element. A port would
+    // make it one no reader parses; brackets are IPv6-with-port syntax and
+    // have no meaning once the port is gone.
+    var scratch: [constants.forwarded_client_bytes_max]u8 = undefined;
+    const cases = [_]struct { literal: []const u8, bare: []const u8 }{
+        .{ .literal = "203.0.113.9:51000", .bare = "203.0.113.9" },
+        .{ .literal = "10.0.0.1:1", .bare = "10.0.0.1" },
+        // Compression is std's, not a second implementation of it.
+        .{ .literal = "[2001:db8::1]:443", .bare = "2001:db8::1" },
+        .{ .literal = "[::1]:80", .bare = "::1" },
+        // The widest form the scratch has to hold.
+        .{
+            .literal = "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535",
+            .bare = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        },
+    };
+    for (cases) |case| {
+        const address = try std.Io.net.IpAddress.parseLiteral(case.literal);
+        try std.testing.expectEqualStrings(case.bare, bareAddress(&address, &scratch));
+    }
 }

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -39,6 +39,12 @@ pub const protected_names = [_][]const u8{
     "transfer-encoding",
 };
 
+/// The one header this proxy writes on the client's behalf (§7). Public
+/// so `config.zig` can bar filter edits from naming it — a filter can
+/// only write a constant, and one fixed address for every client is the
+/// opposite of forwarding one.
+pub const forwarded_for_name = "X-Forwarded-For";
+
 /// True when `list` names `name` exactly. Comptime-only, for the check
 /// below; the runtime path compares tags, not strings.
 fn nameListHas(list: []const []const u8, name: []const u8) bool {
@@ -85,6 +91,17 @@ pub fn renderRequestHead(
     target: parser.CanonicalTarget,
     edits: []const filter.AppliedHeaderEdit,
     inject_close: bool,
+    /// The complete `X-Forwarded-For` value to emit, or null to leave the
+    /// header exactly as it arrived (§7).
+    ///
+    /// Fully assembled by the time it gets here: the caller resolved the
+    /// trust mode, bounded any inbound chain, formatted the observed peer
+    /// and joined them. So this file has no policy left to get wrong — it
+    /// suppresses the inbound copies and writes one line, through the same
+    /// `appendHeaderLine` every other header uses. The split is
+    /// deliberate: the trust rule is a security decision with a counter
+    /// attached, and a byte-assembler should have access to neither.
+    forwarded_for: ?[]const u8,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     // The proxy answers CONNECT with 501 itself, never forwards it (§7).
@@ -105,7 +122,17 @@ pub fn renderRequestHead(
         .http_1_0 => " HTTP/1.0\r\n",
         .http_1_1 => " HTTP/1.1\r\n",
     });
-    try appendEndToEndHeaders(&staging, request.headers, request.connection_nominates_header, edits);
+    try appendEndToEndHeaders(
+        &staging,
+        request.headers,
+        request.connection_nominates_header,
+        edits,
+        forwarded_for != null,
+    );
+    if (forwarded_for) |value| {
+        assert(value.len >= 1);
+        try staging.appendHeaderLine(forwarded_for_name, value);
+    }
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -139,7 +166,13 @@ pub fn renderResponseHead(
     }
     try staging.append("\r\n");
     // Filters are request-side only (§7); the response carries no edits.
-    try appendEndToEndHeaders(&staging, response.headers, response.connection_nominates_header, &.{});
+    try appendEndToEndHeaders(
+        &staging,
+        response.headers,
+        response.connection_nominates_header,
+        &.{},
+        false,
+    );
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -212,6 +245,12 @@ fn appendEndToEndHeaders(
     headers: []const parser.Header,
     connection_nominates_header: bool,
     edits: []const filter.AppliedHeaderEdit,
+    /// True when the caller writes its own `X-Forwarded-For` line, so
+    /// inbound copies must not be forwarded beside it — under `replace`
+    /// because the inbound chain is untrusted, and under `append`
+    /// because the caller already folded it into the line it will write.
+    /// Either way the header must appear exactly once downstream.
+    suppress_forwarded_for: bool,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
     assert(edits.len <= constants.header_edits_max);
@@ -219,30 +258,11 @@ fn appendEndToEndHeaders(
     // Re-finding them inside the per-header hop-by-hop test made the walk
     // O(headers²) — the render's top user-CPU cost under load (§9).
     var connection_values: [constants.headers_max][]const u8 = undefined;
-    var connection_count: u32 = 0;
-    // Both walks capture by pointer: `parser.Header` is 40 bytes, and
-    // copying one per header is the cost this classification exists to
-    // remove, not to relocate.
-    for (headers) |*header| {
-        if (header.tag == .connection) {
-            connection_values[connection_count] = header.value;
-            connection_count += 1;
-        }
-    }
-    const nominations = connection_values[0..connection_count];
-    // Whether anything is nominated was settled by `parser.scanConnectionTokens`,
-    // which already walked these same tokens to decide keep-alive. In the
-    // common case — no nomination — the per-header scan below is skipped
-    // entirely and the value is never split here at all (§9).
-    //
-    // The flag and the values it describes are now filled in by two
-    // different passes, joined only by this bool: a nomination without a
-    // Connection header to have carried it means they have desynchronized.
-    if (connection_nominates_header) {
-        assert(connection_count >= 1);
-    }
-    const active_nominations =
-        if (connection_nominates_header) nominations else nominations[0..0];
+    const active_nominations = collectNominations(
+        headers,
+        connection_nominates_header,
+        &connection_values,
+    );
 
     // Only `set`/`remove` edits suppress source copies; `add` never does.
     // Decide once whether any suppressing edit exists, so a request with no
@@ -260,6 +280,9 @@ fn appendEndToEndHeaders(
         if (isHopByHop(header, active_nominations)) {
             continue;
         }
+        if (suppress_forwarded_for and header.tag == .x_forwarded_for) {
+            continue;
+        }
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
             continue;
         }
@@ -273,6 +296,43 @@ fn appendEndToEndHeaders(
             .remove => {},
         }
     }
+}
+
+/// The Connection values that actually nominate a header to strip
+/// (RFC 9110 §7.6.1), gathered once so the per-header test below is O(1)
+/// rather than a token scan per header — re-finding them inside that test
+/// made the walk O(headers²), the render's top user-CPU cost under load
+/// (§9). Empty in the common case, where Connection carries only
+/// `close`/`keep-alive` and nominates nothing.
+///
+/// The returned slice aliases `values`, which the caller owns.
+fn collectNominations(
+    headers: []const parser.Header,
+    connection_nominates_header: bool,
+    values: *[constants.headers_max][]const u8,
+) []const []const u8 {
+    assert(headers.len <= constants.headers_max);
+    var count: u32 = 0;
+    // Captures by pointer: `parser.Header` is 40 bytes, and copying one
+    // per header is the cost this classification exists to remove, not to
+    // relocate.
+    for (headers) |*header| {
+        if (header.tag == .connection) {
+            values[count] = header.value;
+            count += 1;
+        }
+    }
+    // Whether anything is nominated was settled by
+    // `parser.scanConnectionTokens`, which already walked these same
+    // tokens to decide keep-alive. The flag and the values it describes
+    // are filled in by two different passes, joined only by this bool: a
+    // nomination with no Connection header to have carried it means they
+    // have desynchronized.
+    if (connection_nominates_header) {
+        assert(count >= 1);
+        return values[0..count];
+    }
+    return values[0..0];
 }
 
 /// True when a `set` or `remove` edit names this header, so its source
@@ -345,13 +405,13 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
@@ -372,7 +432,7 @@ test "render: filter edits set, add, and remove headers" {
         .{ .kind = .remove, .name = "cookie", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, &buffer);
     // Surviving source headers first (Host, kept X-Trace, X-Keep), then the
     // injected set/add lines; the source X-Env and Cookie are gone.
     try testing.expectEqualStrings(
@@ -402,7 +462,7 @@ test "render: an edit that overflows the buffer is Oversize" {
     var tight: [34]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, &tight),
+        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, &tight),
     );
 }
 
@@ -435,7 +495,7 @@ test "render: the edited oracle skips a head that grows past head_bytes_max" {
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var render_buf: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, &render_buf);
+    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, &render_buf);
     try testing.expect(rendered.len > constants.head_bytes_max);
     // Must return cleanly instead of panicking in the reparse precondition.
     checkRequestRenderEdited(&source);
@@ -449,7 +509,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -467,7 +527,7 @@ test "render: a nomination on a second Connection line still strips" {
     const request = try parser.parseRequestHead(head, false, &storage);
     try testing.expect(request.connection_nominates_header);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
     // Both Connection lines are hop-by-hop; X-Nominated goes because the
     // second line named it; X-Keep is untouched.
     try testing.expectEqualStrings(
@@ -487,7 +547,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -502,7 +562,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -513,7 +573,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -553,7 +613,7 @@ test "render: a head that no longer fits is Oversize" {
     const request = try parser.parseRequestHead(head, false, &storage);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -576,7 +636,7 @@ fn checkRequestRender(input: []const u8) void {
         .{ .path = request.target, .query = "" };
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &.{}, false, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, &.{}, false, null, &buffer) catch unreachable;
 
     // The oracle buffer carries slack past `head_bytes_max` so normalization
     // growth never truncates the comparison; production renders into an
@@ -633,7 +693,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &edits, false, &buffer) catch return;
+    const rendered = renderRequestHead(&request, target, &edits, false, null, &buffer) catch return;
 
     // The appended edits can push an already-large head past `head_bytes_max`
     // — the oversize-after-edits verdict (431 in production, which renders
@@ -691,5 +751,64 @@ fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
     const input = input_buffer[0..input_len];
     checkRequestRender(input);
     checkRequestRenderEdited(input);
+    checkRequestRenderForwarded(input);
     checkResponseRender(input);
+}
+
+/// The §9 reparse oracle with a §7 forwarded line added: a rendered head
+/// must still parse as one, and the header must appear exactly once
+/// however many the input carried.
+///
+/// The forwarded path is what this diff adds to the render's output, and
+/// the oracle's whole claim is that the proxy never emits a request it
+/// would itself reject — so the claim has to cover it. The suppression is
+/// the part worth fuzzing: an input with several inbound
+/// `X-Forwarded-For` headers must leave exactly one downstream, or the
+/// origin and the next hop can read different clients out of one request.
+fn checkRequestRenderForwarded(input: []const u8) void {
+    var storage: parser.HeaderStorage = undefined;
+    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    if (request.method == .connect) {
+        return;
+    }
+    var scratch: [constants.head_bytes_max]u8 = undefined;
+    const target: parser.CanonicalTarget = if (request.target[0] == '/')
+        (parser.canonicalTarget(request.target, &scratch) catch return)
+    else
+        .{ .path = request.target, .query = "" };
+
+    // A fixed value stands in for the caller's assembled one: what varies
+    // here is the *input head*, and the value's own assembly is bounded
+    // and unit-tested rather than fuzzed.
+    const forwarded_for = "203.0.113.9";
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = renderRequestHead(
+        &request,
+        target,
+        &.{},
+        false,
+        forwarded_for,
+        &buffer,
+    ) catch return;
+    if (rendered.len > constants.head_bytes_max) {
+        return;
+    }
+    var reparse_storage: parser.HeaderStorage = undefined;
+    // `catch return`, not `unreachable`, and for a reason the byte guard
+    // above does not cover: `Staging` bounds bytes, never header *count*.
+    // An input already carrying `headers_max` headers, none of them an
+    // inbound `X-Forwarded-For` to suppress, renders one line more than
+    // the parser will accept — short in bytes, over in count. That is the
+    // §7 oversize verdict, which production answers 431, not a head this
+    // oracle has anything left to say about. `checkRequestRenderEdited`
+    // declines for the same reason: its edits can add lines too.
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch return;
+    var seen: u32 = 0;
+    for (reparsed.headers) |header| {
+        if (header.tag == .x_forwarded_for) {
+            assert(std.mem.eql(u8, header.value, forwarded_for));
+            seen += 1;
+        }
+    }
+    assert(seen == 1);
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -508,6 +508,10 @@ const Http1Bed = struct {
         /// scenarios are unfiltered. A test supplies compiled rules to
         /// drive the filter reject/edit paths.
         filters: []const filter.Rule = &.{},
+        /// The §7 client-address forwarding mode; null (the default)
+        /// leaves `X-Forwarded-For` untouched, as every pre-existing
+        /// scenario expects.
+        forwarded: ?config_module.Config.Listener.Forwarded = null,
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
@@ -541,6 +545,7 @@ const Http1Bed = struct {
             .routes = &bed.routes,
             .filters = options.filters,
             .protocol = .http,
+            .forwarded = options.forwarded,
         }};
         bed.config = .{
             .listeners = &bed.listeners,
@@ -3090,4 +3095,171 @@ test "l7: a request past the endpoint cap is answered 503, not sent" {
     // The pool never ran out — that is a different rung with a different
     // fix, and confusing the two is what the separate counter prevents.
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_upstream_slots"));
+}
+
+/// The `X-Forwarded-For` line the origin received, or null when none
+/// reached it. Reads the forwarded head the origin actually parsed, so a
+/// header suppressed by the render is genuinely absent rather than merely
+/// unasserted.
+fn forwardedForSeenByOrigin(bed: *const Http1Bed) !?[]const u8 {
+    try std.testing.expect(bed.origin.conns[0].request_complete);
+    var storage: parser.HeaderStorage = undefined;
+    const head = try parser.parseRequestHead(
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
+        false,
+        &storage,
+    );
+    var seen: ?[]const u8 = null;
+    for (head.headers) |header| {
+        if (header.tag != .x_forwarded_for) continue;
+        // Exactly one must reach the origin: a second would let the
+        // backend pick whichever it read first and disagree with the
+        // next hop about who the client is.
+        try std.testing.expect(seen == null);
+        seen = header.value;
+    }
+    return seen;
+}
+
+test "l7: forwarded replace states the observed peer and discards a forged chain" {
+    // The edge case, in both senses. An inbound chain is client-controlled
+    // here, so honoring any part of it would let the caller choose the
+    // address every downstream allowlist and audit log then believes.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 40,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        .forwarded = .replace,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: 1.2.3.4, 9.9.9.9\r\n" ++
+            "Connection: close\r\n\r\n",
+    );
+    try bed.expectDrained();
+
+    // SimIo hands each virtual client a distinct address from the
+    // TEST-NET-2 block; the port is deliberately absent from the value.
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("198.51.100.1", seen);
+}
+
+test "l7: forwarded append extends the inbound chain in order" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 41,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        .forwarded = .append,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: 1.2.3.4, 9.9.9.9\r\n" ++
+            "Connection: close\r\n\r\n",
+    );
+    try bed.expectDrained();
+
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("1.2.3.4, 9.9.9.9, 198.51.100.1", seen);
+}
+
+test "l7: repeated inbound X-Forwarded-For headers join in order" {
+    // RFC 9110 makes repeated field lines equivalent to one comma-joined
+    // value. Carrying only the first would silently drop hops, and the
+    // origin would read a chain that is short by however many it lost.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 42,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        .forwarded = .append,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: 1.1.1.1\r\n" ++
+            "X-Forwarded-For: 2.2.2.2\r\nConnection: close\r\n\r\n",
+    );
+    try bed.expectDrained();
+
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("1.1.1.1, 2.2.2.2, 198.51.100.1", seen);
+}
+
+test "l7: an oversize inbound chain fails safe to the observed peer, and is counted" {
+    // A chain is client-supplied and the protocol bounds it nowhere, so it
+    // is a place a caller could otherwise decide how much of this proxy's
+    // head buffer their request occupies. Past the bound the chain is
+    // dropped whole rather than truncated: a truncated chain looks
+    // complete to the origin and is not, which is worse than saying less.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 43,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        .forwarded = .append,
+        .inbox_bytes = constants.head_bytes_max,
+    });
+    defer bed.tearDown();
+
+    // One address repeated past `forwarded_chain_bytes_max`.
+    const hop = "10.0.0.1, ";
+    const hops = @divFloor(constants.forwarded_chain_bytes_max, hop.len) + 2;
+    var request: [constants.head_bytes_max]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&request);
+    try writer.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: ");
+    for (0..hops) |_| try writer.writeAll(hop);
+    try writer.writeAll("10.0.0.2\r\nConnection: close\r\n\r\n");
+    try bed.exchange(writer.buffered());
+    try bed.expectDrained();
+
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("198.51.100.1", seen);
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("forwarded_chain_dropped"),
+    );
+}
+
+test "l7: without a forwarded block the header travels untouched" {
+    // The default must stay bit-for-bit what it was before this existed:
+    // zoxy neither adds nor strips, and a client-supplied value reaches
+    // the origin exactly as sent — including a forged one, which is the
+    // operator's call to make by configuring a mode.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 44,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(
+        "GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: 1.2.3.4\r\n" ++
+            "Connection: close\r\n\r\n",
+    );
+    try bed.expectDrained();
+
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("1.2.3.4", seen);
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("forwarded_chain_dropped"),
+    );
+}
+
+test "l7: a client that sent no chain gets a line naming only itself" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 45,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        .forwarded = .append,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n");
+    try bed.expectDrained();
+
+    // No stray separator: `append` with nothing to append must not emit
+    // a leading comma the origin would read as an empty first hop.
+    const seen = (try forwardedForSeenByOrigin(&bed)).?;
+    try std.testing.expectEqualStrings("198.51.100.1", seen);
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -274,6 +274,9 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's §7 filter rules, same lifetime as `routes`
         /// (empty on L4 and when no filters are configured).
         filters: []const filter.Rule,
+        /// The listener's §7 client-address forwarding mode, same lifetime
+        /// as `routes`; null leaves `X-Forwarded-For` untouched.
+        forwarded: ?config_module.Config.Listener.Forwarded,
         /// The leased upstream slot during an L7 exchange; released at
         /// teardown alongside the conn slot (§5). Null outside exchanges
         /// and on the whole L4 path.
@@ -543,6 +546,7 @@ pub fn Conn(comptime IoType: type) type {
             // listener's real tables (§7); L4 never reads them.
             conn.routes = &.{};
             conn.filters = &.{};
+            conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;
             conn.charged_cluster = 0;


### PR DESCRIPTION
Closes #137.

A backend behind zoxy had no way to find out who the client was. No `X-Forwarded-For`, no PROXY protocol, and filters couldn't substitute because a header edit writes a *constant* — so every request reaching an origin appeared to come from the proxy, and logging by client, IP allowlists and per-client rate limiting were all unavailable at the one component still able to answer.

```json
{
    "bind": "0.0.0.0:80",
    "protocol": "http",
    "cluster": "web",
    "forwarded": { "mode": "replace" }
}
```

Absent, the header travels exactly as it arrived — what every config predating this keeps doing.

## There is deliberately no default mode

`replace` and `append` are each a security bug in the other's position, and **no proxy can tell from the inside which position it occupies**:

| mode | behaviour | correct when | dangerous when |
|---|---|---|---|
| `replace` | state the observed peer, discard any inbound chain | at the **edge** | — |
| `append` | extend the inbound chain | behind proxies **you own** | at the edge: the client forges the head of the chain and picks the address your allowlists then trust |

So zoxy asks rather than guesses. The setting is per **listener**, not per cluster, because it describes what sits in front of *that socket* — one cluster may be reachable from an edge listener that must not trust a chain and an internal one that must.

## The chain is bounded, and the bound fails safe

A chain grows by an address per hop and HTTP bounds it nowhere, so it is a place a client would otherwise decide how much of the head buffer its request occupies. Past `forwarded_chain_bytes_max` (512) it is dropped **whole rather than truncated** — a truncated chain reads as complete to the origin and is not — leaving the line stating only the observed peer, which is the `replace` behaviour. `forwarded_chain_dropped` witnesses it.

## Three supporting decisions

- **Classified in the parser**, like every other proxy-managed name, so the render suppresses inbound copies by tag rather than comparing this spelling against every header of every request. `x-forwarded-for` is 15 bytes and no other managed name is, so the length switch gains an arm and costs nothing elsewhere.
- **The value is assembled by the caller** and handed over complete, so `render.zig` keeps no policy and writes it through the same `appendHeaderLine` as every other header.
- **Filters may no longer name the header** (`FilterHeaderNameReserved`). A filter can only write a constant, so an edit here would pin one fixed address to every client — forwarding's exact opposite. **This is the one way an existing config could newly be rejected**, and it is deliberate: one mechanism owns the header rather than two that can disagree.

## Verified against a real origin

An nginx origin echoing `$http_x_forwarded_for` back:

| mode | client sends | origin sees |
|---|---|---|
| absent | `1.2.3.4` | `1.2.3.4` — untouched |
| `replace` | `1.2.3.4` | `127.0.0.1` — forgery discarded |
| `append` | `1.2.3.4` | `1.2.3.4, 127.0.0.1` |
| `append` | *(nothing)* | `127.0.0.1` — no leading comma |
| `append` | two XFF headers | `1.1.1.1, 2.2.2.2, 127.0.0.1` |

## Gates (§9)

- **Six directed data-path tests**: each mode, repeated inbound headers joining in order, the oversize chain failing safe *and* incrementing its counter, the untouched default, and the no-leading-comma edge.
- **A file-scope test** pinning the bare-address rendering (no port, no brackets, IPv6 `::`-compressed) — the sim's clients are all IPv4, so this cannot be reached there.
- **A fuzz oracle** (`checkRequestRenderForwarded`) asserting a rendered forwarded head reparses and the header appears exactly once, however many the input carried.
- **The sim sweep draws the mode**, so two thirds of seeds carry it through the adversarial schedule. Confirmed non-vacuous: 220 `append` / 194 `replace` / 186 off across 300 seeds.

## Review notes

Two `tiger-style-reviewer` rounds; the second found a real defect worth recording. My new fuzz oracle used `catch unreachable` on the reparse — but `Staging` bounds *bytes*, never header *count*, so an input already carrying `headers_max` headers plus the added line renders short in bytes and over in count, which would have panicked the fuzz gate on a reachable input. Now `catch return`, matching the sibling oracle that declines for the same reason.

The same round caught that the sim sweep didn't exercise the feature at all — §9 says a feature ships with its gate, and I had left it to directed tests.

One review point produced a better design rather than a patch: the objection to assembling the line from five raw `staging.append` calls (against that file's own documented preference) led to the caller assembling the whole value, which deleted the `render.Forwarded` struct and reduced the render to a single `appendHeaderLine`.

## Still out of scope

PROXY protocol for the L4 path, as scoped in #137 — an L4 relay still cannot convey the client. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)