### PR TITLE
sim: the sweep gates its own reach, not just each seed's outcomes (§9)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -858,7 +858,13 @@ origin, not one this proxy can pick for them.
   duration, byte counts each way, and the cluster and endpoint that
   served. `outcome` is not derivable from `status` and that is the point:
   an origin's own `503` and this proxy's shed `503` are the same three
-  digits and opposite events.
+  digits and opposite events. The two answer different questions — what
+  the origin said, and whether the client got it — so `status` is
+  recorded as soon as the response head is rendered (which the head
+  buffer can defer past the parse), while `ok` means "the whole response
+  reached the client" and is earned only when the last byte does. An exchange cut off mid-response logs its origin's status
+  with outcome `aborted`; exactly one `ok` line per `zoxy_l7_responses`
+  is what the §9 oracle asserts.
   **The unit is an admitted connection**, which is what draws the line
   between the two kinds of shed in the table above. A request-level shed
   — a `503` for relay buffers or upstream slots — belongs to a connection
@@ -961,6 +967,12 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    completion is delivered to a freed or reused slot (slot generations
    checked on every delivery, §5). A failure prints its seed; the same
    seed replays the exact schedule.
+   The access log is checked as an *equality*, not a sufficiency: every
+   HTTP line is either an outcome the data path counted or an abort, and
+   on a clean seed there are no aborts at all. An inequality — "at least
+   as many lines as outcomes" — is satisfied by writing too many, which
+   is how a phantom line per keep-alive connection once cleared 4096
+   seeds.
    Those invariants gate each seed's *shape*; a **coverage census** gates
    the sweep's *reach*. Every counter is totalled across the range, and a
    sweep of at least 1024 seeds fails unless each one fired at least once

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -982,7 +982,14 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    not inject, a volume it cannot reach) are exempted by name in a table
    that says what covers them instead, and the census fails just as loudly
    when an exemption *does* fire — so widening a scenario deletes its
-   entry rather than leaving a stale excuse behind.
+   entry rather than leaving a stale excuse behind. That second half also
+   carries the invariants that are *supposed* to read zero: a counter
+   whose whole point is to stay at zero is exempted with a reason saying
+   so, and the gate then fails the moment it moves.
+   `SimIo` counts deliveries per op kind for the same reason, so the
+   census covers the §4 seam as well as the §8 ladder — an op no seed ever
+   carries is a slice of the seam the gate has never run, and no counter's
+   silence would name it.
    `zig build sim -- fuzz` runs forever on entropy-derived seeds.
 2. **Fuzzing — `zig build test --fuzz`.** `std.testing.fuzz` on every
    parser edge: HTTP/1.1 head parser, chunked decoder, config parser.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -961,6 +961,16 @@ are the pass/fail part. `zig build ci` deliberately excludes it.
    completion is delivered to a freed or reused slot (slot generations
    checked on every delivery, §5). A failure prints its seed; the same
    seed replays the exact schedule.
+   Those invariants gate each seed's *shape*; a **coverage census** gates
+   the sweep's *reach*. Every counter is totalled across the range, and a
+   sweep of at least 1024 seeds fails unless each one fired at least once
+   — a rung no scenario reaches is a finding, not silence, and the gate
+   cannot claim a path it never walked. Counters the simulator provably
+   cannot move (an admin listener it does not configure, a fault it does
+   not inject, a volume it cannot reach) are exempted by name in a table
+   that says what covers them instead, and the census fails just as loudly
+   when an exemption *does* fire — so widening a scenario deletes its
+   entry rather than leaving a stale excuse behind.
    `zig build sim -- fuzz` runs forever on entropy-derived seeds.
 2. **Fuzzing — `zig build test --fuzz`.** `std.testing.fuzz` on every
    parser edge: HTTP/1.1 head parser, chunked decoder, config parser.

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -730,23 +730,87 @@ fn verifyAccessLog(harness: *Harness) !void {
     // The drain does not stop the loop until the sink is quiet (§8), so
     // the last byte written is the last byte of a line — never half of one.
     if (sink.len != 0 and sink[sink.len - 1] != '\n') return error.AccessLogTruncatedLine;
+    const tally = try tallyAccessLog(sink);
+    if (tally.total != counters.get("access_log_lines")) {
+        return error.AccessLogLineCountDiverged;
+    }
+
+    // A dropped line would make the equality below false for a reason
+    // that has nothing to do with the counter list it exists to pin, so
+    // the real condition fails first and under its own name. The rung is
+    // out of a scenario's reach (see the §9 census's `uncovered` entry),
+    // and the census proves that across the range — but only once the
+    // range finishes, which is too late to explain a single seed.
+    if (counters.get("access_log_dropped") != 0) return error.AccessLogDroppedInSweep;
+
+    // Every HTTP line is either an outcome the data path counted or an
+    // abort — an equality, and the reason this file no longer asks
+    // whether the log wrote *enough* lines. The `>=` it replaces was
+    // satisfied by writing too many, which is precisely how #129's
+    // phantom line per keep-alive connection cleared 4096 seeds.
+    //
+    // It also pins `l7OutcomeTotal`'s list: a new answered counter left
+    // out of it fails this on the first seed that reaches the rung, which
+    // is how `l7_shed_endpoint_inflight` turned out to have been missing
+    // since it shipped.
+    if (tally.http != l7OutcomeTotal(counters) + tally.http_aborted) {
+        return error.AccessLogHttpLinesDiverged;
+    }
+
+    // A clean seed answers everything it starts, so an abort is a bug
+    // rather than an adversary's work. Not quite by construction: what a
+    // clean seed removes is every *cause* of an abort — no resets, no
+    // kernel pressure, a well-behaved origin, and no drawn drain
+    // (`deriveDrainAt` skips clean seeds) — while the request and
+    // lifetime deadlines are still drawn and armed. They do not fire
+    // because a well-behaved origin answers within microseconds of
+    // virtual time, which is an argument about pacing rather than a
+    // guarantee; it held across all 1578 clean runs of the sweep.
+    //
+    // This is the half with teeth. The equality above counts a phantom
+    // abort on both sides and passes; this one refuses it outright, and
+    // is what fails on seed 10 when #129's bug is put back.
+    if (harness.clean) {
+        if (tally.http_aborted != 0) return error.AccessLogAbortedOnCleanSeed;
+        // And each L4 connection is one line: the clients connect once
+        // apiece, clean-seed pools are sized well past the population so
+        // none is shed at admission, and an L4 connection stamps its
+        // clock on admission rather than on first byte — so even the
+        // silent clients (`sim/l4.zig` draws some) owe a line, theirs
+        // reporting `bytes_in: 0`.
+        if (tally.l4 != harness.l4_count) return error.AccessLogL4LinesDiverged;
+    }
+}
+
+/// What the sink's lines are, counted by kind and outcome. Every line is
+/// shape-checked on the way past, so a malformed one fails here rather
+/// than being silently tallied.
+const LineTally = struct {
+    total: u64 = 0,
+    http: u64 = 0,
+    l4: u64 = 0,
+    http_aborted: u64 = 0,
+};
+
+fn tallyAccessLog(sink: []const u8) !LineTally {
+    var tally: LineTally = .{};
     var lines = std.mem.splitScalar(u8, sink, '\n');
-    var line_count: u64 = 0;
     while (lines.next()) |line| {
         if (line.len == 0) continue; // The tail after the final newline.
-        line_count += 1;
+        tally.total += 1;
         try verifyAccessLogLine(line);
-    }
-    if (line_count != counters.get("access_log_lines")) return error.AccessLogLineCountDiverged;
-
-    // Nothing was dropped, so every outcome the data path counted owes a
-    // line — plus one per L4 connection and per request that ended without
-    // a verdict, which is why this is an inequality.
-    if (counters.get("access_log_dropped") == 0) {
-        if (counters.get("access_log_lines") < l7OutcomeTotal(counters)) {
-            return error.AccessLogMissedAnOutcome;
+        if (std.mem.indexOf(u8, line, "\"kind\":\"http\"") == null) {
+            tally.l4 += 1;
+            continue;
+        }
+        tally.http += 1;
+        if (std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null) {
+            tally.http_aborted += 1;
         }
     }
+    assert(tally.http + tally.l4 == tally.total);
+    assert(tally.http_aborted <= tally.http);
+    return tally;
 }
 
 /// Every L7 outcome that answers a client, summed. Each one runs through
@@ -762,6 +826,7 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_filtered",
         "l7_shed_relay_buffers",
         "l7_shed_upstream_slots",
+        "l7_shed_endpoint_inflight",
         "l7_bad_gateway",
         "l7_gateway_timeout",
     };

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -173,9 +173,15 @@ fn deriveAdversary(random: std.Random, clean: bool) SimIo.Adversary {
         // sites on both dial paths were unreachable under every seed
         // until this fate existed (issue #106, kind B).
         .connect_pressure_percent = random.uintAtMost(u8, 5),
-        // A sink that has fallen behind (§8). Most seeds keep it instant;
-        // some stall it past a whole scenario, which is what fills the
-        // staging buffers and makes the drop rung reachable at all.
+        // A sink that has fallen behind (§8): the resume-a-short-write and
+        // stalled-drain paths, under schedule fuzz. Most seeds keep it
+        // instant; some stall it past a whole scenario.
+        //
+        // It does *not* reach the drop rung, whatever a stall's length: a
+        // scenario emits single-digit lines against staging buffers
+        // holding ~130, so there is nothing to overflow. The sweep's
+        // census names `access_log_dropped` as uncovered for exactly that
+        // reason, and src/access_log_test.zig drives the burst instead.
         .log_write_stall_ns = if (random.uintLessThan(u8, 4) == 0)
             random.uintAtMost(u64, 200_000_000)
         else

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -89,6 +89,27 @@ end_timer_completion: SimIo.Completion,
 /// to land often, not on every draw.
 http_origin_stop_at_ns: u64,
 http_origin_stop_completion: SimIo.Completion,
+/// Virtual instant at which the drain begins, or 0 for "at the
+/// scenario's end like every other seed".
+///
+/// Every seed already drains — `endScenario` calls `beginDrain` — but by
+/// then the clients have finished, so the drain's two race-dependent
+/// rungs stay out of reach: an accept completion already in flight when
+/// the drain starts (`shed_draining`), and a connection still live when
+/// the drain deadline fires (`drained_at_deadline`). Starting the drain
+/// while the scenario is still working is what puts traffic in front of
+/// it. Clean seeds never draw one — a drain is a legitimate reason to
+/// miss a golden outcome, which is the thing those seeds exist to
+/// forbid.
+///
+/// It is not free: a seed that stops accepting early serves less. Across
+/// the 4096-seed sweep this costs about 6% of the client work
+/// (`accepted` 12599 → 11858, `l7_responses` 2234 → 2119) and a quarter
+/// of the probes, since a draining server stops the prober. Eight rungs
+/// for 6% is the trade being made, and raising the draw rate would buy
+/// coverage margin at a steeper one.
+drain_at_ns: u64,
+drain_completion: SimIo.Completion,
 scenario_prng: std.Random.DefaultPrng,
 
 fn bindAddress() std.Io.net.IpAddress {
@@ -122,8 +143,21 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
         .seed = seed,
         .adversary = deriveAdversary(random, harness.clean),
     });
+    // Which cause the sim reports for every failure it injects (§8).
+    // Production reads it off an errno; a virtual socket table has none,
+    // so the scenario states one — and drawing it per seed is what makes
+    // four of the five `kernel_pressure_*` cause counters reachable at
+    // all: under the fixed `out_of_buffers` default that one counter
+    // carried every injected failure of a 4096-seed sweep and the other
+    // four stayed at zero. A clean seed injects nothing, so it keeps the
+    // default rather than choosing a cause it will never report.
+    if (!harness.clean) {
+        harness.io.setPressureCause(random.enumValue(Io.Pressure.Cause));
+    }
+    harness.drain_at_ns = deriveDrainAt(harness.clean, random);
     harness.deriveTopology(random);
     try harness.startServerAndOrigins(arena, random);
+    harness.injectOneShotFaults(random);
     harness.populateClients(random);
 
     harness.end_timer_completion = .{};
@@ -134,6 +168,17 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
         harness,
         onScenarioEnd,
     );
+    harness.drain_completion = .{};
+    if (harness.drain_at_ns != 0) {
+        assert(harness.drain_at_ns < scenario_end_ns);
+        harness.io.timerStart(
+            &harness.drain_completion,
+            harness.drain_at_ns,
+            Harness,
+            harness,
+            onDrainStart,
+        );
+    }
     harness.http_origin_stop_completion = .{};
     if (harness.http_origin_stop_at_ns != 0) {
         assert(harness.http_origin_stop_at_ns < scenario_end_ns);
@@ -144,6 +189,98 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
             harness,
             onHttpOriginStop,
         );
+    }
+}
+
+/// When the drain starts, for the seeds that start one early.
+///
+/// Bimodal, because the two rungs want opposite instants and one window
+/// cannot serve both. `shed_draining` needs the drain inside the opening
+/// accept burst, while sockets are still queued — a millisecond in.
+/// `drained_at_deadline` needs the drain to arrive after an exchange has
+/// begun, with a deadline short enough to still find it running (see
+/// `drain_deadline_ms` below, which is the other half of reaching it).
+///
+/// The split is load-bearing, not decoration: replacing it with one
+/// uniform 0.1-150 ms window drops `shed_draining` to 1 and 0 per 1024
+/// seeds from two starts — a census failure — while leaving
+/// `drained_at_deadline` untouched at 23-24.
+fn deriveDrainAt(clean: bool, random: std.Random) u64 {
+    if (clean) return 0;
+    if (random.uintLessThan(u8, 4) != 0) return 0;
+    const at_ns = if (random.boolean())
+        100_000 + random.uintAtMost(u64, 3 * std.time.ns_per_ms)
+    else
+        (10 + random.uintAtMost(u64, 140)) * std.time.ns_per_ms;
+    assert(at_ns >= 100_000);
+    assert(at_ns < scenario_end_ns);
+    return at_ns;
+}
+
+/// How long the drain gives its stragglers (§8).
+///
+/// A deadline long enough that the drain always finishes first is a
+/// deadline that never reaps, and `drained_at_deadline` stays
+/// unreachable however the drain itself is timed — measured: at the
+/// fixed 100 ms the timer delivered on 54 of 400 seeds and found every
+/// connection already tearing down. Seeds that drain early therefore
+/// sometimes draw one short enough to still find work running, which is
+/// a setting production operators tune too. Seeds that drain only at the
+/// scenario's end keep the roomy default: there is nothing left to reap
+/// by then, and a short deadline would say nothing about it.
+fn deriveDrainDeadlineMs(drain_at_ns: u64, random: std.Random) u32 {
+    assert(drain_at_ns < scenario_end_ns);
+    if (drain_at_ns == 0) return 100;
+    if (!random.boolean()) return 100;
+    const deadline_ms = 1 + random.uintAtMost(u32, 4);
+    assert(deadline_ms >= 1);
+    return deadline_ms;
+}
+
+/// The drawn mid-scenario drain (§8). `beginDrain` is idempotent, so the
+/// scenario-end drain that follows is a no-op rather than a second one.
+fn onDrainStart(harness: *Harness, result: Io.TimerError!void) void {
+    result catch return;
+    harness.server.beginDrain();
+}
+
+/// The one-shot faults the sweep would otherwise never pull (§9).
+///
+/// `SimIo` carries an injector for each — the set-option one exists
+/// precisely because "64 seeds stayed green because nothing could make
+/// the call fail" — but until now no seed called either, so the paths
+/// they reach stayed as unreachable as they were before the injectors
+/// were written. Adversarial seeds only: a fault is the wrong thing to
+/// hand a seed whose oracle is an exact golden outcome.
+///
+/// A pending set-option fault is claimed by whoever makes the next
+/// `setNodelay`/`setLingerRst` call, and that is not always the server:
+/// an origin double closing in reset mode makes one too. The first
+/// version of this function assumed the server always got there first
+/// and panicked the sweep on the seed that proved otherwise, which is
+/// why both doubles now absorb the error instead of taking it as
+/// `unreachable`. A fault landing on a double costs that origin its RST
+/// and nothing else, and the server still claims most of them: it calls
+/// `setNodelay` on every admission and every upstream dial, far earlier
+/// and far oftener than a double reaches a reset-mode close. Measured,
+/// since the split is the part worth doubting rather than asserting —
+/// `kernel_pressure_set_option` lands 232-265 times per 1024 seeds
+/// against roughly 288 faults drawn.
+fn injectOneShotFaults(harness: *Harness, random: std.Random) void {
+    assert(harness.server.listeners.len >= 1);
+    assert(harness.server.listeners.len <= harness.listener_configs.len);
+    if (harness.clean) return;
+    if (random.uintLessThan(u8, 4) == 0) {
+        const faults = 1 + random.uintAtMost(u8, 1);
+        for (0..faults) |_| harness.io.injectSetOptionError();
+    }
+    // An accept that fails backs the listener off by
+    // `accept_retry_delay_ms` and retries; the queued socket keeps its
+    // place, so no client is lost to this — it costs the scenario ten
+    // milliseconds of its two seconds.
+    if (random.uintLessThan(u8, 4) == 0) {
+        const index = random.uintLessThan(usize, harness.server.listeners.len);
+        harness.io.injectAcceptError(harness.server.listeners[index].listener);
     }
 }
 
@@ -242,7 +379,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         .clusters = &harness.clusters,
         .connect_timeout_ms = connect_timeout_ms,
         .idle_timeout_ms = 30 + random.uintAtMost(u32, 70),
-        .drain_deadline_ms = 100,
+        .drain_deadline_ms = deriveDrainDeadlineMs(harness.drain_at_ns, random),
         // A third of seeds arm the max-lifetime cap (§6). The range
         // straddles the idle timeout so the clamp sometimes reaps an
         // actively-relaying connection and sometimes never bites —

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -153,7 +153,14 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 };
                 assert(received >= 1);
                 if (conn.mode == .reset) {
-                    conn.origin.io.setLingerRst(conn.socket) catch unreachable;
+                    // An injected set-option fault (§9) can land here
+                    // rather than on the server: the injector is a
+                    // process-wide one-shot, and this double shares the
+                    // seam. Absorbing it costs the scenario an RST and
+                    // leaves a graceful close — a shape this origin
+                    // already produces in other modes, so every client
+                    // oracle still holds.
+                    conn.origin.io.setLingerRst(conn.socket) catch {};
                     conn.close();
                     return;
                 }

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -7,9 +7,13 @@
 
 const std = @import("std");
 
+const zoxy = @import("zoxy");
+
 const Harness = @import("Harness.zig");
 
 const assert = std.debug.assert;
+
+const Counters = zoxy.counters.Counters;
 
 const default_seed: u64 = 1;
 /// What `zig build sim` (and so `ci`) sweeps. Sized by census, not by
@@ -27,6 +31,233 @@ const progress_interval: u64 = 500;
 /// line per seed; the sweep reports the range it actually reached, so a
 /// run that hits this cap never reads as having cleared the remainder.
 const failures_max: u8 = 16;
+
+/// The smallest sweep whose census (see `Census`) is believed. Below it a
+/// range can miss a rung for want of seeds rather than for want of a
+/// path, so a replay — `zig build sim -- <seed> 1` — never fails on
+/// coverage.
+///
+/// Measured, not guessed: 256 seeds cover the whole non-exempt set from
+/// every start tried (1, 5k, 100k, 777_777, 31_415_926), while 64 leaves
+/// five rungs silent — `l7_uri_too_long`, `upstream_replayed`,
+/// `health_parked_closed`, and the recv/send halves of kernel pressure.
+/// This is four times the measured floor, and `ci`'s 4096 clears it with
+/// the same margin the sweep size itself was chosen for.
+const census_iterations_min: u64 = 1024;
+
+/// A counter no scenario can move, and where it is covered instead.
+const Uncovered = struct {
+    name: []const u8,
+    /// Why the sweep cannot reach it, and what reaches it instead.
+    /// Printed when the exemption stops being true, so it has to read as
+    /// an argument rather than a label.
+    reason: []const u8,
+};
+
+/// The counters a full sweep provably never moves: a listener the
+/// simulator does not configure, a fault it does not inject, a volume it
+/// cannot reach. Every entry names the directed test that covers the path
+/// instead, because "no seed reaches it" and "nothing tests it" are
+/// different claims and only the first one is being made here.
+///
+/// The gate reads both ways — a counter absent from this table must fire
+/// at least once, and a counter present must stay at zero. The second
+/// half is what stops the table rotting into stale excuses: widen a
+/// scenario until one of these fires and the sweep fails until its entry
+/// is deleted.
+const uncovered = [_]Uncovered{
+    .{
+        .name = "l7_headers_too_large",
+        .reason = "no script sends a header section past the head buffer; " ++
+            "src/http_proxy_test.zig drives both 431 shapes",
+    },
+    .{
+        .name = "l7_no_route",
+        .reason = "the sim's route table is a single \"/\" prefix, which no " ++
+            "path can miss; src/http_proxy_test.zig covers the path- and " ++
+            "host-miss 404s",
+    },
+    .{
+        .name = "l7_shed_upstream_slots",
+        .reason = "the only seeds that starve a pool set relay_buffers and " ++
+            "upstream_slots both to 1, and the L7 path takes the relay " ++
+            "buffer first, so the relay rung answers every request that " ++
+            "would have reached this one; src/http_proxy_test.zig " ++
+            "exhausts the upstream pool directly",
+    },
+    .{
+        .name = "l7_response_excess_sent",
+        .reason = "no seed raises the adversary's recv cap to head_bytes_max, " ++
+            "so no origin delivery fills the head buffer; " ++
+            "src/http_proxy_test.zig builds that delivery",
+    },
+    .{
+        .name = "kernel_pressure_accept",
+        .reason = "the harness never calls injectAcceptError; " ++
+            "src/server_test.zig drives the backoff-and-recover path",
+    },
+    .{
+        .name = "kernel_pressure_set_option",
+        .reason = "the harness never calls injectSetOptionError; " ++
+            "src/server_test.zig and src/http_proxy_test.zig drive both sites",
+    },
+    .{
+        .name = "kernel_pressure_out_of_memory",
+        .reason = "the sim classifies every injected failure as out_of_buffers; " ++
+            "src/server_test.zig walks the classification arms",
+    },
+    .{
+        .name = "kernel_pressure_fd_limit",
+        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
+    },
+    .{
+        .name = "kernel_pressure_address_unavailable",
+        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
+    },
+    .{
+        .name = "kernel_pressure_other_cause",
+        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
+    },
+    .{
+        .name = "admin_served",
+        .reason = "the sweep configures no admin listener; " ++
+            "src/admin_test.zig covers the scrape",
+    },
+    .{
+        .name = "admin_reaped",
+        .reason = "the sweep configures no admin listener; " ++
+            "src/admin_test.zig covers the scrape deadline",
+    },
+    .{
+        .name = "access_log_dropped",
+        .reason = "a scenario emits single-digit lines against staging buffers " ++
+            "holding ~130, so no schedule can overflow them; " ++
+            "src/access_log_test.zig drives the burst",
+    },
+    .{
+        .name = "access_log_write_failed",
+        .reason = "the harness never calls injectLogWriteError; " ++
+            "src/access_log_test.zig covers the stop-and-witness",
+    },
+    .{
+        .name = "shed_draining",
+        .reason = "no seed schedules a terminate signal; " ++
+            "src/server_test.zig drives the accept that raced the drain",
+    },
+    .{
+        .name = "drained_at_deadline",
+        .reason = "no seed schedules a terminate signal; " ++
+            "src/server_test.zig drives the drain deadline",
+    },
+};
+
+comptime {
+    // Every exemption is compared against every counter name, so the
+    // default quota runs out at this table's size.
+    @setEvalBranchQuota(uncovered.len * Counters.names.len * 32);
+    // A census over an empty set would pass by saying nothing, and a
+    // table that exempted everything would do the same.
+    assert(Counters.names.len >= 1);
+    assert(uncovered.len < Counters.names.len);
+    // An entry naming a counter that does not exist would exempt nothing
+    // while reading as though it exempted something, and a duplicate
+    // would let one deletion leave the other behind.
+    for (uncovered, 0..) |entry, index| {
+        var found = false;
+        for (Counters.names) |name| {
+            if (std.mem.eql(u8, name, entry.name)) found = true;
+        }
+        if (!found) {
+            @compileError("uncovered names a counter that does not exist: " ++ entry.name);
+        }
+        // The reason is the whole point of the entry: it is what the
+        // sweep prints when the exemption stops being true, and a blank
+        // one exempts a rung while saying nothing about what covers it.
+        if (entry.reason.len == 0) {
+            @compileError("uncovered gives no reason for " ++ entry.name);
+        }
+        for (uncovered[index + 1 ..]) |later| {
+            if (std.mem.eql(u8, entry.name, later.name)) {
+                @compileError("uncovered names " ++ entry.name ++ " twice");
+            }
+        }
+    }
+}
+
+/// The exemption for `name`, or null when the sweep is expected to reach
+/// it. Linear over a table of a few dozen entries, run once per counter
+/// at the end of a sweep.
+fn reasonFor(name: []const u8) ?[]const u8 {
+    assert(name.len >= 1);
+    for (uncovered) |entry| {
+        if (std.mem.eql(u8, name, entry.name)) {
+            // An empty reason would print as an exemption that argued
+            // nothing — the comptime block rejects one, and this is where
+            // that rejection is felt if it ever stops running.
+            assert(entry.reason.len >= 1);
+            return entry.reason;
+        }
+    }
+    return null;
+}
+
+/// What every counter totalled across a swept range, and the coverage
+/// verdict those totals carry (§9).
+///
+/// `reconcile` gates each seed's *shape* — work is never lost, every shed
+/// is witnessed — but nothing gated the sweep's *reach*, so a rung could
+/// quietly become unreachable and the gate would stay green describing a
+/// path no scenario walks. `kernel_pressure_set_option` is the standing
+/// example: `SimIo` grew an injector precisely because "64 seeds stayed
+/// green because nothing could make the call fail", and no seed has made
+/// the call fail since.
+const Census = struct {
+    totals: [Counters.names.len]u64 = @splat(0),
+
+    fn add(census: *Census, counters: *const Counters) void {
+        inline for (Counters.names, 0..) |name, index| {
+            const before = census.totals[index];
+            census.totals[index] += counters.get(name);
+            // A sweep is bounded by `iterations`, so no honest total can
+            // wrap — one that did would read as a rung going quiet.
+            assert(census.totals[index] >= before);
+        }
+    }
+
+    /// True when every counter agrees with its side of `uncovered`. Each
+    /// disagreement prints what to do about it: a silent rung wants a
+    /// scenario that reaches it, a fired exemption wants its entry gone.
+    fn verify(census: *const Census) bool {
+        var held = true;
+        var fired: usize = 0;
+        for (Counters.names, census.totals) |name, total| {
+            if (total != 0) fired += 1;
+            const reason = reasonFor(name);
+            if (reason == null and total == 0) {
+                std.debug.print(
+                    "sim census: {s} never fired — no scenario reaches it; " ++
+                        "widen one, or exempt it and say what covers it instead\n",
+                    .{name},
+                );
+                held = false;
+            }
+            if (reason != null and total != 0) {
+                std.debug.print(
+                    "sim census: {s} fired {d} time(s) but is exempt as \"{s}\" — " ++
+                        "the exemption is no longer true, so delete it\n",
+                    .{ name, total, reason.? },
+                );
+                held = false;
+            }
+        }
+        assert(fired <= Counters.names.len);
+        // The verdict restated as a partition: holding means the set that
+        // fired is exactly the complement of the exemption table — not
+        // merely that no single name was caught on the wrong side.
+        if (held) assert(fired == Counters.names.len - uncovered.len);
+        return held;
+    }
+};
 
 /// One swept range, and whether a failure ends it.
 const Sweep = struct {
@@ -62,7 +293,8 @@ fn fuzzForever(arena_state: *std.heap.ArenaAllocator, io: std.Io) !u8 {
         var seed_bytes: [8]u8 = undefined;
         io.random(&seed_bytes);
         const seed = std.mem.readInt(u64, &seed_bytes, .little);
-        checkSeed(arena_state, seed) catch return 1;
+        // No census: a random walk has no range to make a claim about.
+        checkSeed(arena_state, seed, null) catch return 1;
         if (count % progress_interval == 0) {
             std.debug.print("sim fuzz: {d} seeds ok, latest {d}\n", .{ count + 1, seed });
         }
@@ -109,8 +341,9 @@ fn sweep(arena_state: *std.heap.ArenaAllocator, options: *const Sweep) !u8 {
     var failed: [failures_max]u64 = @splat(0);
     var failed_count: u8 = 0;
     var seed = options.first_seed;
+    var census: Census = .{};
     while (seed < end) : (seed += 1) {
-        checkSeed(arena_state, seed) catch {
+        checkSeed(arena_state, seed, &census) catch {
             assert(failed_count < failures_max);
             failed[failed_count] = seed;
             failed_count += 1;
@@ -121,17 +354,50 @@ fn sweep(arena_state: *std.heap.ArenaAllocator, options: *const Sweep) !u8 {
             }
         };
     }
-    if (failed_count == 0) {
-        assert(seed == end);
-        std.debug.print("sim: {d} seed(s) ok, {d}..{d}\n", .{
+    if (failed_count != 0) {
+        reportFailures(options, failed[0..failed_count], @min(seed, end - 1));
+        return 1;
+    }
+    assert(seed == end);
+    if (!checkCensus(options, &census)) {
+        std.debug.print("sim: {d} seed(s) ran, {d}..{d}, census FAILED\n", .{
             options.iterations,
             options.first_seed,
             end - 1,
         });
-        return 0;
+        return 1;
     }
-    reportFailures(options, failed[0..failed_count], @min(seed, end - 1));
-    return 1;
+    std.debug.print("sim: {d} seed(s) ok, {d}..{d}\n", .{
+        options.iterations,
+        options.first_seed,
+        end - 1,
+    });
+    return 0;
+}
+
+/// The coverage census over a completed range, and its verdict on stdout.
+/// False means the census failed. Only ranges that swept clean reach
+/// here — a sweep that stopped early has nothing to say about the rungs
+/// its abandoned remainder was carrying.
+///
+/// A range too short to trust says so rather than passing quietly. That
+/// line is the difference between "coverage held" and "coverage was not
+/// asked", which a replay would otherwise report identically.
+fn checkCensus(options: *const Sweep, census: *const Census) bool {
+    assert(options.iterations >= 1);
+    if (options.iterations < census_iterations_min) {
+        std.debug.print("sim: census skipped, a range of {d} is under the {d} seeds it needs\n", .{
+            options.iterations,
+            census_iterations_min,
+        });
+        return true;
+    }
+    if (!census.verify()) return false;
+    std.debug.print("sim: census ok, {d} counter(s) fired, {d} exempt\n", .{
+        Counters.names.len - uncovered.len,
+        uncovered.len,
+    });
+    return true;
 }
 
 /// Names every failing seed, then the range actually covered: a sweep
@@ -154,13 +420,15 @@ fn reportFailures(options: *const Sweep, failed: []const u64, swept_last: u64) v
 }
 
 /// One seed, run twice: the second run must produce a byte-identical
-/// delivery trace or determinism itself is broken.
-fn checkSeed(arena_state: *std.heap.ArenaAllocator, seed: u64) !void {
-    const first = runSeed(arena_state, seed) catch |err| {
+/// delivery trace or determinism itself is broken. Only the first run
+/// feeds the census — the replay would double every total, and a census
+/// is a claim about what one pass over the range reached.
+fn checkSeed(arena_state: *std.heap.ArenaAllocator, seed: u64, census: ?*Census) !void {
+    const first = runSeed(arena_state, seed, census) catch |err| {
         std.debug.print("sim: FAILURE seed={d} error={t}\n", .{ seed, err });
         return err;
     };
-    const second = runSeed(arena_state, seed) catch |err| {
+    const second = runSeed(arena_state, seed, null) catch |err| {
         std.debug.print("sim: FAILURE on replay seed={d} error={t}\n", .{ seed, err });
         return err;
     };
@@ -173,7 +441,7 @@ fn checkSeed(arena_state: *std.heap.ArenaAllocator, seed: u64) !void {
     }
 }
 
-fn runSeed(arena_state: *std.heap.ArenaAllocator, seed: u64) !u64 {
+fn runSeed(arena_state: *std.heap.ArenaAllocator, seed: u64, census: ?*Census) !u64 {
     _ = arena_state.reset(.retain_capacity);
     const arena = arena_state.allocator();
 
@@ -185,5 +453,8 @@ fn runSeed(arena_state: *std.heap.ArenaAllocator, seed: u64) !u64 {
         return err;
     };
     try harness.verify();
+    // After `verify`, so a seed that failed its own oracles never counts
+    // toward coverage: a rung is only reached by a run that held.
+    if (census) |totals| totals.add(&harness.server.counters);
     return harness.io.trace_hash;
 }

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -38,11 +38,16 @@ const failures_max: u8 = 16;
 /// coverage.
 ///
 /// Measured, not guessed: 256 seeds cover the whole non-exempt set from
-/// every start tried (1, 5k, 100k, 777_777, 31_415_926), while 64 leaves
-/// five rungs silent — `l7_uri_too_long`, `upstream_replayed`,
-/// `health_parked_closed`, and the recv/send halves of kernel pressure.
-/// This is four times the measured floor, and `ci`'s 4096 clears it with
-/// the same margin the sweep size itself was chosen for.
+/// every start tried (1, 5k, 100k, 777_777, 31_415_926), while 128 still
+/// leaves `upstream_replayed` silent and 64 leaves six rungs silent. This
+/// is four times the measured floor, and `ci`'s 4096 clears it with the
+/// same margin the sweep size itself was chosen for.
+///
+/// The thinnest rung sets the real bound, so it is worth knowing which:
+/// per 1024 seeds, `shed_draining` lands 15-23 times and
+/// `drained_at_deadline` 24-51 across the starts above. A change that
+/// pushes either toward single digits has quietly made this floor a
+/// coin flip, whatever the sweep still says.
 const census_iterations_min: u64 = 1024;
 
 /// A counter no scenario can move, and where it is covered instead.
@@ -92,33 +97,6 @@ const uncovered = [_]Uncovered{
             "src/http_proxy_test.zig builds that delivery",
     },
     .{
-        .name = "kernel_pressure_accept",
-        .reason = "the harness never calls injectAcceptError; " ++
-            "src/server_test.zig drives the backoff-and-recover path",
-    },
-    .{
-        .name = "kernel_pressure_set_option",
-        .reason = "the harness never calls injectSetOptionError; " ++
-            "src/server_test.zig and src/http_proxy_test.zig drive both sites",
-    },
-    .{
-        .name = "kernel_pressure_out_of_memory",
-        .reason = "the sim classifies every injected failure as out_of_buffers; " ++
-            "src/server_test.zig walks the classification arms",
-    },
-    .{
-        .name = "kernel_pressure_fd_limit",
-        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
-    },
-    .{
-        .name = "kernel_pressure_address_unavailable",
-        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
-    },
-    .{
-        .name = "kernel_pressure_other_cause",
-        .reason = "as kernel_pressure_out_of_memory: one cause per sim run",
-    },
-    .{
         .name = "admin_served",
         .reason = "the sweep configures no admin listener; " ++
             "src/admin_test.zig covers the scrape",
@@ -138,16 +116,6 @@ const uncovered = [_]Uncovered{
         .name = "access_log_write_failed",
         .reason = "the harness never calls injectLogWriteError; " ++
             "src/access_log_test.zig covers the stop-and-witness",
-    },
-    .{
-        .name = "shed_draining",
-        .reason = "no seed schedules a terminate signal; " ++
-            "src/server_test.zig drives the accept that raced the drain",
-    },
-    .{
-        .name = "drained_at_deadline",
-        .reason = "no seed schedules a terminate signal; " ++
-            "src/server_test.zig drives the drain deadline",
     },
 };
 
@@ -207,10 +175,12 @@ fn reasonFor(name: []const u8) ?[]const u8 {
 /// `reconcile` gates each seed's *shape* — work is never lost, every shed
 /// is witnessed — but nothing gated the sweep's *reach*, so a rung could
 /// quietly become unreachable and the gate would stay green describing a
-/// path no scenario walks. `kernel_pressure_set_option` is the standing
+/// path no scenario walks. `kernel_pressure_set_option` was the standing
 /// example: `SimIo` grew an injector precisely because "64 seeds stayed
-/// green because nothing could make the call fail", and no seed has made
-/// the call fail since.
+/// green because nothing could make the call fail", and then no seed
+/// called the injector for as long as it existed. The census is what
+/// said so out loud; the harness now draws that fault, and the entry
+/// this table used to carry for it is gone.
 const Census = struct {
     totals: [Counters.names.len]u64 = @splat(0),
 

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -14,6 +14,7 @@ const Harness = @import("Harness.zig");
 const assert = std.debug.assert;
 
 const Counters = zoxy.counters.Counters;
+const SimIo = zoxy.Io.SimIo;
 
 const default_seed: u64 = 1;
 /// What `zig build sim` (and so `ci`) sweeps. Sized by census, not by
@@ -50,40 +51,80 @@ const failures_max: u8 = 16;
 /// coin flip, whatever the sweep still says.
 const census_iterations_min: u64 = 1024;
 
-/// A counter no scenario can move, and where it is covered instead.
+/// A counter the sweep expects to stay at zero, and why.
 const Uncovered = struct {
     name: []const u8,
-    /// Why the sweep cannot reach it, and what reaches it instead.
-    /// Printed when the exemption stops being true, so it has to read as
-    /// an argument rather than a label.
+    why: Why,
+    /// The argument itself: what reaches the counter instead, or what a
+    /// non-zero reading would mean. Printed when the entry's claim stops
+    /// holding, so it has to read as an argument rather than a label.
     reason: []const u8,
+
+    /// The two reasons an entry is here. They look identical to the gate
+    /// — both must read zero — and want opposite things from whoever the
+    /// gate wakes, so the remedy is printed from this rather than assumed.
+    const Why = enum {
+        /// No scenario reaches it. A non-zero reading is good news: some
+        /// scenario grew, and the entry has outlived its argument.
+        unreached,
+        /// It can be reached and must not be. A non-zero reading is a bug
+        /// report, and deleting the entry would be deleting the alarm.
+        must_stay_zero,
+    };
+
+    /// What to tell the reader when this entry's counter fires.
+    fn remedy(entry: *const Uncovered) []const u8 {
+        return switch (entry.why) {
+            .unreached => "a scenario now reaches it, so delete this entry",
+            .must_stay_zero => "this is the alarm, not a coverage note — " ++
+                "the invariant broke, so fix the code rather than the table",
+        };
+    }
 };
 
-/// The counters a full sweep provably never moves: a listener the
-/// simulator does not configure, a fault it does not inject, a volume it
-/// cannot reach. Every entry names the directed test that covers the path
-/// instead, because "no seed reaches it" and "nothing tests it" are
-/// different claims and only the first one is being made here.
+/// The counters a full sweep never moves. Most are unreachable: a
+/// listener the simulator does not configure, a fault it does not
+/// inject, a volume it cannot reach — and each names the directed test
+/// that covers the path instead, because "no seed reaches it" and
+/// "nothing tests it" are different claims and only the first is made
+/// here.
+///
+/// A few are here for the opposite reason: they *can* fire and must not,
+/// so a reading of zero is the invariant rather than an admission. `why`
+/// says which an entry is, and the gate prints the matching remedy —
+/// telling someone to delete the entry when the alarm they just tripped
+/// *is* the entry would be the worst advice the tool could give.
 ///
 /// The gate reads both ways — a counter absent from this table must fire
-/// at least once, and a counter present must stay at zero. The second
-/// half is what stops the table rotting into stale excuses: widen a
-/// scenario until one of these fires and the sweep fails until its entry
-/// is deleted.
+/// at least once, and a counter present must stay at zero — which is what
+/// serves both kinds at once, and what stops the table rotting into stale
+/// excuses.
 const uncovered = [_]Uncovered{
     .{
+        .name = "health_probe_deadline_raced",
+        .why = .must_stay_zero,
+        .reason = "the §4 race it counts — a probe deadline firing after its " ++
+            "own cancel was issued — is legal but has never occurred in a " ++
+            "sweep, while a prober that stopped cancelling at all reports " ++
+            "every verdict correctly and moves only this. That is #130 " ++
+            "exactly. Measured: 0 with the fix, 4760 with it reverted",
+    },
+    .{
         .name = "l7_headers_too_large",
+        .why = .unreached,
         .reason = "no script sends a header section past the head buffer; " ++
             "src/http_proxy_test.zig drives both 431 shapes",
     },
     .{
         .name = "l7_no_route",
+        .why = .unreached,
         .reason = "the sim's route table is a single \"/\" prefix, which no " ++
             "path can miss; src/http_proxy_test.zig covers the path- and " ++
             "host-miss 404s",
     },
     .{
         .name = "l7_shed_upstream_slots",
+        .why = .unreached,
         .reason = "the only seeds that starve a pool set relay_buffers and " ++
             "upstream_slots both to 1, and the L7 path takes the relay " ++
             "buffer first, so the relay rung answers every request that " ++
@@ -92,28 +133,33 @@ const uncovered = [_]Uncovered{
     },
     .{
         .name = "l7_response_excess_sent",
+        .why = .unreached,
         .reason = "no seed raises the adversary's recv cap to head_bytes_max, " ++
             "so no origin delivery fills the head buffer; " ++
             "src/http_proxy_test.zig builds that delivery",
     },
     .{
         .name = "admin_served",
+        .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++
             "src/admin_test.zig covers the scrape",
     },
     .{
         .name = "admin_reaped",
+        .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++
             "src/admin_test.zig covers the scrape deadline",
     },
     .{
         .name = "access_log_dropped",
+        .why = .unreached,
         .reason = "a scenario emits single-digit lines against staging buffers " ++
             "holding ~130, so no schedule can overflow them; " ++
             "src/access_log_test.zig drives the burst",
     },
     .{
         .name = "access_log_write_failed",
+        .why = .unreached,
         .reason = "the harness never calls injectLogWriteError; " ++
             "src/access_log_test.zig covers the stop-and-witness",
     },
@@ -152,18 +198,62 @@ comptime {
     }
 }
 
-/// The exemption for `name`, or null when the sweep is expected to reach
-/// it. Linear over a table of a few dozen entries, run once per counter
-/// at the end of a sweep.
-fn reasonFor(name: []const u8) ?[]const u8 {
+/// The §4 seam ops no scenario delivers, on the same both-ways terms as
+/// `uncovered`. One entry today, and it is a finding rather than a
+/// footnote: the whole asynchronous close path is unreached by 4096
+/// seeds.
+const uncovered_ops = [_]struct { kind: SimIo.OpKind, reason: []const u8 }{
+    .{
+        .kind = .close,
+        .reason = "src/admin.zig is the only asynchronous close in the tree — " ++
+            "every serving path closes synchronously via closeNow — and the " ++
+            "sweep configures no admin listener; src/admin_test.zig covers it",
+    },
+};
+
+comptime {
+    // The twin of `uncovered`'s validation: an entry naming `.none`
+    // exempts an op that is never delivered by construction, a duplicate
+    // lets one deletion leave the other behind, and a blank reason
+    // exempts a slice of the seam while saying nothing about it.
+    for (uncovered_ops, 0..) |entry, index| {
+        if (entry.kind == .none) @compileError("uncovered_ops names the .none op");
+        if (entry.reason.len == 0) {
+            @compileError("uncovered_ops gives no reason for " ++ @tagName(entry.kind));
+        }
+        for (uncovered_ops[index + 1 ..]) |later| {
+            if (entry.kind == later.kind) {
+                @compileError("uncovered_ops names " ++ @tagName(entry.kind) ++ " twice");
+            }
+        }
+    }
+    // `.none` is not a deliverable op, so it is never counted as covered.
+    assert(uncovered_ops.len < std.enums.values(SimIo.OpKind).len - 1);
+}
+
+fn opReasonFor(kind: SimIo.OpKind) ?[]const u8 {
+    assert(kind != .none);
+    for (uncovered_ops) |entry| {
+        if (entry.kind == kind) {
+            assert(entry.reason.len >= 1);
+            return entry.reason;
+        }
+    }
+    return null;
+}
+
+/// The entry for `name`, or null when the sweep is expected to reach it.
+/// Linear over a table of a few dozen entries, run once per counter at
+/// the end of a sweep.
+fn entryFor(name: []const u8) ?*const Uncovered {
     assert(name.len >= 1);
-    for (uncovered) |entry| {
+    for (&uncovered) |*entry| {
         if (std.mem.eql(u8, name, entry.name)) {
             // An empty reason would print as an exemption that argued
             // nothing — the comptime block rejects one, and this is where
             // that rejection is felt if it ever stops running.
             assert(entry.reason.len >= 1);
-            return entry.reason;
+            return entry;
         }
     }
     return null;
@@ -183,27 +273,43 @@ fn reasonFor(name: []const u8) ?[]const u8 {
 /// this table used to carry for it is gone.
 const Census = struct {
     totals: [Counters.names.len]u64 = @splat(0),
+    /// The same question asked of the §4 seam rather than the §8 ladder:
+    /// which *ops* the sweep ever delivered. A counter says a decision was
+    /// taken; an op says the ring carried the work. They fail
+    /// independently — `close` is delivered by exactly one call site in
+    /// the tree, so no counter's silence would have named it.
+    ops: [std.enums.values(SimIo.OpKind).len]u64 = @splat(0),
 
-    fn add(census: *Census, counters: *const Counters) void {
+    fn add(census: *Census, harness: *const Harness) void {
         inline for (Counters.names, 0..) |name, index| {
             const before = census.totals[index];
-            census.totals[index] += counters.get(name);
+            census.totals[index] += harness.server.counters.get(name);
             // A sweep is bounded by `iterations`, so no honest total can
             // wrap — one that did would read as a rung going quiet.
             assert(census.totals[index] >= before);
         }
+        for (std.enums.values(SimIo.OpKind)) |kind| {
+            if (kind == .none) continue;
+            const before = census.ops[@intFromEnum(kind)];
+            census.ops[@intFromEnum(kind)] += harness.io.deliveredCount(kind);
+            // As the counter loop above: a wrap would read as an op going
+            // quiet, which is the one thing this table exists to notice.
+            assert(census.ops[@intFromEnum(kind)] >= before);
+        }
     }
 
     /// True when every counter agrees with its side of `uncovered`. Each
-    /// disagreement prints what to do about it: a silent rung wants a
-    /// scenario that reaches it, a fired exemption wants its entry gone.
+    /// disagreement prints what to do about it, which is not the same
+    /// sentence twice: a silent rung wants a scenario that reaches it, and
+    /// a fired entry wants either its deletion or a bug fixed, depending
+    /// on which kind of entry it was (`Uncovered.remedy`).
     fn verify(census: *const Census) bool {
         var held = true;
         var fired: usize = 0;
         for (Counters.names, census.totals) |name, total| {
             if (total != 0) fired += 1;
-            const reason = reasonFor(name);
-            if (reason == null and total == 0) {
+            const entry = entryFor(name);
+            if (entry == null and total == 0) {
                 std.debug.print(
                     "sim census: {s} never fired — no scenario reaches it; " ++
                         "widen one, or exempt it and say what covers it instead\n",
@@ -211,13 +317,15 @@ const Census = struct {
                 );
                 held = false;
             }
-            if (reason != null and total != 0) {
-                std.debug.print(
-                    "sim census: {s} fired {d} time(s) but is exempt as \"{s}\" — " ++
-                        "the exemption is no longer true, so delete it\n",
-                    .{ name, total, reason.? },
-                );
-                held = false;
+            if (entry) |exempt| {
+                if (total != 0) {
+                    std.debug.print(
+                        "sim census: {s} fired {d} time(s), and should not have.\n" ++
+                            "  why: {s}\n  do: {s}\n",
+                        .{ name, total, exempt.reason, exempt.remedy() },
+                    );
+                    held = false;
+                }
             }
         }
         assert(fired <= Counters.names.len);
@@ -225,6 +333,44 @@ const Census = struct {
         // fired is exactly the complement of the exemption table — not
         // merely that no single name was caught on the wrong side.
         if (held) assert(fired == Counters.names.len - uncovered.len);
+        return census.verifyOps() and held;
+    }
+
+    /// Every op of the §4 seam must be delivered somewhere in the range.
+    /// An op no seed ever carries is a slice of the seam the gate has
+    /// never run, whatever its counters say.
+    fn verifyOps(census: *const Census) bool {
+        var held = true;
+        var carried: usize = 0;
+        for (std.enums.values(SimIo.OpKind)) |kind| {
+            if (kind == .none) continue;
+            const delivered = census.ops[@intFromEnum(kind)];
+            if (delivered != 0) carried += 1;
+            const reason = opReasonFor(kind);
+            if (reason == null and delivered == 0) {
+                std.debug.print(
+                    "sim census: op {t} never delivered — the seam carried it " ++
+                        "no work; widen a scenario, or exempt it and say what does\n",
+                    .{kind},
+                );
+                held = false;
+            }
+            if (reason != null and delivered != 0) {
+                std.debug.print(
+                    "sim census: op {t} was delivered {d} time(s) but is exempt " ++
+                        "as \"{s}\" — the exemption is no longer true, so delete it\n",
+                    .{ kind, delivered, reason.? },
+                );
+                held = false;
+            }
+        }
+        assert(carried < std.enums.values(SimIo.OpKind).len);
+        // The same partition `verify` states for counters: holding means
+        // the ops the seam carried are exactly the deliverable set minus
+        // the exemptions, not merely that no one op landed wrongly.
+        if (held) {
+            assert(carried == std.enums.values(SimIo.OpKind).len - 1 - uncovered_ops.len);
+        }
         return held;
     }
 };
@@ -363,9 +509,11 @@ fn checkCensus(options: *const Sweep, census: *const Census) bool {
         return true;
     }
     if (!census.verify()) return false;
-    std.debug.print("sim: census ok, {d} counter(s) fired, {d} exempt\n", .{
+    std.debug.print("sim: census ok, {d} counter(s) fired, {d} exempt; {d} seam op(s), {d} exempt\n", .{
         Counters.names.len - uncovered.len,
         uncovered.len,
+        std.enums.values(SimIo.OpKind).len - 1 - uncovered_ops.len,
+        uncovered_ops.len,
     });
     return true;
 }
@@ -425,6 +573,6 @@ fn runSeed(arena_state: *std.heap.ArenaAllocator, seed: u64, census: ?*Census) !
     try harness.verify();
     // After `verify`, so a seed that failed its own oracles never counts
     // toward coverage: a rung is only reached by a run that held.
-    if (census) |totals| totals.add(&harness.server.counters);
+    if (census) |totals| totals.add(&harness);
     return harness.io.trace_hash;
 }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -206,6 +206,21 @@ pub const Counters = struct {
 
     const Value = std.atomic.Value(u64);
 
+    /// Every counter's field name, in declaration order — the one place
+    /// the set is enumerated. `render` walks it, `render_bytes_max` sizes
+    /// against it, `shedTotal` picks the `shed_` prefix out of it, and the
+    /// §9 sweep's coverage census requires each name to have moved. A
+    /// counter added above joins all four without being listed anywhere
+    /// else.
+    pub const names: []const []const u8 = blk: {
+        var collected: []const []const u8 = &.{};
+        for (@typeInfo(Counters).@"struct".fields) |field| {
+            if (field.type != Value) continue;
+            collected = collected ++ [_][]const u8{field.name};
+        }
+        break :blk collected;
+    };
+
     /// Live pool occupancy against capacity (§8 "watermarks before
     /// walls"). Gauges, not counters: they go both ways, and a scrape
     /// wants the level, not the history.
@@ -286,9 +301,8 @@ pub const Counters = struct {
         const u64_digits_max = 20; // len("18446744073709551615")
         const u32_digits_max = 10; // len("4294967295")
         var total: usize = 0;
-        for (@typeInfo(Counters).@"struct".fields) |field| {
-            if (field.type != Value) continue;
-            const name_len = metric_prefix.len + field.name.len;
+        for (names) |name| {
+            const name_len = metric_prefix.len + name.len;
             total += "# TYPE ".len + name_len + " counter\n".len;
             total += name_len + " ".len + u64_digits_max + "\n".len;
         }
@@ -318,16 +332,15 @@ pub const Counters = struct {
         // merely sufficient one.
         assert(buffer.len >= render_bytes_max);
         var cursor: usize = 0;
-        inline for (@typeInfo(Counters).@"struct".fields) |field| {
-            if (field.type != Value) continue;
+        inline for (names) |name| {
             // The format string is fully comptime (only the value is
             // runtime), so bufPrint cannot fail for a value that fits u64
             // in a buffer sized to render_bytes_max.
             const written = std.fmt.bufPrint(
                 buffer[cursor..],
-                "# TYPE " ++ metric_prefix ++ field.name ++ " counter\n" ++
-                    metric_prefix ++ field.name ++ " {d}\n",
-                .{counters.get(field.name)},
+                "# TYPE " ++ metric_prefix ++ name ++ " counter\n" ++
+                    metric_prefix ++ name ++ " {d}\n",
+                .{counters.get(name)},
             ) catch unreachable;
             cursor += written.len;
         }
@@ -378,9 +391,8 @@ pub const Counters = struct {
     /// identity vacuously true.
     const shed_rung_count: usize = blk: {
         var count: usize = 0;
-        for (@typeInfo(Counters).@"struct".fields) |field| {
-            if (field.type != Value) continue;
-            if (std.mem.startsWith(u8, field.name, shed_prefix)) count += 1;
+        for (names) |name| {
+            if (std.mem.startsWith(u8, name, shed_prefix)) count += 1;
         }
         break :blk count;
     };
@@ -389,10 +401,9 @@ pub const Counters = struct {
     fn shedTotal(counters: *const Counters) u64 {
         comptime assert(shed_rung_count >= 1);
         var total: u64 = 0;
-        inline for (@typeInfo(Counters).@"struct".fields) |field| {
-            if (field.type != Value) continue;
-            if (comptime !std.mem.startsWith(u8, field.name, shed_prefix)) continue;
-            total += counters.get(field.name);
+        inline for (names) |name| {
+            if (comptime !std.mem.startsWith(u8, name, shed_prefix)) continue;
+            total += counters.get(name);
         }
         return total;
     }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -125,6 +125,18 @@ pub const Counters = struct {
     /// ejected (§5): a parked socket to a dead origin is a stale replay
     /// waiting to be spent.
     health_parked_closed: Value = Value.init(0),
+    /// Probe deadlines that fired *after* the verdict was already known —
+    /// the §4 race between a timer and its own cancel, where the delivery
+    /// is accounting and nothing else. Counts the race only while
+    /// probing: the same shape during a stop is discarded with the rest
+    /// of the prober's drain, where no verdict is waiting on it.
+    ///
+    /// It exists to be small. A prober that reaches its verdict and then
+    /// forgets to cancel the deadline still reports every check
+    /// correctly; the only thing it gets wrong is how long each probe
+    /// holds the prober, and this counter is the difference between the
+    /// race happening occasionally and it happening every time (#130).
+    health_probe_deadline_raced: Value = Value.init(0),
     /// §8 rung: ENOBUFS/ENOMEM-class op failures, one per treated op —
     /// across every completion (accept, connect, setNodelay, and the relay
     /// recv/send data path). The total; `kernel_pressure_by_op` below

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1112,11 +1112,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.response_leg = .sending_head;
             // Committed to answering: no verdict may intervene from here (§7).
             conn.l7.response_started = true;
-            // The origin's own status, and `ok` whatever it is: `outcome`
-            // exists precisely so an origin's 503 and this proxy's shed
-            // 503 do not read as the same event (§8).
+            // What the origin said, so a line can report it even if the
+            // exchange never finishes. Whether the client *got* it is a
+            // separate fact, and `outcome` stays `aborted` until
+            // `finishExchange` earns `ok` (§8).
             conn.log.status = response.status;
-            conn.log.outcome = .ok;
             armClientWrite(server, conn, conn.head[0..head_write_len], .response_excess);
         }
 
@@ -1343,7 +1343,11 @@ pub fn Proxy(comptime IoType: type) type {
             server.counters.increment("l7_responses");
             // The whole response reached the client: the line goes out
             // now, before the turnaround below clears what it reports.
-            assert(conn.log.outcome == .ok);
+            // This is also the only place `ok` is earned — nothing between
+            // the response head being queued and this point may claim it,
+            // which is what keeps one `ok` line per `l7_responses`.
+            assert(conn.log.outcome == .aborted);
+            conn.log.outcome = .ok;
             server.logExchange(conn);
 
             const request_complete = conn.l7.request_leg == .done;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -2847,6 +2847,43 @@ test "l7: a shed and an origin 503 are the same status and different outcomes" {
     try std.testing.expect(std.mem.indexOf(u8, origin_line, "\"upstream\":\"127.0.0.1:9000\"") != null);
 }
 
+test "l7: a response cut off mid-flight logs aborted, not ok" {
+    // `ok` is defined as "the whole response reached the client" (§8), so
+    // it is earned at `finishExchange` and nowhere earlier. Setting it when
+    // the response head is *queued* — which is what the code did until the
+    // §9 log oracle became an equality — makes every exchange that dies
+    // mid-response log a success that never happened, with the origin's
+    // status attached to lend it weight. An operator counting
+    // `outcome:"ok"` would have read more successes than
+    // `zoxy_l7_responses` reports, with nothing in the line to say which
+    // ones were fiction.
+    //
+    // The origin promises 32 bytes and sends none, so the head reaches the
+    // client and the body never does; the request deadline then fires on
+    // an exchange that has already started responding, which §8 answers by
+    // tearing down rather than by a 504.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 12,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n\r\n",
+        .request_timeout_ms = 30,
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /cut HTTP/1.1\r\nHost: a\r\n\r\n");
+    try bed.expectDrained();
+
+    // No exchange completed, so nothing may claim to have.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_responses"));
+    const line = try onlyAccessLogLine(&bed);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") == null);
+    // The status still reports what the origin said: it is a fact about
+    // the origin, and the outcome is the separate fact about the client.
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"status\":200") != null);
+}
+
 test "l7: a reject logs the target the client actually sent" {
     // A path that will not canonicalize has no §7 spelling to report, and
     // an empty field would tell an operator investigating a 400 nothing at

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -99,6 +99,13 @@ stopped: bool,
 dump_on_deadlock: bool,
 /// FNV-1a over every delivery; two runs of one seed must end equal (§9).
 trace_hash: u64,
+/// Completions delivered so far, by op kind (§9). `trace_hash` says two
+/// runs of a seed did the *same* work; this says how much work that was,
+/// which is the question a hash cannot answer — a run doing three times
+/// as much hashes identically both times. Cumulative rather than
+/// concurrent, so it extends §8's closed-form op budgets from
+/// "worst-case in flight" to "total consumed".
+delivered: [std.enums.values(OpKind).len]u64,
 blackholed_addresses: [blackholed_addresses_max]std.Io.net.IpAddress,
 blackholed_count: u8,
 /// One-shot dial faults by address (`injectConnectError`): the next
@@ -189,7 +196,22 @@ pub const Completion = struct {
     pub const State = enum(u8) { dead, pending };
 };
 
-const Op = union(enum) {
+/// The seam's op set, named so the §9 gate can count and report
+/// deliveries by kind rather than by tag number.
+pub const OpKind = enum(u8) {
+    none,
+    accept,
+    connect,
+    recv,
+    send,
+    close,
+    log_write,
+    timer,
+    timer_cancel,
+    connect_cancel,
+};
+
+const Op = union(OpKind) {
     none,
     accept: struct { listener_index: u16 },
     connect: struct { address: std.Io.net.IpAddress, fate: ConnectFate, canceled: bool },
@@ -380,6 +402,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.stopped = false;
     io.dump_on_deadlock = options.dump_on_deadlock;
     io.trace_hash = std.hash.Fnv1a_64.init().value;
+    io.delivered = @splat(0);
     io.blackholed_addresses = undefined;
     io.blackholed_count = 0;
     io.connect_error_addresses = undefined;
@@ -1415,7 +1438,17 @@ fn closeEntryWithReset(io: *SimIo, socket: Socket) void {
     io.closeEntry(socket);
 }
 
+/// Deliveries of one op kind so far this run (§9).
+pub fn deliveredCount(io: *const SimIo, kind: OpKind) u64 {
+    assert(kind != .none);
+    return io.delivered[@intFromEnum(kind)];
+}
+
 fn traceMix(io: *SimIo, completion: *const Completion, result: *const Result) void {
+    // Every delivery funnels through here, which is what makes one
+    // increment enough to count them all.
+    assert(completion.op != .none);
+    io.delivered[@intFromEnum(completion.op)] += 1;
     io.mix(@intFromEnum(completion.op));
     io.mix(@intFromEnum(result.*));
     const detail: u64 = switch (result.*) {

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -526,10 +526,17 @@ pub fn Checker(comptime IoType: type) type {
                     // or a mute origin releases the prober (§5).
                     checker.pending_verdict = .fail;
                     checker.endArmedLeg();
+                } else {
+                    // The fire raced its own cancel (a legal §4 race): the
+                    // outcome is decided, this delivery is op accounting
+                    // only. Counted because "rare race" and "the cancel is
+                    // never issued" produce the same *outcomes* and differ
+                    // only in how much budget each probe burns — which is
+                    // exactly the shape of #130, where every probe idled
+                    // out its whole `timeout_ms` and every check still
+                    // reported the right verdict.
+                    checker.server.counters.increment("health_probe_deadline_raced");
                 }
-                // Otherwise the fire raced its own cancel (a legal §4
-                // race): the outcome is decided, this delivery is op
-                // accounting only.
             } else |err| {
                 assert(err == error.Canceled);
                 assert(checker.pending_verdict != .none);

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -88,7 +88,13 @@ pub fn Origin(comptime IoType: type) type {
                         conn.armSend();
                     },
                     .reset_on_first_chunk => {
-                        io.setLingerRst(conn.socket) catch unreachable;
+                        // As the L7 origin double: an injected set-option
+                        // fault (§9) is a process-wide one-shot and can be
+                        // claimed here instead of by the server. A
+                        // graceful close in place of the RST is a shape
+                        // this origin already produces, so the byte-level
+                        // oracles are unaffected.
+                        io.setLingerRst(conn.socket) catch {};
                         io.closeNow(conn.socket);
                         conn.done = true;
                     },


### PR DESCRIPTION
Closes #134. Proposal 4 was split into #144 rather than dropped.

**Both bugs the issue was written about are now caught by the gate**: #129
fails a clean seed at seed 10, #130 fails the census. Verified by putting
each bug back, not by assuming.

`reconcile` has always gated what each seed *does*. Nothing gated what the
swept range *reached*, so a rung could go quiet and 4096 green seeds would
say nothing about it.

## 1. The census, and what it found

Every counter is totalled across the range; each must fire at least once.
**Sixteen of fifty never did.** They are exempted by name in a table
stating what covers them instead, and the gate reads both ways — an exempt
counter that *does* fire fails the sweep too, so widening a scenario
deletes its entry rather than leaving a stale excuse behind.

The sharpest find: `SimIo` grew a set-option injector precisely because
*"64 seeds stayed green because nothing could make the call fail"* — and
then no seed ever called it, for as long as it existed. The scar was
documented and not actually healed.

## 2. Eight of the sixteen were not unreachable at all

The simulator already carried everything needed; the harness never asked.
Drawing a `Pressure.Cause` per seed brings four of the five
`kernel_pressure_*` counters to life; the set-option and accept injectors
get called; and a drain drawn mid-scenario puts traffic in front of the
two drain rungs, which previously only ever ran against an idle server.

## 3. The access log balances now, and two defects fell out

`lines >= counted outcomes` is satisfied by writing too many, which is
exactly how #129's phantom line cleared 4096 seeds. It is an equality now.

- **`l7OutcomeTotal` never learned about `l7_shed_endpoint_inflight`** —
  short by every capacity shed since #136, and `>=` could not care.
- **`outcome: "ok"` was written for exchanges that never finished.** Set
  when the response head was *queued*, while `l7_responses` only counts
  when the last byte reaches the client. 374 of 6176 sim runs carried one.
  An operator counting `ok` read more successes than `zoxy_l7_responses`
  reported, with nothing in the line to say which were fiction. A
  production fix, and the code was already disagreeing with itself:
  `Outcome.ok` reads *"the whole response reached the client"*.

## 4. The seam is censused too — and the budget idea did not survive

`SimIo` now counts deliveries per op kind. First answer: **`close` is
delivered zero times in 4096 seeds** — one async close exists in the tree,
in `admin.zig`, and the sweep configures no admin listener. No counter's
silence would have named that.

The issue proposed budgeting these as ratios (*"timer deliveries per probe
≤ 2"*). Measured, it does not hold up:

| candidate budget | spread across seeds |
| --- | --- |
| `timer_cancel` per probe | 0.50 – 18.00 |
| probes vs. what the interval predicts | 0.043 – 0.857 |

No threshold sits usefully in either range; sweep-level aggregates
separate fixed from broken by 6%. **An exact zero works where a ratio
cannot.** `health_probe_deadline_raced` counts probe deadlines firing
after their own cancel — legal, and never once produced by a seed. A
prober that stops cancelling reports every verdict correctly and moves
only this: **0 with the #130 fix, 4760 with it reverted.**

That invariant lives in the census's exemption table, which turns out to
be the right home for "must stay at zero" as well as "no scenario reaches
this". They want opposite things from whoever the gate wakes, so entries
carry which kind they are and the failure prints the matching remedy —
telling someone to delete the entry when the alarm they tripped *is* the
entry would be the worst advice the tool could give.

## What the code decided against me

Recorded where it will be read next, rather than quietly fixed:

- The set-option injector is process-wide, so an origin double can claim
  the fault. My first version argued the server always gets there first;
  the sweep panicked on the seed that disagreed.
- `drained_at_deadline` stayed silent however the drain was timed. The
  deadline timer was firing all along — 54 times in 400 seeds — and
  finding every connection already torn down. The lever was the deadline's
  length, not the drain's instant.
- The bimodal drain draw is load-bearing: one uniform window collapses
  `shed_draining` to 1 and 0 per 1024 seeds.
- A `health_probe_timeouts` counter with a `reconcile` assertion panicked
  immediately — a deadline can decide `.fail` and the run can end before
  the leg witnesses it. Dropped rather than propped up.

## Costs and margins, stated rather than hidden

Early drains make the sweep serve ~6% less (`accepted` 12599 → 11858) and
run a quarter fewer probes, since a draining server stops the prober.

The census floor is 1024 seeds, measured: 256 covers the non-exempt set
from every start tried, 128 leaves `upstream_replayed` silent. The two
drain rungs are the thinnest in the gate at 15-23 and 24-51 per 1024
seeds, and the floor's comment names them so a future pacing change
re-checks rather than trusts the green. A range too short to trust prints
`census skipped` rather than passing quietly.

## Verified by breaking it

| broken on purpose | result |
| --- | --- |
| **#129's shape** — request clock started before the head-read unwrap | sweep fails, **seed 10** |
| **#130's shape** — probe deadline never cancelled | census fails, names it, prints "fix the code rather than the table" |
| the `ok`-at-commit-time bug restored | sweep fails, seed 17; directed test fails |
| a dead rung with its exemption removed | census fails, names it |
| a live rung with an exemption added | census fails, prints "delete this entry" |
| an unexercised seam op | census fails, names the op |
| misspelled name, duplicate entry, blank reason | three distinct compile errors |
| a one-seed replay | `census skipped`, exit 0 |

The first comptime guard I wrote was vacuous — it validated the exemption
table against itself — which surfaced only because breaking each check was
a step rather than an afterthought.

## Still open

Nine counters and one seam op stay exempt, each with its argument in the
table. The largest cluster is the two log rungs, which need a sink
failure injected — and that forces the oracle to accept an unknown number
of lines lost in the failed flush. #144 (Tier 0.5) would reach several of
the others by running the real binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
