### PR TITLE
config: accept a root `$schema` editor hint instead of rejecting it (§5)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -463,7 +463,12 @@ Rules:
   Schema can express: the loader's semantic checks (canonical
   prefixes/hosts, address literals, reserved header names, port ≠ 0) and
   the "exactly one of" forks stay the loader's job, so passing the schema
-  means well-shaped, not accepted.
+  means well-shaped, not accepted. The one concession strictness makes to
+  the schema is a root `$schema` key: it is a declared, optional field that
+  the loader parses and ignores, so an editor can point a config at the
+  document without the proxy refusing to start over the pointer. It buys no
+  general laxity — `$schemas`, or a `$schema` nested inside any other
+  object, is still an unknown field.
 - **A slot is released only when its armed-op set is empty.** Teardown is
   where the races live — a lesson paid for in implementation time and
   simulator seeds last iteration. Every op references a completion

--- a/src/config.zig
+++ b/src/config.zig
@@ -432,6 +432,12 @@ fn resolveAccessLogBuffer(
 // `config_schema.zig` walks the same DTOs to emit the JSON Schema. Public
 // so the emitter and its tests can reflect over the real wire shape.
 pub const ConfigJson = struct {
+    /// Editor hint only: the URL of the JSON Schema this file claims to
+    /// follow (`$id` in the emitted document). Declared so an editor may add
+    /// it for completion and validation without the loader rejecting the
+    /// file; parsed, never read. Strictness is unharmed — a near miss like
+    /// `$schemas` is still an unknown field.
+    @"$schema": ?[]const u8 = null,
     listeners: []const ListenerJson,
     clusters: ClustersJson,
     timeouts: TimeoutsJson,
@@ -450,6 +456,9 @@ pub const ConfigJson = struct {
         "IP:port literal parsing, reserved header names, endpoint port != 0) " ++
         "are enforced by the loader and are not expressible in JSON Schema.";
     pub const schema_fields = .{
+        .@"$schema" = .{
+            .desc = "URL of the JSON Schema this config follows; an editor hint, ignored by the loader.",
+        },
         .listeners = .{
             .desc = "Sockets the proxy accepts connections on.",
             .min_items = 1,
@@ -2330,6 +2339,38 @@ test "config: strictness rejects unknown and duplicate fields" {
     );
     try expectParseError(error.MissingField,
         \\{"clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+}
+
+test "config: a `$schema` editor hint loads and is ignored" {
+    // Editors point at the shipped schema by writing `$schema` into the
+    // file; a strict loader that rejected it would make the schema asset
+    // unusable for the very files it describes.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"$schema":"https://zoxy.io/schema/config.schema.json",
+            \\ "listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+        );
+        // Accepted, and it changed nothing about the resolved config.
+        try std.testing.expectEqual(@as(usize, 1), parsed.listeners.len);
+        try std.testing.expectEqual(@as(usize, 1), parsed.clusters.len);
+    }
+    // The hint buys no general laxity: a near miss is still unknown, and it
+    // is only a root key — nested objects reject it like any other extra.
+    try expectParseError(error.UnknownField,
+        \\{"$schemas":"x",
+        \\ "listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
+    );
+    try expectParseError(error.UnknownField,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","$schema":"x"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":1,"drain_deadline_ms":1}}
     );
 }

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -332,6 +332,25 @@ test "config_schema: the emitted document is valid, documented JSON" {
     try std.testing.expectEqual(false, root.object.get("additionalProperties").?.bool);
 }
 
+test "config_schema: the `$schema` editor hint is a declared root property" {
+    // `additionalProperties: false` is what makes the schema mirror the
+    // strict loader, so the key an editor writes to *find* this schema has
+    // to be declared here too — otherwise pointing at it flags the pointer.
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer parsed.deinit();
+
+    const properties = parsed.value.object.get("properties").?.object;
+    const hint = properties.get("$schema").?.object;
+    try std.testing.expectEqualStrings("string", hint.get("type").?.string);
+    // Optional, exactly as the loader has it: a config without the hint is
+    // still valid.
+    for (parsed.value.object.get("required").?.array.items) |name| {
+        try std.testing.expect(!std.mem.eql(u8, name.string, "$schema"));
+    }
+}
+
 test "config_schema: emission is deterministic" {
     var buffer_a: [64 * 1024]u8 = undefined;
     var buffer_b: [64 * 1024]u8 = undefined;


### PR DESCRIPTION
## The bug

The loader parses with `ignore_unknown_fields = false`, so a config carrying
the `$schema` key an editor writes to attach a schema failed to load:

```
error.UnknownField
```

That is the exact key that points a file at the schema zoxy itself emits
(`zig build schema`, shipped as a release asset with
`$id: https://zoxy.io/schema/config.schema.json`) — the generated schema was
unusable for the very files it describes.

## The fix

Declare `$schema` as an optional field on `ConfigJson`: the parser accepts it
and nothing reads it. Because `config_schema.zig` reflects over that same DTO,
it lands in the emitted document as an optional string property, so
`additionalProperties: false` no longer flags the pointer — no special-casing
in either the loader or the emitter.

Strictness is otherwise untouched. `$schemas`, and a `$schema` nested inside
any other object, are still unknown fields; both are pinned by test, as is the
schema document's declaration of the key and its absence from `required`.

`docs/DESIGN.md` §5 records the concession and its limits.

## Verification

- `zig build ci` green — unit tests + fuzz corpus, boundary lint, 4096-seed sim
- `zig fmt --check` clean
- `tiger-style-reviewer` on the diff: no violations
- the real binary boots and serves against a config carrying the key

## Note

`config/example.json` is deliberately left without a `$schema` line: adding one
would demonstrate the feature, but I could not verify that
`https://zoxy.io/schema/config.schema.json` is actually served. If it 404s,
everyone copying the example gets an editor fetch error instead of completions.
Happy to add it if that URL is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)