### PR TITLE
ci: tell zoxy.io to refresh /config when a release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,3 +164,28 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "zoxy: update to $version"
           git push
+
+      # zoxy.io's /config page is generated from this release: the config JSON
+      # Schema asset published above, config/example.json at this tag, and the
+      # tarball sizes. Tell the site to pull them — it documents the zoxy people
+      # can install, so a release is the only event that changes the page.
+      # SITE_DISPATCH_TOKEN is a fine-grained PAT with contents:write on
+      # zoxy-io/site (its refresh-config.yml commits the refreshed files).
+      #
+      # Last step on purpose: the release and the tap are already published by
+      # the time it runs, so a rejected token fails loudly here without holding
+      # either of them up. Left strict rather than continue-on-error for that
+      # reason — a red step is how an expired token gets noticed, and the site's
+      # weekly refresh catches the page up in the meantime.
+      - name: Notify zoxy-io/site
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # the body goes in as JSON rather than as -f/-F fields: client_payload
+          # is a nested object, and this leaves no question about how the key is
+          # parsed or the tag typed
+          jq -n --arg tag "$TAG" \
+            '{event_type: "zoxy-release", client_payload: {tag: $tag}}' |
+            gh api repos/zoxy-io/site/dispatches --input -


### PR DESCRIPTION
zoxy.io now renders its configuration reference at [/config](https://zoxy.io/config/) from the config JSON Schema this workflow ships as a release asset — every field, type, bound, default and enum on that page, plus the prose beside each one, is read out of that document. `config/example.json` at the tag and the tarball sizes come along with it.

A release is the only event that changes any of it: the page documents the zoxy people can install, not `main`. So the site pulls on a `repository_dispatch` from here rather than on a schedule it would mostly sleep through. `zoxy-io/site`'s `refresh-config.yml` receives `zoxy-release`, fetches the assets at `client_payload.tag`, builds as a gate, and commits only if something actually changed.

The step runs last, after the release and the Homebrew formula are published, so a rejected `SITE_DISPATCH_TOKEN` fails visibly without holding either up. Left strict rather than `continue-on-error` on purpose — a red step is how an expired token gets noticed, and the site's weekly refresh covers the page until it's fixed.

The body goes in as JSON via `jq` rather than `gh api -f/-F` fields: `client_payload` is a nested object, and this leaves no question about how the key is parsed or the tag typed.

Needs the `SITE_DISPATCH_TOKEN` secret — a fine-grained PAT with `contents: write` on `zoxy-io/site` (already configured).

Follow-on, no action here: #145 makes the loader accept a root `$schema` hint, so the starter config on /config grows its `$schema` line by itself on the first release that ships the updated schema — the site reads that capability off the schema document rather than hardcoding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)