### PR TITLE
style: bring two functions back under the 70-line limit (§9)

### DIFF
--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -192,6 +192,22 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
     }
 }
 
+/// One of the two optional deadlines a scenario may arm, or 0 for "off".
+///
+/// A third of seeds arm each, over a range that straddles the connect and
+/// idle timeouts drawn alongside them — so an armed one sometimes fires
+/// inside a dial, sometimes mid-exchange, and sometimes never, all under
+/// the adversary. The two callers share this because they share the
+/// question; what differs is the clock each hangs off, which is what
+/// their call sites say.
+fn deriveOptionalDeadlineMs(random: std.Random) u32 {
+    if (random.uintLessThan(u8, 3) != 0) return 0;
+    const deadline_ms = 10 + random.uintAtMost(u32, 90);
+    assert(deadline_ms >= 10);
+    assert(deadline_ms <= 100);
+    return deadline_ms;
+}
+
 /// When the drain starts, for the seeds that start one early.
 ///
 /// Bimodal, because the two rungs want opposite instants and one window
@@ -380,23 +396,12 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         .connect_timeout_ms = connect_timeout_ms,
         .idle_timeout_ms = 30 + random.uintAtMost(u32, 70),
         .drain_deadline_ms = deriveDrainDeadlineMs(harness.drain_at_ns, random),
-        // A third of seeds arm the max-lifetime cap (§6). The range
-        // straddles the idle timeout so the clamp sometimes reaps an
-        // actively-relaying connection and sometimes never bites —
-        // both paths under the adversary. 0 leaves it disabled.
-        .max_lifetime_ms = if (random.uintLessThan(u8, 3) == 0)
-            10 + random.uintAtMost(u32, 90)
-        else
-            0,
-        // Same shape for the §8 request deadline: a third of seeds arm
-        // it, over a range that straddles both the connect and idle
-        // timeouts drawn above — so it sometimes fires inside a dial,
-        // sometimes mid-exchange, and sometimes never, all under the
-        // adversary. 0 leaves it disabled.
-        .request_timeout_ms = if (random.uintLessThan(u8, 3) == 0)
-            10 + random.uintAtMost(u32, 90)
-        else
-            0,
+        // The §6 age cap: measured from the connection's birth, so the
+        // clamp sometimes reaps an actively-relaying connection.
+        .max_lifetime_ms = deriveOptionalDeadlineMs(random),
+        // The §8 per-exchange deadline: measured from routing instead, so
+        // the same range lands on a different clock.
+        .request_timeout_ms = deriveOptionalDeadlineMs(random),
         // Three seeds in four run with the access log on, so the sink,
         // its staging swap, and the per-request captures all take the
         // schedule fuzz; the fourth leaves it off, which is the shape

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1156,6 +1156,31 @@ pub fn Proxy(comptime IoType: type) type {
             renderResponse(server, conn, &response);
         }
 
+        /// The §8 persistence decision, made once and honored: keep the
+        /// client's connection unless pipelining, pressure, or drain says
+        /// otherwise — then announce whatever was decided (§2).
+        ///
+        /// Only relay pressure suppresses keep-alive: the next request on
+        /// this connection would claim a relay buffer the pool is running
+        /// out of. Conn-slot pressure deliberately does not reach here
+        /// (`keepAliveSuppressed`, #57) — under slot scarcity this serving
+        /// connection *is* the population, and closing it trades one
+        /// briefly-free slot for a reconnect wave. An until-close body
+        /// forces the close unconditionally: the FIN is the only thing
+        /// delimiting the relayed body for the client, exactly as it
+        /// delimited it for us.
+        fn downstreamKeepAlive(
+            server: *const ServerType,
+            conn: *const ConnType,
+            response: *const parser.ResponseHead,
+        ) bool {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            return conn.l7.client_keep_alive and
+                !conn.l7.client_pipelined and !server.draining and
+                !server.keepAliveSuppressed() and response.framing != .until_close;
+        }
+
         /// Render the origin's head into conn.head (free once the request
         /// head has vacated it) and forward the coalesced body excess
         /// straight from upstream.head — never copied through a relay
@@ -1170,22 +1195,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.request_head_vacated);
             const upstream = conn.upstream.?;
 
-            // The §8 persistence decision, made once and honored: honor
-            // the client's ask unless pipelining, pressure, or drain says
-            // otherwise — then announce whatever was decided (§2). Only
-            // relay pressure suppresses keep-alive: the next request on
-            // this connection would claim a relay buffer the pool is
-            // running out of. Conn-slot pressure deliberately does not
-            // reach here (`keepAliveSuppressed`, #57) — under slot
-            // scarcity this serving connection *is* the population, and
-            // closing it trades one briefly-free slot for a reconnect
-            // wave. An until-close body forces the close
-            // unconditionally: the FIN is the only thing delimiting the
-            // relayed body for the client, exactly as it delimited it
-            // for us.
-            const keep_downstream = conn.l7.client_keep_alive and
-                !conn.l7.client_pipelined and !server.draining and
-                !server.keepAliveSuppressed() and response.framing != .until_close;
+            const keep_downstream = downstreamKeepAlive(server, conn, response);
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const rendered = render.renderResponseHead(


### PR DESCRIPTION
Housekeeping, no behaviour change. `deriveTopology` (75 lines) and
`renderResponse` (74) have both been over TIGER_STYLE's 70-line hard limit
for a while. The last three reviews each noted it and left it — correctly,
since none of those slices was making them worse — so this clears them on
their own, separable from the work that kept bumping into them.

| function | before | after |
| --- | --- | --- |
| `deriveTopology` | 75 | 64 |
| `renderResponse` | 74 | 59 |

Both extractions were already sitting there:

- The two optional deadlines (`max_lifetime_ms`, `request_timeout_ms`)
  were drawn by **identical** five-line expressions — same one-in-three
  chance, same 10-100 ms range. One helper now; what actually differs
  between the callers is which clock the deadline hangs off, and that is
  a line at each call site.
- The §8 keep-alive decision was thirteen lines of rationale wrapped
  around a four-line boolean, in the middle of a function about rendering
  a head and forwarding a body.

## Verified rather than asserted

The real risk was the scenario PRNG. The original used short-circuit
`and`, so the second deadline draw was *conditional* — a careless
extraction would have shifted the stream and quietly changed every seed in
the sweep, with the gate still green because the new scenarios are equally
valid.

So rather than argue it: a baseline worktree at the merge base (c458cff, after #141) and this tree, the
same census-dump instrumentation added to both, a full 4096-seed sweep on
each, and a diff of the results.

```
lines: before=61 after=61
IDENTICAL — every counter and op total matches across 4096 seeds
```

All 50 counter totals and all 9 seam-op totals byte-identical.

## What that check could not see

The extraction initially left `renderResponse`'s doc comment attached to
the function inserted above it — Zig binds a contiguous `///` block to
whatever declaration follows — so the render-and-forward path was briefly
documented as a keep-alive predicate and had nothing of its own. Caught in
review, fixed here.

Worth stating plainly because it is the point: byte-identical counters
prove the scenarios and the PRNG stream are untouched, and prove exactly
nothing about whether the comments landed on the right functions.

## Left alone

- `deriveTopology` still carries no assertions of its own; it calls
  helpers that assert internally. Pre-existing and unrelated to the line
  count, so it belongs in its own change.
- `deriveOptionalDeadlineMs` returns `u32` with 0-as-off while
  `deriveMaxInflight` nearby uses `?u32`. The `u32` mirrors the config
  fields' own documented "0 disables" convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebased onto #141

#141 landed first and touched both files this PR does — `sim/Harness.zig`
and, heavily, `src/http/proxy.zig` (+146 lines). The rebase applied
without conflicts, but "no conflict" is not the property that matters
here, so all of the above was re-run against the new base: both functions
are still under the limit (`deriveTopology` 64, `renderResponse` 59), CI
is green, and the census-total comparison is byte-identical against
c458cff rather than against the base it was first checked on.

One incidental confirmation: the sweep now reports **43** counters fired
rather than 42 — #141 added one and the census is already holding it to
account, with no change needed here.
