### PR TITLE
config: a working config is a listener and a cluster (§5, §8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ zoxy --version       # print the version (-V)
 Signals: `SIGTERM`/`SIGINT` drain in-flight connections and exit 0;
 `SIGUSR1` dumps counters to stdout.
 
-A minimal config — one L4 listener forwarding to one origin
-([`config/example.json`](config/example.json)):
+A minimal config — one L4 listener forwarding to one origin. For a fuller
+one with health checks, tuned timeouts and the access log, see
+[`config/example.json`](config/example.json):
 
 ```json
 {
@@ -48,14 +49,13 @@ A minimal config — one L4 listener forwarding to one origin
     ],
     "clusters": {
         "origin": { "endpoints": ["127.0.0.1:9000"] }
-    },
-    "timeouts": {
-        "connect_ms": 5000,
-        "idle_ms": 60000,
-        "drain_deadline_ms": 10000
     }
 }
 ```
+
+That is the whole file: every other block — `timeouts`, `limits`,
+`access_log` — has defaults, so tuning is what you opt into rather than
+what you start with.
 
 ## Configuration
 
@@ -298,14 +298,26 @@ the cluster from the original path, so a rewrite never re-routes.
 }
 ```
 
-| field | meaning |
-|---|---|
-| `connect_ms` **required** | per-try upstream connect budget |
-| `idle_ms` **required** | idle and head-read deadline — what a slowloris meets |
-| `drain_deadline_ms` **required** | how long a `SIGTERM` drain waits before reaping stragglers |
-| `max_lifetime_ms` | absolute connection-age cap regardless of activity; `0` disables |
-| `request_ms` | cap on one L7 exchange, **not** refreshed by activity — bounds a request that is merely slow, where `idle_ms` only bounds one that has stalled; `0` disables |
-| `health_interval_ms` | pause between health-probe sweeps |
+The whole block is optional, and so is every field in it — the values
+above are the defaults, written out. An explicit `0` disables the three
+caps; for `connect_ms` and `idle_ms` it is rejected, since a zero-length
+dial or idle budget is a mistake rather than a policy.
+
+| field | default | meaning |
+|---|---|---|
+| `connect_ms` | `5000` | per-try upstream connect budget |
+| `idle_ms` | `60000` | idle and head-read deadline — what a slowloris meets |
+| `drain_deadline_ms` | `0` | how long a `SIGTERM` drain waits before reaping stragglers; `0` waits for the last connection |
+| `max_lifetime_ms` | `0` | absolute connection-age cap regardless of activity; `0` disables |
+| `request_ms` | `0` | cap on one L7 exchange, **not** refreshed by activity — bounds a request that is merely slow, where `idle_ms` only bounds one that has stalled; `0` disables |
+| `health_interval_ms` | `2000` | pause between health-probe sweeps |
+
+`drain_deadline_ms` defaults to waiting indefinitely because there is no
+figure to borrow: nginx, HAProxy and Caddy all wait forever by default,
+Traefik picks 10 s and Envoy 600 s. Whatever sent the signal already owns
+the upper bound — systemd's `TimeoutStopSec`, Kubernetes'
+`terminationGracePeriodSeconds` — and ends the wait with `SIGKILL`. Set a
+number here when you want zoxy to give up before your platform does.
 
 ### Limits
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -380,6 +380,22 @@ Three shared pools, all owned and touched only by the loop thread:
    at its ejection — a parked socket to a dead origin is a stale replay
    waiting to be spent.
 
+Defaults shape. **A working config is a listener and a cluster.** Every
+other block — `timeouts`, `limits`, `access_log` — is optional, and so is
+every field inside them, so tuning is what an operator opts into rather
+than what they must supply to start. The rule for whether a field gets a
+default is what zoxy can honestly answer: `connect_ms` and `idle_ms` have
+conventional figures to borrow (nginx ships 60 s and 75 s for the same
+budgets), so they default; `request_ms` is a policy set against a
+particular origin's latency, so it defaults *off* rather than to a guess.
+`drain_deadline_ms` is the interesting one — nginx, HAProxy and Caddy all
+wait indefinitely by default, Traefik picks 10 s and Envoy 600 s, and a
+sixty-fold spread across mature implementations is not a consensus
+waiting to be found. It defaults to `0`, "no cap", and the supervisor
+that sent the signal keeps the upper bound it already enforces with
+`SIGKILL`. Where a zero would break rather than disable — a 0 ms dial,
+idle, or probe interval — it stays rejected.
+
 Sizing shape. The comptime constants are the hard, budget-asserted
 *ceilings*; the config `limits` block sizes the *effective* pools anywhere
 from 1 up to them. An omitted block takes the lean **defaults**, so the
@@ -959,6 +975,19 @@ stop honoring downstream keep-alive (`Connection: close` injection), let
 admitted work finish under one drain deadline (`drain_deadline_ms`), then
 tear down stragglers and exit. Drain reuses the pressure machinery — it
 is maximum pressure — and the zero-alloc gate runs it (§9).
+By default that deadline is `0` — no cap (§5): no timer is armed, and the
+drain ends when the last connection does. That is the majority behaviour
+among comparable proxies, and under a supervisor that keeps its own
+stopwatch — systemd's `TimeoutStopSec`, Kubernetes'
+`terminationGracePeriodSeconds` — it is bounded in practice by the
+`SIGKILL` that follows. Under a bare init with no such timeout it is
+genuinely unbounded, and a deployment there should set a number. Setting
+one means zoxy gives up *before* its platform would, which is a narrower
+thing than being bounded at all.
+What still bounds a straggler either way is its own per-connection
+deadlines: `idle_ms` always, plus `request_ms` and `max_lifetime_ms` when
+configured, and the drain's `Connection: close` injection stops an idle
+keep-alive connection from waiting on a request that will never come.
 
 ## 9. Testing — required from day 0
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -244,9 +244,16 @@ fn deriveDrainAt(clean: bool, random: std.Random) u64 {
 /// a setting production operators tune too. Seeds that drain only at the
 /// scenario's end keep the roomy default: there is nothing left to reap
 /// by then, and a short deadline would say nothing about it.
+///
+/// A minority draw 0 — "no cap" (§5), the shape a config that names no
+/// deadline gets, where `beginDrain` arms no timer at all and the drain
+/// ends only when the last connection does. Kept a minority on purpose:
+/// those seeds cannot reach `drained_at_deadline`, and that rung's
+/// census margin is already the thinnest in the gate.
 fn deriveDrainDeadlineMs(drain_at_ns: u64, random: std.Random) u32 {
     assert(drain_at_ns < scenario_end_ns);
     if (drain_at_ns == 0) return 100;
+    if (random.uintLessThan(u8, 4) == 0) return 0;
     if (!random.boolean()) return 100;
     const deadline_ms = 1 + random.uintAtMost(u32, 4);
     assert(deadline_ms >= 1);

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -46,12 +46,17 @@ const failures_max: u8 = 16;
 ///
 /// The thinnest rung sets the real bound, so it is worth knowing which,
 /// and it is not the one this comment first named. Per 1024 seeds across
-/// the starts above, `shed_draining` lands 15-23 times and
-/// `drained_at_deadline` 24-51 — but `upstream_replayed` lands 1-8, and
+/// the starts above, `shed_draining` lands 11-25 times and
+/// `drained_at_deadline` 19-33 — but `upstream_replayed` lands 1-8, and
 /// the 1 is start 5000. It is the rung the paragraph above already caught
 /// standing alone at 128 seeds, so the floor rests on it rather than on
 /// either of the others. A change that pushes *it* down has made this
 /// floor a coin flip, whatever the sweep still says.
+///
+/// The two drain figures are lower than they were: a quarter of
+/// early-draining seeds now draw an unbounded deadline (§5), which by
+/// construction reaps nothing. They stayed two-digit, so the floor did
+/// not move — but that is what re-measuring them was for.
 const census_iterations_min: u64 = 1024;
 
 /// A counter the sweep expects to stay at zero, and why.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -247,13 +247,23 @@ pub fn Server(comptime IoType: type) type {
             // Parked upstreams are idle capacity; the drain sheds them
             // first (§8). Synchronous closes: no armed op to wait for.
             server.reapParked(true);
-            server.io.timerStart(
-                &server.drain_deadline_completion,
-                @as(u64, server.config.drain_deadline_ms) * std.time.ns_per_ms,
-                Self,
-                server,
-                onDrainDeadline,
-            );
+            // A zero deadline is "no cap" (§5): the drain waits for the
+            // last connection however long that takes, which is what
+            // nginx, HAProxy and Caddy all do by default. Whoever sent
+            // the signal owns the upper bound — systemd's
+            // `TimeoutStopSec`, Kubernetes' `terminationGracePeriodSeconds`
+            // — and answers a drain that will not end with SIGKILL. Not
+            // arming the timer is what makes that true rather than
+            // merely documented.
+            if (server.config.drain_deadline_ms != 0) {
+                server.io.timerStart(
+                    &server.drain_deadline_completion,
+                    @as(u64, server.config.drain_deadline_ms) * std.time.ns_per_ms,
+                    Self,
+                    server,
+                    onDrainDeadline,
+                );
+            }
             server.maybeStopAfterDrain();
         }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -468,7 +468,11 @@ pub const ConfigJson = struct {
     @"$schema": ?[]const u8 = null,
     listeners: []const ListenerJson,
     clusters: ClustersJson,
-    timeouts: TimeoutsJson,
+    /// Optional as a whole, like `limits` below and for the same reason
+    /// (§5): an omitted block takes the defaults, so a working config is
+    /// a listener and a cluster, and tuning is what an operator opts
+    /// into.
+    timeouts: TimeoutsJson = .{},
     /// Optional pool sizes and the CQ-fill headroom knob (§5, §8); absent
     /// fields take the lean defaults, not the compiled ceilings.
     limits: LimitsJson = .{},
@@ -867,9 +871,26 @@ pub const ClusterHashJson = struct {
 };
 
 pub const TimeoutsJson = struct {
-    connect_ms: u32,
-    idle_ms: u32,
-    drain_deadline_ms: u32,
+    /// Optional: nginx ships 60 s for the same budget and HAProxy's
+    /// `timeout connect` is conventionally single-digit seconds, so a
+    /// value zoxy can pick without guessing at anyone's policy. Zero
+    /// stays rejected — it would fail every dial before it left.
+    connect_ms: u32 = constants.connect_ms_default,
+    /// Optional, same argument: nginx's `keepalive_timeout` is 75 s and
+    /// its `client_header_timeout` 60 s. Zero would reap on arrival.
+    idle_ms: u32 = constants.idle_ms_default,
+    /// Optional, and `0` means "no cap" — the drain waits for the last
+    /// connection however long that takes (§8).
+    ///
+    /// Unlike the two above there is no convention to borrow: nginx,
+    /// HAProxy and Caddy all default to waiting indefinitely, while
+    /// Traefik picks 10 s and Envoy 600 s. A sixty-fold spread across
+    /// mature implementations is not a default waiting to be discovered,
+    /// so zoxy declines to invent one and joins the majority. The
+    /// supervisor that sent the signal already owns the upper bound and
+    /// enforces it with SIGKILL; an operator who wants zoxy to give up
+    /// sooner than their platform does sets a number here.
+    drain_deadline_ms: u32 = 0,
     /// Optional: absent or `0` means "no cap" (§6). The default keeps every
     /// pre-existing config valid and leaves max-lifetime opt-in.
     max_lifetime_ms: u32 = 0,
@@ -895,8 +916,8 @@ pub const TimeoutsJson = struct {
             .maximum = constants.timeout_ms_max,
         },
         .drain_deadline_ms = .{
-            .desc = "Graceful-drain deadline on shutdown.",
-            .minimum = 1,
+            .desc = "Graceful-drain deadline on shutdown; 0 waits indefinitely.",
+            .minimum = 0,
             .maximum = constants.timeout_ms_max,
         },
         .max_lifetime_ms = .{
@@ -1688,16 +1709,17 @@ fn clusterIndexOf(
 }
 
 fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
-    // The three lifecycle timeouts are correctness bounds — a 0 ms connect,
-    // idle, or drain deadline would reap instantly, so zero is a mistake.
-    // The health-probe interval rides the same rule from the other side:
-    // zero would probe in a tight loop (§7) — probing is switched by the
-    // cluster `check` flag, never by zeroing its pace.
-    const required = [_]u32{
-        timeouts.connect_ms,        timeouts.idle_ms,
-        timeouts.drain_deadline_ms, timeouts.health_interval_ms,
+    // Deadlines a zero would break rather than disable: a 0 ms connect or
+    // idle budget reaps on arrival, and a 0 ms probe interval would probe
+    // in a tight loop (§7) — probing is switched by the cluster `check`
+    // flag, never by zeroing its pace. Each has a default, so absence is
+    // fine here and only an explicit zero is the mistake.
+    const nonzero = [_]u32{
+        timeouts.connect_ms,
+        timeouts.idle_ms,
+        timeouts.health_interval_ms,
     };
-    for (required) |value| {
+    for (nonzero) |value| {
         if (value == 0) {
             return error.TimeoutZero;
         }
@@ -1705,18 +1727,27 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
             return error.TimeoutOverLimit;
         }
     }
-    // The two optional bounds (§6, §8): 0 means "no cap" on either, so only
-    // the shared ceiling is enforced — zero stays legal.
-    const optional = [_]u32{ timeouts.max_lifetime_ms, timeouts.request_ms };
+    // The three optional caps (§6, §8): 0 means "no cap" on each — no age
+    // limit, no request deadline, and a drain that waits for the last
+    // connection — so only the shared ceiling is enforced.
+    const optional = [_]u32{
+        timeouts.max_lifetime_ms,
+        timeouts.request_ms,
+        timeouts.drain_deadline_ms,
+    };
     for (optional) |value| {
         if (value > constants.timeout_ms_max) {
             return error.TimeoutOverLimit;
         }
     }
-    // Postconditions: reaching here means every required bound is in
-    // range — what every consumer of these values relies on.
-    for (required) |value| {
+    // Postconditions: reaching here means every bound a consumer reads
+    // without checking is in range, and every optional one is at most the
+    // ceiling — zero included, which each consumer reads as "off".
+    for (nonzero) |value| {
         assert(value >= 1);
+        assert(value <= constants.timeout_ms_max);
+    }
+    for (optional) |value| {
         assert(value <= constants.timeout_ms_max);
     }
 }
@@ -1819,9 +1850,65 @@ test "config: request_ms is optional, defaults off, and shares the timeout ceili
     }
 }
 
-test "config: max_lifetime_ms accepts zero (the one legal zero timeout) and real values" {
-    // Explicit 0 is legal — it is *not* a TimeoutZero, unlike the other
-    // three timeouts (§6).
+test "config: the whole timeouts block is optional, and every default is usable" {
+    // A config that names none of them is the out-of-box shape (§5), the
+    // same argument `limits` already makes: an operator opts into tuning,
+    // never into a working config.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}}}
+    );
+    try std.testing.expectEqual(constants.connect_ms_default, parsed.connect_timeout_ms);
+    try std.testing.expectEqual(constants.idle_ms_default, parsed.idle_timeout_ms);
+    try std.testing.expectEqual(constants.health_interval_ms_default, parsed.health_interval_ms);
+    // The three caps default off, the drain one included: nginx, HAProxy
+    // and Caddy all wait indefinitely, and the supervisor that sent the
+    // signal owns the upper bound.
+    try std.testing.expectEqual(@as(u32, 0), parsed.drain_deadline_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
+}
+
+test "config: a zero drain deadline is no cap, but a zero connect or idle is still a mistake" {
+    // The asymmetry is the point: 0 disables a *cap*, and there is no
+    // sense in which a 0 ms dial or idle budget is a policy rather than a
+    // configuration error, so those two keep rejecting it.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(),
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"drain_deadline_ms":0}}
+        );
+        try std.testing.expectEqual(@as(u32, 0), parsed.drain_deadline_ms);
+    }
+    const rejected = [_][]const u8{
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":0}}
+        ,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"idle_ms":0}}
+        ,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"health_interval_ms":0}}
+        ,
+    };
+    for (rejected) |json| {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        try std.testing.expectError(error.TimeoutZero, parse(arena_state.allocator(), json));
+    }
+}
+
+test "config: max_lifetime_ms accepts zero (a legal zero timeout) and real values" {
+    // Explicit 0 is legal — it is *not* a TimeoutZero, unlike the dial
+    // and idle budgets (§6).
     {
         var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena_state.deinit();

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -317,6 +317,22 @@ pub const header_edits_max: u16 = 16;
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
 
+/// Default `timeouts.connect_ms`: the per-try upstream dial budget when
+/// the config omits it (§5). Five seconds is the conventional figure — an
+/// order below nginx's 60 s `proxy_connect_timeout`, which is a read
+/// timeout's worth of patience for what is only a handshake. A dial that
+/// has not completed in five seconds is answered 504 and, on a
+/// multi-endpoint cluster, retried elsewhere sooner.
+pub const connect_ms_default: u32 = 5_000;
+
+/// Default `timeouts.idle_ms`: the idle and head-read deadline when the
+/// config omits it (§5). nginx's neighbours are `keepalive_timeout` at
+/// 75 s and `client_header_timeout` at 60 s; this takes the lower of the
+/// two, since the same number here also bounds a slowloris dribbling its
+/// head. Shortened further under pool pressure (§8), so this is the
+/// unpressured ceiling rather than what a busy proxy actually waits.
+pub const idle_ms_default: u32 = 60_000;
+
 /// Bytes of inbound `X-Forwarded-For` chain an `append` listener will
 /// carry (§7). A chain grows by one address at every hop, and nothing in
 /// the protocol bounds it — so a client that sends a megabyte of forged
@@ -636,6 +652,23 @@ comptime {
     assert(loop_completions_per_tick_max >= 1);
     assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);
+    // The two defaulted deadlines must themselves be configs the loader
+    // would accept: non-zero, and under the shared ceiling.
+    assert(connect_ms_default >= 1);
+    assert(connect_ms_default <= timeout_ms_max);
+    assert(idle_ms_default >= 1);
+    assert(idle_ms_default <= timeout_ms_max);
+    // The dial budget must sit below the idle one. A connection's first
+    // deadline is armed at `connect_ms` (`Server.entryTimeoutMs`) and the
+    // dial's completion re-stores it to `idle_ms`, but the *physical*
+    // timer never moves earlier — only the stored target does (§4). So an
+    // idle budget below the dial budget is not shortened by the
+    // handoff; it waits out the connect-phase timer instead.
+    //
+    // This guards the pair above and nothing else: `validateTimeouts`
+    // does not cross-check an operator's own two values, so the same
+    // ordering is unenforced for a hand-written config.
+    assert(connect_ms_default < idle_ms_default);
     assert(accept_retry_delay_ms >= 1);
     assert(pressure_idle_divisor >= 2);
     assert(head_bytes_max >= 1024);

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -571,6 +571,42 @@ test "server: kernel-pressure on the upstream dial is witnessed and the conn tor
     try bed.expectDrained();
 }
 
+test "drain: a zero deadline waits for the straggler instead of reaping it" {
+    // `drain_deadline_ms: 0` is "no cap" (§5, §8) — the shape a config
+    // that names no deadline gets, and what nginx, HAProxy and Caddy all
+    // do by default. `beginDrain` arms no timer at all, so the same
+    // silent client the test below reaps at the deadline is left alone
+    // here and leaves on its own terms.
+    //
+    // What bounds this in production is the supervisor that sent the
+    // signal — systemd's `TimeoutStopSec`, Kubernetes'
+    // `terminationGracePeriodSeconds` — which is why the drain is allowed
+    // to be unbounded rather than obliged to invent a number. Here it is
+    // the client closing that ends it.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 41 },
+        // Short enough that the connection ends the run rather than
+        // hanging the test, and far longer than the drain deadline the
+        // sibling test relies on: the point is that *this* is what ends
+        // it, not a drain timer.
+        .idle_timeout_ms = 50,
+        .drain_deadline_ms = 0,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, false);
+    bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 5_000_000);
+    try bed.sim_io.run();
+
+    // Nothing was reaped by a deadline that does not exist.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("drained_at_deadline"));
+    // And the drain still completed: the idle deadline ended the
+    // connection, the pools drained, and the loop stopped.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
 test "drain: terminate signal stops accepting and reaps stragglers at the drain deadline" {
     var bed: TestBed = undefined;
     try bed.setUp(std.testing.allocator, .{ .sim = .{ .seed = 41 }, .idle_timeout_ms = 60_000 });


### PR DESCRIPTION
Three of the six `timeouts` fields were required. Two of them had
conventional values available all along, and the third had no consensus
value worth inventing — so all three get defaults, and the block joins
`limits` in being optional as a whole.

**A working config is now a listener and a cluster.** The README's minimal
example lost its `timeouts` block entirely, which is the visible point.

| field | before | after |
| --- | --- | --- |
| `connect_ms` | required | `5000` |
| `idle_ms` | required | `60000` |
| `drain_deadline_ms` | required, zero rejected | `0` — no cap |
| the `timeouts` block | required | optional |

An explicit `0` still means *no cap* on the three caps, and is still
rejected for `connect_ms`, `idle_ms` and `health_interval_ms` — a
zero-length dial or idle budget is a configuration error, not a policy.

## Why `drain_deadline_ms` defaults to waiting

There is no figure to borrow. Checked against the field's neighbours:

| proxy | setting | default |
| --- | --- | --- |
| nginx | `worker_shutdown_timeout` | — (waits indefinitely) |
| HAProxy | `hard-stop-after` | unset (soft-stop unbounded) |
| Caddy | `grace_period` | eternal |
| Traefik | `lifeCycle.graceTimeOut` | 10s |
| Envoy | `--drain-time-s` | 600s |

Three of five decline to pick a number, and the two that do disagree by
sixty-fold. That is not a consensus waiting to be discovered, so zoxy
declines too and joins the majority: `beginDrain` arms no timer, and the
drain ends when the last connection does.

It is not open-ended in practice. Whatever sent the signal is already
holding a stopwatch — systemd's `TimeoutStopSec`, Kubernetes'
`terminationGracePeriodSeconds` — and ends the wait with `SIGKILL`.
Setting a number here means zoxy gives up *before* the platform would,
which is a narrower and more deliberate thing than being bounded at all.

## Verified

The `0` case is a behaviour change, not just parsing, so it was checked
three ways rather than one:

- the new `drain: a zero deadline waits for the straggler instead of
  reaping it` test **fails** when the `!= 0` guard is neutered;
- the 4096-seed sweep is green with 360 of 1508 early-draining runs now
  taking the unbounded path;
- the **ReleaseFast binary** started on a `timeouts`-free config, proxied
  three connections (`accepted 3, admitted 3, completed 3`) and drained on
  `SIGTERM` with `drained_at_deadline 0`. This is a config-surface change
  and the simulator never parses JSON, so the live run is the only thing
  that exercises what an operator actually types.

The generated JSON schema follows automatically — `config_schema.zig`
derives `required` from Zig field defaults, so root `required` drops to
`["listeners","clusters"]` and `drain_deadline_ms` emits `"minimum": 0,
"default": 0`. The published schema asset, the `/config` page and editor
hints all track it with no hand-editing.

## A census margin was diluted, deliberately

A quarter of early-draining sim seeds now draw an unbounded deadline,
which by construction reaps nothing. `drained_at_deadline` fell from 24-51
to 19-33 per 1024 seeds and `shed_draining` from 15-23 to 11-25, measured
across four shifted windows rather than assumed. Both stay two-digit
against a 1024-seed census floor, and the floor's comment carries the new
figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known gap, not introduced here

The comptime assert guards the *defaults* ordering (`connect_ms <
idle_ms`) and nothing else. A connection's first deadline is armed at
`connect_ms` and re-stored to `idle_ms` once the dial completes, but the
physical timer never moves earlier (§4) — so an operator who explicitly
sets `connect_ms: 90000, idle_ms: 60000` gets an idle deadline that waits
out the connect-phase timer instead. `validateTimeouts` does not
cross-check the two, and did not before this change either. Filed rather
than fixed here, since adding a new config rejection is a breaking change
that does not belong in the same commit as a defaults change.
