### PR TITLE
config: let the shipped example demonstrate the defaults, not restate them

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ zoxy --version       # print the version (-V)
 Signals: `SIGTERM`/`SIGINT` drain in-flight connections and exit 0;
 `SIGUSR1` dumps counters to stdout.
 
-A minimal config — one L4 listener forwarding to one origin. For a fuller
-one with health checks, tuned timeouts and the access log, see
+A minimal config — one L4 listener forwarding to one origin. For one with
+health checks and the access log turned on, see
 [`config/example.json`](config/example.json):
 
 ```json

--- a/config/example.json
+++ b/config/example.json
@@ -8,11 +8,5 @@
             "check": { "type": "tcp", "fall": 3, "rise": 2 }
         }
     },
-    "timeouts": {
-        "connect_ms": 5000,
-        "idle_ms": 60000,
-        "drain_deadline_ms": 10000,
-        "max_lifetime_ms": 0
-    },
     "access_log": { "sink": "stdout" }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -1775,14 +1775,19 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(Config.Cluster.Check.Kind.tcp, example_check.kind);
     try std.testing.expectEqual(@as(u8, 3), example_check.fall);
     try std.testing.expectEqual(@as(u8, 2), example_check.rise);
-    try std.testing.expectEqual(@as(u32, 5000), example_check.timeout_ms);
+    try std.testing.expectEqual(constants.connect_ms_default, example_check.timeout_ms);
     try std.testing.expectEqual(@as(?Config.Cluster.Check.Http, null), example_check.http);
-    try std.testing.expectEqual(@as(u32, 5000), parsed.connect_timeout_ms);
-    try std.testing.expectEqual(@as(u32, 60000), parsed.idle_timeout_ms);
-    try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
-    try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
-    // The example omits the probe interval: the HAProxy-inter default.
+    // The example names no `timeouts` block at all, so every deadline
+    // here is a default — which is the thing it is demonstrating. A
+    // check's omitted budget still inherits the connect timeout, so this
+    // also pins that the inheritance reads the *resolved* value rather
+    // than only an explicitly configured one.
+    try std.testing.expectEqual(constants.connect_ms_default, parsed.connect_timeout_ms);
+    try std.testing.expectEqual(constants.idle_ms_default, parsed.idle_timeout_ms);
     try std.testing.expectEqual(constants.health_interval_ms_default, parsed.health_interval_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.drain_deadline_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
+    try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
 }
 
 test "config: max_lifetime_ms is optional and defaults to disabled" {
@@ -2634,8 +2639,35 @@ var fuzz_arena_buffer: [1 << 20]u8 = undefined;
 // Zig 0.16.0 toolchain bug: the bundled compiler/test_runner.zig fails to
 // compile under -ffuzz (StackTrace type mismatch, line 566). The corpus
 // still runs deterministically as part of `zig build test`.
+/// A second corpus seed carrying the blocks the shipped example leaves to
+/// their defaults. The example is the better *documentation* for having
+/// dropped its `timeouts` block, but a corpus seed is judged on the token
+/// vocabulary it hands the mutator, and one that never spells
+/// `drain_deadline_ms` gives it no path to that branch of the parser.
+const fuzz_seed_json =
+    \\{"listeners":[{"bind":"127.0.0.1:8080","routes":[{"prefix":"/","cluster":"o"}],
+    \\ "protocol":"http"}],
+    \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000"],"pick":"p2c","max_inflight":8,
+    \\ "check":{"type":"http","path":"/health","expect_status":200,"timeout_ms":250}}},
+    \\ "timeouts":{"connect_ms":5000,"idle_ms":60000,"drain_deadline_ms":10000,
+    \\ "max_lifetime_ms":300000,"request_ms":30000,"health_interval_ms":2000},
+    \\ "limits":{"conn_slots":64,"relay_buffers":32,"upstream_slots":32},
+    \\ "access_log":{"sink":"stdout"},"admin":{"bind":"127.0.0.1:9901"}}
+;
+
+test "config: the fuzz seed carrying every block parses" {
+    // It is a corpus entry, so it has to be a *valid* config — an
+    // unparseable seed would still fuzz, just from a worse starting point,
+    // and nothing else would say so.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(), fuzz_seed_json);
+    try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
+    try std.testing.expectEqual(@as(u32, 30000), parsed.request_timeout_ms);
+}
+
 test "fuzz: parse never panics — parse or reject, no third outcome" {
-    try std.testing.fuzz({}, fuzzParse, .{ .corpus = &.{example_json} });
+    try std.testing.fuzz({}, fuzzParse, .{ .corpus = &.{ example_json, fuzz_seed_json } });
 }
 
 fn fuzzParse(context: void, smith: *std.testing.Smith) !void {


### PR DESCRIPTION
Follow-up to #149, which made the whole `timeouts` block optional. Every
value the shipped example named is now what it would get by saying
nothing — so the block teaches the reader nothing about zoxy, and one of
its lines had quietly stopped being true (`drain_deadline_ms: 10000`
outlived the default becoming "no cap").

```json
{
    "listeners": [
        { "bind": "127.0.0.1:8080", "cluster": "origin", "protocol": "l4" }
    ],
    "clusters": {
        "origin": {
            "endpoints": ["127.0.0.1:9000"],
            "check": { "type": "tcp", "fall": 3, "rise": 2 }
        }
    },
    "access_log": { "sink": "stdout" }
}
```

Only one resolved value changes: `drain_deadline_ms`, 10000 → 0.
`connect_ms` and `idle_ms` default to exactly the numbers the block spelled
out, which is some evidence the defaults were picked right.

## The part worth reviewing

`config/example.json` is also the config **fuzz corpus seed**. A corpus
entry is judged on the token vocabulary it hands the mutator, not on how
tidy it reads — and an example that never spells `drain_deadline_ms` gives
the fuzzer no path into that branch of the parser.

So a second seed spells out every block: routes, `p2c`, `max_inflight`, an
HTTP check with `path`/`expect_status`, all six timeouts, `limits`,
`admin`. That turns out to *widen* the corpus rather than merely restore
it — `request_ms`, `health_interval_ms`, `limits` and `admin` were never
in it at all, before or after this change. A test pins that the seed
parses, since an invalid corpus entry still fuzzes, just from a worse
starting point, and nothing else would report it.

Still absent from the corpus, and out of scope here because it predates
this change: `filters`, `forwarded`, route `host`, `pick: "hash"` and two
`limits` fields.

## Test changes

The example's test now reads defaults from `constants.*_default` rather
than literals — the property under test is "omitting the block round-trips
to the shared default", which a hardcoded `5000` would only test
coincidentally. It also gains an assertion that a check's omitted
`timeout_ms` inherits the *resolved* connect timeout, a behaviour that
only becomes observable once the example stops configuring one.

Docs and tests only; no serving-path code touched, so no release needed.