### PR TITLE
main: say which build this is, not just which release it claims to be (§9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,16 @@ jobs:
             label="$(echo "$pair" | cut -d: -f2)"
             cpu="$(echo "$pair" | cut -d: -f3)"
             echo "::group::$label ($zig_t${cpu:+, -Dcpu=$cpu})"
+            # -Dbuild-id is passed rather than left to build.zig's `git
+            # describe` fallback: this checkout is shallow and carries no
+            # tags, so describe would fall back to a bare commit SHA and
+            # stamp every release binary with one. Handing it the tag makes
+            # the identifier equal the version, which `zoxy --version`
+            # recognises and omits — a release says `zoxy 0.0.7` and
+            # nothing else, whatever the checkout depth happens to be.
             devenv shell -- zig build \
-              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseFast --prefix "out/$label"
+              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseFast \
+              -Dbuild-id="${{ steps.ver.outputs.tag }}" --prefix "out/$label"
             tar czf "dist/zoxy-$version-$label.tar.gz" -C "out/$label/bin" zoxy
             echo "::endgroup::"
           done

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ zoxy --help          # usage summary (-h)
 zoxy --version       # print the version (-V)
 ```
 
+A release prints its bare version, `zoxy 0.0.7`. A build made from source
+after that release adds what distinguishes it —
+`zoxy 0.0.7 (v0.0.7-5-gabc1234)`, and `-dirty` when the tree had
+uncommitted changes — so a version in a bug report is never a release's
+number attached to something else. Packagers can name their own build
+with `zig build -Dbuild-id=…`. The same line opens the startup banner,
+which is what a bug report usually pastes.
+
 Signals: `SIGTERM`/`SIGINT` drain in-flight connections and exit 0;
 `SIGUSR1` dumps counters to stdout.
 

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,7 @@ pub fn build(b: *std.Build) void {
     const zoxy_version = @import("build.zig.zon").version;
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "version", zoxy_version);
+    build_options.addOption([]const u8, "build_id", resolveBuildId(b));
 
     // libxev is pinned by content hash to the zoxy-io fork's
     // zoxy-ring-flags branch: the audited upstream snapshot plus the
@@ -352,4 +353,47 @@ pub fn build(b: *std.Build) void {
         "Line coverage via kcov (Linux): unit tests + sim, merged to zig-out/coverage",
     );
     cov_step.dependOn(&install_cov.step);
+}
+
+/// Which build this binary is, beyond its release version.
+///
+/// A release binary's version already names one commit — the tag points at
+/// exactly one — so this is empty there and `zoxy --version` stays the bare
+/// `zoxy 0.0.7`. What it exists for is every *other* build: one made from
+/// `main` five commits later reports the same version string as the release
+/// unless something says otherwise, which turns a bug report's "0.0.7" into
+/// a claim that is not true. `git describe` answers exactly that question —
+/// `0.0.7-5-gabc1234`, and `-dirty` when the tree carries uncommitted
+/// changes, which is otherwise unanswerable from a binary.
+///
+/// `-Dbuild-id=...` overrides, for a builder that has the answer but no
+/// `.git` — a source tarball, or a CI checkout too shallow to describe.
+/// Absent both, empty: an unknown build says nothing rather than guessing.
+///
+/// This is the one place the build shells out *unconditionally*. The
+/// `coverage` step runs `kcov` and `sed`, but through `addSystemCommand`,
+/// so those fire only when that step is asked for; this runs during
+/// `build()` itself and so on every `zig build`, `test`, `sim` and `ci`.
+/// That is a `git` invocation's worth of cost per invocation, and it makes
+/// the *identifier* non-hermetic — deliberately, because a local build
+/// that cannot say what it is is the problem being solved. Nothing about
+/// the produced code depends on it, and a failure is not one: no git, no
+/// repository, or a killed process all land in the `catch` below and
+/// report nothing rather than breaking the build.
+fn resolveBuildId(b: *std.Build) []const u8 {
+    if (b.option([]const u8, "build-id", "Build identifier, e.g. git describe output")) |given| {
+        return given;
+    }
+    // `runAllowFail` reports a non-zero exit as an error and only then
+    // writes `exit_code`, so the catch is the whole failure path — reading
+    // the code on success would read whatever the variable held. It is
+    // initialized anyway rather than left `undefined`, because a future
+    // reader tempted to check it should find a number rather than garbage.
+    var exit_code: u8 = 0;
+    const described = b.runAllowFail(
+        &.{ "git", "describe", "--tags", "--always", "--dirty" },
+        &exit_code,
+        .ignore,
+    ) catch return "";
+    return std.mem.trim(u8, described, " \t\r\n");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,41 @@ comptime {
     assert(build_options.version.len > 0);
 }
 
+/// What this build is, when the version alone does not say it.
+///
+/// A release binary is built at its tag, so `git describe` returns exactly
+/// `v<version>` and repeating it would be noise — that case reports the
+/// bare version. Every other build is the reason this exists: one made
+/// from `main` after a release otherwise claims the release's version
+/// string, which is not merely vague but false. There the suffix carries
+/// the distance and commit (`v0.0.7-5-gabc1234`), and `-dirty` when the
+/// tree had uncommitted changes, which no binary can otherwise be asked.
+///
+/// Empty when the build could not tell — no `.git`, no `-Dbuild-id` — and
+/// an unknown build says nothing rather than guessing.
+const build_id_suffix: []const u8 = buildIdSuffix(build_options.version, build_options.build_id);
+
+/// The suffix itself, as a function of the two strings, so the three cases
+/// it decides between are testable rather than only observable by building
+/// at a tag and not at one.
+fn buildIdSuffix(comptime version: []const u8, comptime id: []const u8) []const u8 {
+    // The same invariant the module-level block guards, restated where the
+    // `"v" ++ version` comparison below depends on it.
+    assert(version.len > 0);
+    if (id.len == 0) return "";
+    // `describe` spells the *tag*, which carries the `v` the version does
+    // not; both spellings name the same build as the version already does.
+    // Full equality, not a prefix test: `0.0.70` must not be swallowed by
+    // a build whose version is `0.0.7`.
+    if (comptime std.mem.eql(u8, id, "v" ++ version)) return "";
+    if (comptime std.mem.eql(u8, id, version)) return "";
+    const suffix = " (" ++ id ++ ")";
+    // Whatever it reports, it appends to a version rather than replacing
+    // one, so it always starts with the separating space.
+    assert(suffix[0] == ' ');
+    return suffix;
+}
+
 /// The sigaction handler needs a stable address before main returns;
 /// the loop lives for the whole process (§3).
 var global_io: XevIo = undefined;
@@ -172,7 +207,7 @@ fn printVersion(io: std.Io) !void {
     var buffer: [64]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;
-    try writer.print("zoxy {s}\n", .{build_options.version});
+    try writer.print("zoxy {s}{s}\n", .{ build_options.version, build_id_suffix });
     try writer.flush();
 }
 
@@ -238,8 +273,11 @@ fn printBudgets(
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;
+    // The version leads, because this banner is what a bug report pastes
+    // and `--version` is what it does not think to run.
     try writer.print(
-        \\zoxy budgets (closed-form, DESIGN.md §5/§8):
+        \\zoxy {s}{s}
+        \\budgets (closed-form, DESIGN.md §5/§8):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + access log {d} KiB
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
@@ -247,6 +285,8 @@ fn printBudgets(
         \\  config  {d} listener(s), {d} cluster(s), access log {s}
         \\
     , .{
+        build_options.version,
+        build_id_suffix,
         memory_total / 1024,
         limits.conn_slots,
         @sizeOf(ServerXev.ConnType),
@@ -315,6 +355,34 @@ test "classifyArgs: a single positional is the config path" {
 test "classifyArgs: --help and -h request help" {
     try testing.expect(classifyArgs(&.{ "zoxy", "--help" }) == .help);
     try testing.expect(classifyArgs(&.{ "zoxy", "-h" }) == .help);
+}
+
+test "buildIdSuffix: a release says nothing extra, every other build says what it is" {
+    // The case the whole thing exists for: built after a release, the
+    // version alone would claim to *be* that release.
+    try testing.expectEqualStrings(
+        " (v0.0.7-5-gabc1234)",
+        buildIdSuffix("0.0.7", "v0.0.7-5-gabc1234"),
+    );
+    // And the question a binary cannot otherwise be asked.
+    try testing.expectEqualStrings(
+        " (v0.0.7-5-gabc1234-dirty)",
+        buildIdSuffix("0.0.7", "v0.0.7-5-gabc1234-dirty"),
+    );
+    // At the tag `describe` returns the tag, which is the version with a
+    // `v`. Repeating it would make every release binary noisier to read
+    // for no information, so both spellings collapse to nothing.
+    try testing.expectEqualStrings("", buildIdSuffix("0.0.7", "v0.0.7"));
+    try testing.expectEqualStrings("", buildIdSuffix("0.0.7", "0.0.7"));
+    // No `.git` and no `-Dbuild-id`: an unknown build stays quiet instead
+    // of inventing a provenance.
+    try testing.expectEqualStrings("", buildIdSuffix("0.0.7", ""));
+    // An override that is not a version at all still travels — a tarball
+    // or distro build naming itself is the point of the flag.
+    try testing.expectEqualStrings(" (nixpkgs-25.05)", buildIdSuffix("0.0.7", "nixpkgs-25.05"));
+    // A *different* version's tag is not this build's version, so it is
+    // reported rather than swallowed by the prefix match.
+    try testing.expectEqualStrings(" (v0.0.6)", buildIdSuffix("0.0.7", "v0.0.6"));
 }
 
 test "classifyArgs: --version and -V request the version" {


### PR DESCRIPTION
`--version` reads `build.zig.zon`, so a binary built from `main` five
commits after v0.0.7 reports `zoxy 0.0.7` — the exact string the release
prints. That is not vague, it is **false**, and it arrives in bug reports
looking like a fact.

A build id now travels beside the version:

| build | reports |
| --- | --- |
| a release | `zoxy 0.0.7` |
| five commits later | `zoxy 0.0.7 (v0.0.7-5-gabc1234)` |
| …with uncommitted changes | `zoxy 0.0.7 (v0.0.7-5-gabc1234-dirty)` |
| a packager's own build | `zoxy 0.0.7 (nixpkgs-25.05)` |
| no git, no `-Dbuild-id` | `zoxy 0.0.7` |

At a release tag `git describe` returns the tag, which is the version
with a `v`, so a release still prints bare and every *other* build says
what it is. `-dirty` is the one a binary can otherwise never be asked.

**The startup banner leads with that line now.** It never named a version
at all, and it is the output a bug report actually pastes — `--version` is
the one nobody thinks to run:

```
zoxy 0.0.7 (v0.0.7-1-g91d03b1-dirty)
budgets (closed-form, DESIGN.md §5/§8):
  memory  total 35059 KiB = ...
```

## Why the release workflow passes `-Dbuild-id` explicitly

Its checkout is shallow and carries no tags, so `describe --tags --always`
would degrade to a bare commit SHA and stamp one on every release binary.
Handing it the tag makes the id equal the version, which the suffix logic
omits — the released output is the same whatever the checkout depth,
rather than depending on it.

## The trade, stated

`resolveBuildId` runs during `build()` itself, so a `git` invocation on
every `zig build`, `test`, `sim` and `ci` — not behind a step the way
`coverage`'s `kcov` is. It is the one *unconditional* shell-out in the
build and it makes the identifier non-hermetic. Deliberate: a local build
that cannot tell you what it is was the problem being solved. Nothing
about the emitted code depends on it, and no git, no repository, or a
killed process all report nothing rather than failing the build.

Checked against what the repo actually claims: DESIGN.md's only
"reproducible binaries" line is about the Nix-packaged HAProxy comparison
binary, Nix pins the *toolchain* rather than build determinism, and
content-hash pinning covers Zig dependencies. No stated invariant is
undermined — but this is the first external-tool call at configure time
rather than deferred, which is new in kind and worth signing off on
knowingly.

## Verified

All five shapes produced from the real binary, not reasoned about.
`buildIdSuffix` has a directed test over seven inputs, including a
packager override and a *different* version's tag (`v0.0.6` on an 0.0.7
build must be reported, not swallowed). `zig build ci` and `zig build
lint` green. Nothing in `bench/`, `scripts/` or the tests parses either
the version line or the banner.

One bug found during implementation and worth recording: `runAllowFail`
only writes its `out_code` out-param when the command *fails*. My first
version read it on success — `undefined`, observed as 170 — and threw away
a perfectly good describe output, producing a bare version with no error.
The `catch` is the whole failure path.

## Not exercised until it ships

This is the first change to make release binaries depend on an explicit
`-Dbuild-id`, and that path only runs when a tag is pushed. `release.yml`
accepts `workflow_dispatch` with a tag input if we want to prove it before
cutting a real version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
