### PR TITLE
bench: fix the overload stall gate, then move the generator to zrk v1.4.1 (§9)

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -248,10 +248,29 @@ fn runOverload(
     return overloadPassed(rss_before_kb, rss_after_kb, &report, drained_cleanly);
 }
 
-/// The overload gates. Accept-RSTs (connect errors) are the conn-slot
-/// shed working as designed; read errors and timeouts are relay stalls
-/// and stay under 1% of completions — a shed must be fast and correct,
-/// never a hang.
+/// The overload gates. The stall gate holds `timeouts` — and only
+/// `timeouts` — under 1% of completions, because that is the one
+/// client-visible failure that belongs to *admitted* work: a request that
+/// completed is a sample whatever its status, and one that never got an
+/// answer is a timeout.
+///
+/// Connect, write and read errors are all the conn-slot wall's RST,
+/// observed at whichever syscall the generator happened to be in when it
+/// landed. Measured (#82): with `timeouts` at zero the three are the
+/// whole of zrk's `socketErrors()`, and on the four runs that captured
+/// zoxy's counters alongside, that total landed within 0.1% of its
+/// `shed_conn_slots` — one socket error per connection the wall refused.
+/// How they divide is pure race: across six runs the connect share ranged
+/// 28–54%, write 43–71%, read 1.3–3.3%. The old gate exempted the connect share
+/// as "the shed working as designed", ignored the write share, and failed
+/// the run on the read share, so it measured how much load was refused
+/// rather than how well the proxy served what it took: 2–14% against a 1%
+/// ceiling, with `timeouts` at zero every time.
+///
+/// A relay that genuinely breaks mid-exchange is still gated — by
+/// `proxiesHealthy` on the keep-alive, close and large-body bands, where
+/// no RST wall fires and a socket error can only be the proxy's fault.
+/// What this band cannot do is tell the two apart, so it does not try.
 fn overloadPassed(
     rss_before_kb: u64,
     rss_after_kb: u64,
@@ -277,8 +296,8 @@ fn overloadPassed(
     }
     // Bounded latency for admitted work: every completion (2xx and fast
     // 5xx sheds alike) landed within zrk's wire timeout, or it would be
-    // a timeout below, not a sample.
-    const stalls = counters.read_errors + counters.timeouts;
+    // a timeout here, not a sample.
+    const stalls = counters.timeouts;
     const stalls_ok = stalls * 100 < counters.completed;
     if (!stalls_ok) {
         std.debug.print(
@@ -286,6 +305,16 @@ fn overloadPassed(
             .{ stalls, counters.completed },
         );
     }
+    // The band log is read by a human (§9), so print the split every run
+    // rather than only when the gate trips: a threshold whose margin is
+    // invisible until it fails cannot be watched across runs, which is how
+    // this one sat mis-specified (#82). The refused count is the wall's
+    // work, not a fault — it belongs in the log, never in the verdict.
+    const refused = counters.connect_errors + counters.write_errors + counters.read_errors;
+    std.debug.print(
+        "zoxy overload refused {d} at the wall (connect {d}, write {d}, read {d}); {d} timed out\n",
+        .{ refused, counters.connect_errors, counters.write_errors, counters.read_errors, stalls },
+    );
     if (!drained_cleanly) {
         std.debug.print("FAIL: overload zoxy did not drain cleanly\n", .{});
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -63,9 +63,19 @@
         // the cloud benchmark runs, so a local band and a fleet number
         // come off the same generator; runs on mismatched versions are not
         // comparable, which is a trap this pin exists to close.
+        //
+        // v1.4.1, matching zoxy-io/benchmark's `bench/build.zig.zon`
+        // verbatim — including the `?ref=` form, which the other three pins
+        // here do not use: zrk is the one dependency whose *version* the
+        // comparability rule above is stated in, so the tag is carried in
+        // the URL where a reader sees it without resolving the sha.
+        // Since v1.3.1 it carries three UB/panic guards
+        // found in review (zoxy-io/zrk#46) and two dashboard fixes that the
+        // harness does not reach; what matters to a band is the zio pin
+        // below, which #46 moved and v1.4.1 settled.
         .zrk = .{
-            .url = "git+https://github.com/zoxy-io/zrk#3940a4570c02ff70094c46d1507ecebadf3e6404",
-            .hash = "zrk-1.3.1-WqdFOzSEBABi11K0XkWd67ny1dp-nYFBXRtIOLqLBiB7",
+            .url = "git+https://github.com/zoxy-io/zrk?ref=v1.4.1#b2b7ddaa0b125817ea105f258710563f65d42bdc",
+            .hash = "zrk-1.4.1-WqdFO0rIBAABbP3sI9jkhfqcIn4ZQM2zQ2HL9eh4KaAP",
         },
         // zrk embeds its load off a zio (io_uring) runtime, not the default
         // std.Io.Threaded backend — plain Threaded is missing pieces zrk
@@ -77,9 +87,19 @@
         // rather than a fork, deliberately — a fork of a dependency we do
         // not patch is a second thing to keep in sync with zrk's pin, and
         // the only way it can differ from upstream is by being wrong.
+        //
+        // b822fda is lalinsky/zio#628, "flush a full submission queue
+        // instead of dropping SQEs". Before it, zio dropped a cancel when
+        // the io_uring SQ was full, leaving the target completion stuck
+        // `.running` forever and the awaiting task blocked with it — which a
+        // c10k load reaches reliably, since ten thousand per-operation
+        // timeouts expiring together submit thousands of cancels at once
+        // (lalinsky/zio#623). It postdates the v0.16.0 tag, so there is no
+        // release to name and this pins the bare commit — as zrk's own zio
+        // entry does, which is what makes the two identical.
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
-            .hash = "zio-0.16.0-xHbVVDxFJADhW5CgWRdQmPa8bg_YrOAiPFHTKGFq8jwk",
+            .url = "git+https://github.com/lalinsky/zio#b822fda55af546ce47918776950338cdf23315c0",
+            .hash = "zio-0.16.0-xHbVVJqoJADE1sz0O0ssHXOjaYODH86TWCUG9Pg4N69C",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1086,6 +1086,48 @@ is answered by the idle-timeout division plus the accept-time RST wall —
 the nginx/haproxy norm: never close an established keep-alive connection
 to admit a newcomer.
 
+## The overload stall gate was counting the shed, not the stall (#82)
+
+The Tier-1 overload band gated `read_errors + timeouts` under 1% of
+completions. On this box it failed 4 runs in 5 at 2.0–6.2% (zrk v1.3.1),
+and 4 in 4 at 4.8–14.2% after the v1.4.1 pin move — reproducibly, with
+nothing wrong with the proxy.
+
+The filed theory was that the queue is legitimately deeper than zrk's 2 s
+wire timeout, so a slice of requests crossing it is arithmetic.
+Measurement says otherwise: **`timeouts` is 0 in every failing run**, and
+the run with the lowest tail (p99 642 µs, three orders inside the
+timeout) failed at 2.04%. The stall rate does not track the tail at all.
+
+What it tracks is the conn-slot wall. With `timeouts` at zero, zrk's
+`connect + write + read` is the whole of its `socketErrors()`, and on the
+four runs that captured zoxy's counters alongside, that total landed
+within 0.1% of `shed_conn_slots` — one socket error per RST'd connection.
+How it divides is pure race, and it moves run to run: across six runs the
+connect share ranged 28–54%, write 43–71%, read 1.3–3.3%. Which bucket a
+given connection lands in is only how far the generator got before the RST
+arrived. Meanwhile zoxy witnessed no relay fault at all on those runs:
+`deadline_expired`, `upstream_connect_failed`, every `kernel_pressure_*`,
+`l7_bad_gateway` and `l7_gateway_timeout` all 0, with
+`accepted = admitted + shed_conn_slots` balancing exactly. Causally
+confirmed: raising the scenario's `conn_slots` 64 → 200, nothing else
+changed, cut the shed 205k → 46k and the gate passed.
+
+So the old gate exempted the connect share as "the shed working as
+designed", ignored the write share, and failed the run on the read share.
+Raising the ceiling or lowering the offered rate would both have made it
+pass — by producing fewer RSTs, which is why neither was the fix.
+
+Verdict (settled): the stall gate holds `timeouts` alone, the one
+client-visible failure that belongs to *admitted* work. Every socket
+error in this band is a connection that was never admitted, already
+witnessed by the 5xx status gate and the accept-RST count. A genuine
+mid-exchange break is still gated by `proxiesHealthy` on the keep-alive,
+close and large-body bands, where no RST wall fires and a socket error
+can only be the proxy's fault. The band now prints the refused/timed-out
+split every run: a threshold whose margin is invisible until it trips is
+how this one sat mis-specified for a week.
+
 ## Phase 0 baselines (2026-07-10/11)
 
 - Debug-build zoxy over loopback (`zig build bench`, nginx origin, rate


### PR DESCRIPTION
Closes #82. Two commits: the gate fix first, then the pin move that depends on it.

## Why they land together

The zrk bump turns #82 from a flake into a permanently red merge gate. On
v1.3.1 the overload band failed 4 runs in 5; on v1.4.1 it failed 4 in 4, best
margin 4.8× over the ceiling. So the fix has to precede the bump rather than
follow it.

## 1. The gate was counting the shed, not the stall

The band held `read_errors + timeouts` under 1% of completions. The filed
theory was that the queue is legitimately deeper than zrk's 2 s wire timeout,
so a slice crossing it is arithmetic. Measured, that is not what happens:

- **`timeouts` is 0 in every failing run.** The run with the lowest tail —
  p99 642 µs, three orders inside the timeout — still failed, at 2.04%. The
  stall rate does not track the tail.
- With `timeouts` at zero, zrk's `connect + write + read` is the whole of its
  `socketErrors()`, and that total lands within 0.1% of zoxy's
  `shed_conn_slots`. One socket error per connection the wall refused, divided
  between the three buckets by nothing but how far the generator got before the
  RST arrived — across six runs the connect share ranged 28–54%, write 43–71%,
  read 1.3–3.3%.
- zoxy witnessed no relay fault on those runs: `deadline_expired`,
  `upstream_connect_failed`, every `kernel_pressure_*`, `l7_bad_gateway`,
  `l7_gateway_timeout` all 0, with `accepted = admitted + shed_conn_slots`
  balancing exactly.
- Causal check: raising the scenario's `conn_slots` 64 → 200, nothing else
  changed, cut the shed 205k → 46k and the gate passed.

The old gate exempted the connect share as "the shed working as designed",
ignored the write share, and failed the run on the read share. Raising the
ceiling or lowering the offered rate — two of the options weighed in the issue
— would both have made it pass by producing fewer RSTs, which is why neither
is the fix.

**The threshold is unchanged at 1%; the population is corrected.** The gate
holds `timeouts` alone, the one client-visible failure belonging to *admitted*
work. Every socket error in this band is a connection that was never admitted,
already witnessed by the 5xx status gate and the accept-RST count. A genuine
mid-exchange break is still gated by `proxiesHealthy` on the keep-alive, close
and large-body bands, where no RST wall fires and a socket error can only be
the proxy's fault. This band cannot tell the two apart, so it no longer claims
to.

The band now also prints the refused/timed-out split every run, not only when
the gate trips — a margin invisible until it fails is how this sat
mis-specified.

Not taken: gating the shed *identity* (scrape `shed_conn_slots` and assert
socket errors are accounted for). That is a stronger claim and the harness
could carry it, but it asserts shed-accounting correctness, which is a
different property than "admitted work is served promptly" and wants its own
gate rather than being folded into this one.

## 2. zrk v1.3.1 → v1.4.1, zio 3566a3a → b822fda

The pin's own rule is that zrk tracks the version the cloud benchmark runs;
`zoxy-io/benchmark` moved to v1.4.1 and local was behind, which is exactly the
incomparability the pin exists to prevent. Now identical to its
`bench/build.zig.zon` entry.

zio moves with it because that comment already required it — the pin must be
exactly what zrk carries, or two copies of zio become two runtimes. `b822fda`
is lalinsky/zio#628, "io_uring: flush a full submission queue instead of
dropping SQEs": before it, zio dropped a cancel when the SQ was full and left
the target completion stuck `.running` forever with its awaiting task blocked
(lalinsky/zio#623).

## Verification

- `zig build ci` green (4096-seed sweep), `zig fmt --check` clean.
- Two full bench runs on v1.4.1 pass the fixed gate with `timeouts` 0, where
  the old gate would have failed them at 12.0% and 16.3%.
- Bands unchanged within noise on the new generator: keep-alive hop overhead
  p50 zoxy L4 +24 µs / L7 +21 µs against haproxy tcp +21 µs / http +22 µs, RSS
  flat, clean drains.
- `tiger-style-reviewer` clean after correcting an overstated run count in the
  first draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)