### PR TITLE
Code review cleanup: stale comments and duplication

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -875,7 +875,7 @@ origin, not one this proxy can pick for them.
   parsed, no declared body left to read, nothing pipelined past it), the
   client asked for keep-alive, the proxy is not draining, and relay
   pressure has not suppressed keep-alive (#57). Otherwise the lingering
-  close (§2) drains the client's inbound and closes. The
+  close (§7) drains the client's inbound and closes. The
   head-framing rejects — `400` malformed, `414`, `431` — can never keep:
   where the next request begins is exactly what the parser could not
   determine, so keeping would hand a smuggler a desynchronized stream.

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -329,7 +329,7 @@ pub fn Client(comptime IoType: type) type {
                         return ClientError.GoldenOutcomeMissed;
                     }
                 }
-                // §2: a pipelined first response must announce the close
+                // §7: a pipelined first response must announce the close
                 // that follows it.
                 if (entry.golden_first_announces_close and walk.keep_alives[0]) {
                     return ClientError.GoldenOutcomeMissed;
@@ -341,7 +341,7 @@ pub fn Client(comptime IoType: type) type {
             complete_count: u8,
             offset: u32,
             statuses: [responses_max]u16,
-            /// Per-response persistence verdicts (§2): version defaults
+            /// Per-response persistence verdicts (§7): version defaults
             /// plus Connection tokens, as the parser computed them.
             keep_alives: [responses_max]bool,
             violation: ?ClientError,

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -48,7 +48,7 @@ pub const Script = enum(u8) {
     /// reusable.
     keepalive_pair,
     /// Two GETs in one send: the proxy answers the first, announces
-    /// close (§2), and never serves the second.
+    /// close (§7), and never serves the second.
     pipelined,
     /// Connects and sends nothing: the head-read deadline reaps it;
     /// any response byte is a violation.
@@ -114,7 +114,7 @@ pub const Spec = struct {
     /// script degrades to a single-exchange transcript when its first
     /// response refuses reuse.
     second_request_when_reusable: bool = false,
-    /// Clean seeds demand the first response announces close (§2) —
+    /// Clean seeds demand the first response announces close (§7) —
     /// the pipelined shape: the proxy serves the first request and
     /// refuses to look at the second.
     golden_first_announces_close: bool = false,

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -63,9 +63,12 @@ pub const Outcome = enum(u8) {
     /// `502` (§7, §8) — a refused dial, a dead origin, an unparseable
     /// response head.
     upstream_failed,
-    /// No answer was delivered: the connection was torn down mid-request.
-    /// The client left, the deadline fired with a response already in
-    /// flight, or a drain reaped a straggler.
+    /// No complete answer reached the client: the connection was torn
+    /// down mid-request or mid-response. The client left, the deadline
+    /// fired (possibly with a response already in flight, in which case
+    /// the origin's status is still recorded), or a drain reaped a
+    /// straggler. The default outcome, so any teardown path that skips
+    /// setting a more specific one lands here too.
     aborted,
     /// L4 only: both directions drained and the connection closed cleanly.
     closed,

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -157,6 +157,18 @@ pub fn Admin(comptime IoType: type) type {
             admin.server.io.accept(admin.listener, &admin.op_accept, Self, admin, onAccept);
         }
 
+        /// The admin plane is done accepting and now quiescent: stop
+        /// listening, go idle, and let the server re-check whether the
+        /// whole drain can finish. Shared by every drain exit path so they
+        /// cannot drift on the sequencing.
+        fn quiesceForDrain(admin: *Self) void {
+            assert(admin.server.draining);
+            assert(admin.armedCount() == 0);
+            admin.listening = false;
+            admin.state = .off;
+            admin.server.maybeStopAfterDrain();
+        }
+
         fn onAccept(admin: *Self, result: Io.AcceptError!IoType.Socket) void {
             assert(admin.state == .accepting);
             admin.disarm("accept");
@@ -172,9 +184,7 @@ pub fn Admin(comptime IoType: type) type {
                 if (result) |socket| {
                     shed.closeQuietly(IoType, admin.server.io, socket);
                 } else |_| {}
-                admin.listening = false;
-                admin.state = .off;
-                admin.server.maybeStopAfterDrain();
+                admin.quiesceForDrain();
                 return;
             }
             const socket = result catch |err| {
@@ -218,9 +228,7 @@ pub fn Admin(comptime IoType: type) type {
             // was pending is handled by cleaning up instead of re-arming.
             result catch unreachable;
             if (admin.server.draining) {
-                admin.listening = false;
-                admin.state = .off;
-                admin.server.maybeStopAfterDrain();
+                admin.quiesceForDrain();
                 return;
             }
             admin.armAccept();
@@ -429,9 +437,7 @@ pub fn Admin(comptime IoType: type) type {
             if (admin.state != .closing) return;
             if (admin.armedCount() != 0) return;
             if (admin.server.draining) {
-                admin.listening = false;
-                admin.state = .off;
-                admin.server.maybeStopAfterDrain();
+                admin.quiesceForDrain();
                 return;
             }
             admin.armAccept();

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -7,7 +7,7 @@
 //!
 //! Lifecycle of one scrape: accept → send the rendered response → lingering
 //! close (half-close the write side, drain client input to EOF so the close
-//! never RSTs the response away, §2) → re-arm accept. A per-scrape deadline
+//! never RSTs the response away, §7) → re-arm accept. A per-scrape deadline
 //! (`admin_scrape_deadline_ms`) reaps a stalled or slowloris client so it
 //! cannot pin the single slot, exactly as every data-path socket is reaped
 //! (§8). Drain (§8) closes the listener and tears down any in-flight scrape,
@@ -83,7 +83,7 @@ pub fn Admin(comptime IoType: type) type {
             /// Writing the rendered response to the client.
             sending,
             /// Write side half-closed; discarding client input to EOF so
-            /// the close does not RST the response away (§2).
+            /// the close does not RST the response away (§7).
             draining,
             /// Teardown: sockets shut down, data op draining, close not yet
             /// submitted (the abnormal path — deadline, error, server drain).
@@ -276,7 +276,7 @@ pub fn Admin(comptime IoType: type) type {
                 return;
             }
             // Response fully sent: half-close the write side and drain the
-            // client's input to EOF so the close does not RST it away (§2).
+            // client's input to EOF so the close does not RST it away (§7).
             admin.server.counters.increment("admin_served");
             admin.state = .draining;
             admin.server.io.shutdown(admin.socket, .write);

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -129,8 +129,8 @@ pub fn Admin(comptime IoType: type) type {
             assert(admin.state == .off);
         }
 
-        /// Set the bind address before `start` (main.zig, from the env var;
-        /// the simulator sets it directly). A no-op default leaves admin off.
+        /// Set the bind address before `start`. A no-op default leaves
+        /// admin off.
         pub fn setBind(admin: *Self, bind_address: std.Io.net.IpAddress) void {
             assert(admin.state == .off);
             assert(!admin.listening);
@@ -138,7 +138,7 @@ pub fn Admin(comptime IoType: type) type {
         }
 
         /// Open the listener and arm the first accept, or stay off when no
-        /// bind is configured. Called from `Server.start`.
+        /// bind is configured.
         pub fn start(admin: *Self) Io.ListenError!void {
             assert(admin.state == .off);
             assert(!admin.listening);

--- a/src/config.zig
+++ b/src/config.zig
@@ -1778,10 +1778,10 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
 const example_json = @embedFile("example_config");
 
 test "config: the shipped example parses and resolves" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
 
-    const parsed = try parse(arena_state.allocator(), example_json);
+    const parsed = try expectParseOk(&arena_state, example_json);
     try std.testing.expectEqual(@as(usize, 1), parsed.listeners.len);
     try std.testing.expectEqual(@as(usize, 1), parsed.clusters.len);
     // The `"cluster"` sugar resolves to one catch-all route.
@@ -1816,9 +1816,9 @@ test "config: the shipped example parses and resolves" {
 test "config: max_lifetime_ms is optional and defaults to disabled" {
     // The field is absent here — pre-existing configs stay valid and the
     // cap defaults off (§6).
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -1837,29 +1837,29 @@ test "config: request_ms is optional, defaults off, and shares the timeout ceili
     // Absent: pre-existing configs stay valid and the §8 request deadline
     // defaults off, the same shape as max_lifetime_ms.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
         );
         try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
     }
     // Explicit 0 is legal — "no cap", not a TimeoutZero.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1,\"request_ms\":0}}",
         );
         try std.testing.expectEqual(@as(u32, 0), parsed.request_timeout_ms);
     }
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1,\"request_ms\":250}}",
         );
         try std.testing.expectEqual(@as(u32, 250), parsed.request_timeout_ms);
@@ -1867,14 +1867,13 @@ test "config: request_ms is optional, defaults off, and shares the timeout ceili
     // The shared ceiling still binds — an optional cap is not an unbounded
     // one.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-        defer arena_state.deinit();
         const json = try std.fmt.allocPrint(
-            arena_state.allocator(),
+            std.testing.allocator,
             "{s}\"timeouts\":{{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1,\"request_ms\":{d}}}}}",
             .{ head, @as(u64, constants.timeout_ms_max) + 1 },
         );
-        try std.testing.expectError(error.TimeoutOverLimit, parse(arena_state.allocator(), json));
+        defer std.testing.allocator.free(json);
+        try expectParseError(error.TimeoutOverLimit, json);
     }
 }
 
@@ -1882,9 +1881,9 @@ test "config: the whole timeouts block is optional, and every default is usable"
     // A config that names none of them is the out-of-box shape (§5), the
     // same argument `limits` already makes: an operator opts into tuning,
     // never into a working config.
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}}}
     );
@@ -1904,9 +1903,9 @@ test "config: a zero drain deadline is no cap, but a zero connect or idle is sti
     // sense in which a 0 ms dial or idle budget is a policy rather than a
     // configuration error, so those two keep rejecting it.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"drain_deadline_ms":0}}
@@ -1928,9 +1927,7 @@ test "config: a zero drain deadline is no cap, but a zero connect or idle is sti
         ,
     };
     for (rejected) |json| {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-        defer arena_state.deinit();
-        try std.testing.expectError(error.TimeoutZero, parse(arena_state.allocator(), json));
+        try expectParseError(error.TimeoutZero, json);
     }
 }
 
@@ -1964,18 +1961,13 @@ test "config: the dial budget must sit below the idle one" {
         ,
     };
     for (rejected) |json| {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-        defer arena_state.deinit();
-        try std.testing.expectError(
-            error.TimeoutOrderInvalid,
-            parse(arena_state.allocator(), json),
-        );
+        try expectParseError(error.TimeoutOrderInvalid, json);
     }
     // A single millisecond of ordering is all the rule asks for, and the
     // shipped defaults clear it by an order of magnitude.
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":5000,"idle_ms":5001}}
@@ -1989,9 +1981,9 @@ test "config: max_lifetime_ms accepts zero (a legal zero timeout) and real value
     // Explicit 0 is legal — it is *not* a TimeoutZero, unlike the dial
     // and idle budgets (§6).
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1,"max_lifetime_ms":0}}
@@ -1999,9 +1991,9 @@ test "config: max_lifetime_ms accepts zero (a legal zero timeout) and real value
         try std.testing.expectEqual(@as(u32, 0), parsed.max_lifetime_ms);
     }
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1,"max_lifetime_ms":1800000}}
@@ -2013,9 +2005,9 @@ test "config: max_lifetime_ms accepts zero (a legal zero timeout) and real value
 test "config: listener protocol defaults to l4 and accepts http" {
     // Absent field: pre-L7 configs stay valid.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -2023,9 +2015,9 @@ test "config: listener protocol defaults to l4 and accepts http" {
         try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
     }
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -2035,9 +2027,9 @@ test "config: listener protocol defaults to l4 and accepts http" {
 }
 
 test "config: explicit routes resolve, sorted longest-prefix-first" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","routes":[
         \\   {"prefix":"/","cluster":"root"},
         \\   {"prefix":"/api/v2","cluster":"v2"},
@@ -2102,9 +2094,9 @@ test "config: routing schema rejects malformed tables" {
 }
 
 test "config: host routes resolve, host-specific sorted before any-host" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","routes":[
         \\   {"prefix":"/","cluster":"root"},
         \\   {"host":"api.example.com","prefix":"/","cluster":"api"},
@@ -2134,9 +2126,9 @@ test "config: host routes resolve, host-specific sorted before any-host" {
 }
 
 test "config: filters compile into rules with matches and actions" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","filters":[
         \\   {"match":{"method":["GET","POST"],"path_prefix":"/admin",
         \\             "headers":[{"name":"X-Env","equals":"prod"}]},
@@ -2242,9 +2234,9 @@ test "config: a filter set over the header-edit budget is rejected" {
 test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
     // Explicit rr and p2c both resolve; absent defaults to p2c.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"pick":"rr"},
             \\   "b":{"endpoints":["127.0.0.1:3"],"pick":"p2c"},
@@ -2264,9 +2256,9 @@ test "config: cluster pick policy parses, defaults to p2c, rejects typos" {
 }
 
 test "config: a check block resolves its kind, thresholds and budget" {
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(),
+    const parsed = try expectParseOk(&arena_state,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
         \\     "check":{"type":"tcp","fall":5,"rise":1,"timeout_ms":250}},
@@ -2290,9 +2282,9 @@ test "config: a check block resolves its kind, thresholds and budget" {
 
 test "config: an http check resolves its request and expected status" {
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
             \\     "check":{"type":"http","path":"/healthz","host":"api.example",
@@ -2308,9 +2300,9 @@ test "config: an http check resolves its request and expected status" {
     }
     // Host is optional: absent means the endpoint's own literal (§7).
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],
             \\     "check":{"type":"http","path":"/health"}}},
@@ -2382,9 +2374,9 @@ test "config: a check block rejects every shape it cannot run" {
 test "config: health interval parses, defaults to inter, rejects zero" {
     // Explicit value resolves; absent means the HAProxy-inter default.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1,
@@ -2393,9 +2385,9 @@ test "config: health interval parses, defaults to inter, rejects zero" {
         try std.testing.expectEqual(@as(u32, 250), parsed.health_interval_ms);
     }
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -2420,9 +2412,9 @@ test "config: health interval parses, defaults to inter, rejects zero" {
 test "config: limits shrink pools below the ceilings, never past them" {
     // Partial limits: relay buffers derive from the effective conn slots.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1},
@@ -2440,9 +2432,9 @@ test "config: limits shrink pools below the ceilings, never past them" {
     }
     // Full limits resolve verbatim; absent block keeps the ceilings.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1},
@@ -2455,9 +2447,9 @@ test "config: limits shrink pools below the ceilings, never past them" {
         try std.testing.expectEqual(@as(u32, 4), parsed.limits.cq_fill_eighths);
     }
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
             \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -2498,10 +2490,8 @@ test "config: limits shrink pools below the ceilings, never past them" {
     // budgets for: the pair is pinned, so a conn slot's worst case
     // includes the upstream slot it may hold (see `conn_slots_max`).
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-        defer arena_state.deinit();
         const json = try std.fmt.allocPrint(
-            arena_state.allocator(),
+            std.testing.allocator,
             "{s}{s}\"limits\":{{\"conn_slots\":{d},\"upstream_slots\":{d},\"cq_fill_eighths\":{d}}}}}",
             .{
                 head,
@@ -2511,7 +2501,8 @@ test "config: limits shrink pools below the ceilings, never past them" {
                 constants.cq_fill_eighths_max - 1,
             },
         );
-        try std.testing.expectError(error.LimitConnSlotsOverCqFill, parse(arena_state.allocator(), json));
+        defer std.testing.allocator.free(json);
+        try expectParseError(error.LimitConnSlotsOverCqFill, json);
     }
 }
 
@@ -2523,17 +2514,17 @@ test "config: admin block resolves a bind literal, absent leaves it off" {
     ;
     // Absent: the admin plane stays off.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(), head ++ tail ++ "}");
+        const parsed = try expectParseOk(&arena_state, head ++ tail ++ "}");
         try std.testing.expect(parsed.admin_bind == null);
     }
     // Present: the bind resolves to the given IP:port.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ tail ++ ",\"admin\":{\"bind\":\"127.0.0.1:9100\"}}",
         );
         try std.testing.expect(parsed.admin_bind != null);
@@ -2570,6 +2561,18 @@ fn expectParseError(expected: ParseError, json_bytes: []const u8) !void {
     try std.testing.expectError(expected, parse(arena_state.allocator(), json_bytes));
 }
 
+/// The success-path mirror of `expectParseError`: inits `arena_state`
+/// (caller-owned, so the returned `Config`'s slices stay valid as long as
+/// the caller needs them and `deinit` is the caller's to call) and parses
+/// `json_bytes` from it. `arena_state` is `undefined` until this returns —
+/// callers `defer arena_state.deinit()` right after declaring it, so
+/// nothing fallible may run between that `defer` and this call, or an
+/// early return would deinit an uninitialized arena.
+fn expectParseOk(arena_state: *std.heap.ArenaAllocator, json_bytes: []const u8) !Config {
+    arena_state.* = std.heap.ArenaAllocator.init(std.testing.allocator);
+    return parse(arena_state.allocator(), json_bytes);
+}
+
 test "config: strictness rejects unknown and duplicate fields" {
     try expectParseError(error.UnknownField,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","nope":1}],
@@ -2597,9 +2600,9 @@ test "config: a `$schema` editor hint loads and is ignored" {
     // file; a strict loader that rejected it would make the schema asset
     // unusable for the very files it describes.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"$schema":"https://zoxy.io/schema/config.schema.json",
             \\ "listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
@@ -2733,9 +2736,9 @@ test "config: the fuzz seed carrying every block parses" {
     // It is a corpus entry, so it has to be a *valid* config — an
     // unparseable seed would still fuzz, just from a worse starting point,
     // and nothing else would say so.
-    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    const parsed = try parse(arena_state.allocator(), fuzz_seed_json);
+    const parsed = try expectParseOk(&arena_state, fuzz_seed_json);
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
     try std.testing.expectEqual(@as(u32, 30000), parsed.request_timeout_ms);
 }
@@ -2783,18 +2786,18 @@ test "config: the access-log block resolves a sink, absent leaves it off" {
     // zero exactly then, which is how `accessLogBytes` reads "off" off one
     // number instead of needing the sink beside it (§5, §8).
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(), head ++ tail ++ "}");
+        const parsed = try expectParseOk(&arena_state, head ++ tail ++ "}");
         try std.testing.expect(parsed.access_log_sink == null);
         try std.testing.expectEqual(@as(u32, 0), parsed.limits.access_log_buffer_bytes);
     }
     // Present: the sink resolves and the staging buffers take the default.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}}",
         );
         try std.testing.expectEqual(Config.AccessLogSink.stdout, parsed.access_log_sink.?);
@@ -2805,10 +2808,10 @@ test "config: the access-log block resolves a sink, absent leaves it off" {
     }
     // A sized buffer alongside a sink resolves verbatim.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}," ++
                 "\"limits\":{\"access_log_buffer_bytes\":65536}}",
         );
@@ -2857,10 +2860,10 @@ test "config: a cluster name is bounded, because the access log echoes it" {
     // line's width would be a function of the config file rather than of
     // constants.zig (§8).
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ at_limit ++ "\"}],\"clusters\":{\"" ++ at_limit ++
                 "\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
                 "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
@@ -2889,10 +2892,10 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
     // `pick: hash` with no `hash` block takes the default key, so the
     // common case needs no second line of config.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ endpoints ++ ",\"pick\":\"hash\"" ++ tail,
         );
         try std.testing.expectEqual(Config.Cluster.Pick.hash, parsed.clusters[0].pick);
@@ -2900,10 +2903,10 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
     }
     // Naming the key explicitly resolves to the same thing.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ endpoints ++ ",\"pick\":\"hash\",\"hash\":{\"key\":\"source_ip\"}" ++ tail,
         );
         try std.testing.expectEqual(Config.Cluster.HashKey.source_ip, parsed.clusters[0].hash_key);
@@ -2911,9 +2914,9 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
     // A cluster that says nothing keeps the p2c default and the default
     // key, which is inert there.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(), head ++ endpoints ++ tail);
+        const parsed = try expectParseOk(&arena_state, head ++ endpoints ++ tail);
         try std.testing.expectEqual(Config.Cluster.Pick.p2c, parsed.clusters[0].pick);
     }
 
@@ -2948,9 +2951,9 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
 
 test "config: max_inflight resolves, defaults to uncapped, rejects the useless" {
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(),
+        const parsed = try expectParseOk(&arena_state,
             \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"max_inflight":64},
             \\   "b":{"endpoints":["127.0.0.1:3"]}},
@@ -2977,15 +2980,15 @@ test "config: max_inflight resolves, defaults to uncapped, rejects the useless" 
     // only if every conn and upstream slot in the process piles onto one
     // endpoint, which is a real (if extreme) shape rather than a no-op.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
-        defer arena_state.deinit();
         var buffer: [512]u8 = undefined;
         const json = try std.fmt.bufPrint(
             &buffer,
             "{s}{d}{s}",
             .{ head, constants.endpoint_inflight_max, tail },
         );
-        const parsed = try parse(arena_state.allocator(), json);
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, json);
         try std.testing.expectEqual(
             @as(?u32, constants.endpoint_inflight_max),
             parsed.clusters[0].max_inflight,
@@ -3001,17 +3004,17 @@ test "config: the forwarded block resolves a mode, and is http-only" {
     // Absent: the header is untouched, which is what every config that
     // predates this feature must keep doing.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(), head ++ ",\"protocol\":\"http\"" ++ tail);
+        const parsed = try expectParseOk(&arena_state, head ++ ",\"protocol\":\"http\"" ++ tail);
         try std.testing.expect(parsed.listeners[0].forwarded == null);
     }
     // Both modes resolve; neither is a default.
     inline for (.{ "replace", "append" }) |mode| {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(
-            arena_state.allocator(),
+        const parsed = try expectParseOk(
+            &arena_state,
             head ++ ",\"protocol\":\"http\",\"forwarded\":{\"mode\":\"" ++ mode ++ "\"}" ++ tail,
         );
         try std.testing.expectEqual(
@@ -3062,9 +3065,9 @@ test "config: a filter may not name the header zoxy manages" {
     // A neighbouring name is still editable — the guard is the header, not
     // a prefix of it.
     {
-        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try parse(arena_state.allocator(), head ++
+        const parsed = try expectParseOk(&arena_state, head ++
             "{\"actions\":[{\"header_set\":{\"name\":\"X-Forwarded-Proto\",\"value\":\"https\"}}]}" ++ tail);
         try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].filters.len);
     }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -43,7 +43,7 @@ pub const admin_conn_ops_max: u32 = 3;
 /// round trip — and independent of the data path's `idle_timeout_ms`.
 pub const admin_scrape_deadline_ms: u32 = 5_000;
 
-/// Throwaway buffer for the admin lingering-close drain (§2): the scrape's
+/// Throwaway buffer for the admin lingering-close drain (§7): the scrape's
 /// request is discarded, never inspected, so one small fixed buffer read
 /// in a loop to EOF suffices — sized only to keep the read count modest.
 pub const admin_drain_scratch_bytes: u32 = 512;

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -5,8 +5,9 @@
 //! canonical forms so a filter and the router never disagree) and an
 //! ordered action list drawn from a closed enum. Cluster selection is NOT
 //! an action: the route table owns the backend decision (§7), so filters
-//! never compete with routing. This module holds the compiled shapes; the
-//! interpreter and the config-load compiler live in slices to come.
+//! never compete with routing. This module holds the compiled shapes and
+//! the interpreter (`firstReject`, `collectForward`); the config-load
+//! compiler lives in `config.zig`.
 
 const std = @import("std");
 

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -1202,12 +1202,7 @@ pub fn isForwardableByte(byte: u8) bool {
 }
 
 fn hexDigitValue(byte: u8) u4 {
-    return switch (byte) {
-        '0'...'9' => @intCast(byte - '0'),
-        'a'...'f' => @intCast(byte - 'a' + 10),
-        'A'...'F' => @intCast(byte - 'A' + 10),
-        else => unreachable, // Caller matched a hex digit.
-    };
+    return @intCast(hexNibble(byte) orelse unreachable); // Caller matched a hex digit.
 }
 
 // Tests. Head-parse cases go through the public wrapper only — hparse's

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -5,7 +5,7 @@
 //!
 //! Lifecycle: `l7_reading_head` accumulates the request head and
 //! re-parses from byte 0 on each recv (§7 detect-and-retry); verdicts
-//! answer comptime static responses (§8) with a lingering close (§2). A
+//! answer comptime static responses (§8) with a lingering close (§7). A
 //! valid request acquires its relay buffer and upstream slot (both §8
 //! rungs, 503), dials (`l7_dialing`), then `l7_exchanging` runs two
 //! semi-independent legs over the two data ops: the request leg sends
@@ -17,7 +17,7 @@
 //! sides independently: the upstream connection parks on its endpoint's
 //! idle list when the origin allowed reuse (checked out again by any
 //! later request — §3's shared-pool win), and the downstream connection
-//! honors what its rendered response announced (§2), going idle at the
+//! honors what its rendered response announced (§7), going idle at the
 //! cost of a slot + head buffer only (§5). Pipelining is unsupported
 //! (first response, then an announced close). A stale checkout takes one
 //! free replay on a fresh dial (§7), and an expired exchange or dial
@@ -956,7 +956,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// request's own framing; a client-side recv cannot be forced, so a
         /// pending verdict makes the arm illegal and a settled verdict on a
         /// send diverts. A short body tail past the framing is a pipelined
-        /// next request (§2 note). Failures doom the exchange: a recv EOF is
+        /// next request (§7 note). Failures doom the exchange: a recv EOF is
         /// a truncated request (teardown), a send failure is the origin
         /// giving out (`upstreamFailed`).
         const RequestBodyPolicy = struct {
@@ -996,7 +996,7 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.log.bytes_in += fr.consumed;
                 if (fr.consumed < received) {
                     // Bytes past the body are a pipelined next request; the
-                    // connection will close after this exchange (§2 note).
+                    // connection will close after this exchange (§7 note).
                     conn.l7.client_pipelined = true;
                 }
             }
@@ -1158,7 +1158,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         /// The §8 persistence decision, made once and honored: keep the
         /// client's connection unless pipelining, pressure, or drain says
-        /// otherwise — then announce whatever was decided (§2).
+        /// otherwise — then announce whatever was decided (§7).
         ///
         /// Only relay pressure suppresses keep-alive: the next request on
         /// this connection would claim a relay buffer the pool is running
@@ -1458,7 +1458,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// The response reached the client in full: settle both sides.
         /// The upstream connection parks for reuse when the origin allowed
         /// it and the request went out completely (§5); the downstream
-        /// connection honors what its response announced (§2). An early
+        /// connection honors what its response announced (§7). An early
         /// response with the request still in flight forfeits both — the
         /// two byte streams are no longer alignable.
         fn finishExchange(server: *ServerType, conn: *ConnType) void {
@@ -1776,7 +1776,7 @@ pub fn Proxy(comptime IoType: type) type {
         ///     is unread bytes still to come; draining it is what the
         ///     lingering close is for.
         ///   - the client sent nothing past the head. Trailing bytes are a
-        ///     pipelined next request, which §2 does not serve — and
+        ///     pipelined next request, which §7 does not serve — and
         ///     leaving them buffered to be read as the *start* of the next
         ///     request is the desynchronization §7 exists to prevent.
         ///
@@ -1878,7 +1878,7 @@ pub fn Proxy(comptime IoType: type) type {
             // reconnect loop. Keeping is one send.
             //
             // The same three brakes the render-time persistence decision
-            // honors apply here (§2, §8): the client's own ask, the drain,
+            // honors apply here (§7, §8): the client's own ask, the drain,
             // and relay pressure — a proxy shedding buffers should not also
             // be holding connections open for their next request.
             const keep = staticResponseResyncable(conn) and
@@ -1891,7 +1891,7 @@ pub fn Proxy(comptime IoType: type) type {
             // spellings are comptime byte arrays; only the choice is runtime,
             // and it must match what happens after the send — an announced
             // close that kept serving, or a kept connection the client was
-            // told to stop using, are both §2 violations.
+            // told to stop using, are both §7 violations.
             if (keep) {
                 armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
             } else {
@@ -1935,7 +1935,7 @@ pub fn Proxy(comptime IoType: type) type {
         }
 
         /// The static response is out and the stream is still synchronized:
-        /// serve the next request on this connection (§2, §8). `respond`
+        /// serve the next request on this connection (§7, §8). `respond`
         /// already released the relay buffer and any attached upstream, so
         /// this is `resetForNextRequest` minus the exchange it never had.
         fn resumeAfterStaticResponse(server: *ServerType, conn: *ConnType) void {
@@ -1964,7 +1964,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         /// A client can still be sending its request — a body, or the rest
         /// of an oversize head — when we answer an error. Closing then
-        /// would RST and discard the response we just sent (§2). Instead
+        /// would RST and discard the response we just sent (§7). Instead
         /// half-close the write side (the client sees our response and
         /// FIN) and drain the client's remaining input to EOF before the
         /// teardown; the head-read deadline bounds a client that never

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -108,10 +108,10 @@ pub fn Proxy(comptime IoType: type) type {
         //
         // Scoped to the request head deliberately. The origin's *response*
         // head accumulates the same way in `onResponseHeadRecv`, into the
-        // upstream slot's buffer, and does not need a source: Phase 3a
-        // terminates TLS on the client side only, so the upstream leg stays
-        // plaintext (kTLS on the origin side, if it ever comes, would revisit
-        // this).
+        // upstream slot's buffer, and does not need a source: §4's TLS
+        // termination applies to the client side only, so the upstream leg
+        // stays plaintext (kTLS on the origin side, if it ever comes, would
+        // revisit this).
         //
         // The third stays `parseAndDispatch`, the single answer to "what do
         // these bytes mean": read again, 400, 414, 431, or route. That matters

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -494,6 +494,22 @@ pub fn Proxy(comptime IoType: type) type {
             beginUpstream(server, conn, request, &keys.views);
         }
 
+        /// Picks a live endpoint under the §8 per-endpoint inflight cap, or
+        /// sheds 503 and returns null when every endpoint of this cluster
+        /// is already at it. Shared by the first-try and replay dial paths
+        /// so the cap and its shed counter cannot drift between them.
+        fn pickEndpointOrShed(server: *ServerType, conn: *ConnType) ?Balancer.Pick {
+            return server.balancer.pick(
+                conn.cluster_index,
+                &server.endpointLoad(),
+                &server.health.healthy,
+                &conn.client_address,
+            ) orelse {
+                respond(server, conn, 503, "l7_shed_endpoint_inflight");
+                return null;
+            };
+        }
+
         /// Route resolved and a relay buffer held: choose an endpoint and
         /// get onto it, by reuse when the pool has one parked and by a
         /// fresh dial otherwise. Split from `routeRequest` because the
@@ -512,19 +528,12 @@ pub fn Proxy(comptime IoType: type) type {
             // beats a fresh dial. A close that slipped through while it
             // was parked surfaces as a failure on first use — absorbed by
             // the §7 free replay (`upstreamFailed`).
-            const pick = server.balancer.pick(
-                conn.cluster_index,
-                &server.endpointLoad(),
-                &server.health.healthy,
-                &conn.client_address,
-            ) orelse {
-                // Every endpoint of this cluster is at its §8 cap. The
-                // reuse path is capped too, deliberately: checking out a
-                // parked connection starts a request the origin has to
-                // serve, which is the thing being bounded — the saved
-                // handshake does not make it free.
-                return respond(server, conn, 503, "l7_shed_endpoint_inflight");
-            };
+            //
+            // The §8 cap binds the reuse path too, deliberately: checking
+            // out a parked connection starts a request the origin has to
+            // serve, which is the thing being bounded — the saved
+            // handshake does not make it free.
+            const pick = pickEndpointOrShed(server, conn) orelse return;
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
@@ -1720,17 +1729,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.directions = .{ .{}, .{} };
             // A fresh pick and a fresh dial — never another checkout (§7):
             // the endpoint's whole idle list may be stale the same way.
-            const pick = server.balancer.pick(
-                conn.cluster_index,
-                &server.endpointLoad(),
-                &server.health.healthy,
-                &conn.client_address,
-            ) orelse {
-                // The replay is a fresh try against the same cluster, so
-                // it meets the same cap. Its budget is already spent, so
-                // this answers rather than replaying again (§7).
-                return respond(server, conn, 503, "l7_shed_endpoint_inflight");
-            };
+            //
+            // The replay is a fresh try against the same cluster, so it
+            // meets the same §8 cap; its budget is already spent (§7), so
+            // a cap hit here answers rather than replaying again.
+            const pick = pickEndpointOrShed(server, conn) orelse return;
             dialUpstream(server, conn, pick);
         }
 

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -2,7 +2,7 @@
 //! *rendered* into a fixed staging buffer, never edited in place — the
 //! zero-copy slices of the source head stay valid throughout. Rendering
 //! strips hop-by-hop headers both ways (RFC 9110 §7.6.1), injects
-//! `Connection: close` when the proxy will close (§2), and applies the §7
+//! `Connection: close` when the proxy will close, and applies the §7
 //! filter header edits that matched the request. A head that no longer
 //! fits after rendering is oversize — 431 downstream, teardown upstream
 //! (§7) — which now includes a head that outgrows the buffer only once the
@@ -81,7 +81,7 @@ comptime {
 /// Renders the upstream request line and end-to-end headers from a
 /// parsed head. The client's version is preserved — framing decisions on
 /// both hops key off the real versions — and `inject_close` announces
-/// that this upstream connection will not be reused (§2). `edits` are the
+/// that this upstream connection will not be reused (§7). `edits` are the
 /// §7 filter header mutations that matched this request: a set/remove
 /// suppresses the source copies of its name, a set/add appends its
 /// (config-validated, injection-safe) line — proxy-managed names can never
@@ -144,7 +144,7 @@ pub fn renderRequestHead(
 /// Renders the downstream status line and end-to-end headers. The
 /// origin's version and reason phrase are preserved verbatim;
 /// `inject_close` announces that the proxy will close the downstream
-/// connection after this response (§2).
+/// connection after this response (§7).
 pub fn renderResponseHead(
     response: *const parser.ResponseHead,
     inject_close: bool,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -741,6 +741,18 @@ fn expectRejectedAfterDial(bed: *const Http1Bed) !void {
     try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
 }
 
+/// Parses what the origin actually received as a request head, into
+/// `storage` — caller-owned so the returned head's slices (into
+/// `storage` and the origin's own request buffer) stay valid as long as
+/// the caller needs them.
+fn forwardedRequest(bed: *const Http1Bed, storage: *parser.HeaderStorage) !parser.RequestHead {
+    return parser.parseRequestHead(
+        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
+        false,
+        storage,
+    );
+}
+
 test "l7: a head that fits on arrival but not after forwarding is 431" {
     // Two arms the head-parse verdicts above cannot reach: a head the parser
     // accepted, rejected only when the proxy renders what it will forward
@@ -845,11 +857,7 @@ test "l7: OPTIONS asterisk-form is forwarded as \"*\", not as the \"/\" it match
 
     try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqual(parser.Method.options, forwarded.method);
     try std.testing.expectEqualStrings("*", forwarded.target);
     try bed.expectDrained();
@@ -875,11 +883,7 @@ test "l7: a GET is proxied and the origin's response relayed back" {
     // The origin received the request, rewritten with Connection: close.
     try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqual(parser.Method.get, forwarded.method);
     try std.testing.expectEqualStrings("/path", forwarded.target);
     // The client asked to close, but that is hop-by-hop: the upstream
@@ -905,11 +909,7 @@ test "l7: the origin sees the canonical path, query verbatim (§7)" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     // Router and origin agree on the same canonical resource: /a/.. pops
     // to /, then /b/./c collapses to /b/c; the query rides along untouched.
     try std.testing.expectEqualStrings("/b/c?x=1%2F2", forwarded.target);
@@ -1414,11 +1414,7 @@ test "l7: filter header edits reach the origin, applied once" {
     // gone, and exactly one request served.
     try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqualStrings("prod", parser.headerValue(forwarded.headers, "x-env").?);
     try std.testing.expectEqualStrings("on", parser.headerValue(forwarded.headers, "x-trace").?);
     try std.testing.expectEqual(@as(?[]const u8, null), parser.headerValue(forwarded.headers, "cookie"));
@@ -1452,11 +1448,7 @@ test "l7: a filter rewrite changes only the forwarded path, not the route" {
     );
     try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqualStrings("/new/x?q=1", forwarded.target);
     try bed.expectDrained();
 }
@@ -1484,11 +1476,7 @@ test "l7: a header edit reaches the origin exactly once under adversarial delive
 
         try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
         var storage: parser.HeaderStorage = undefined;
-        const forwarded = try parser.parseRequestHead(
-            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-            false,
-            &storage,
-        );
+        const forwarded = try forwardedRequest(&bed, &storage);
         // The client sent dev; the edit replaced it with exactly one prod.
         try std.testing.expectEqualStrings("prod", parser.headerValue(forwarded.headers, "x-env").?);
         try bed.expectDrained();
@@ -1519,11 +1507,7 @@ test "l7: a path rewrite forwards the rewritten path under adversarial delivery"
 
         try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
         var storage: parser.HeaderStorage = undefined;
-        const forwarded = try parser.parseRequestHead(
-            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-            false,
-            &storage,
-        );
+        const forwarded = try forwardedRequest(&bed, &storage);
         try std.testing.expectEqualStrings("/new/x", forwarded.target);
         try bed.expectDrained();
     }
@@ -1579,11 +1563,7 @@ test "l7: a POST body is forwarded and a sized response returned, byte-exact und
         // The origin received the whole 11-byte body after the head.
         try std.testing.expect(bed.origin.conns[0].request_complete);
         var storage: parser.HeaderStorage = undefined;
-        const forwarded = try parser.parseRequestHead(
-            bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-            false,
-            &storage,
-        );
+        const forwarded = try forwardedRequest(&bed, &storage);
         const body = bed.origin.conns[0].request_buffer[forwarded.head_len..bed.origin.conns[0].request_len];
         try std.testing.expectEqualStrings("hello world", body);
         try bed.expectDrained();
@@ -1620,11 +1600,7 @@ test "l7: a body coalesced with the head, larger than a relay buffer, forwards i
     // The origin received the whole 6000-byte body byte-for-byte.
     try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
-    const forwarded = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const forwarded = try forwardedRequest(&bed, &storage);
     const forwarded_body = bed.origin.conns[0].request_buffer[forwarded.head_len..bed.origin.conns[0].request_len];
     try std.testing.expectEqualStrings(request[head.len..request_len], forwarded_body);
     try bed.expectDrained();
@@ -2221,89 +2197,80 @@ test "l7: the §7 replay inherits the request deadline, it does not restart it" 
     try bed.expectDrained();
 }
 
-test "l7: the 504 verdict path allocates nothing after init" {
-    // §9 zero-alloc gate for the pending-verdict machinery: the forced
-    // completion, the settle, and the static 504 answer must all run
-    // without an allocation. Counting run, then a failing run pinned to
-    // the init count.
+/// §9 zero-alloc gate shared by every "allocates nothing after init" test
+/// below: run `Scenario.run` under a counting allocator, confirm no
+/// allocation past init, then rerun the identical scenario under an
+/// allocator that *fails* past that same count — surviving proves the
+/// hot path never asks. `Scenario.verify`, if declared, checks the
+/// scenario actually exercised the path it gates; it only runs on the
+/// counting pass, since the strict pass only needs to survive.
+fn zeroAllocGate(comptime Scenario: type, options: Http1Bed.Options) !void {
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
     var bed: Http1Bed = undefined;
-    try bed.setUp(failing.allocator(), .{ .seed = 73, .origin_mute = true });
+    try bed.setUp(failing.allocator(), options);
     defer bed.tearDown();
     const allocations_after_init = failing.allocations;
-    try bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+    try Scenario.run(&bed);
     try bed.expectDrained();
-    // The verdict must actually have fired, or this gates nothing.
-    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    if (@hasDecl(Scenario, "verify")) try Scenario.verify(&bed);
     try std.testing.expectEqual(allocations_after_init, failing.allocations);
 
     var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
         .fail_index = allocations_after_init,
     });
     var strict_bed: Http1Bed = undefined;
-    try strict_bed.setUp(strict.allocator(), .{ .seed = 73, .origin_mute = true });
+    try strict_bed.setUp(strict.allocator(), options);
     defer strict_bed.tearDown();
-    try strict_bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+    try Scenario.run(&strict_bed);
     try strict_bed.expectDrained();
+}
+
+test "l7: the 504 verdict path allocates nothing after init" {
+    // §9 zero-alloc gate for the pending-verdict machinery: the forced
+    // completion, the settle, and the static 504 answer must all run
+    // without an allocation.
+    const Scenario = struct {
+        fn run(bed: *Http1Bed) !void {
+            try bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
+        }
+        fn verify(bed: *Http1Bed) !void {
+            // The verdict must actually have fired, or this gates nothing.
+            try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+        }
+    };
+    try zeroAllocGate(Scenario, .{ .seed = 73, .origin_mute = true });
 }
 
 test "l7: a single close-terminated exchange allocates nothing after init" {
     // §9 zero-alloc gate for the L7 upstream leg: a full proxied
-    // exchange — dial, request head + body, response, forward, close —
-    // under a counting allocator, then again under one that *fails* past
-    // the init count.
+    // exchange — dial, request head + body, response, forward, close.
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
-    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
-    var bed: Http1Bed = undefined;
-    try bed.setUp(failing.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
-    defer bed.tearDown();
-    const allocations_after_init = failing.allocations;
-    try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
-    try bed.expectDrained();
-    try std.testing.expectEqual(allocations_after_init, failing.allocations);
-
-    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
-        .fail_index = allocations_after_init,
-    });
-    var strict_bed: Http1Bed = undefined;
-    try strict_bed.setUp(strict.allocator(), .{ .seed = 9, .partial_io = true, .origin_response = response });
-    defer strict_bed.tearDown();
-    try strict_bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
-    try strict_bed.expectDrained();
+    const Scenario = struct {
+        fn run(bed: *Http1Bed) !void {
+            try bed.exchange("POST /p HTTP/1.1\r\nHost: o\r\nConnection: close\r\nContent-Length: 3\r\n\r\nabc");
+        }
+    };
+    try zeroAllocGate(Scenario, .{ .seed = 9, .partial_io = true, .origin_response = response });
 }
 
 test "l7: the keep-alive reuse turnaround allocates nothing after init" {
     // §9 zero-alloc gate for the §5 park/checkout/reset path: two
     // requests on one client connection reuse the parked upstream — the
     // most allocation-prone L7 lifecycle code, and the one a single
-    // close-terminated exchange never touches. Counting run, then a
-    // failing run pinned to the init count.
+    // close-terminated exchange never touches.
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
-    const second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
-    const first_request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
-
-    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
-    var bed: Http1Bed = undefined;
-    try bed.setUp(failing.allocator(), .{ .seed = 50, .origin_response = response });
-    defer bed.tearDown();
-    const allocations_after_init = failing.allocations;
-    bed.client.second_request = second_request;
-    try bed.exchange(first_request);
-    try bed.expectDrained();
-    // The turnaround must actually have parked and reused the upstream,
-    // or this gates nothing.
-    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
-    try std.testing.expectEqual(allocations_after_init, failing.allocations);
-
-    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
-        .fail_index = allocations_after_init,
-    });
-    var strict_bed: Http1Bed = undefined;
-    try strict_bed.setUp(strict.allocator(), .{ .seed = 50, .origin_response = response });
-    defer strict_bed.tearDown();
-    strict_bed.client.second_request = second_request;
-    try strict_bed.exchange(first_request);
-    try strict_bed.expectDrained();
+    const Scenario = struct {
+        fn run(bed: *Http1Bed) !void {
+            bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+            try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+        }
+        fn verify(bed: *Http1Bed) !void {
+            // The turnaround must actually have parked and reused the
+            // upstream, or this gates nothing.
+            try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+        }
+    };
+    try zeroAllocGate(Scenario, .{ .seed = 50, .origin_response = response });
 }
 
 test "l7: an http listener admits without a relay buffer" {
@@ -2693,42 +2660,24 @@ test "l7: the stale replay survives 1-byte adversarial delivery across seeds" {
 test "l7: the replay path allocates nothing after init" {
     // §9 zero-alloc gate for the §7 replay: stale detection, slot
     // disposal, the re-parse, and the fresh dial must all run without an
-    // allocation. Counting run, then a failing run pinned to the count.
+    // allocation.
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
-    const second_request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
-    const first_request = "GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
-
-    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
-    var bed: Http1Bed = undefined;
-    try bed.setUp(failing.allocator(), .{
+    const Scenario = struct {
+        fn run(bed: *Http1Bed) !void {
+            bed.client.next = &bed.client2;
+            bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+            try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+        }
+        fn verify(bed: *Http1Bed) !void {
+            // The replay must actually have fired, or this gates nothing.
+            try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
+        }
+    };
+    try zeroAllocGate(Scenario, .{
         .seed = 57,
         .origin_response = response,
         .origin_closes = true,
     });
-    defer bed.tearDown();
-    const allocations_after_init = failing.allocations;
-    bed.client.next = &bed.client2;
-    bed.client2.request = second_request;
-    try bed.exchange(first_request);
-    try bed.expectDrained();
-    // The replay must actually have fired, or this gates nothing.
-    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
-    try std.testing.expectEqual(allocations_after_init, failing.allocations);
-
-    var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
-        .fail_index = allocations_after_init,
-    });
-    var strict_bed: Http1Bed = undefined;
-    try strict_bed.setUp(strict.allocator(), .{
-        .seed = 57,
-        .origin_response = response,
-        .origin_closes = true,
-    });
-    defer strict_bed.tearDown();
-    strict_bed.client.next = &strict_bed.client2;
-    strict_bed.client2.request = second_request;
-    try strict_bed.exchange(first_request);
-    try strict_bed.expectDrained();
 }
 
 /// The single line the §8 access log wrote during a scenario. Fails rather
@@ -3104,11 +3053,7 @@ test "l7: a request past the endpoint cap is answered 503, not sent" {
 fn forwardedForSeenByOrigin(bed: *const Http1Bed) !?[]const u8 {
     try std.testing.expect(bed.origin.conns[0].request_complete);
     var storage: parser.HeaderStorage = undefined;
-    const head = try parser.parseRequestHead(
-        bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
-        false,
-        &storage,
-    );
+    const head = try forwardedRequest(bed, &storage);
     var seen: ?[]const u8 = null;
     for (head.headers) |header| {
         if (header.tag != .x_forwarded_for) continue;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -23,7 +23,7 @@ const ServerSim = Server(SimIo);
 
 /// A scripted HTTP client: sends `request` (the adversary may split the
 /// send), then reads until the peer closes, recording the response bytes
-/// and whether the close was an orderly FIN or an RST — the §2 property
+/// and whether the close was an orderly FIN or an RST — the §7 property
 /// (a delivered response must end in FIN, never a data-discarding RST).
 const HttpClient = struct {
     io: *SimIo = undefined,
@@ -1115,7 +1115,7 @@ test "l7: an upstream-slot shed keeps the connection, and the client's ask decid
     //
     // The two responses differ in exactly one header, and the difference is
     // the *client's* ask, not the status: keep-alive is kept, `Connection:
-    // close` is honored (§2). One test, both spellings, so neither branch
+    // close` is honored (§7). One test, both spellings, so neither branch
     // can rot into the other.
     // The single upstream slot goes to a client the origin never answers,
     // so it stays leased and every other request meets the wall.
@@ -1214,7 +1214,7 @@ test "l7: a 501 keeps the connection, and the next request is served" {
 }
 
 test "l7: a reject closes when the client pipelined the next request" {
-    // Bytes past the head are a pipelined next request, which §2 does not
+    // Bytes past the head are a pipelined next request, which §7 does not
     // serve. Keeping the connection here would leave those bytes sitting in
     // the head buffer to be read as the *start* of the next request — the
     // desynchronization a request-smuggler wants (§7). A wide inbox carries
@@ -1283,7 +1283,7 @@ test "l7: a drain closes a reject that would otherwise be kept" {
     // so a reject arriving mid-drain is a connection the drain is waiting
     // on. Keeping it would park an idle connection until `drain_deadline_ms`
     // and turn a clean shutdown into a deadline-forced one — so the drain
-    // is a brake on keeping, exactly as it is on the render path (§2, §8).
+    // is a brake on keeping, exactly as it is on the render path (§7, §8).
     //
     // The client connects at once and is admitted, then holds its head back
     // until after the drain has begun.
@@ -1353,7 +1353,7 @@ test "l7: relay pressure closes a reject that would otherwise be kept" {
 test "l7: a reject closes when the request carries a body" {
     // A declared body is unread bytes still to come, so the stream is not
     // on a message boundary and the connection cannot resynchronize — the
-    // lingering close is what drains it (§2). Robust to delivery timing:
+    // lingering close is what drains it (§7). Robust to delivery timing:
     // if the body arrives coalesced with the head it fails the
     // nothing-past-the-head condition, and if it arrives later it fails the
     // framing-done one. Either way, close.
@@ -2059,7 +2059,7 @@ test "l7: a dial re-basing an already-expired deadline defers past the cancel" {
         // connection either way. What this pins is the discipline on the
         // way there, not a response — the exchange is condemned before it
         // can be answered, so the close is a FIN or (with the client's
-        // head still unread) an RST, and §2 constrains neither: no
+        // head still unread) an RST, and §7 constrains neither: no
         // response byte was ever delivered.
         try std.testing.expect(bed.client.outcome != .pending);
         try std.testing.expect(bed.server.counters.get("deadline_expired") >= 1);

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1285,23 +1285,36 @@ fn earliestWakeNs(io: *const SimIo) u64 {
     return earliest;
 }
 
-fn maybeInjectReset(io: *SimIo) void {
-    if (io.adversary.reset_percent == 0) return;
+/// Rolls `percent` against the adversary's dice and, on a hit, probes up
+/// to 8 random socket-table indices for a live connected one, mixing
+/// `mix_seed` with the winning index into the trace hash. Returns the
+/// entry found, or null on a miss, an empty table, or an unlucky probe.
+/// Shared by `maybeInjectReset` and `maybeInjectKernelPressure` so a
+/// change to the probe bound or the liveness check cannot land in one and
+/// miss the other.
+fn pickRandomLiveConnectedSocket(io: *SimIo, percent: u8, mix_seed: u64) ?*SocketEntry {
+    if (percent == 0) return null;
     const random = io.prng.random();
-    if (random.uintLessThan(u8, 100) >= io.adversary.reset_percent) return;
-    if (io.sockets.acquired_count == 0) return;
+    if (random.uintLessThan(u8, 100) >= percent) return null;
+    if (io.sockets.acquired_count == 0) return null;
 
     var probe: u8 = 0;
     while (probe < 8) : (probe += 1) {
         const index = random.uintLessThan(u16, sockets_max);
         const entry = &io.sockets.slots[index];
         if (io.sockets.isAcquired(entry) and entry.peer != peer_none) {
-            entry.reset = true;
-            io.peerEntry(entry).reset = true;
-            io.mix(@as(u64, index) +% 0x52535421);
-            return;
+            io.mix(@as(u64, index) +% mix_seed);
+            assert(io.sockets.isAcquired(entry) and entry.peer != peer_none);
+            return entry;
         }
     }
+    return null;
+}
+
+fn maybeInjectReset(io: *SimIo) void {
+    const entry = io.pickRandomLiveConnectedSocket(io.adversary.reset_percent, 0x52535421) orelse return;
+    entry.reset = true;
+    io.peerEntry(entry).reset = true;
 }
 
 /// §8 kernel-pressure rung on the data path: flag one random live
@@ -1310,21 +1323,9 @@ fn maybeInjectReset(io: *SimIo) void {
 /// picked socket's next op fails, the peer is untouched — so the relay
 /// witnesses it and tears the connection down.
 fn maybeInjectKernelPressure(io: *SimIo) void {
-    if (io.adversary.kernel_pressure_percent == 0) return;
-    const random = io.prng.random();
-    if (random.uintLessThan(u8, 100) >= io.adversary.kernel_pressure_percent) return;
-    if (io.sockets.acquired_count == 0) return;
-
-    var probe: u8 = 0;
-    while (probe < 8) : (probe += 1) {
-        const index = random.uintLessThan(u16, sockets_max);
-        const entry = &io.sockets.slots[index];
-        if (io.sockets.isAcquired(entry) and entry.peer != peer_none) {
-            entry.kernel_pressure = true;
-            io.mix(@as(u64, index) +% 0x454e4f42); // "ENOB"
-            return;
-        }
-    }
+    const mix_seed_enob: u64 = 0x454e4f42; // "ENOB"
+    const entry = io.pickRandomLiveConnectedSocket(io.adversary.kernel_pressure_percent, mix_seed_enob) orelse return;
+    entry.kernel_pressure = true;
 }
 
 fn partialLen(io: *SimIo, available: u32) u32 {

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1205,10 +1205,8 @@ fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
         // A send that was already in flight when the teardown shut the
         // write side down (§5: shutdown flushes pending ops); the kernel
         // answers EPIPE. That is the peer being gone, not the kernel being
-        // short of anything — `error.Reset`, matching what XevIo now maps
-        // `BrokenPipe` to. The sim reproduced the production
-        // misclassification faithfully, comment and all, which is why no
-        // seed ever flagged it.
+        // short of anything — `error.Reset`, matching what XevIo maps
+        // `BrokenPipe` to.
         return error.Reset;
     }
     if (entry.peer == peer_none) {

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1203,7 +1203,7 @@ fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
     }
     if (entry.write_shutdown) {
         // A send that was already in flight when the teardown shut the
-        // write side down (§2: shutdown flushes pending ops); the kernel
+        // write side down (§5: shutdown flushes pending ops); the kernel
         // answers EPIPE. That is the peer being gone, not the kernel being
         // short of anything — `error.Reset`, matching what XevIo now maps
         // `BrokenPipe` to. The sim reproduced the production

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -185,7 +185,7 @@ pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
     // (§1, §3): N independent zoxy processes bind the same port and the
     // kernel load-balances new connections across them, with share-nothing
     // isolation at the process boundary. The intra-process accept imbalance
-    // that made SO_REUSEPORT a liability in the previous iteration (§2)
+    // that made SO_REUSEPORT a liability in the previous iteration (§3)
     // cannot arise here — each process still has exactly one accepting loop,
     // so the kernel balances between processes, never between contending
     // loops. Must precede bind; libxev sets SO_REUSEADDR inside bind, so the

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -27,6 +27,8 @@
 //!   shutdown(io, socket, how) void                      (sync control op)
 //!   closeNow(io, socket) void                           (sync; un-admitted sheds)
 //!   peerAddress(io, socket) IpAddress                   (sync; who connected)
+//!   lastPressure(io) Pressure                           (classified cause
+//!       of the op just delivered, §8)
 //!   nowNs(io) u64                                       (per-tick clock, §4)
 //!   nowWallNs(io) u64                                   (epoch clock, §8 log)
 //!   run(io) RunError!void, stop(io) void

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -113,10 +113,10 @@ pub const ClientWrite = struct {
         response_excess,
         /// The coalesced excess is out: the body pump, or the exchange ends.
         response_body,
-        /// A static response is out: the lingering close (§2, §8).
+        /// A static response is out: the lingering close (§7, §8).
         lingering_close,
         /// A static response is out and the client's byte stream is still
-        /// synchronized: serve the next request on this connection (§2,
+        /// synchronized: serve the next request on this connection (§7,
         /// §8). The keep half of the ladder's "then keep or close per
         /// pressure" — see `proxy.staticResponseResyncable` for what
         /// earns it.
@@ -331,7 +331,7 @@ pub fn Conn(comptime IoType: type) type {
             // `l7_responding` writes a static error response (§8); and
             // `l7_draining_request` half-closes the write side after a
             // response and drains the client's remaining input so the
-            // close does not RST away that response (§2 lingering close).
+            // close does not RST away that response (§7 lingering close).
             l7_reading_head,
             l7_dialing,
             l7_exchanging,
@@ -448,7 +448,7 @@ pub fn Conn(comptime IoType: type) type {
             client_keep_alive: bool = false,
             /// What the rendered response told the client. The connection
             /// honors its own announcement: a keep-alive answer keeps
-            /// serving, an announced close closes (§2).
+            /// serving, an announced close closes (§7).
             downstream_close_announced: bool = true,
             /// The origin's persistence verdict from its response head;
             /// parking requires it (§5).
@@ -456,7 +456,7 @@ pub fn Conn(comptime IoType: type) type {
             /// The client sent bytes past the request's framing — a
             /// pipelined next request. Pipelining is unsupported: the
             /// exchange completes and the connection closes, dropping the
-            /// early bytes (§2 note; clients recover per RFC).
+            /// early bytes (§7 note; clients recover per RFC).
             client_pipelined: bool = false,
             /// This try runs over a checked-out parked connection (§5) —
             /// the precondition for the §7 stale replay: only a *reused*

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -37,13 +37,13 @@
 //!   sendSlice(conn) []const u8            what a send writes; empty = drained
 //!   creditSend(conn, sent)                credit whichever cursor tracks the wire
 //!
-//! **The transform seam** (the last five). A plain relay recvs and sends the
+//! **The transform seam** (the last six). A plain relay recvs and sends the
 //! same bytes, so one buffer per direction serves both halves and the framed
 //! debt (`DirectionState`) is settled in the units it was incurred. A
 //! *transforming* direction is neither: its halves live in different buffers,
 //! and the bytes on the wire are not the bytes that arrived nor the same
 //! count of them — §4's TLS termination decrypts what it reads and encrypts
-//! what it writes. These five hooks are the only places that difference is
+//! what it writes. These six hooks are the only places that difference is
 //! encoded, and a policy declaring none of them gets exactly the plain
 //! behaviour, so the L4 and L7 body paths are unaffected by construction.
 //!

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -31,7 +31,7 @@
 //! 1-byte deliveries across a spread of seeds: the payload must reach the
 //! origin whole, and the origin's echo must come back framed and whole. The
 //! scratch lives here rather than on `Conn` — a slot does not grow a field
-//! for a test, and issue #75 is about the one it already has.
+//! for a test, and issue #75 already measured the cost of the one it has.
 
 const std = @import("std");
 

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -108,7 +108,13 @@ const Scratch = struct {
 };
 
 /// Everything both directions share: the L4 shape — no framing of its own,
-/// EOF is a half-close, teardown once both directions finish.
+/// EOF is a half-close, teardown once both directions finish. Deliberately
+/// narrower than `relay.zig`'s production `Policy`: no idle-deadline
+/// extension on half-close, no kernel-pressure witnessing on a recv error.
+/// Both are already exercised against the real `Policy` in
+/// `server_test.zig`; this file's adversary never enables reset or
+/// kernel-pressure injection, so replaying that behavior here would be
+/// dead code — the transform seam is this file's only job.
 fn Base(comptime direction: Direction) type {
     return struct {
         fn state(conn: *ConnSim) *conn_module.DirectionState {

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -5,11 +5,10 @@
 //! pool-acquired for its whole connected life: leased while serving a
 //! request, parked on an idle list between requests (it still holds an
 //! fd), released only at teardown. A parked upstream holds no armed data
-//! op (§5); its deadline timer — embedded when the L7 state machine
-//! lands — is the idle timeout, and an origin close that slips through
-//! is detected at checkout. Exhaustion is a shed signal (§8), never
-//! growth. Idle lists are doubly linked so a deadline-fired teardown
-//! unparks from the middle of a list in O(1).
+//! op (§5); `deadline_ns` is the idle timeout, and an origin close that
+//! slips through is detected at checkout. Exhaustion is a shed signal
+//! (§8), never growth. Idle lists are doubly linked so a deadline-fired
+//! teardown unparks from the middle of a list in O(1).
 
 const std = @import("std");
 
@@ -41,10 +40,10 @@ pub fn UpstreamPool(comptime IoType: type) type {
         const Self = @This();
 
         /// One upstream connection slot (§5 pool 3): identity, socket,
-        /// idle links, and the head buffer response heads are parsed
-        /// into and rendered upstream heads are staged in. Embedded
-        /// completions and the deadline timer join with the L7 state
-        /// machine, one field per proven race (the Conn precedent).
+        /// idle links, the idle deadline, and the head buffer response
+        /// heads are parsed into and rendered upstream heads are staged
+        /// in. The dial and data-op completions live on the owning
+        /// `Conn`, one field per proven race (the Conn precedent).
         pub const Upstream = struct {
             pool_next: u32,
             generation: u32,

--- a/src/root.zig
+++ b/src/root.zig
@@ -26,7 +26,8 @@ pub const RelayBuffer = @import("net/relay.zig").RelayBuffer;
 pub const UpstreamPool = @import("net/upstream.zig").UpstreamPool;
 pub const Server = @import("Server.zig").Server;
 pub const shed = @import("shed.zig");
-/// Shared test-support harness pieces (used by server_test and the sim).
+/// Shared test-support harness pieces, factored out so multiple test
+/// suites can drive the same origin double instead of growing their own.
 pub const testing = struct {
     pub const Origin = @import("testing/origin.zig").Origin;
     pub const Mode = @import("testing/origin.zig").Mode;

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -9,7 +9,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 /// Whether the downstream connection survives a static response. `close`
-/// announces it in the response (§2: clients that pipeline into an
+/// announces it in the response (§7: clients that pipeline into an
 /// unannounced close read errors); `keep` leaves the connection serving.
 pub const Persistence = enum {
     keep,

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -1,8 +1,8 @@
-//! A shared scripted origin for the L4 harnesses (server_test.zig and the
-//! sim). It accepts connections and runs the same strict recv → send →
-//! recv echo the proxy relays through, with per-connection misbehavior
-//! modes for the adversarial paths (§9). Generic over the Io backend;
-//! both current users instantiate `Origin(SimIo)`. The scripted *clients*
+//! A shared scripted origin for L4 test harnesses. It accepts connections
+//! and runs the same strict recv → send → recv echo the proxy relays
+//! through, with per-connection misbehavior modes for the adversarial
+//! paths (§9). Generic over the Io backend; both current users instantiate
+//! `Origin(SimIo)`. The scripted *clients*
 //! are deliberately not shared — the directed suite tracks connection
 //! outcomes and drives drain races, while the sim tracks byte-exact
 //! integrity under the adversary, and unifying them would force an

--- a/src/zero_alloc_test.zig
+++ b/src/zero_alloc_test.zig
@@ -9,19 +9,20 @@ const std = @import("std");
 
 const server_test = @import("server_test.zig");
 
-test "zero-alloc gate: the serving path allocates nothing after init" {
-    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+/// Runs the same scenario under `failing` end to end and returns the
+/// allocation count observed right after init. The §8 access log renders
+/// and writes on the serving path, so it has to be inside this gate
+/// rather than beside it: the two staging buffers come out of the
+/// startup arena and everything after — the render, the swap, the sink
+/// write — must ask for nothing. A log left off here would leave that
+/// unproven.
+fn runOnce(failing: *std.testing.FailingAllocator) !usize {
     var bed: server_test.TestBed = undefined;
     try bed.setUp(failing.allocator(), .{
         .sim = .{
             .seed = 7,
             .adversary = .{ .partial_io = true, .connect_delay_ns_max = 1_000_000 },
         },
-        // The §8 access log renders and writes on the serving path, so it
-        // has to be inside this gate rather than beside it: the two
-        // staging buffers come out of the startup arena and everything
-        // after — the render, the swap, the sink write — must ask for
-        // nothing. A log left off here would leave that unproven.
         .access_log = true,
     });
     defer bed.tearDown();
@@ -30,6 +31,12 @@ test "zero-alloc gate: the serving path allocates nothing after init" {
     bed.startClients(2, true);
     try bed.sim_io.run();
     try bed.expectDrained();
+    return allocations_after_init;
+}
+
+test "zero-alloc gate: the serving path allocates nothing after init" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const allocations_after_init = try runOnce(&failing);
     try std.testing.expectEqual(allocations_after_init, failing.allocations);
 
     // Second run: exactly the same scenario, but any allocation past the
@@ -37,21 +44,5 @@ test "zero-alloc gate: the serving path allocates nothing after init" {
     var strict = std.testing.FailingAllocator.init(std.testing.allocator, .{
         .fail_index = allocations_after_init,
     });
-    var strict_bed: server_test.TestBed = undefined;
-    try strict_bed.setUp(strict.allocator(), .{
-        .sim = .{
-            .seed = 7,
-            .adversary = .{ .partial_io = true, .connect_delay_ns_max = 1_000_000 },
-        },
-        // The §8 access log renders and writes on the serving path, so it
-        // has to be inside this gate rather than beside it: the two
-        // staging buffers come out of the startup arena and everything
-        // after — the render, the swap, the sink write — must ask for
-        // nothing. A log left off here would leave that unproven.
-        .access_log = true,
-    });
-    defer strict_bed.tearDown();
-    strict_bed.startClients(2, true);
-    try strict_bed.sim_io.run();
-    try strict_bed.expectDrained();
+    _ = try runOnce(&strict);
 }


### PR DESCRIPTION
## Summary

Fixes from a code review pass over stale/excess comments and code duplication (18 commits, one per finding):

**Stale/excess comments** (13 commits, no logic changes):
- Dangling `(§2)` references across 9 files, repointed to §7/§3/§5 (DESIGN.md's old §2 was folded away in `7c940c1`, leaving a gap — this widened well beyond the 5 spots the original review caught, to 18 total spots across the codebase)
- `pump.zig`'s transform-seam hook count (5 → 6, `transformEnded` was added later)
- `filter.zig`'s "interpreter lives in slices to come" (it already ships)
- `proxy.zig`'s undefined "Phase 3a" label
- `upstream.zig`'s stale future-tense comments (one misattributed where completions live)
- A closed-issue citation in `pump_transform_test.zig` reworded to read as settled context, not a live TODO
- `io.zig`'s contract-shape doc, missing `lastPressure`
- `access_log.zig`'s self-contradictory `Outcome.aborted` doc
- `SimIo.zig`'s debugging-journal narration, trimmed
- Caller-referencing comments in `admin.zig`/`root.zig`/`origin.zig` (CLAUDE.md forbids naming callers)
- `pump_transform_test.zig`'s `Base` documented as deliberately narrower than production's `Policy` (investigated — not a bug, just undocumented scope)

**Code duplication** (5 commits, real refactors):
- `SimIo.zig`'s two fault-injector functions → shared probe helper
- `admin.zig`'s 3-way drain-exit sequence → `quiesceForDrain`
- `parser.zig`'s two hex-nibble decoders → consolidated
- `proxy.zig`'s duplicated endpoint-admission block → `pickEndpointOrShed`
- Three test-file dedups: `zero_alloc_test.zig`'s TestBed setup, `http_proxy_test.zig`'s zero-alloc-gate pattern + forwarded-request parse, `config.zig`'s success-path arena scaffolding (~40 call sites — caught and fixed a genuine latent-UB bug along the way, where a fallible call between an arena's `defer deinit()` and its initializer would deinit undefined memory on error)

Every commit ran `zig build ci` + `zig fmt --check` clean, and every logic-changing commit (not the pure comment fixes) was reviewed by the `tiger-style-reviewer` agent before landing. A final holistic pass reviewed the whole branch for composition-level issues.

## Test plan
- [x] `zig build ci` passes (4096-seed sim sweep, fuzz corpus, boundary lint) on the full branch
- [x] `zig fmt --check` clean
- [x] Each logic-changing commit individually reviewed by tiger-style-reviewer
- [x] Full branch diff reviewed holistically for cross-commit consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)