### PR TITLE
The operator sizes their deployment: eight config-shape ceilings removed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,13 @@ direnv activates the shell). Read before writing code:
   C FFI — `@cImport` is lint-forbidden.
 - Boundaries (lint-enforced): raw syscalls and the `xev` import live only
   under `src/io/`; `hparse` is imported only by `src/http/parser.zig`.
-- Zero allocation after startup. Every limit is a named constant in
-  `src/constants.zig`; the memory, fd, and ring budgets are closed-form
-  functions of those constants, comptime-asserted.
+- Zero allocation after startup. The memory, fd, and ring budgets are
+  closed-form functions of `src/constants.zig` and the loaded config.
+  Where a budget is a property of one constant it is comptime-asserted;
+  where it is a property of a combination the config chooses — listener
+  count, cluster and endpoint counts — it is rejected at startup instead
+  (`cqFillFits`, `ensureFdBudget`). Config shape is the operator's to
+  size; see DESIGN.md §5.
 - Workflow: small slices, one commit per slice, descriptive commit
   messages (§ references welcome). Push and open PRs only when asked.
 - Before committing a slice, run the `tiger-style-reviewer` agent on the

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ escapes) are rejected with `400`; no matching route is a `404`.
 
 A cluster is a named set of endpoints — static `IP:port` literals, resolved
 once at load, since dynamic DNS is deliberately out of scope — plus how one
-is chosen. Up to 16 clusters, 64 endpoints each.
+is chosen. Cluster and endpoint counts are bounded by your config, not
+by a compiled ceiling — the startup banner prints what the endpoint tables cost.
 
 ```json
 "clusters": {

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ reserves nor demands the ceiling's resources.
 
 The defaults are deliberately lean — 1386 connection slots, 1386 relay buffer
 pairs, 1313 upstream slots, roughly 34 MiB of pools — sized to start under a
-stock 4096 `RLIMIT_NOFILE`. The ceiling is 11463 of each. Raising the pools
+stock 4096 `RLIMIT_NOFILE`. The ceiling is 11466 of each. Raising the pools
 raises the file-descriptor demand, which zoxy asserts against `RLIMIT_NOFILE`
 at startup rather than discovering as `EMFILE` later.
 

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -600,7 +600,7 @@ fn readProcHead(io: Io, path: []const u8, out: []u8, scratch: []u8) ?[]const u8 
 /// too small.
 ///
 /// io_uring's fdinfo renders a line per pending SQE and CQE, ~89 and ~34
-/// bytes, and `constants.in_flight_ops_max` is what bounds how many there
+/// bytes, and the ring's own in-flight budget is what bounds how many there
 /// can be: ~57k ops at the compiled ceiling, so ~5 MB of text at the
 /// worst moment. The kernel appears to want the whole record to fit
 /// rather than handing back a prefix, which is why a 64 KiB buffer still

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -593,8 +593,10 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   "/api", "cluster": "api" }, …]`; the existing `"cluster"` field stays
   as sugar for a single catch-all route). The table is resolved at
   config load into an immutable arena table sorted longest-prefix-first
-  — matching is a bounded linear scan, never an allocation — and
-  `routes_max` caps it. No route matches → static `404` (§8). Matching
+  — matching is a bounded linear scan, never an allocation. The scan's
+  bound is the table's own length, fixed once config load returns; there
+  is no constant capping it, because the table sizes nothing but its own
+  arena slice. No route matches → static `404` (§8). Matching
   consults only the **canonical path**, computed once in the trust
   boundary: the query splits off untouched (opaque to the proxy,
   forwarded verbatim); unreserved percent-escapes (RFC 3986 §2.3) are
@@ -681,8 +683,13 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   at config time* into bounded, immutable tables in the config arena
   (match programs over method/host/path/header slices; action lists drawn
   from a closed enum: reject-with-status, add/remove/set header, rewrite
-  path prefix), each with a static limit
-  (`rules_per_route_max`, `actions_per_rule_max`, `header_edits_max`).
+  path prefix). The rule table, a rule's action list and a rule's header
+  matches carry no static limit: each is an arena slice at exactly the
+  length the config asked for, and evaluation is a bounded loop over
+  that length. `header_edits_max` is the one static limit here, and the
+  difference is the rule — it bounds a *fixed buffer* the renderer
+  materializes the matched rules' edits into, so it must be known before
+  the config is read.
   Cluster selection is deliberately *not* a filter action: the route
   table (host + path) is the single mechanism that decides which backend
   serves a request, so there is one precedence rule, not two engines

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -437,6 +437,13 @@ is its per-request capture: the method, host and path a line reports live
 in the head buffer, which the response head renders over (§7), so they
 have to be copied out while they are still there.
 
+The config arena is in that total for the same reason — it is never
+freed — but it is the one term that is **measured rather than derived**,
+and the banner labels it so. There is no constant bounding a config
+file's size: what the operator writes is what it costs, so the only
+honest thing the budget can do is report it. Every other term is still
+closed-form in `src/constants.zig`.
+
 The ceilings sit on one completion-queue line — a conn slot costs
 `conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
 is **pinned to the conn ceiling**, so that line has a single divisor:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -780,9 +780,11 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   the eligible set the health mask already produced: no table, no
   rebuild, and only the clients of an ejected endpoint move (the 1/n
   optimum — measured at 13.1% of clients for a 1-of-8 ejection). The
-  cost is O(n) per pick instead of O(log n), which is why
-  `endpoints_per_cluster_max` matters: 71 ns at the 64 endpoints a
-  cluster may hold, against a request served in ~100 µs. Jump consistent
+  cost is O(n) per pick instead of O(log n), which is why a cluster's
+  endpoint count is a cost the operator chooses: 71 ns per pick at 64
+  endpoints, against a request served in ~100 µs, and linear in the
+  count from there. Nothing caps it — the pick simply gets slower, and
+  that trade is visible where it is made. Jump consistent
   hash is excluded outright — it can only add or remove the *last*
   bucket, and an ejection removes an arbitrary one.
   Two honest costs. Stickiness holds only while processes agree on the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -423,9 +423,9 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 11463 | ~1.7 KiB state + 8 KiB head |
-| relay buffers | 1386 | 11463 | 2 × 4 KiB |
-| upstream slots | 1313 | 11463 | ~40 B state + 8 KiB head |
+| conn slots | 1386 | 11466 | ~1.7 KiB state + 8 KiB head |
+| relay buffers | 1386 | 11466 | 2 × 4 KiB |
+| upstream slots | 1313 | 11466 | ~40 B state + 8 KiB head |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
 
 The access log (§8) adds one fixed reservation beside the pools — two
@@ -447,7 +447,7 @@ closed-form in `src/constants.zig`.
 The ceilings sit on one completion-queue line — a conn slot costs
 `conn_ops_max` ring ops, an upstream slot one — and the upstream ceiling
 is **pinned to the conn ceiling**, so that line has a single divisor:
-`conn_ops_max + 1` ring ops per admitted connection, 11463 of them. On
+`conn_ops_max + 1` ring ops per admitted connection, 11466 of them. On
 the L7 path a connection that is mid-exchange holds an upstream slot as
 well as its conn slot, and at saturation every admitted connection can be
 mid-exchange at once — so an upstream ceiling below the conn ceiling is
@@ -475,10 +475,22 @@ deployment that means to fill its conn pool raises both together through
 Rules:
 
 - **Pools never grow.** Exhaustion is a shed signal (§8), never a realloc.
-- **Limit relationships are comptime-asserted** in `src/constants.zig`
-  (TIGER_STYLE): e.g. `relay_buffers_max ≤ conn_slots_max`, and the same
-  for the defaults. Note that `relay_buffers` — not conn slots — is the
-  true bound on concurrent L4 connections plus active L7 relays (§6).
+- **Limit relationships are comptime-asserted where they can be** in
+  `src/constants.zig` (TIGER_STYLE): e.g. `relay_buffers_max ≤
+  conn_slots_max`, and the same for the defaults. Note that
+  `relay_buffers` — not conn slots — is the true bound on concurrent L4
+  connections plus active L7 relays (§6).
+
+  "Where they can be" is a real qualifier, not hedging. A budget that is
+  a property of one constant is asserted at build time. A budget that is
+  a property of a *combination the config chooses* has no compile-time
+  point to assert — there is no listener, cluster or endpoint ceiling to
+  evaluate it at — so it is refused at load instead: `cqFillFits` for the
+  ring (`LimitConnSlotsOverCqFill`) and `ensureFdBudget` for the fds.
+  Same arithmetic, refused milliseconds later. The compiled ceilings
+  `conn_slots_max`/`upstream_slots_max` are therefore stated at *zero*
+  configured listeners, and each listener a config declares spends from
+  the same budget.
 - **The CQ fill is a headroom knob, not a pool shrink.**
   `limits.cq_fill_eighths` sets how many eighths of the completion queue
   the worst-case in-flight ops may fill: ⅞ (the default, the fill the c10k

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -78,15 +78,24 @@ infeasible pair at config load (`cqFillFits` already exists and already
 runs unconditionally — this would stop it being shadowed by a comptime
 pre-decision).
 
-The cost: `assert(in_flight_ops_max <= completion_queue_entries)` in §5
-(DESIGN.md) states a property of *the chosen point*; with independent
+The cost was: `assert(in_flight_ops_max <= completion_queue_entries)` in
+§5 (DESIGN.md) states a property of *the chosen point*; with independent
 ceilings there's no chosen point, so it becomes a startup rejection
 instead of a comptime assertion — a real narrowing of "budgets are
 comptime-asserted" to "comptime-asserted where a budget is a property of
 one constant, rejected at startup where it's a property of a
-combination." Nothing else moves: `SimIo`'s `ready_buffer` is already
-sized off `in_flight_ops_max` (the budget itself, not the ceilings'
-product), so it doesn't grow.
+combination."
+
+**That cost has since been paid in full, by a different change.**
+Removing `listeners_max` ("Config shape is the operator's to size",
+below) deleted `in_flight_ops_max` and `fds_max` outright and moved both
+checks to load — `cqFillFits` and `ensureFdBudget` — so the narrowing is
+shipped and DESIGN.md §5 and CLAUDE.md already say it. What is left of
+this question is only the conn/upstream pair itself, and it no longer has
+an invariant to spend: the wording above is the state of the code, not a
+price still to be paid. Two details there are now stale — the pair reads
+11466/11466, not 11464, and `SimIo` sizes its buffer from its own
+`listeners_max` rather than from the deleted `in_flight_ops_max`.
 
 Entry gate: demonstrate a workload that actually saturates the
 *current* conn-slot ceiling first (the c10k runs that motivated the
@@ -1192,6 +1201,82 @@ Raising the ceiling or lowering the offered rate would both have made it
 pass — by producing fewer RSTs, which is why neither was the fix.
 
 Verdict (settled): the stall gate holds `timeouts` alone, the one
+## Config shape is the operator's to size (2026-08-01)
+
+Eight compile-time ceilings removed across four slices: `routes_max`,
+`filters_per_listener_max`, `actions_per_filter_max`,
+`header_matches_per_filter_max` (7e194f6), `config_bytes_max` (5f81788),
+`clusters_max` and `endpoints_per_cluster_max` (10205eb, 77c8bb9), and
+`listeners_max` (a991db6). A config's shape is now bounded by what the
+operator writes and by what the ring and fd budgets admit at load, not by
+numbers chosen on their behalf at build time.
+
+**They were a capability ceiling, not a memory cost — that is the
+finding.** Measured with a `@sizeOf` probe against the pre-change tree:
+`Server` 36,160 -> 16,736 bytes, so **19,424 bytes per process** of state
+a deployment below the compile ceiling never used (`UpstreamPool` 6,184
+-> 80, `Balancer` 8,336 -> 72, `Checker` 12,320 -> 9,296). Against the
+35,060 KiB the binary prints, that is **0.055%**. It was real resident
+memory — `init` zeroed every one of those tables at startup, so the pages
+were faulted in — but anyone expecting this work to reclaim memory should
+read that number first. What it actually buys is that 16 clusters, 64
+endpoints, 32 routes, 32 filters and 8 listeners stop being walls no
+price could pass.
+
+The eight split into four classes, and the class decided the work:
+
+- **Bounded nothing** (routes, filters, actions, header matches). Already
+  `arena.alloc(..., json.len)`. Pure deletion of config-load gates and
+  JSON Schema `maxItems`.
+- **Sized something** (clusters x endpoints, whose product sized seven
+  endpoint-keyed tables). Needed `EndpointKeys{stride, count}` derived
+  from the loaded config, and `pick`'s stack array had to become
+  preallocated scratch — a runtime-length stack array is the dynamic
+  allocation §5 forbids.
+- **A budget input** (`listeners_max`). Not a config-shape cap at all: it
+  was a term in the derivation of `conn_slots_max`,
+  `completion_queue_entries`, `fds_max` and `in_flight_ops_max`. Removing
+  it is what spent the comptime invariant; see the Pool ceilings question
+  above.
+- **Type-width guards**, which stay. `Conn.endpoint_none` is
+  `maxInt(u16)`, so `constants.endpoint_index_max` bounds real indices
+  and `Conn` asserts the relationship. `header_edits_max` stays too, and
+  the rule it illustrates is the useful one: **a limit that sizes a fixed
+  buffer must precede the config; a limit that only gates a config need
+  not exist.**
+
+### What a ceiling was quietly holding up
+
+The recurring hazard, and the reason each slice took a review: a ceiling
+does load-bearing work far from where it is declared, and removing it
+exposes whatever was leaning on it.
+
+- **`keys_seen_max = 4096`**, a loop backstop sitting *above*
+  `clusters_max`. Left in place it would have become the new cluster
+  limit — an undocumented wall replacing a documented one.
+- **Two O(n^2) scans**, duplicate cluster names and duplicate listener
+  binds. Both were harmless at 16 and 8 (~120 and ~64 compares) and cost
+  ~2.1e9 and ~8e8 compares once the ceilings went — minutes of startup
+  for configs whose *memory* fits easily. Both are sorted-neighbour
+  compares now.
+- **The admin listener.** `XevIo`'s listener table was sized by
+  `listeners_max`, which silently covered `Admin.start` binding through
+  the same `listen`. Sizing it to the configured count instead made every
+  admin-enabled deployment fail at startup with `AddressUnavailable` — a
+  full table reported as a bad address. The suite could not catch it:
+  `Server(XevIo)` is instantiated only by main.zig and `admin_test` runs
+  over `SimIo`. `init` now folds in `admin_listeners` itself, and a
+  contract test locks it.
+- **The §5 budget promise, broken twice.** Removing `config_bytes_max`
+  left the config arena unbounded *and* unreported, so the startup total
+  understated what the process holds; the endpoint tables then did it
+  again by allocating after `printBudgets` ran. Both are now terms in the
+  printed budget — the arena measured, the tables closed-form via
+  `Server.endpointTableBytes`.
+
+Every one of these was found by `tiger-style-reviewer` on the slice's own
+diff, not by the gates: `zig build ci` was green for all of them.
+
 client-visible failure that belongs to *admitted* work. Every socket
 error in this band is a connection that was never admitted, already
 witnessed by the 5xx status gate and the accept-RST count. A genuine

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -52,7 +52,7 @@ pub fn Server(comptime IoType: type) type {
         /// `u16` for the same reason `leased_counts` is: one charge per
         /// live conn slot bounds every entry by `conn_slots_max`, which
         /// `constants` asserts fits (`conn_slots_max - 1 <= maxInt(u16)`).
-        l4_inflight: [upstream_module.endpoint_keys_max]u16,
+        l4_inflight: []u16,
         listeners: []ListenerState,
         listeners_count: u16,
         /// The load-balancing policy: resolves a cluster to the endpoint to
@@ -147,6 +147,50 @@ pub fn Server(comptime IoType: type) type {
             accepting: bool,
         };
 
+        /// The endpoint index space this config needs (§7): one row per
+        /// cluster, each `stride` wide, where `stride` is the widest
+        /// cluster the operator declared. Derived from the loaded config
+        /// rather than from a compiled ceiling, so the tables cost what
+        /// this deployment uses.
+        pub fn endpointKeysFor(
+            config: *const config_module.Config,
+        ) upstream_module.EndpointKeys {
+            assert(config.clusters.len >= 1);
+            var stride: u16 = 1;
+            for (config.clusters) |cluster| {
+                assert(cluster.endpoints.len >= 1);
+                stride = @max(stride, @as(u16, @intCast(cluster.endpoints.len)));
+            }
+            assert(stride >= 1);
+            return .init(@intCast(config.clusters.len), stride);
+        }
+
+        /// What the endpoint-keyed tables take from the startup arena for
+        /// this config (§5) — closed-form in the config, like every pool
+        /// term, so the printed budget stays a prediction rather than a
+        /// measurement. Every width comes from the owning module's own
+        /// element type: a table that changes type changes this number
+        /// without anyone remembering to.
+        ///
+        /// `init` below allocates exactly these, in this order.
+        pub fn endpointTableBytes(config: *const config_module.Config) u64 {
+            const keys = endpointKeysFor(config);
+            const count: u64 = keys.count;
+            const per_key =
+                @sizeOf(u32) + // UpstreamPool.idle_heads
+                @sizeOf(u16) + // UpstreamPool.leased_counts
+                @sizeOf(u64) + // Balancer.endpoint_hashes
+                @sizeOf(u16) + // Server.l4_inflight
+                @sizeOf(bool) + // Checker.healthy
+                @sizeOf(u8) + // Checker.fail_streaks
+                @sizeOf(u8); // Checker.ok_streaks
+            const cursors = @as(u64, config.clusters.len) * @sizeOf(u64);
+            const scratch = @as(u64, keys.stride) * @sizeOf(u16);
+            const total = count * per_key + cursors + scratch;
+            assert(total > 0);
+            return total;
+        }
+
         pub fn init(
             server: *Self,
             arena: std.mem.Allocator,
@@ -180,11 +224,15 @@ pub fn Server(comptime IoType: type) type {
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
-            try server.upstreams.init(arena, options.upstream_slots);
-            @memset(&server.l4_inflight, 0);
+            // One index space, derived once and shared by every
+            // endpoint-keyed table so they cannot disagree about a key.
+            const keys = endpointKeysFor(config);
+            try server.upstreams.init(arena, options.upstream_slots, keys);
+            server.l4_inflight = try arena.alloc(u16, keys.count);
+            @memset(server.l4_inflight, 0);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
             server.listeners_count = @intCast(config.listeners.len);
-            server.balancer.init(config);
+            try server.balancer.init(arena, config, keys);
             server.counters = .{};
             server.draining = false;
             server.relay_pressure = false;
@@ -198,7 +246,7 @@ pub fn Server(comptime IoType: type) type {
             server.admin.init(server, config.admin_bind);
             server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
             try server.access_log.reserve(arena);
-            server.health.init(server);
+            try server.health.init(arena, server, keys);
         }
 
         /// Override the admin/metrics bind before `start` — the simulator
@@ -688,7 +736,7 @@ pub fn Server(comptime IoType: type) type {
             const pick = server.balancer.pick(
                 cluster_index,
                 &server.endpointLoad(),
-                &server.health.healthy,
+                server.health.healthy,
                 &conn.client_address,
             ) orelse {
                 // Every endpoint is at its §8 cap. An L4 listener has no
@@ -1086,8 +1134,8 @@ pub fn Server(comptime IoType: type) type {
         /// writer.
         pub fn endpointLoad(server: *const Self) upstream_module.Load {
             return .{
-                .l7 = &server.upstreams.leased_counts,
-                .l4 = &server.l4_inflight,
+                .l7 = server.upstreams.leased_counts,
+                .l4 = server.l4_inflight,
             };
         }
 
@@ -1098,7 +1146,7 @@ pub fn Server(comptime IoType: type) type {
         fn chargeL4(server: *Self, conn: *ConnType, cluster_index: u16, endpoint_index: u16) void {
             assert(conn.protocol == .l4);
             assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
-            const key = upstream_module.endpointKey(cluster_index, endpoint_index);
+            const key = server.upstreams.keys.key(cluster_index, endpoint_index);
             server.l4_inflight[key] += 1;
             // Every charge is held by a live conn slot, so one endpoint's
             // count can never pass the conn pool's own size — the same
@@ -1115,7 +1163,7 @@ pub fn Server(comptime IoType: type) type {
         /// its dial, or torn down twice, has nothing charged.
         fn releaseL4(server: *Self, conn: *ConnType) void {
             if (conn.charged_endpoint == conn_module.LogState.endpoint_none) return;
-            const key = upstream_module.endpointKey(conn.charged_cluster, conn.charged_endpoint);
+            const key = server.upstreams.keys.key(conn.charged_cluster, conn.charged_endpoint);
             assert(server.l4_inflight[key] >= 1);
             server.l4_inflight[key] -= 1;
             conn.charged_endpoint = conn_module.LogState.endpoint_none;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -199,7 +199,7 @@ pub fn Server(comptime IoType: type) type {
             options: InitOptions,
         ) error{OutOfMemory}!void {
             assert(config.listeners.len >= 1);
-            assert(config.listeners.len <= constants.listeners_max);
+            assert(config.listeners.len <= std.math.maxInt(u16));
             // The deadline handoff depends on this ordering (§4/§5): a
             // connection's first deadline is armed at the connect budget
             // and `onConnect` re-stores it to the idle one, but the armed

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -41,7 +41,6 @@
 const std = @import("std");
 
 const config_module = @import("config.zig");
-const constants = @import("constants.zig");
 const upstream = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
@@ -113,9 +112,8 @@ pub const Balancer = struct {
     /// Per-cluster round-robin cursors, used by `.rr` clusters only.
     /// u64 so a cursor never wraps in any realistic process lifetime — a
     /// u16 wrap reset the rotation phase and double-picked one endpoint
-    /// for non-power-of-two cluster sizes. Fixed at the config ceiling:
-    /// 16 × 8 bytes of static state beats an arena allocation.
-    cursors: [constants.clusters_max]u64,
+    /// for non-power-of-two cluster sizes. One per configured cluster.
+    cursors: []u64,
     /// xorshift64* draw state, used by `.p2c` clusters only. Seeded from
     /// a fixed named constant, never the clock: the simulator replays
     /// every seed twice and demands byte-identical traces (§9), and load
@@ -128,37 +126,63 @@ pub const Balancer = struct {
     /// the exact disruption consistent hashing exists to avoid. Computed
     /// once at init because a pick would otherwise re-hash every candidate
     /// address on every request.
-    endpoint_hashes: [upstream.endpoint_keys_max]u64,
+    endpoint_hashes: []u64,
+    /// The config's endpoint index space, shared with the pool and the
+    /// health checker so all three agree on what a key means.
+    keys: upstream.EndpointKeys,
+    /// Scratch for `pick`'s eligible-endpoint list, `keys.stride` long.
+    /// It was a stack array sized by the old compile-time ceiling; with
+    /// the ceiling gone the length is a runtime value, and a
+    /// runtime-length stack array is exactly the dynamic allocation §5
+    /// forbids — so it is allocated once at init and reused. Sound
+    /// because a pick never overlaps another: the loop is single-threaded
+    /// and `pick` neither suspends nor re-enters.
+    eligible_scratch: []u16,
 
     /// Any nonzero constant seeds xorshift64* soundly; this one is the
     /// 64-bit golden-ratio constant, chosen for being recognizable.
     const pick_seed: u64 = 0x9E3779B97F4A7C15;
 
-    pub fn init(balancer: *Balancer, config: *const config_module.Config) void {
+    pub fn init(
+        balancer: *Balancer,
+        arena: std.mem.Allocator,
+        config: *const config_module.Config,
+        keys: upstream.EndpointKeys,
+    ) error{OutOfMemory}!void {
         assert(config.clusters.len >= 1);
-        assert(config.clusters.len <= constants.clusters_max);
+        assert(keys.count >= 1);
+        // The keys must describe *this* config. Tests and the simulator
+        // build a `Config` directly, bypassing the loader, so a mismatched
+        // pair would size these tables for one shape and index them for
+        // another — which is what the `clusters_max` ceiling used to catch
+        // here, before the tables stopped being sized by it.
+        assert(keys.count == @as(u32, @intCast(config.clusters.len)) * keys.stride);
         balancer.config = config;
-        @memset(&balancer.cursors, 0);
+        balancer.keys = keys;
+        balancer.cursors = try arena.alloc(u64, config.clusters.len);
+        balancer.endpoint_hashes = try arena.alloc(u64, keys.count);
+        balancer.eligible_scratch = try arena.alloc(u16, keys.stride);
+        @memset(balancer.cursors, 0);
         balancer.pick_state = pick_seed;
         assert(balancer.pick_state != 0); // xorshift64* cycles on nonzero state.
-        // Every key, not only the configured ones: an unconfigured slot is
-        // never read, and zeroing the whole table keeps "what did init
-        // leave here" a question with one answer.
-        @memset(&balancer.endpoint_hashes, 0);
+        // Every key, not only the configured ones: a ragged config leaves
+        // holes between clusters, those slots are never read, and zeroing
+        // the whole table keeps "what did init leave here" a question with
+        // one answer.
+        @memset(balancer.endpoint_hashes, 0);
         for (config.clusters, 0..) |cluster, cluster_index| {
             // Re-checked here rather than trusted from the loader, the
             // same defense `pick` and `eligibleEndpoints` keep: this loop
-            // indexes a table sized by that ceiling.
+            // indexes a table sized by that stride.
             assert(cluster.endpoints.len >= 1);
-            assert(cluster.endpoints.len <= constants.endpoints_per_cluster_max);
+            assert(cluster.endpoints.len <= keys.stride);
             for (cluster.endpoints, 0..) |*address, endpoint_index| {
-                const key = upstream.endpointKey(
-                    @intCast(cluster_index),
-                    @intCast(endpoint_index),
-                );
+                const key = keys.key(@intCast(cluster_index), @intCast(endpoint_index));
                 balancer.endpoint_hashes[key] = endpointId(address);
             }
         }
+        assert(balancer.cursors.len == config.clusters.len);
+        assert(balancer.endpoint_hashes.len == keys.count);
     }
 
     /// A pick names the endpoint both ways: the address to dial and the
@@ -179,13 +203,13 @@ pub const Balancer = struct {
         balancer: *Balancer,
         cluster_index: u16,
         load: *const upstream.Load,
-        healthy: *const [upstream.endpoint_keys_max]bool,
+        healthy: []const bool,
         client_address: *const std.Io.net.IpAddress,
     ) ?Pick {
         assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
         assert(cluster.endpoints.len >= 1);
-        assert(cluster.endpoints.len <= constants.endpoints_per_cluster_max);
+        assert(cluster.endpoints.len <= balancer.keys.stride);
         if (cluster.endpoints.len == 1 and cluster.max_inflight == null) {
             // Neither a rotation nor a draw: uncapped single-endpoint
             // clusters stay branch-cheap and policy state is untouched.
@@ -194,8 +218,8 @@ pub const Balancer = struct {
             // general path below.
             return .{ .address = cluster.endpoints[0], .endpoint_index = 0 };
         }
-        var eligible: [constants.endpoints_per_cluster_max]u16 = undefined;
-        const count = eligibleEndpoints(cluster_index, cluster, load, healthy, &eligible);
+        const eligible = balancer.eligible_scratch;
+        const count = eligibleEndpoints(balancer.keys, cluster_index, cluster, load, healthy, eligible);
         if (count == 0) {
             // Every endpoint is at its §8 cap. Unlike the health mask
             // this does *not* fail open: an ejected cluster means "we do
@@ -231,17 +255,19 @@ pub const Balancer = struct {
     /// is judged over the endpoints health would have used, so a cluster
     /// that fails open still respects its caps.
     fn eligibleEndpoints(
+        keys: upstream.EndpointKeys,
         cluster_index: u16,
         cluster: *const config_module.Config.Cluster,
         load: *const upstream.Load,
-        healthy: *const [upstream.endpoint_keys_max]bool,
-        eligible: *[constants.endpoints_per_cluster_max]u16,
+        healthy: []const bool,
+        eligible: []u16,
     ) u16 {
         assert(cluster.endpoints.len >= 1);
+        assert(cluster.endpoints.len <= eligible.len);
         var count: u16 = 0;
         for (0..cluster.endpoints.len) |endpoint_index| {
             const index: u16 = @intCast(endpoint_index);
-            if (healthy[upstream.endpointKey(cluster_index, index)]) {
+            if (healthy[keys.key(cluster_index, index)]) {
                 eligible[count] = index;
                 count += 1;
             }
@@ -257,7 +283,7 @@ pub const Balancer = struct {
             assert(cap >= 1);
             var under: u16 = 0;
             for (eligible[0..count]) |index| {
-                if (load.inFlight(upstream.endpointKey(cluster_index, index)) < cap) {
+                if (load.inFlight(keys.key(cluster_index, index)) < cap) {
                     eligible[under] = index;
                     under += 1;
                 }
@@ -315,8 +341,8 @@ pub const Balancer = struct {
         // slot, so before this view the draw on a pure-L4 cluster read a
         // table of zeros and spread uniformly while presenting as
         // load-aware.
-        const first_load = load.inFlight(upstream.endpointKey(cluster_index, first));
-        const second_load = load.inFlight(upstream.endpointKey(cluster_index, second));
+        const first_load = load.inFlight(balancer.keys.key(cluster_index, first));
+        const second_load = load.inFlight(balancer.keys.key(cluster_index, second));
         return if (second_load < first_load) second else first;
     }
 
@@ -380,7 +406,7 @@ pub const Balancer = struct {
         assert(cluster_index < balancer.config.clusters.len);
         assert(endpoint_index < balancer.config.clusters[cluster_index].endpoints.len);
         const endpoint_hash =
-            balancer.endpoint_hashes[upstream.endpointKey(cluster_index, endpoint_index)];
+            balancer.endpoint_hashes[balancer.keys.key(cluster_index, endpoint_index)];
         // Both operands are already avalanched, so the xor combines them
         // without structure and the final mix restores it to a uniform
         // 64-bit score.
@@ -403,18 +429,36 @@ pub const Balancer = struct {
     }
 };
 
-const test_counts_len = upstream.endpoint_keys_max;
+/// The index space every test here builds its tables against. Wider than
+/// any test cluster on both axes, so a stride bug shows up as a key
+/// landing in another cluster's row rather than out of bounds.
+const test_keys: upstream.EndpointKeys = .init(4, 8);
+
+/// The index space a test's own config implies — the same derivation
+/// `Server.endpointKeysFor` does in production, which `init` now asserts
+/// the caller got right. Tables below stay `test_keys`-sized (wider than
+/// any test config) because every test indexes cluster 0, where the key
+/// is the endpoint index whatever the stride is.
+fn testKeysFor(config: *const config_module.Config) upstream.EndpointKeys {
+    var stride: u16 = 1;
+    for (config.clusters) |cluster| {
+        stride = @max(stride, @as(u16, @intCast(cluster.endpoints.len)));
+    }
+    return .init(@intCast(config.clusters.len), stride);
+}
+
+const test_counts_len = test_keys.count;
 
 /// The no-prober baseline every pre-mask test picks through: all healthy,
 /// exactly what `Checker.init` hands a server whose clusters never check.
-const test_healthy_all = [_]bool{true} ** upstream.endpoint_keys_max;
+const test_healthy_all = [_]bool{true} ** test_keys.count;
 
 /// The L4 half of the load view, all zero: what a pure-L7 test sees.
-const test_l4_idle = [_]u16{0} ** upstream.endpoint_keys_max;
+const test_l4_idle = [_]u16{0} ** test_keys.count;
 
 /// A load view over an L7 lease table, for the tests that only vary
 /// that half. The pair-of-tables shape is what production passes.
-fn testLoad(l7: *const [upstream.endpoint_keys_max]u16) upstream.Load {
+fn testLoad(l7: *const [test_keys.count]u16) upstream.Load {
     return .{ .l7 = l7, .l4 = &test_l4_idle };
 }
 
@@ -448,12 +492,14 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Rotation is exact whatever the load table says: rr ignores it.
     var counts = [_]u16{0} ** test_counts_len;
-    counts[upstream.endpointKey(0, 0)] = 100;
+    counts[test_keys.key(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
         const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
@@ -470,8 +516,10 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
     const state_before = balancer.pick_state;
 
     const counts = [_]u16{0} ** test_counts_len;
@@ -495,14 +543,16 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Endpoint 1 is drowning; 0 and 2 are idle. Whatever pair is drawn,
     // the pick must never be the drowning endpoint: any pair containing
     // it also contains an idle endpoint that wins the comparison.
     var counts = [_]u16{0} ** test_counts_len;
-    counts[upstream.endpointKey(0, 1)] = 100;
+    counts[test_keys.key(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
         const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
@@ -520,8 +570,10 @@ test "balancer: p2c spreads across endpoints under equal load" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // With every count equal the tie rule keeps the first candidate — a
     // uniform draw — so all endpoints must be hit over a modest run.
@@ -546,10 +598,14 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     };
     const config = testConfig(&clusters);
 
+    var left_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer left_arena.deinit();
     var left: Balancer = undefined;
-    left.init(&config);
+    try left.init(left_arena.allocator(), &config, testKeysFor(&config));
+    var right_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer right_arena.deinit();
     var right: Balancer = undefined;
-    right.init(&config);
+    try right.init(right_arena.allocator(), &config, testKeysFor(&config));
 
     // The simulator replays every seed twice and hashes the traces (§9);
     // two same-seed balancers must agree draw for draw.
@@ -573,13 +629,15 @@ test "balancer: rr rotates over the healthy endpoints only" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Endpoint 1 is ejected (§7): rotation covers the survivors exactly,
     // never the ejected one.
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, 1)] = false;
+    healthy[test_keys.key(0, 1)] = false;
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2, 0 };
     for (expected) |want_index| {
@@ -598,16 +656,18 @@ test "balancer: p2c never picks an ejected endpoint" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Even the least-loaded endpoint is off the table while ejected —
     // health outranks load (§7).
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, 1)] = false;
+    healthy[test_keys.key(0, 1)] = false;
     var counts = [_]u16{0} ** test_counts_len;
-    counts[upstream.endpointKey(0, 0)] = 50;
-    counts[upstream.endpointKey(0, 2)] = 50;
+    counts[test_keys.key(0, 0)] = 50;
+    counts[test_keys.key(0, 2)] = 50;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
         const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
@@ -624,14 +684,16 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
     const state_before = balancer.pick_state;
 
     // One survivor: the pick is forced, so the PRNG must not advance —
     // the same no-draw rule as a single-endpoint cluster.
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, 0)] = false;
+    healthy[test_keys.key(0, 0)] = false;
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
@@ -651,15 +713,17 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Every endpoint ejected: the mask must not brick the cluster —
     // rotation runs over the full set as if no prober existed (§7).
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, 0)] = false;
-    healthy[upstream.endpointKey(0, 1)] = false;
-    healthy[upstream.endpointKey(0, 2)] = false;
+    healthy[test_keys.key(0, 0)] = false;
+    healthy[test_keys.key(0, 1)] = false;
+    healthy[test_keys.key(0, 2)] = false;
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
@@ -678,8 +742,10 @@ test "balancer: policies keep independent state across clusters" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Interleaving a p2c cluster's draws must not perturb the rr
     // cluster's rotation: cursor and PRNG are separate state.
@@ -717,8 +783,10 @@ test "balancer: hash sends one client to one endpoint, every time" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     const counts = [_]u16{0} ** test_counts_len;
     const client = testAddress("203.0.113.9:51000");
@@ -732,7 +800,7 @@ test "balancer: hash sends one client to one endpoint, every time" {
     // The load table is what p2c reads; hash must ignore it, or two
     // processes under different load would disagree about one client.
     var loaded = [_]u16{0} ** test_counts_len;
-    loaded[upstream.endpointKey(0, first)] = 10_000;
+    loaded[test_keys.key(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
         balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client).?.endpoint_index,
@@ -747,8 +815,10 @@ test "balancer: hash spends no PRNG state and needs none" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
     const state_before = balancer.pick_state;
 
     const counts = [_]u16{0} ** test_counts_len;
@@ -765,8 +835,10 @@ test "balancer: hash spreads distinct clients across every endpoint" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     const counts = [_]u16{0} ** test_counts_len;
     const clients: u16 = 4000;
@@ -797,8 +869,10 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     const counts = [_]u16{0} ** test_counts_len;
     const clients: u16 = 4000;
@@ -810,7 +884,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
 
     const ejected: u16 = 3;
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, ejected)] = false;
+    healthy[test_keys.key(0, ejected)] = false;
 
     var moved: u32 = 0;
     index = 0;
@@ -870,10 +944,14 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     const forward_config = testConfig(&forward_clusters);
     const reversed_config = testConfig(&reversed_clusters);
 
+    var left_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer left_arena.deinit();
     var left: Balancer = undefined;
-    left.init(&forward_config);
+    try left.init(left_arena.allocator(), &forward_config, testKeysFor(&forward_config));
+    var right_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer right_arena.deinit();
     var right: Balancer = undefined;
-    right.init(&reversed_config);
+    try right.init(right_arena.allocator(), &reversed_config, testKeysFor(&reversed_config));
 
     const counts = [_]u16{0} ** test_counts_len;
     var index: u16 = 0;
@@ -896,8 +974,10 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     const counts = [_]u16{0} ** test_counts_len;
     const first = testAddress("[2001:db8:1:2:aaaa:bbbb:cccc:dddd]:51000");
@@ -976,11 +1056,13 @@ test "balancer: a fully ejected hash cluster still answers, deterministically" {
         .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
     };
     const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     const counts = [_]u16{0} ** test_counts_len;
-    const none_healthy = [_]bool{false} ** upstream.endpoint_keys_max;
+    const none_healthy = [_]bool{false} ** test_keys.count;
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
         const client = testClientAt(index);
@@ -1016,8 +1098,10 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // A pure-L4 cluster: the lease table stays empty for its whole life,
     // so before the load view this draw compared zero against zero and
@@ -1026,7 +1110,7 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
     // contains a calmer endpoint, so it must never win.
     const l7_idle = [_]u16{0} ** test_counts_len;
     var l4 = [_]u16{0} ** test_counts_len;
-    l4[upstream.endpointKey(0, 1)] = 100;
+    l4[test_keys.key(0, 1)] = 100;
     const load: upstream.Load = .{ .l7 = &l7_idle, .l4 = &l4 };
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
@@ -1043,8 +1127,10 @@ test "balancer: p2c compares the sum of both protocols" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Endpoint 0 carries 5 requests and no connections; endpoint 1
     // carries 1 request and 9 connections. Reading either table alone
@@ -1052,12 +1138,12 @@ test "balancer: p2c compares the sum of both protocols" {
     // the origin actually feels.
     var l7 = [_]u16{0} ** test_counts_len;
     var l4 = [_]u16{0} ** test_counts_len;
-    l7[upstream.endpointKey(0, 0)] = 5;
-    l7[upstream.endpointKey(0, 1)] = 1;
-    l4[upstream.endpointKey(0, 1)] = 9;
+    l7[test_keys.key(0, 0)] = 5;
+    l7[test_keys.key(0, 1)] = 1;
+    l4[test_keys.key(0, 1)] = 9;
     const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
-    try std.testing.expectEqual(@as(u32, 5), load.inFlight(upstream.endpointKey(0, 0)));
-    try std.testing.expectEqual(@as(u32, 10), load.inFlight(upstream.endpointKey(0, 1)));
+    try std.testing.expectEqual(@as(u32, 5), load.inFlight(test_keys.key(0, 0)));
+    try std.testing.expectEqual(@as(u32, 10), load.inFlight(test_keys.key(0, 1)));
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
@@ -1076,14 +1162,16 @@ test "balancer: a capped endpoint is skipped while another has room" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Endpoint 0 is at its cap, endpoint 1 is not. Rotation must land on
     // 1 every time — a cap narrows the eligible set, it does not shed
     // while any endpoint can still take work.
     var l7 = [_]u16{0} ** test_counts_len;
-    l7[upstream.endpointKey(0, 0)] = 2;
+    l7[test_keys.key(0, 0)] = 2;
     const load = testLoad(&l7);
     var round: u32 = 0;
     while (round < 8) : (round += 1) {
@@ -1103,22 +1191,24 @@ test "balancer: a fully capped cluster refuses rather than failing open" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Both endpoints at capacity: no pick. This is the deliberate
     // difference from the health mask, which fails *open* — an ejected
     // cluster means "we do not know", a capped one means "we know they
     // are full", and dialing anyway is what the cap exists to stop.
     var l7 = [_]u16{0} ** test_counts_len;
-    l7[upstream.endpointKey(0, 0)] = 3;
-    l7[upstream.endpointKey(0, 1)] = 3;
+    l7[test_keys.key(0, 0)] = 3;
+    l7[test_keys.key(0, 1)] = 3;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
         balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client),
     );
     // One request completes on endpoint 1 and the cluster serves again.
-    l7[upstream.endpointKey(0, 1)] = 2;
+    l7[test_keys.key(0, 1)] = 2;
     try std.testing.expectEqual(
         @as(u16, 1),
         balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client).?.endpoint_index,
@@ -1133,24 +1223,26 @@ test "balancer: the cap counts both protocols, and covers one endpoint" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // A single-endpoint cluster takes the fast path when uncapped; with
     // a cap it must not, or the one endpoint could never be protected.
     // Three L7 requests and one L4 connection is four: at the cap.
     var l7 = [_]u16{0} ** test_counts_len;
     var l4 = [_]u16{0} ** test_counts_len;
-    l7[upstream.endpointKey(0, 0)] = 3;
-    l4[upstream.endpointKey(0, 0)] = 1;
+    l7[test_keys.key(0, 0)] = 3;
+    l4[test_keys.key(0, 0)] = 1;
     const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
         balancer.pick(0, &load, &test_healthy_all, &test_client),
     );
     // Reading either table alone would leave room and dial anyway.
-    try std.testing.expect(l7[upstream.endpointKey(0, 0)] < 4);
-    try std.testing.expect(l4[upstream.endpointKey(0, 0)] < 4);
+    try std.testing.expect(l7[test_keys.key(0, 0)] < 4);
+    try std.testing.expect(l4[test_keys.key(0, 0)] < 4);
 }
 
 test "balancer: capacity is judged over the endpoints health left" {
@@ -1162,24 +1254,26 @@ test "balancer: capacity is judged over the endpoints health left" {
     };
     const config = testConfig(&clusters);
 
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
     var balancer: Balancer = undefined;
-    balancer.init(&config);
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
 
     // Endpoint 0 is ejected, so health leaves only endpoint 1 — which is
     // at its cap. The cap runs second and refuses: a cluster whose only
     // healthy endpoint is full must not be handed the request anyway.
     var healthy = test_healthy_all;
-    healthy[upstream.endpointKey(0, 0)] = false;
+    healthy[test_keys.key(0, 0)] = false;
     var l7 = [_]u16{0} ** test_counts_len;
-    l7[upstream.endpointKey(0, 1)] = 1;
+    l7[test_keys.key(0, 1)] = 1;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
         balancer.pick(0, &testLoad(&l7), &healthy, &test_client),
     );
     // And when health fails open — every endpoint ejected — the caps
     // still apply to the whole set rather than being bypassed with it.
-    healthy[upstream.endpointKey(0, 1)] = false;
-    l7[upstream.endpointKey(0, 0)] = 1;
+    healthy[test_keys.key(0, 1)] = false;
+    l7[test_keys.key(0, 0)] = 1;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
         balancer.pick(0, &testLoad(&l7), &healthy, &test_client),

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -32,8 +32,8 @@
 //! (§3). A 64-endpoint ring at any useful virtual-node count is a
 //! thousands-of-entries sort per flap. Rendezvous has no table to rebuild:
 //! it scans the eligible set the health mask already produced. It costs
-//! O(n) instead of O(log n), which is why the endpoint ceiling matters —
-//! measured at 71 ns per pick for the 64 endpoints a cluster may hold,
+//! O(n) instead of O(log n), which is why a cluster's endpoint count is a
+//! cost the operator chooses: measured at 71 ns per pick at 64 endpoints,
 //! against a request this proxy serves in ~100 µs. Jump consistent hash is
 //! excluded outright: it can only add or remove the *last* bucket, and an
 //! ejection removes an arbitrary one.
@@ -416,7 +416,7 @@ pub const Balancer = struct {
     /// xorshift64* (Vigna): the full-period 64-bit shift generator with a
     /// multiplicative output scramble — plenty for candidate draws, one
     /// mul and three shifts on the pick path. The modulo bias of a draw
-    /// is ≤ 2⁻⁵⁸ for the ≤ 64 endpoints a cluster may hold — negligible.
+    /// is ≤ 2⁻⁴⁸ even at the u16 index type's edge — negligible.
     fn next(balancer: *Balancer) u64 {
         assert(balancer.pick_state != 0);
         var x = balancer.pick_state;

--- a/src/config.zig
+++ b/src/config.zig
@@ -764,7 +764,6 @@ pub const ClusterJson = struct {
         .endpoints = .{
             .desc = "IP:port endpoint literals (port must be non-zero).",
             .min_items = 1,
-            .max_items = constants.endpoints_per_cluster_max,
         },
         .pick = .{
             .desc = "Endpoint-pick policy: p2c (power-of-two-choices), rr (strict " ++
@@ -928,33 +927,35 @@ pub const TimeoutsJson = struct {
     };
 };
 
-/// JSON object map of cluster name → cluster, parsed into a bounded array
+/// JSON object map of cluster name → cluster, parsed into an ordered list
 /// so duplicate keys can be rejected in stage 2 (std.json's map types
 /// silently keep the last duplicate — negative space we refuse to have).
-/// Bodies past the capacity are skipped but counted, so the over-limit
-/// error stays distinct from a syntax error.
 pub const ClustersJson = struct {
-    entries: [constants.clusters_max]Entry,
-    seen_count: u32,
+    /// Every key the object carried, in order. Arena-backed and grown as
+    /// the object is read: there is no ceiling on cluster count, so there
+    /// is no capacity to skip past either — what used to be parsed-then-
+    /// discarded past a cluster ceiling is now simply parsed.
+    entries: []const Entry,
 
     const Entry = struct {
         name: []const u8,
         cluster: ClusterJson,
     };
 
-    /// Hard ceiling on keys consumed before giving up entirely — a bound
-    /// on the bound (an adversarial config cannot spin this loop).
-    const keys_seen_max: u32 = 4096;
-
     pub fn jsonParse(
         allocator: std.mem.Allocator,
         source: anytype,
         options: std.json.ParseOptions,
     ) !@This() {
-        var clusters: @This() = .{ .entries = undefined, .seen_count = 0 };
+        var entries: std.ArrayList(Entry) = .empty;
         if (try source.next() != .object_begin) {
             return error.UnexpectedToken;
         }
+        // Terminated by the object's own `}` or by the input running out,
+        // which the scanner reports as an error — the same bound every
+        // other array in this config now has, and the reason the old
+        // `keys_seen_max` backstop is gone: with no ceiling above it, that
+        // 4096 would have quietly become the new cluster limit.
         while (true) {
             const token = try source.nextAlloc(allocator, .alloc_if_needed);
             const name: []const u8 = switch (token) {
@@ -963,21 +964,19 @@ pub const ClustersJson = struct {
                 .allocated_string => |slice| slice,
                 else => return error.UnexpectedToken,
             };
-            if (clusters.seen_count < constants.clusters_max) {
-                clusters.entries[clusters.seen_count] = .{
-                    .name = name,
-                    .cluster = try std.json.innerParse(ClusterJson, allocator, source, options),
-                };
-            } else {
-                try source.skipValue();
-            }
-            clusters.seen_count += 1;
-            if (clusters.seen_count > keys_seen_max) {
-                return error.UnexpectedToken;
-            }
+            try entries.append(allocator, .{
+                .name = name,
+                .cluster = try std.json.innerParse(ClusterJson, allocator, source, options),
+            });
         }
-        assert(clusters.seen_count <= keys_seen_max);
-        return clusters;
+        const seen = entries.items.len;
+        const parsed: @This() = .{ .entries = try entries.toOwnedSlice(allocator) };
+        // The postcondition every sibling resolver states: the handed-back
+        // slice is every key the object carried, not a prefix of them —
+        // which is exactly what the removed skip-past-capacity branch used
+        // to make untrue.
+        assert(parsed.entries.len == seen);
+        return parsed;
     }
 };
 
@@ -1059,21 +1058,47 @@ fn resolveClusters(
     connect_timeout_ms: u32,
 ) ParseError![]const Config.Cluster {
     assert(connect_timeout_ms >= 1);
-    if (clusters_json.seen_count < constants.clusters_min) {
+    if (clusters_json.entries.len < constants.clusters_min) {
         return error.ClustersEmpty;
     }
-    if (clusters_json.seen_count > constants.clusters_max) {
+    // No upper bound: a cluster costs an arena `Config.Cluster` and a row
+    // in the §7 endpoint tables, both sized from this count (§5), so how
+    // many is the operator's call. `u16` is the one hard edge left — the
+    // index type the endpoint key and every `cluster_index` field use.
+    if (clusters_json.entries.len > std.math.maxInt(u16)) {
         return error.ClustersOverLimit;
     }
 
-    const count: u16 = @intCast(clusters_json.seen_count);
+    const count: u16 = @intCast(clusters_json.entries.len);
     const clusters = try arena.alloc(Config.Cluster, count);
-    for (clusters_json.entries[0..count], 0..) |entry, index| {
-        for (clusters_json.entries[0..index]) |previous| {
-            if (std.mem.eql(u8, previous.name, entry.name)) {
-                return error.ClusterNameDuplicate;
-            }
+
+    // Duplicate names in O(n log n), by sorting an index permutation and
+    // comparing neighbours. It was a nested scan over the entries, which
+    // the 16-cluster ceiling kept to ~120 compares; with the ceiling gone
+    // that same scan would cost ~2.1e9 string compares on a config at the
+    // index type's edge — minutes of startup for a config whose memory
+    // fits easily. Which name is reported first changes, and nothing
+    // reads it: the error carries no payload.
+    const order = try arena.alloc(u16, count);
+    for (order, 0..) |*slot, index| slot.* = @intCast(index);
+    const ByName = struct {
+        entries: []const ClustersJson.Entry,
+        fn lessThan(ctx: @This(), a: u16, b: u16) bool {
+            return std.mem.lessThan(u8, ctx.entries[a].name, ctx.entries[b].name);
         }
+    };
+    std.mem.sort(u16, order, ByName{ .entries = clusters_json.entries }, ByName.lessThan);
+    for (order[1..], order[0 .. order.len - 1]) |current, previous| {
+        if (std.mem.eql(
+            u8,
+            clusters_json.entries[current].name,
+            clusters_json.entries[previous].name,
+        )) {
+            return error.ClusterNameDuplicate;
+        }
+    }
+
+    for (clusters_json.entries, 0..) |entry, index| {
         // A name is an identifier an operator writes and the access log
         // echoes (§8): bounding it is what keeps a log line's width a
         // function of `constants.zig` rather than of the config file.
@@ -1104,7 +1129,13 @@ fn resolveEndpoints(
     if (endpoint_literals.len == 0) {
         return error.EndpointsEmpty;
     }
-    if (endpoint_literals.len > constants.endpoints_per_cluster_max) {
+    // No policy bound: endpoints cost an arena address each and a column
+    // in the §7 endpoint tables, both sized from this count (§5). What is
+    // left is the index type's own edge — `n` endpoints produce indices
+    // `0..n-1`, and the largest of those must stay inside
+    // `endpoint_index_max`, which `Conn` asserts sits below its
+    // no-endpoint sentinel.
+    if (endpoint_literals.len > @as(usize, constants.endpoint_index_max) + 1) {
         return error.EndpointsOverLimit;
     }
 
@@ -1681,7 +1712,9 @@ fn clusterIndexOf(
     name: []const u8,
 ) error{ClusterUnknown}!u16 {
     assert(clusters.len >= 1);
-    assert(clusters.len <= constants.clusters_max);
+    // The `@intCast` below is why: `resolveClusters` rejects a count past
+    // the index type, so every position here fits the `u16` it returns.
+    assert(clusters.len <= std.math.maxInt(u16));
     for (clusters, 0..) |cluster, index| {
         if (std.mem.eql(u8, cluster.name, name)) {
             return @intCast(index);

--- a/src/config.zig
+++ b/src/config.zig
@@ -241,7 +241,6 @@ pub const Config = struct {
 };
 
 pub const ValidationError = error{
-    ConfigTooLarge,
     ListenersEmpty,
     ListenersOverLimit,
     ListenerBindInvalid,
@@ -308,10 +307,6 @@ pub const ValidationError = error{
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
 
 pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config {
-    if (json_bytes.len > constants.config_bytes_max) {
-        return error.ConfigTooLarge;
-    }
-
     const parsed = try std.json.parseFromSliceLeaky(ConfigJson, arena, json_bytes, .{
         .duplicate_field_behavior = .@"error",
         .ignore_unknown_fields = false,
@@ -1197,6 +1192,9 @@ fn resolveFilters(
     if (header_edits > constants.header_edits_max) {
         return error.FilterHeaderEditsOverLimit;
     }
+    // The one bound left on this table, and the render buffer depends on
+    // it — so state it positively rather than trusting the guard above.
+    assert(header_edits <= constants.header_edits_max);
     assert(rules.len == filters_json.len);
     return rules;
 }
@@ -1204,6 +1202,10 @@ fn resolveFilters(
 /// The number of header-edit actions (set/add/remove) in a rule — the
 /// reject and rewrite actions contribute no render-time header edit.
 fn countHeaderEdits(actions: []const filter.Action) u32 {
+    // Reached only through `resolveActions`, which rejects an empty
+    // action list — so the caps this function once asserted against are
+    // gone, but the shape they implied still holds.
+    assert(actions.len >= 1);
     var count: u32 = 0;
     for (actions) |action| {
         switch (action) {
@@ -1292,6 +1294,7 @@ fn resolveActions(
     if (actions_json.len == 0) {
         return error.FilterActionsEmpty;
     }
+    assert(actions_json.len >= 1); // Past the empty guard.
     const actions = try arena.alloc(filter.Action, actions_json.len);
     for (actions_json, actions) |action_json, *action| {
         action.* = try resolveAction(&action_json);
@@ -2550,6 +2553,47 @@ fn expectParseOk(arena_state: *std.heap.ArenaAllocator, json_bytes: []const u8) 
     return parse(arena_state.allocator(), json_bytes);
 }
 
+test "config: a table far past the old caps parses, and is bounded only by itself" {
+    // Replaces the deleted oversize-input test, and covers what took its
+    // place: 200 routes and 200 filters are each ~6x the caps that used
+    // to reject them (`routes_max`/`filters_per_listener_max`, 32), and
+    // the whole input is well past the 256 KiB `config_bytes_max` era's
+    // intent. Nothing may cap it now but the operator's own file, so the
+    // assertion is simply that it round-trips at full length.
+    const route_count = 200;
+    const json = comptime blk: {
+        // 200 rounds of `comptimePrint` each cost far more than the
+        // default 3000-branch budget allows.
+        @setEvalBranchQuota(200_000);
+        var routes: []const u8 = "";
+        var filters: []const u8 = "";
+        var index: u16 = 0;
+        while (index < route_count) : (index += 1) {
+            const n = std.fmt.comptimePrint("{d}", .{index});
+            if (index != 0) {
+                routes = routes ++ ",";
+                filters = filters ++ ",";
+            }
+            routes = routes ++ "{\"prefix\":\"/p" ++ n ++ "\",\"cluster\":\"a\"}";
+            // One header match and one action per rule — both counts the
+            // per-rule caps used to bound. No header edits: the whole
+            // table's edits still have to fit `header_edits_max`.
+            filters = filters ++
+                "{\"match\":{\"headers\":[{\"name\":\"X-K" ++ n ++ "\",\"present\":true}]}," ++
+                "\"actions\":[{\"reject\":404}]}";
+        }
+        break :blk "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+            "\"routes\":[" ++ routes ++ "],\"filters\":[" ++ filters ++ "]}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    };
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state, json);
+    try std.testing.expectEqual(@as(usize, route_count), parsed.listeners[0].routes.len);
+    try std.testing.expectEqual(@as(usize, route_count), parsed.listeners[0].filters.len);
+}
+
 test "config: strictness rejects unknown and duplicate fields" {
     try expectParseError(error.UnknownField,
         \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","nope":1}],
@@ -2680,11 +2724,6 @@ test "config: listeners over the limit" {
         ;
     }
     try expectParseError(error.ListenersOverLimit, over_limit_json);
-}
-
-test "config: oversized input is rejected before parsing" {
-    const oversized = [_]u8{' '} ** (constants.config_bytes_max + 1);
-    try expectParseError(error.ConfigTooLarge, &oversized);
 }
 
 var fuzz_arena_buffer: [1 << 20]u8 = undefined;

--- a/src/config.zig
+++ b/src/config.zig
@@ -486,7 +486,6 @@ pub const ConfigJson = struct {
         .listeners = .{
             .desc = "Sockets the proxy accepts connections on.",
             .min_items = 1,
-            .max_items = constants.listeners_max,
         },
         .clusters = .{ .desc = "Named upstream clusters, keyed by cluster name." },
         .timeouts = .{ .desc = "Connection lifecycle deadlines (milliseconds)." },
@@ -1161,7 +1160,11 @@ fn resolveListeners(
     if (listeners_json.len == 0) {
         return error.ListenersEmpty;
     }
-    if (listeners_json.len > constants.listeners_max) {
+    // No policy ceiling: a listener costs two ring ops and one fd, and
+    // both are checked against this config's own budget — `cqFillFits`
+    // for the ring (`LimitConnSlotsOverCqFill`), `ensureFdBudget` for the
+    // fds. What is left is the `u16` the listener index is stored in.
+    if (listeners_json.len > std.math.maxInt(u16)) {
         return error.ListenersOverLimit;
     }
 
@@ -1170,11 +1173,6 @@ fn resolveListeners(
         const bind_address = std.Io.net.IpAddress.parseLiteral(listener_json.bind) catch {
             return error.ListenerBindInvalid;
         };
-        for (listeners[0..index]) |previous| {
-            if (std.meta.eql(previous.bind_address, bind_address)) {
-                return error.ListenerBindDuplicate;
-            }
-        }
         const protocol = try protocolOf(listener_json.protocol);
         listeners[index] = .{
             .bind_address = bind_address,
@@ -1184,8 +1182,47 @@ fn resolveListeners(
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
         };
     }
+
+    // Duplicate binds in O(n log n), for the reason `resolveClusters`
+    // sorts its names: the nested scan this replaces was bounded by
+    // `listeners_max` at 8 (~64 comparisons), and with the ceiling gone
+    // it is bounded only by what `cqFillFits` admits — tens of thousands
+    // at small pool sizes, which is ~8e8 comparisons at config load.
+    const order = try arena.alloc(u16, listeners.len);
+    for (order, 0..) |*slot, index| slot.* = @intCast(index);
+    const ByBind = struct {
+        listeners: []const Config.Listener,
+        fn lessThan(ctx: @This(), a: u16, b: u16) bool {
+            return bindOrder(ctx.listeners[a].bind_address) <
+                bindOrder(ctx.listeners[b].bind_address);
+        }
+    };
+    std.mem.sort(u16, order, ByBind{ .listeners = listeners }, ByBind.lessThan);
+    for (order[1..], order[0 .. order.len - 1]) |current, previous| {
+        if (std.meta.eql(
+            listeners[current].bind_address,
+            listeners[previous].bind_address,
+        )) {
+            return error.ListenerBindDuplicate;
+        }
+    }
+
     assert(listeners.len == listeners_json.len);
+    assert(order.len == listeners.len);
     return listeners;
+}
+
+/// A total order over bind addresses, for the duplicate sort above. Only
+/// the ordering matters, never the value: equal keys are re-checked with
+/// `std.meta.eql`, so a collision costs a comparison rather than a wrong
+/// verdict.
+fn bindOrder(address: std.Io.net.IpAddress) u160 {
+    return switch (address) {
+        .ip4 => |v4| (@as(u160, 0) << 152) |
+            (@as(u160, std.mem.readInt(u32, &v4.bytes, .big)) << 16) | v4.port,
+        .ip6 => |v6| (@as(u160, 1) << 152) |
+            (@as(u160, std.mem.readInt(u128, &v6.bytes, .big)) << 16) | v6.port,
+    };
 }
 
 /// Compile a listener's §7 filter rules into immutable arena tables.
@@ -2739,24 +2776,51 @@ test "config: every emptiness and limit has its own error" {
     );
 }
 
-test "config: listeners over the limit" {
-    comptime var over_limit_json: []const u8 =
-        \\{"listeners":[
-    ;
-    comptime {
-        var index: u32 = 0;
-        while (index <= constants.listeners_max) : (index += 1) {
-            if (index > 0) over_limit_json = over_limit_json ++ ",";
-            over_limit_json = over_limit_json ++ std.fmt.comptimePrint(
-                \\{{"bind":"127.0.0.1:{d}","cluster":"a"}}
-            , .{1000 + index});
-        }
-        over_limit_json = over_limit_json ++
-            \\],"clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
-            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
-        ;
+/// Builds a config with `count` listeners and the given `limits` body.
+fn listenersJson(comptime count: u32, comptime limits: []const u8) []const u8 {
+    var json: []const u8 = "{\"listeners\":[";
+    var index: u32 = 0;
+    while (index < count) : (index += 1) {
+        if (index > 0) json = json ++ ",";
+        json = json ++ std.fmt.comptimePrint(
+            \\{{"bind":"127.0.0.1:{d}","cluster":"a"}}
+        , .{1000 + index});
     }
-    try expectParseError(error.ListenersOverLimit, over_limit_json);
+    return json ++ "]," ++ limits ++
+        \\"clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+}
+
+test "config: listeners are bounded by the ring budget, not by a count" {
+    // Replaces the old over-`listeners_max` test. 64 listeners — 8x the
+    // ceiling that used to refuse them — load fine at the default pools,
+    // because what a listener actually costs is two ring ops.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state, comptime listenersJson(64, ""));
+    try std.testing.expectEqual(@as(usize, 64), parsed.listeners.len);
+}
+
+test "config: listeners that overflow the ring budget are refused at load" {
+    // The comptime `assert(in_flight_ops_max <= completion_queue_entries)`
+    // this replaces could only ever speak about the ceilings. This is the
+    // same arithmetic against a real config: conn slots at the ceiling
+    // leave no room for a listener's two ops, so the pair is refused —
+    // the startup rejection that the removed ceiling used to pre-empt.
+    // Both pools at their ceilings leaves 3 of the 57344-op fill budget
+    // spare at zero listeners — which is exactly what `conn_slots_max` is
+    // derived to leave — so the second listener is already one too many.
+    const at_ceiling = std.fmt.comptimePrint(
+        "\"limits\":{{\"conn_slots\":{d},\"upstream_slots\":{d}}},",
+        .{ constants.conn_slots_max, constants.upstream_slots_max },
+    );
+    try expectParseError(error.LimitConnSlotsOverCqFill, comptime listenersJson(2, at_ceiling));
+    // One listener still fits, so the refusal above is the budget talking
+    // and not the pools alone.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    _ = try expectParseOk(&arena_state, comptime listenersJson(1, at_ceiling));
 }
 
 var fuzz_arena_buffer: [1 << 20]u8 = undefined;

--- a/src/config.zig
+++ b/src/config.zig
@@ -269,24 +269,20 @@ pub const ValidationError = error{
     ListenerClusterOrRoutes,
     ListenerL4Routes,
     RoutesEmpty,
-    RoutesOverLimit,
     RoutePrefixNotCanonical,
     RouteHostNotCanonical,
     RouteDuplicate,
     ListenerL4Filters,
     ListenerL4Forwarded,
     ListenerForwardedModeUnknown,
-    FiltersOverLimit,
     FilterMethodEmpty,
     FilterMethodUnknown,
-    FilterHeaderMatchesOverLimit,
     FilterHeaderMatchKind,
     FilterHeaderContainsEmpty,
     FilterHeaderNameInvalid,
     FilterHeaderNameReserved,
     FilterHeaderValueInvalid,
     FilterActionsEmpty,
-    FilterActionsOverLimit,
     FilterActionKind,
     FilterRejectStatus,
     FilterHeaderEditsOverLimit,
@@ -599,11 +595,9 @@ pub const ListenerJson = struct {
         .routes = .{
             .desc = "Explicit longest-prefix route table (http listeners only).",
             .min_items = 1,
-            .max_items = constants.routes_max,
         },
         .filters = .{
             .desc = "Request filter rules, evaluated top-down (http listeners only).",
-            .max_items = constants.filters_per_listener_max,
         },
         .protocol = .{
             .desc = "What the listener speaks: l4 relays bytes blindly, http runs the reverse-proxy state machine.",
@@ -645,7 +639,6 @@ pub const FilterJson = struct {
         .actions = .{
             .desc = "Actions applied in order when the rule matches.",
             .min_items = 1,
-            .max_items = constants.actions_per_filter_max,
         },
     };
 };
@@ -668,7 +661,6 @@ pub const MatchJson = struct {
         .path_prefix = .{ .desc = "Canonical origin-form path prefix; must start with a slash." },
         .headers = .{
             .desc = "Header predicates; all must match.",
-            .max_items = constants.header_matches_per_filter_max,
         },
     };
 };
@@ -1190,9 +1182,6 @@ fn resolveFilters(
     if (filters_json.len == 0) {
         return &.{};
     }
-    if (filters_json.len > constants.filters_per_listener_max) {
-        return error.FiltersOverLimit;
-    }
     const rules = try arena.alloc(filter.Rule, filters_json.len);
     var header_edits: u32 = 0;
     for (filters_json, rules) |rule_json, *rule| {
@@ -1209,14 +1198,12 @@ fn resolveFilters(
         return error.FilterHeaderEditsOverLimit;
     }
     assert(rules.len == filters_json.len);
-    assert(rules.len <= constants.filters_per_listener_max);
     return rules;
 }
 
 /// The number of header-edit actions (set/add/remove) in a rule — the
 /// reject and rewrite actions contribute no render-time header edit.
 fn countHeaderEdits(actions: []const filter.Action) u32 {
-    assert(actions.len <= constants.actions_per_filter_max);
     var count: u32 = 0;
     for (actions) |action| {
         switch (action) {
@@ -1261,9 +1248,6 @@ fn resolveHeaderMatches(
     arena: std.mem.Allocator,
     headers_json: []const HeaderMatchJson,
 ) ParseError![]const filter.HeaderMatch {
-    if (headers_json.len > constants.header_matches_per_filter_max) {
-        return error.FilterHeaderMatchesOverLimit;
-    }
     const matches = try arena.alloc(filter.HeaderMatch, headers_json.len);
     for (headers_json, matches) |header_json, *match| {
         try validateHeaderName(header_json.name);
@@ -1308,15 +1292,11 @@ fn resolveActions(
     if (actions_json.len == 0) {
         return error.FilterActionsEmpty;
     }
-    if (actions_json.len > constants.actions_per_filter_max) {
-        return error.FilterActionsOverLimit;
-    }
     const actions = try arena.alloc(filter.Action, actions_json.len);
     for (actions_json, actions) |action_json, *action| {
         action.* = try resolveAction(&action_json);
     }
     assert(actions.len == actions_json.len);
-    assert(actions.len <= constants.actions_per_filter_max);
     return actions;
 }
 
@@ -1467,9 +1447,6 @@ fn resolveRoutes(
     if (routes_json.len == 0) {
         return error.RoutesEmpty;
     }
-    if (routes_json.len > constants.routes_max) {
-        return error.RoutesOverLimit;
-    }
     const routes = try arena.alloc(router.Route, routes_json.len);
     for (routes_json, 0..) |route_json, index| {
         try validateRoutePrefix(route_json.prefix);
@@ -1495,7 +1472,6 @@ fn resolveRoutes(
     // group the longest prefix. Ties are rejected as duplicates above.
     std.mem.sort(router.Route, routes, {}, routeMoreSpecific);
     assert(routes.len >= 1);
-    assert(routes.len <= constants.routes_max);
     return routes;
 }
 
@@ -2214,9 +2190,10 @@ test "config: a filter set over the header-edit budget is rejected" {
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
     ;
-    // One header_edits_max+1 header edits spread one-per-rule (each rule
-    // stays under actions_per_filter_max): the whole-table total is what
-    // the renderer's fixed buffer must hold, so it is the total that caps.
+    // header_edits_max+1 header edits spread one-per-rule: neither the
+    // rule count nor a rule's action count is bounded any more, so the
+    // whole-table total is the only thing that caps — which is the point,
+    // since that total is what the renderer's fixed buffer must hold.
     const rules = comptime blk: {
         var s: []const u8 = "";
         var edit: u16 = 0;
@@ -2765,7 +2742,6 @@ fn fuzzParse(context: void, smith: *std.testing.Smith) !void {
         assert(parsed.connect_timeout_ms < parsed.idle_timeout_ms);
         for (parsed.listeners) |listener| {
             assert(listener.routes.len >= 1);
-            assert(listener.routes.len <= constants.routes_max);
             for (listener.routes) |route| {
                 assert(route.cluster_index < parsed.clusters.len);
                 assert(route.prefix.len >= 1);

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -265,17 +265,20 @@ fn writeMethodEnum(out: *Stringify) Writer.Error!void {
     comptime assert(emitted); // at least one real method token exists
 }
 
-/// The clusters map: a name-keyed object whose values are cluster schemas,
-/// bounded by `clusters_max`. The DTO is a custom parser (not a plain
-/// struct), so its shape is emitted here rather than reflected.
+/// The clusters map: a name-keyed object whose values are cluster schemas.
+/// The DTO is a custom parser (not a plain struct), so its shape is
+/// emitted here rather than reflected.
+///
+/// `minProperties` only: there is no `maxProperties` because there is no
+/// cluster ceiling left to emit. The loader's one remaining rejection is
+/// the `u16` index type's edge, which is not a number worth putting in a
+/// schema an editor uses for completion.
 fn writeClustersMap(out: *Stringify) Writer.Error!void {
-    comptime assert(constants.clusters_max >= constants.clusters_min);
+    comptime assert(constants.clusters_min >= 1);
     try out.objectField("type");
     try out.write("object");
     try out.objectField("minProperties");
     try out.write(constants.clusters_min);
-    try out.objectField("maxProperties");
-    try out.write(constants.clusters_max);
     try out.objectField("additionalProperties");
     try out.beginObject();
     try writeObjectBody(out, config.ClusterJson, true);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -292,18 +292,17 @@ pub const health_check_host_bytes_max: u16 = host_bytes_max;
 pub const health_check_request_bytes_max: u32 =
     64 + health_check_path_bytes_max + health_check_host_bytes_max;
 
-/// Upper bound on routes in one listener's path-routing table (§7). Config
-/// data, not a runtime pool: routes are immutable arena slices, and the
-/// request-time match is a bounded linear scan over at most this many.
-pub const routes_max: u16 = 32;
-
-/// §7 "filters are data" bounds — one listener's rule table and each
-/// rule's shape. Config data, not pools: rules are immutable arena
-/// slices and evaluation is bounded loops over at most these many, so a
-/// filter set cannot make request handling unbounded.
-pub const filters_per_listener_max: u16 = 32;
-pub const actions_per_filter_max: u16 = 8;
-pub const header_matches_per_filter_max: u16 = 8;
+// Routes and filters carry no ceiling of their own (§7 "filters are
+// data"). They are immutable arena slices allocated at exactly the
+// length the config asked for, so they size nothing that a comptime
+// bound could protect: what a large table costs is arena bytes and a
+// longer request-time linear scan, both of which are the operator's
+// call to make in their own config. The request-time loops stay bounded
+// — by a length fixed at startup rather than by a constant here.
+//
+// `header_edits_max` below is the exception, and the difference is the
+// rule: it bounds a *fixed buffer* the renderer materializes into, so
+// the number must be known before the config is read.
 
 /// Upper bound on a listener's *total* header-edit actions (set/add/remove
 /// summed across every rule). A request applies the edits of all rules it
@@ -644,10 +643,6 @@ comptime {
     assert(endpoint_inflight_max == conn_slots_max + upstream_slots_max);
     assert(endpoint_inflight_max >= conn_slots_max);
     assert(endpoint_inflight_max >= upstream_slots_max);
-    assert(routes_max >= 1);
-    assert(filters_per_listener_max >= 1);
-    assert(actions_per_filter_max >= 1);
-    assert(header_matches_per_filter_max >= 1);
     assert(header_edits_max >= 1);
     assert(loop_completions_per_tick_max >= 1);
     assert(config_bytes_max >= 1024);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -7,11 +7,8 @@ const std = @import("std");
 
 const assert = std.debug.assert;
 
-/// Upper bound on configured listeners.
-pub const listeners_max: u16 = 8;
-
 /// The single dedicated admin/metrics listener (DESIGN.md §8): separate
-/// from the configured `listeners_max` so a scrape can
+/// from the configured listeners so a scrape can
 /// never consume a data-path listener slot, and reserved in the fd and
 /// ring budgets below unconditionally — the ceiling is a comptime
 /// constant, so it must cover the worst case (admin enabled) even when a
@@ -59,13 +56,24 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
 /// parked-upstream, admin, access-log and health-probe reservations
 /// carved out first, this caps at
-/// `(57344 - 27) / (conn_ops_max + 1) = 11463` —
-/// comptime-derived below (the 27 is the fixed ops: two per config and
-/// admin listener [18], the admin client's op budget [3], the access log's
+/// `(57344 - 11) / (conn_ops_max + 1) = 11466` —
+/// comptime-derived below (the 11 is the fixed ops: two for the admin
+/// listener [2], the admin client's op budget [3], the access log's
 /// in-flight sink write [1], the health prober's op budget [3], the signal
 /// wake [1], and the drain timer [1]). That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
+///
+/// **Configured listeners are not in that 11.** They cost two ring ops
+/// each like the admin listener does, but there is no listener ceiling to
+/// reserve against — so this is the ceiling at *zero* configured
+/// listeners, and each one a config declares spends two ops out of the
+/// same budget. `cqFillFits` refuses the combination at load
+/// (`LimitConnSlotsOverCqFill`) rather than a comptime assert refusing it
+/// at build time, which is the trade this ceiling now rests on: a
+/// deployment wanting both the maximum conn slots and many listeners is
+/// told so at startup instead of being pre-empted by a number chosen for
+/// it here.
 ///
 /// `upstream_slots_max` is pinned to this, and the `+ 1` in the divisor
 /// is that pin: on the L7 path an admitted connection that is mid-exchange
@@ -73,8 +81,8 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// every admitted connection can be mid-exchange at once. A conn ceiling
 /// above the upstream ceiling is therefore capacity that cannot be served
 /// — slots that admit connections the pool has no upstream for — and one
-/// below it is a pool that can never be drawn down. `11463` is the
-/// largest N with `N * (conn_ops_max + 1) <= 57317`, which keeps both
+/// below it is a pool that can never be drawn down. `11466` is the
+/// largest N with `N * (conn_ops_max + 1) <= 57333`, which keeps both
 /// ceilings clear of a round 10k: what §1 asks for, c10k reachable on
 /// either axis rather than a shape tuned for it.
 ///
@@ -85,7 +93,7 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// The pair is still a policy choice made on the operator's behalf;
 /// IMPLEMENTATION_NOTES.md ("Open questions" — pool ceilings) holds the
 /// standing question of handing it to them instead.
-pub const conn_slots_max: u32 = 11463;
+pub const conn_slots_max: u32 = 11466;
 
 /// Relay buffer pairs (`Pool(RelayBuffer)`) — the bound on concurrent L4
 /// connections plus active L7 body relays (§5, §6). Sized to the
@@ -446,18 +454,27 @@ pub const access_log_line_bytes_max: u32 = blk: {
 /// evaluated on the *effective* pool sizes too (XevIo's per-deployment CQ),
 /// not only the ceilings; the admin, access-log and health-probe
 /// reservations are fixed — always covered even when a config leaves them
-/// off; `in_flight_ops_max` is it at the ceilings.
+/// off.
+///
+/// There is no `in_flight_ops_max` companion any more, and its absence is
+/// the shape of this whole budget now: with no listener ceiling there is
+/// no "at the ceilings" point to evaluate, because the listener term is a
+/// property of the config rather than of `constants.zig`. What used to be
+/// `assert(in_flight_ops_max <= completion_queue_entries)` at comptime is
+/// `cqFillFits` at config load (`LimitConnSlotsOverCqFill`) — the same
+/// arithmetic, refused a few milliseconds later.
 pub fn inFlightOps(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(conn_slots <= conn_slots_max);
     assert(upstream_slots <= upstream_slots_max);
-    assert(listeners <= listeners_max);
+    // No policy ceiling to check against, but the argument is not
+    // unbounded either: every caller sources it from a config the
+    // loader has already held to the `u16` a listener index is stored in.
+    assert(listeners <= std.math.maxInt(u16));
     return conn_slots * conn_ops_max + upstream_slots +
         2 * (listeners + admin_listeners) +
         admin_conns * admin_conn_ops_max + access_log_ops_max +
         health_probe_ops_max + 1 + 1;
 }
-pub const in_flight_ops_max: u32 =
-    inFlightOps(conn_slots_max, upstream_slots_max, listeners_max);
 
 /// Kernel maximum for an IORING_SETUP_CQSIZE completion queue
 /// (IORING_MAX_CQ_ENTRIES = 2 × IORING_MAX_ENTRIES) on current kernels.
@@ -541,8 +558,15 @@ pub fn cqFillFits(
 /// deployment at the compiled ceilings would request. This is the kernel
 /// maximum (65536), which is exactly what makes `conn_slots_max` the c10k
 /// ceiling — as deep as one ring allows, independent of `ring_entries`.
+/// Derived at *zero* configured listeners: with no listener ceiling there
+/// is no worst case to reserve for, so the compiled depth covers the
+/// pools and the fixed reservations, and a config's own listeners are
+/// checked against it by `cqFillFits` at load. The depth clamps to the
+/// kernel maximum either way, so the listener term never actually moved
+/// this number — it only made it look derived from a ceiling that no
+/// longer exists.
 pub const completion_queue_entries: u32 =
-    completionQueueDepthFor(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_default);
+    completionQueueDepthFor(conn_slots_max, upstream_slots_max, 0, cq_fill_eighths_default);
 
 /// The fds a deployment needs (§8: fds are pre-budgeted, not shed): stdio
 /// + ring + async eventfd + listeners (configured + admin) + two sockets
@@ -552,16 +576,19 @@ pub const completion_queue_entries: u32 =
 /// which belongs to no connection + the one socket the in-flight health
 /// probe may hold while dialing (§7). Closed form so `ensureFdBudget` can
 /// check the *effective* size against RLIMIT_NOFILE; the admin and
-/// health-probe reservations are fixed; `fds_max` is it at the ceilings.
+/// health-probe reservations are fixed.
+///
+/// No `fds_max` companion, for the reason `in_flight_ops_max` has none:
+/// the listener term makes this a property of a config, not of this file.
+/// `ensureFdBudget` was always the real gate — it compares this against
+/// the actual RLIMIT_NOFILE — and it is now the only one.
 pub fn fdsRequired(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
     assert(conn_slots <= conn_slots_max);
     assert(upstream_slots <= upstream_slots_max);
-    assert(listeners <= listeners_max);
+    assert(listeners <= std.math.maxInt(u16));
     return 3 + 1 + 1 + (listeners + admin_listeners) +
         2 * conn_slots + 1 + admin_conns + upstream_slots + 1;
 }
-pub const fds_max: u32 =
-    fdsRequired(conn_slots_max, upstream_slots_max, listeners_max);
 
 /// Default effective pool sizes when the config omits a `limits` block: a
 /// lean out-of-box footprint (~33 MiB of pools, well under a routine 4096
@@ -628,8 +655,7 @@ comptime {
     assert(upstream_slots_default >= 1 and upstream_slots_default <= upstream_slots_max);
     assert(relay_buffers_max <= conn_slots_max);
     assert(relay_buffers_max >= 1);
-    assert(listeners_max >= 1);
-    assert(in_flight_ops_max <= completion_queue_entries);
+    assert(inFlightOps(conn_slots_max, upstream_slots_max, 0) <= completion_queue_entries);
     assert(conn_slots_max - 1 <= std.math.maxInt(u16));
     assert(relay_buffer_bytes >= 512);
     assert(clusters_min >= 1);
@@ -690,7 +716,7 @@ comptime {
     assert(upstream_slots_max == conn_slots_max);
     assert(conn_slots_max == @divFloor(
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
-            2 * (@as(u32, listeners_max) + admin_listeners) -
+            2 * admin_listeners -
             admin_conns * admin_conn_ops_max - access_log_ops_max -
             health_probe_ops_max - 1 - 1,
         conn_ops_max + 1,
@@ -826,11 +852,11 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
 }
 
 test "budgets: in-flight ops fit the completion queue with headroom" {
-    try std.testing.expect(in_flight_ops_max <= completion_queue_entries);
+    try std.testing.expect(inFlightOps(conn_slots_max, upstream_slots_max, 0) <= completion_queue_entries);
     // Headroom is deliberate: at least an eighth of the CQ stays free for
     // completion bursts even at the worst-case armed-op count (the default
     // = loosest fill the ceiling is derived at).
-    try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
+    try std.testing.expect(inFlightOps(conn_slots_max, upstream_slots_max, 0) <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
 }
 
 test "pressure: relay watermarks have a hysteresis gap at every capacity" {
@@ -902,8 +928,8 @@ test "budgets: c10k ceiling fd count needs a raised NOFILE" {
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 34406), fds_max);
-    try std.testing.expect(fds_max <= 65536);
+    try std.testing.expectEqual(@as(u32, 34407), fdsRequired(conn_slots_max, upstream_slots_max, 0));
+    try std.testing.expect(fdsRequired(conn_slots_max, upstream_slots_max, 0) <= 65536);
     // The out-of-box side of this is pinned by "the default deployment is
     // lean" below, not restated here.
 }
@@ -928,9 +954,9 @@ test "budgets: conn slots sit at the completion-queue ceiling" {
     // caps concurrent connections; conn_slots_max is the largest value
     // that still satisfies it after the parked-upstream reservation, so
     // one more slot would break the budget.
-    try std.testing.expect(in_flight_ops_max <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
+    try std.testing.expect(inFlightOps(conn_slots_max, upstream_slots_max, 0) <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
     const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
-        2 * (@as(u32, listeners_max) + admin_listeners) +
+        2 * admin_listeners +
         admin_conns * admin_conn_ops_max + access_log_ops_max +
         health_probe_ops_max + 1 + 1;
     try std.testing.expect(one_more > @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
@@ -945,8 +971,8 @@ test "budgets: a tighter cq fill trades ceiling for burst headroom" {
     // The conn-slot ceiling fits only at the max fill; one eighth tighter
     // overflows even the deepest kernel CQ — the loader must reject that
     // pairing (`cqFillFits` is the guard).
-    try std.testing.expect(cqFillFits(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_max));
-    try std.testing.expect(!cqFillFits(conn_slots_max, upstream_slots_max, listeners_max, cq_fill_eighths_max - 1));
+    try std.testing.expect(cqFillFits(conn_slots_max, upstream_slots_max, 0, cq_fill_eighths_max));
+    try std.testing.expect(!cqFillFits(conn_slots_max, upstream_slots_max, 0, cq_fill_eighths_max - 1));
     // The lean default still fits with plenty of room to spare, even at the
     // old ¾ (= 6/8) fill and at the tightest floor.
     try std.testing.expect(cqFillFits(conn_slots_default, upstream_slots_default, 1, 6));

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -216,8 +216,14 @@ pub const conn_ops_max: u32 = 4;
 /// bounds both callback batches and `Io.now_ns` staleness (§4).
 pub const loop_completions_per_tick_max: u32 = 256;
 
-/// Upper bound on configured clusters.
-pub const clusters_max: u16 = 16;
+/// The largest endpoint index a cluster may produce — the index type's
+/// edge, not a policy ceiling. `Conn.endpoint_none` is `maxInt(u16)` and
+/// must never collide with a real index, so this sits one below it. The
+/// loader rejects a cluster that would produce a larger index
+/// (`EndpointsOverLimit`) and `Conn` asserts the relationship, so the two
+/// halves are tied together by this constant rather than by two files
+/// happening to spell `maxInt(u16)` the same way.
+pub const endpoint_index_max: u16 = std.math.maxInt(u16) - 1;
 
 /// Upper bound on a cluster's name. Names are identifiers an operator
 /// writes and the access log echoes (§8), so the bound is what keeps a
@@ -228,9 +234,6 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// nowhere, so the loader rejects an empty map and the config JSON Schema
 /// emits it as `minProperties`.
 pub const clusters_min: u16 = 1;
-
-/// Upper bound on endpoints in one cluster.
-pub const endpoints_per_cluster_max: u16 = 64;
 
 /// The largest in-flight total one endpoint can ever carry (§7), and so
 /// the ceiling a configured `max_inflight` is validated against: one L7
@@ -630,8 +633,6 @@ comptime {
     assert(conn_slots_max - 1 <= std.math.maxInt(u16));
     assert(relay_buffer_bytes >= 512);
     assert(clusters_min >= 1);
-    assert(clusters_max >= clusters_min);
-    assert(endpoints_per_cluster_max >= 1);
     // The §8 cap ceiling is the largest load one endpoint can carry: one
     // L7 lease per upstream slot plus one L4 charge per conn slot, since
     // a connection of either kind holds exactly one. Asserted rather than

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -772,6 +772,17 @@ pub const PoolSizes = struct {
     /// holds for its life, and §5's promise is that the printed total
     /// covers all of that. `accessLogBytes` is the closed form.
     access_log_bytes: u64,
+    /// The endpoint-keyed tables (§7) — the pool's idle heads and lease
+    /// counts, the balancer's endpoint hashes, cursors and pick scratch,
+    /// the server's L4 charges, and the health checker's mask and two
+    /// streak counters. Startup arena memory held for the process's life,
+    /// so §5's promise covers it.
+    ///
+    /// Passed in rather than derived here because the per-entry widths
+    /// belong to those modules' element types, not to this file: computing
+    /// it from hardcoded widths would silently drift the moment one of
+    /// them changed. `Server.endpointTableBytes` is the closed form.
+    endpoint_table_bytes: u64,
 };
 
 /// What the access log reserves: nothing when it is off, both staging
@@ -808,7 +819,7 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
-        sizes.access_log_bytes;
+        sizes.access_log_bytes + sizes.endpoint_table_bytes;
     assert(total > 0);
     return total;
 }
@@ -838,6 +849,9 @@ test "budgets: memory total matches the closed form" {
     const conn_bytes: u64 = 10240;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
     const upstream_bytes: u64 = head_bytes_max + 64;
+    // The endpoint-keyed tables (§7): like the access log, a reservation
+    // that must move the total by exactly its own size and nothing else.
+    const endpoint_tables: u64 = 4096;
     // At the ceilings and at a shrunken (config-limits) shape alike, with
     // the access log on at the ceiling and off below it — the term is a
     // fixed reservation, so it must move the total by exactly its own size
@@ -845,7 +859,7 @@ test "budgets: memory total matches the closed form" {
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
-        accessLogBytes(access_log_buffer_bytes_default);
+        accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables;
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
@@ -854,6 +868,7 @@ test "budgets: memory total matches the closed form" {
         .upstream_slots = upstream_slots_max,
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(access_log_buffer_bytes_default),
+        .endpoint_table_bytes = endpoint_tables,
     }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
@@ -864,6 +879,7 @@ test "budgets: memory total matches the closed form" {
         .upstream_slots = 8,
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(0),
+        .endpoint_table_bytes = 0,
     }));
     // An unconfigured access log reserves nothing (§5), and a configured
     // one reserves both buffers at whatever size it was given — the term

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -216,9 +216,6 @@ pub const conn_ops_max: u32 = 4;
 /// bounds both callback batches and `Io.now_ns` staleness (§4).
 pub const loop_completions_per_tick_max: u32 = 256;
 
-/// Upper bound on the config file size read at startup.
-pub const config_bytes_max: u32 = 256 * 1024;
-
 /// Upper bound on configured clusters.
 pub const clusters_max: u16 = 16;
 
@@ -645,7 +642,6 @@ comptime {
     assert(endpoint_inflight_max >= upstream_slots_max);
     assert(header_edits_max >= 1);
     assert(loop_completions_per_tick_max >= 1);
-    assert(config_bytes_max >= 1024);
     assert(timeout_ms_max >= 1000);
     // The two defaulted deadlines must themselves be configs the loader
     // would accept: non-zero, and under the shared ceiling.

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -502,7 +502,7 @@ pub fn Proxy(comptime IoType: type) type {
             return server.balancer.pick(
                 conn.cluster_index,
                 &server.endpointLoad(),
-                &server.health.healthy,
+                server.health.healthy,
                 &conn.client_address,
             ) orelse {
                 respond(server, conn, 503, "l7_shed_endpoint_inflight");

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -40,7 +40,18 @@ comptime {
     // silently loses the piecewise head arrival it covers today.
     assert(inbox_bytes_default < constants.head_bytes_max);
 }
-const pending_ops_max: u32 = constants.in_flight_ops_max;
+/// The simulator's own in-flight-op bound (§9), derived from *its*
+/// listener limit rather than production's — which no longer has one, so
+/// there is no `constants.in_flight_ops_max` left to borrow. SimIo
+/// already keeps a `listeners_max` of its own for the same reason: it is
+/// a test double whose bounds describe what the simulator drives, not
+/// what a deployment may configure. At the shared pool ceilings this is
+/// at least what any scenario can arm.
+const pending_ops_max: u32 = constants.inFlightOps(
+    constants.conn_slots_max,
+    constants.upstream_slots_max,
+    listeners_max,
+);
 const pending_signals_max: u8 = 8;
 /// The clock starts at one virtual second, not zero, so code that would
 /// misbehave at t=0 gets caught.

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -70,7 +70,28 @@ const ListenerEntry = struct {
 /// `cq_entries` is the completion-queue depth to request for this
 /// deployment (`constants.completionQueueDepthFor` of the effective config,
 /// §8) — the io_uring backend sizes its ring to it; other backends ignore it.
-pub fn init(io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
+pub fn init(
+    io: *XevIo,
+    arena: std.mem.Allocator,
+    cq_entries: u32,
+    /// Configured data-path listeners — the config's own count, *not*
+    /// including the admin listener (§5). There is no compiled ceiling to
+    /// size this against any more.
+    ///
+    /// The admin reservation is added here rather than asked of the
+    /// caller, the same way `fdsRequired`, `inFlightOps` and
+    /// `completionQueueDepthFor` all fold in `admin_listeners`
+    /// internally. That is not tidiness: sizing this array to exactly the
+    /// configured count leaves `Admin.start` — which binds through this
+    /// same `listen` — with nowhere to go, and it fails as
+    /// `AddressUnavailable`, which reads as a bad bind rather than a full
+    /// table. Every admin-enabled deployment hits it, and nothing in the
+    /// test suite would: `Server(XevIo)` is instantiated only by main.
+    configured_listeners: u32,
+) !void {
+    assert(configured_listeners <= std.math.maxInt(u16) - constants.admin_listeners);
+    const listeners = configured_listeners + constants.admin_listeners;
+    assert(listeners >= 1);
     if (comptime needs_thread_pool) {
         io.thread_pool = xev.ThreadPool.init(.{});
     }
@@ -87,7 +108,7 @@ pub fn init(io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
     errdefer io.notifier.deinit();
     io.timer = try xev.Timer.init();
     errdefer io.timer.deinit();
-    io.listeners = try arena.alloc(ListenerEntry, constants.listeners_max);
+    io.listeners = try arena.alloc(ListenerEntry, listeners);
     io.listeners_count = 0;
     io.last_pressure = Io.Pressure.none;
     io.notifier_completion = .{};
@@ -176,8 +197,8 @@ pub fn deinit(io: *XevIo) void {
 }
 
 pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener {
-    assert(io.listeners_count <= constants.listeners_max);
-    if (io.listeners_count == constants.listeners_max) {
+    assert(io.listeners_count <= io.listeners.len);
+    if (io.listeners_count == io.listeners.len) {
         return error.AddressUnavailable;
     }
     const tcp = xev.TCP.init(address) catch return error.Unexpected;

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -66,11 +66,16 @@ const init_attempts_max: u8 = 5;
 /// failed about half its runs at around the tenth. A bounded retry
 /// with a short pause is the honest answer to a transient; production
 /// creates one ring at startup and must keep failing loudly.
+/// `listeners_reserved` is what the old `listeners_max` used to supply
+/// implicitly: contract tests bind a handful of sockets, so a small fixed
+/// reservation covers every scenario here.
+const listeners_reserved: u32 = 8;
+
 fn initTestIo(xev_io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
     var attempt: u8 = 1;
     while (true) : (attempt += 1) {
         assert(attempt <= init_attempts_max);
-        if (XevIo.init(xev_io, arena, cq_entries)) |_| {
+        if (XevIo.init(xev_io, arena, cq_entries, listeners_reserved)) |_| {
             return;
         } else |err| {
             if (err != error.SystemResources) return err;
@@ -774,4 +779,31 @@ test "xevio: canceling a stuck dial delivers Canceled and releases the op" {
     try std.testing.expect(canceled);
     const result = outcome orelse return error.ConnectNeverCompleted;
     try std.testing.expectError(error.Canceled, result);
+}
+
+test "xevio: the listener table reserves a slot for the admin listener" {
+    // Regression for slice 4 of the operator-sized-limits change, which
+    // sized this table to exactly the *configured* listener count. The
+    // admin listener binds through the same `listen`, so every
+    // admin-enabled deployment failed to start with `AddressUnavailable`
+    // — a full table reported as a bad address. Nothing caught it:
+    // `Server(XevIo)` is instantiated only by main.zig, and admin_test
+    // runs over SimIo.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var xev_io: XevIo = undefined;
+    // One configured listener; capacity must be that plus the admin slot.
+    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1);
+    defer xev_io.deinit();
+
+    const loopback = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0");
+    const configured = try xev_io.listen(loopback);
+    _ = configured;
+    // The admin listener: this is the bind that used to fail.
+    const admin = try xev_io.listen(loopback);
+    _ = admin;
+
+    // And the reservation is exactly one — not open-ended.
+    try std.testing.expectError(error.AddressUnavailable, xev_io.listen(loopback));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -297,6 +297,7 @@ fn printBudgets(
         @intCast(config.listeners.len),
     );
     const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
+    const endpoint_stride = ServerXev.endpointKeysFor(config).stride;
     // §5's promise is that the printed total covers everything this
     // process holds for its life. The config arena qualifies — it is
     // never freed — so it joins the total even though it is the one term
@@ -309,6 +310,7 @@ fn printBudgets(
         .upstream_slots = limits.upstream_slots,
         .upstream_bytes = @sizeOf(UpstreamType),
         .access_log_bytes = access_log_bytes,
+        .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
     }) + config_arena_bytes;
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
@@ -320,6 +322,7 @@ fn printBudgets(
         \\budgets (closed-form, DESIGN.md §5/§8):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + access log {d} KiB
+        \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
         \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
@@ -336,6 +339,9 @@ fn printBudgets(
         limits.upstream_slots,
         @sizeOf(UpstreamType),
         access_log_bytes / 1024,
+        ServerXev.endpointTableBytes(config),
+        config.clusters.len,
+        endpoint_stride,
         config_arena_bytes / 1024,
         fds_required,
         constants.ring_entries,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,6 @@
 //! zoxy startup (DESIGN.md §5, §8): read config into the arena (the only
 //! allocating region), resolve it, verify the fd budget against
-//! RLIMIT_NOFILE, print the closed-form budgets, install signal handlers
+//! RLIMIT_NOFILE, print the budgets, install signal handlers
 //! (the only raw syscall surface outside src/io/, held to the rlimit and
 //! sigaction allowlist by lint), then hand the process to the event loop
 //! until a drain completes. `--help` and `--version` are answered before any
@@ -107,12 +107,12 @@ pub fn main(init: std.process.Init) !void {
     );
     // The effective config never exceeds the compiled ceilings (§8): the
     // pools, the ring, and the fd demand all fit what the constants proved.
-    assert(fds_required <= zoxy.constants.fds_max);
+
     assert(cq_entries <= zoxy.constants.completion_queue_entries);
     try ensureFdBudget(fds_required);
     try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
 
-    try global_io.init(arena, cq_entries);
+    try global_io.init(arena, cq_entries, listeners_count);
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
     try server.start();
@@ -319,7 +319,7 @@ fn printBudgets(
     // and `--version` is what it does not think to run.
     try writer.print(
         \\zoxy {s}{s}
-        \\budgets (closed-form, DESIGN.md §5/§8):
+        \\budgets (DESIGN.md §5/§8; closed-form except where marked):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,19 +83,12 @@ pub fn main(init: std.process.Init) !void {
         },
     };
 
-    const config_bytes = std.Io.Dir.cwd().readFileAlloc(
-        init.io,
-        config_path,
-        arena,
-        .limited(zoxy.constants.config_bytes_max),
-    ) catch |err| {
-        std.debug.print("zoxy: cannot read config '{s}': {t}\n", .{ config_path, err });
-        return err;
-    };
-    const config = zoxy.config.parse(arena, config_bytes) catch |err| {
-        std.debug.print("zoxy: invalid config '{s}': {t}\n", .{ args[1], err });
-        return err;
-    };
+    // Measured across the read, not assumed from the file size: the
+    // parse allocates its own structures beside the text it parses, and
+    // both live in the arena for the process's life (§5).
+    const arena_before = init.arena.queryCapacity();
+    const config = try readConfig(init.io, arena, config_path);
+    const config_arena_bytes = init.arena.queryCapacity() - arena_before;
 
     // fds and the ring are sized to the *effective* config, not the
     // compiled ceilings (§5, §8): a lean deployment neither demands the
@@ -117,7 +110,7 @@ pub fn main(init: std.process.Init) !void {
     assert(fds_required <= zoxy.constants.fds_max);
     assert(cq_entries <= zoxy.constants.completion_queue_entries);
     try ensureFdBudget(fds_required);
-    try printBudgets(init.io, &config, fds_required, cq_entries);
+    try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
 
     try global_io.init(arena, cq_entries);
     var server: ServerXev = undefined;
@@ -131,6 +124,44 @@ pub fn main(init: std.process.Init) !void {
     assert(server.isIdle());
     const gauges = server.gauges();
     server.counters.dump(&gauges);
+}
+
+/// Read and parse the config file, or say on stderr why it cannot be.
+///
+/// The read is deliberately unlimited. The config is operator-provided
+/// at startup rather than attacker-controlled input, and its size is now
+/// the operator's own statement of how much startup arena this
+/// deployment should cost (§5) — there is no constant left to check it
+/// against, and none that could be justified.
+///
+/// What that trades away is worth stating plainly: a fixed cap failed a
+/// too-large file deterministically, and this does not. The arena runs
+/// over `std.heap.page_allocator`, so under Linux's default heuristic
+/// overcommit a large request can succeed at `mmap` and only fail as the
+/// read faults pages in — where the kernel's OOM killer, not a returned
+/// `OutOfMemory`, is what intervenes. The guarantee is therefore "the
+/// operator is told what their config cost" (the caller measures the
+/// arena across this call and the startup banner prints it), not "an
+/// oversized config is refused cleanly".
+fn readConfig(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    config_path: []const u8,
+) !zoxy.config.Config {
+    assert(config_path.len >= 1);
+    const config_bytes = std.Io.Dir.cwd().readFileAlloc(
+        io,
+        config_path,
+        arena,
+        .unlimited,
+    ) catch |err| {
+        std.debug.print("zoxy: cannot read config '{s}': {t}\n", .{ config_path, err });
+        return err;
+    };
+    return zoxy.config.parse(arena, config_bytes) catch |err| {
+        std.debug.print("zoxy: invalid config '{s}': {t}\n", .{ config_path, err });
+        return err;
+    };
 }
 
 /// What the command line asked for: run against a config, or one of the
@@ -248,6 +279,11 @@ fn printBudgets(
     config: *const zoxy.config.Config,
     fds_required: u32,
     cq_entries: u32,
+    /// What the config text and its parsed structures took from the
+    /// startup arena, measured (§5). Not closed-form like the pools —
+    /// it is whatever the operator's config file needed — which is
+    /// exactly why it is reported rather than derived.
+    config_arena_bytes: u64,
 ) !void {
     const constants = zoxy.constants;
     const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
@@ -261,6 +297,10 @@ fn printBudgets(
         @intCast(config.listeners.len),
     );
     const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
+    // §5's promise is that the printed total covers everything this
+    // process holds for its life. The config arena qualifies — it is
+    // never freed — so it joins the total even though it is the one term
+    // measured rather than derived from constants.
     const memory_total = constants.memoryBytesTotal(&.{
         .conn_slots = limits.conn_slots,
         .conn_bytes = @sizeOf(ServerXev.ConnType),
@@ -269,7 +309,7 @@ fn printBudgets(
         .upstream_slots = limits.upstream_slots,
         .upstream_bytes = @sizeOf(UpstreamType),
         .access_log_bytes = access_log_bytes,
-    });
+    }) + config_arena_bytes;
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;
@@ -280,6 +320,7 @@ fn printBudgets(
         \\budgets (closed-form, DESIGN.md §5/§8):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + access log {d} KiB
+        \\          + config arena {d} KiB (measured, not closed-form)
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
         \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
         \\  config  {d} listener(s), {d} cluster(s), access log {s}
@@ -295,6 +336,7 @@ fn printBudgets(
         limits.upstream_slots,
         @sizeOf(UpstreamType),
         access_log_bytes / 1024,
+        config_arena_bytes / 1024,
         fds_required,
         constants.ring_entries,
         cq_entries,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -171,12 +171,19 @@ pub const LogState = struct {
     path: [constants.access_log_path_bytes_max]u8 = undefined,
 
     /// No endpoint has been picked. `maxInt` rather than a separate flag:
-    /// the pool's own ceiling is asserted below `maxInt(u16)`, so the
-    /// sentinel can never collide with a real index.
+    /// the loader rejects a cluster declaring more than `maxInt(u16)`
+    /// endpoints (`EndpointsOverLimit`), so a real index stops at
+    /// `maxInt(u16) - 1` and the sentinel can never collide with one.
+    /// That bound used to be `endpoints_per_cluster_max`; with the policy
+    /// ceiling gone, the index type is what is left holding it up.
     pub const endpoint_none: u16 = std.math.maxInt(u16);
 
     comptime {
-        assert(constants.endpoints_per_cluster_max < endpoint_none);
+        // A relationship, not a restatement: the loader bounds real
+        // indices by `endpoint_index_max`, and this is what makes that
+        // bound the right one. Widening either past the other is a
+        // compile error rather than a sentinel that means two things.
+        assert(constants.endpoint_index_max < endpoint_none);
     }
 
     /// Start a fresh request's accounting. Only the scalars: the three

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -46,15 +46,15 @@ pub fn Checker(comptime IoType: type) type {
 
     return struct {
         server: *ServerType,
-        /// The §7 balancing mask, indexed by `upstream.endpointKey`. All
+        /// The §7 balancing mask, indexed by `upstream.EndpointKeys`. All
         /// true at start; only probed (checked) endpoints ever flip.
-        healthy: [upstream.endpoint_keys_max]bool,
+        healthy: []bool,
         /// Consecutive failed probes toward `health_probe_fall`; tracked
         /// only while the endpoint is healthy, reset by any pass.
-        fail_streaks: [upstream.endpoint_keys_max]u8,
+        fail_streaks: []u8,
         /// Consecutive passed probes toward `health_probe_rise`; tracked
         /// only while the endpoint is ejected, reset by any fail.
-        ok_streaks: [upstream.endpoint_keys_max]u8,
+        ok_streaks: []u8,
         /// Endpoints under checks — static after `init` (the sum of
         /// `endpoints.len` over every `check` cluster); zero leaves the
         /// prober `.off` forever.
@@ -143,11 +143,20 @@ pub fn Checker(comptime IoType: type) type {
             _pad: u2 = 0,
         };
 
-        pub fn init(checker: *Self, server: *ServerType) void {
+        pub fn init(
+            checker: *Self,
+            arena: std.mem.Allocator,
+            server: *ServerType,
+            keys: upstream.EndpointKeys,
+        ) error{OutOfMemory}!void {
+            assert(keys.count >= 1);
             checker.server = server;
-            @memset(&checker.healthy, true);
-            @memset(&checker.fail_streaks, 0);
-            @memset(&checker.ok_streaks, 0);
+            checker.healthy = try arena.alloc(bool, keys.count);
+            checker.fail_streaks = try arena.alloc(u8, keys.count);
+            checker.ok_streaks = try arena.alloc(u8, keys.count);
+            @memset(checker.healthy, true);
+            @memset(checker.fail_streaks, 0);
+            @memset(checker.ok_streaks, 0);
             checker.checked_count = 0;
             checker.unhealthy_count = 0;
             checker.state = .off;
@@ -169,13 +178,17 @@ pub fn Checker(comptime IoType: type) type {
             checker.op_cancel = .{};
             const clusters = server.config.clusters;
             assert(clusters.len >= 1);
-            assert(clusters.len <= constants.clusters_max);
+            // Same pairing check the balancer makes: `keys` must describe
+            // this config, or the mask is sized for one shape and indexed
+            // for another. `clusters.len <= healthy.len` does *not* say
+            // that — it holds for any `stride >= 1`.
+            assert(keys.count == @as(u32, @intCast(clusters.len)) * keys.stride);
             for (clusters) |cluster| {
                 if (cluster.check != null) {
                     checker.checked_count += @intCast(cluster.endpoints.len);
                 }
             }
-            assert(checker.checked_count <= upstream.endpoint_keys_max);
+            assert(checker.checked_count <= checker.healthy.len);
             assert(checker.armedCount() == 0);
         }
 
@@ -626,7 +639,7 @@ pub fn Checker(comptime IoType: type) type {
         fn witnessPass(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
             const rise = checker.checkOf(cluster_index).rise;
             assert(rise >= 1);
-            const key = upstream.endpointKey(cluster_index, endpoint_index);
+            const key = checker.server.upstreams.keys.key(cluster_index, endpoint_index);
             checker.fail_streaks[key] = 0;
             if (checker.healthy[key]) {
                 assert(checker.ok_streaks[key] == 0);
@@ -646,7 +659,7 @@ pub fn Checker(comptime IoType: type) type {
             const fall = checker.checkOf(cluster_index).fall;
             assert(fall >= 1);
             checker.server.counters.increment("health_probes_failed");
-            const key = upstream.endpointKey(cluster_index, endpoint_index);
+            const key = checker.server.upstreams.keys.key(cluster_index, endpoint_index);
             checker.ok_streaks[key] = 0;
             // Already ejected: nothing further to count — streaks resume
             // meaning only once a pass starts a recovery.
@@ -669,7 +682,7 @@ pub fn Checker(comptime IoType: type) type {
         fn closeParked(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
             // Only an ejection reaches here: the endpoint was just marked
             // unhealthy by the caller.
-            assert(!checker.healthy[upstream.endpointKey(cluster_index, endpoint_index)]);
+            assert(!checker.healthy[checker.server.upstreams.keys.key(cluster_index, endpoint_index)]);
             const server = checker.server;
             const capacity = server.upstreams.capacity();
             var reaped: u32 = 0;

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -25,7 +25,7 @@ const idle_none: u32 = std.math.maxInt(u32);
 /// Seven tables are keyed by it — the pool's idle heads and lease
 /// counts, the balancer's cursors-adjacent endpoint hashes, the server's
 /// L4 in-flight charges, and the health checker's mask and two streak
-/// counters. All were `clusters_max × endpoints_per_cluster_max` fixed
+/// counters. All were fixed 16 × 64 = 1024-entry
 /// arrays sized for the worst config any build could accept; they are
 /// now sized for the config this process actually loaded, so a
 /// two-endpoint deployment stops carrying a 1024-entry table.

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -20,22 +20,60 @@ const assert = std.debug.assert;
 /// `idle_next`/`idle_prev`/`idle_heads` value marking "no slot".
 const idle_none: u32 = std.math.maxInt(u32);
 
-/// Idle lists are indexed by the flattened endpoint key, so the head
-/// array covers the worst-case config shape.
-pub const endpoint_keys_max: u32 =
-    @as(u32, constants.clusters_max) * constants.endpoints_per_cluster_max;
+/// The flattened endpoint index space for one loaded config (§7).
+///
+/// Seven tables are keyed by it — the pool's idle heads and lease
+/// counts, the balancer's cursors-adjacent endpoint hashes, the server's
+/// L4 in-flight charges, and the health checker's mask and two streak
+/// counters. All were `clusters_max × endpoints_per_cluster_max` fixed
+/// arrays sized for the worst config any build could accept; they are
+/// now sized for the config this process actually loaded, so a
+/// two-endpoint deployment stops carrying a 1024-entry table.
+///
+/// `stride` is the widest cluster in the config rather than each
+/// cluster's own length, which wastes `stride - len` entries per
+/// cluster. That buys a multiply instead of a per-cluster offset lookup
+/// on the pick path, and the waste is bounded by the config the operator
+/// wrote — the same trade the fixed arrays made, minus the part that had
+/// nothing to do with this deployment.
+pub const EndpointKeys = struct {
+    /// Entries per cluster: the largest endpoint count any one cluster
+    /// declares. At least 1, so a key is always addressable.
+    stride: u16,
+    /// `clusters × stride` — the length every endpoint-keyed table has.
+    count: u32,
+
+    pub fn init(cluster_count: u16, stride: u16) EndpointKeys {
+        assert(cluster_count >= 1);
+        assert(stride >= 1);
+        const count = @as(u32, cluster_count) * stride;
+        assert(count >= 1);
+        return .{ .stride = stride, .count = count };
+    }
+
+    pub fn key(keys: EndpointKeys, cluster_index: u16, endpoint_index: u16) u32 {
+        assert(keys.stride >= 1);
+        assert(endpoint_index < keys.stride);
+        const flat = @as(u32, cluster_index) * keys.stride + endpoint_index;
+        assert(flat < keys.count);
+        return flat;
+    }
+};
 
 pub fn UpstreamPool(comptime IoType: type) type {
     return struct {
         slot_pool: Pool(Upstream),
-        idle_heads: [endpoint_keys_max]u32,
+        /// The config's endpoint index space; every table below has
+        /// `keys.count` entries.
+        keys: EndpointKeys,
+        idle_heads: []u32,
         /// Parked slots across all endpoints; leased = acquired − idle.
         idle_count: u32,
         /// Slots leased per endpoint — the §7 P2C load signal: a lease
         /// is a request in flight against that endpoint, so the balancer
         /// compares two candidates' counts and picks the calmer one.
         /// u16 holds the whole pool (`upstream_slots_max` ≤ 65535).
-        leased_counts: [endpoint_keys_max]u16,
+        leased_counts: []u16,
 
         const Self = @This();
 
@@ -73,13 +111,20 @@ pub fn UpstreamPool(comptime IoType: type) type {
             pool: *Self,
             arena: std.mem.Allocator,
             count: u32,
+            keys: EndpointKeys,
         ) error{OutOfMemory}!void {
             assert(count >= 1);
+            assert(keys.count >= 1);
             try pool.slot_pool.init(arena, count);
-            @memset(&pool.idle_heads, idle_none);
+            pool.keys = keys;
+            pool.idle_heads = try arena.alloc(u32, keys.count);
+            pool.leased_counts = try arena.alloc(u16, keys.count);
+            @memset(pool.idle_heads, idle_none);
             pool.idle_count = 0;
-            @memset(&pool.leased_counts, 0);
+            @memset(pool.leased_counts, 0);
             assert(pool.slot_pool.slots.len == count);
+            assert(pool.idle_heads.len == keys.count);
+            assert(pool.leased_counts.len == keys.count);
             assert(pool.leasedCount() == 0);
         }
 
@@ -87,8 +132,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
         /// pool is exhausted — the caller sheds (§8: 503). The socket is
         /// left undefined for the dialer to fill in.
         pub fn acquire(pool: *Self, cluster_index: u16, endpoint_index: u16) ?*Upstream {
-            assert(cluster_index < constants.clusters_max);
-            assert(endpoint_index < constants.endpoints_per_cluster_max);
+            assert(endpoint_index < pool.keys.stride);
             const upstream = pool.slot_pool.acquire() orelse return null;
             upstream.cluster_index = cluster_index;
             upstream.endpoint_index = endpoint_index;
@@ -97,7 +141,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.idle_prev = idle_none;
             upstream.head_len = 0;
             upstream.deadline_ns = 0;
-            const key = endpointKey(cluster_index, endpoint_index);
+            const key = pool.keys.key(cluster_index, endpoint_index);
             pool.leased_counts[key] += 1;
             assert(pool.leased_counts[key] <= pool.slot_pool.slots.len);
             assert(pool.idle_count < pool.slot_pool.acquired_count);
@@ -112,7 +156,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             assert(upstream.idle_next == idle_none);
             assert(upstream.idle_prev == idle_none);
             const index = pool.slot_pool.indexOf(upstream);
-            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+            const key = pool.keys.key(upstream.cluster_index, upstream.endpoint_index);
 
             upstream.idle_next = pool.idle_heads[key];
             if (upstream.idle_next != idle_none) {
@@ -131,9 +175,9 @@ pub fn UpstreamPool(comptime IoType: type) type {
         /// The most recently parked connection for the endpoint, leased
         /// again — or null, and the caller dials fresh via `acquire`.
         pub fn checkout(pool: *Self, cluster_index: u16, endpoint_index: u16) ?*Upstream {
-            assert(cluster_index < constants.clusters_max);
-            assert(endpoint_index < constants.endpoints_per_cluster_max);
-            const key = endpointKey(cluster_index, endpoint_index);
+            assert(endpoint_index < pool.keys.stride);
+
+            const key = pool.keys.key(cluster_index, endpoint_index);
             const head = pool.idle_heads[key];
             if (head == idle_none) {
                 return null;
@@ -153,7 +197,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             assert(upstream.parked);
             assert(pool.idle_count >= 1);
             const index = pool.slot_pool.indexOf(upstream);
-            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+            const key = pool.keys.key(upstream.cluster_index, upstream.endpoint_index);
 
             if (upstream.idle_prev == idle_none) {
                 assert(pool.idle_heads[key] == index);
@@ -181,7 +225,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             assert(!upstream.parked);
             assert(upstream.idle_next == idle_none);
             assert(upstream.idle_prev == idle_none);
-            const key = endpointKey(upstream.cluster_index, upstream.endpoint_index);
+            const key = pool.keys.key(upstream.cluster_index, upstream.endpoint_index);
             assert(pool.leased_counts[key] >= 1);
             pool.leased_counts[key] -= 1;
             pool.slot_pool.release(upstream);
@@ -216,14 +260,6 @@ pub fn UpstreamPool(comptime IoType: type) type {
     };
 }
 
-/// Flattened per-endpoint key into `idle_heads`/`leased_counts`. Public so
-/// the balancer indexes the same load table the pool maintains (§7 P2C).
-pub fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
-    assert(cluster_index < constants.clusters_max);
-    assert(endpoint_index < constants.endpoints_per_cluster_max);
-    return @as(u32, cluster_index) * constants.endpoints_per_cluster_max + endpoint_index;
-}
-
 /// How much work an endpoint is carrying right now, across both
 /// protocols (§7). Two tables rather than one running total, because
 /// each has its own provable bound and its own single writer: the pool
@@ -243,14 +279,17 @@ pub fn endpointKey(cluster_index: u16, endpoint_index: u16) u32 {
 /// reached by both an `l4` and an `http` listener is representable, and
 /// there the total is that mixed unit.
 pub const Load = struct {
-    l7: *const [endpoint_keys_max]u16,
-    l4: *const [endpoint_keys_max]u16,
+    /// Both tables have `EndpointKeys.count` entries, which is why the
+    /// bound below is read off the slice rather than a constant.
+    l7: []const u16,
+    l4: []const u16,
 
     /// Total in-flight work against one endpoint. `u32` because the two
     /// ceilings sum past a `u16`'s range in principle, even though no
     /// single deployment reaches both at once.
     pub fn inFlight(load: *const Load, key: u32) u32 {
-        assert(key < endpoint_keys_max);
+        assert(load.l7.len == load.l4.len);
+        assert(key < load.l7.len);
         return @as(u32, load.l7[key]) + load.l4[key];
     }
 };
@@ -264,11 +303,16 @@ const TestIo = struct {
 
 const TestPool = UpstreamPool(TestIo);
 
+/// A deliberately ragged test index space — 4 clusters of up to 8
+/// endpoints — so a key is never accidentally equal to its endpoint
+/// index and a stride bug cannot pass unnoticed.
+const test_keys: EndpointKeys = .init(4, 8);
+
 test "upstream: dial-park-checkout-release keeps the same connection" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 4);
+    try pool.init(arena_state.allocator(), 4, test_keys);
 
     const dialed = pool.acquire(0, 0).?;
     dialed.socket = 77;
@@ -294,7 +338,7 @@ test "upstream: checkout is LIFO per endpoint" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 4);
+    try pool.init(arena_state.allocator(), 4, test_keys);
 
     const first = pool.acquire(0, 0).?;
     const second = pool.acquire(0, 0).?;
@@ -314,7 +358,7 @@ test "upstream: endpoints do not share idle connections" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 4);
+    try pool.init(arena_state.allocator(), 4, test_keys);
 
     const parked = pool.acquire(1, 2).?;
     pool.park(parked);
@@ -332,7 +376,7 @@ test "upstream: unpark removes from the middle of an idle list" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 4);
+    try pool.init(arena_state.allocator(), 4, test_keys);
 
     const first = pool.acquire(0, 0).?;
     const second = pool.acquire(0, 0).?;
@@ -360,7 +404,7 @@ test "upstream: exhaustion is a shed signal, parked slots stay counted" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 2);
+    try pool.init(arena_state.allocator(), 2, test_keys);
 
     const first = pool.acquire(0, 0).?;
     const second = pool.acquire(0, 1).?;
@@ -382,9 +426,9 @@ test "upstream: leased counts track every lease transition per endpoint" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 4);
-    const key_a = endpointKey(0, 0);
-    const key_b = endpointKey(0, 1);
+    try pool.init(arena_state.allocator(), 4, test_keys);
+    const key_a = test_keys.key(0, 0);
+    const key_b = test_keys.key(0, 1);
 
     // Fresh dials lease against their own endpoints.
     const first = pool.acquire(0, 0).?;
@@ -424,7 +468,7 @@ test "upstream: zero allocations after init" {
     var arena_state = std.heap.ArenaAllocator.init(failing.allocator());
     defer arena_state.deinit();
     var pool: TestPool = undefined;
-    try pool.init(arena_state.allocator(), 8);
+    try pool.init(arena_state.allocator(), 8, test_keys);
     const allocations_after_init = failing.allocations;
 
     var cycle: u32 = 0;

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -43,7 +43,7 @@ pub const Scenario = struct {
 
     fn sampleL4Charge(context: ?*anyopaque) void {
         const scenario: *Scenario = @ptrCast(@alignCast(context.?));
-        scenario.l4_sample = scenario.server.l4_inflight[upstream_module.endpointKey(0, 0)];
+        scenario.l4_sample = scenario.server.l4_inflight[scenario.server.upstreams.keys.key(0, 0)];
     }
 
     fn clientEnded(scenario: *Scenario) void {
@@ -1043,7 +1043,7 @@ test "relay: an L4 connection charges its endpoint, and gives it back" {
     // file and every sim seed (§9).
     try std.testing.expectEqual(
         @as(u16, 0),
-        bed.server.l4_inflight[upstream_module.endpointKey(0, 0)],
+        bed.server.l4_inflight[bed.server.upstreams.keys.key(0, 0)],
     );
     try bed.expectDrained();
 }


### PR DESCRIPTION
Removes eight compile-time ceilings so a config's shape is bounded by what the operator writes and by what the ring and fd budgets admit at load, not by numbers chosen on their behalf at build time.

`routes_max` (32), `filters_per_listener_max` (32), `actions_per_filter_max` (8), `header_matches_per_filter_max` (8), `config_bytes_max` (256 KiB), `clusters_max` (16), `endpoints_per_cluster_max` (64), `listeners_max` (8).

## The measurement that reframes it

They were a **capability wall, not a memory cost**. A `@sizeOf` probe against the pre-change tree:

| struct | before | after | saved |
|---|---|---|---|
| `UpstreamPool` | 6,184 B | 80 B | 6,104 |
| `Balancer` | 8,336 B | 72 B | 8,264 |
| `Checker` | 12,320 B | 9,296 B | 3,024 |
| **`Server`** (contains all three + `l4_inflight`) | **36,160 B** | **16,736 B** | **19,424 B** |

19,424 bytes per process — **0.055%** of the 35,060 KiB the binary prints. Anyone expecting reclaimed memory should read that number first. What this actually buys is that 16 clusters, 64 endpoints, 32 routes, 32 filters and 8 listeners stop being walls no price could pass. Verified end to end: 20 clusters x 100 endpoints, and 32 listeners, all start and serve.

## The invariant this spends

`listeners_max` was not a config-shape cap at all — it was a term in the derivation of `conn_slots_max`, `completion_queue_entries`, `fds_max` and `in_flight_ops_max`. Removing it deletes the last two and moves their checks to load:

- `assert(in_flight_ops_max <= completion_queue_entries)` -> `cqFillFits` (`LimitConnSlotsOverCqFill`, which already ran there)
- `assert(fds_required <= fds_max)` -> `ensureFdBudget` against `RLIMIT_NOFILE`

`conn_slots_max` moves 11463 -> 11466: the fixed-op reservation drops to the admin listener's 2, so the ceiling is stated at *zero* configured listeners and each one a config declares spends from the same budget.

DESIGN.md §5 and CLAUDE.md now state the split rather than claiming budgets are flatly comptime-asserted: **comptime where a budget is a property of one constant, refused at startup where it is a property of a combination the config chooses.** That is the exact narrowing the "Pool ceilings" open question predicted; that question is updated, since the price it listed is now paid.

This trade was taken deliberately after costing the alternative (raise to 64, keep everything comptime, lose 22 conn slots).

## What a ceiling was quietly holding up

The recurring hazard, and why every slice took a review — a ceiling does load-bearing work far from where it is declared:

- **`keys_seen_max = 4096`**, a loop backstop sitting *above* `clusters_max`. Left in place it would have become the new cluster limit — an undocumented wall replacing a documented one.
- **Two O(n²) scans** (duplicate cluster names, duplicate listener binds). Harmless at 16 and 8 (~120 and ~64 compares); ~2.1e9 and ~8e8 compares once the ceilings went — minutes of startup for configs whose *memory* fits easily. Both are sorted-neighbour compares now.
- **The admin listener.** `XevIo`'s listener table had been sized by `listeners_max`, silently covering `Admin.start` binding through the same `listen`. Sizing it to the configured count made **every admin-enabled deployment fail at startup** with `AddressUnavailable` — a full table reported as a bad address. Reproduced against the real binary. The suite could not catch it: `Server(XevIo)` is instantiated only by main.zig and `admin_test` runs over SimIo. `init` now folds in `admin_listeners` itself, and a contract test locks it.
- **The §5 budget promise, broken twice.** Removing `config_bytes_max` left the config arena unbounded *and* unreported; the endpoint tables then did it again by allocating after `printBudgets` ran. Both are now printed terms — the arena measured, the tables closed-form via `Server.endpointTableBytes`.

Every one of these was found by `tiger-style-reviewer` on the slice's own diff. `zig build ci` was green for all of them.

## What stays, and the rule

Type-width guards stay: `Conn.endpoint_none` is `maxInt(u16)`, so `constants.endpoint_index_max` bounds real indices and `Conn` asserts the relationship. `header_edits_max` stays too, and it illustrates the rule the whole change turns on:

> A limit that sizes a fixed buffer must precede the config. A limit that only gates a config need not exist.

Out of scope: the `conn_slots_max`/`upstream_slots_max` pair (still the "Pool ceilings" open question, though it no longer has an invariant to spend), and the head-buffer work in #162.

## Slices

| | |
|---|---|
| `7e194f6` | four caps that bounded nothing — routes, filters, actions, header matches |
| `ec524a1` | §7 docs for the above |
| `5f81788` | `config_bytes_max`; the config arena becomes a measured budget term |
| `10205eb` | `EndpointKeys` — seven tables sized from the config |
| `77c8bb9` | `clusters_max`, `endpoints_per_cluster_max` |
| `a991db6` | `listeners_max`; ring/fd fit moves to startup |
| `25e1d3a` | IMPLEMENTATION_NOTES record + Pool-ceilings update |

## Gates

`zig build ci` green at every slice (4096 sim seeds), `zig fmt --check` clean, `tiger-style-reviewer` run per slice with all findings addressed. Smoke-tested against the real binary: default config, 20x100 clusters/endpoints, 32 listeners, and admin enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)