### PR TITLE
Head buffers leave the slots: the §5 ring, the upstream pool, and the size knob (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,10 @@ reserves nor demands the ceiling's resources.
 "limits": {
     "conn_slots": 4096,
     "relay_buffers": 4096,
-    "upstream_slots": 4096
+    "upstream_slots": 4096,
+    "head_buffers": 1024,
+    "upstream_head_buffers": 512,
+    "head_buffer_bytes": 16384
 }
 ```
 
@@ -353,6 +356,15 @@ pairs, 1313 upstream slots, roughly 34 MiB of pools — sized to start under a
 stock 4096 `RLIMIT_NOFILE`. The ceiling is 11466 of each. Raising the pools
 raises the file-descriptor demand, which zoxy asserts against `RLIMIT_NOFILE`
 at startup rather than discovering as `EMFILE` later.
+
+`head_buffers` and `upstream_head_buffers` bound *request heads in flight*
+rather than open connections: idle keep-alive connections and parked origin
+connections hold no head buffer, so these default to their never-shedding
+ceilings (`conn_slots` and `upstream_slots`) and are the knobs a keep-alive-
+heavy deployment trades down for memory. `head_buffer_bytes` sizes every head
+buffer and is therefore the largest HTTP head accepted (oversize requests are
+answered `414`/`431`) — raise it for big-cookie/JWT traffic, 1 KiB to 1 MiB,
+default 8 KiB.
 
 `cq_fill_eighths` trades connection ceiling for `io_uring` completion-queue
 burst headroom; `access_log_buffer_bytes` sizes the access log's staging

--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -43,9 +43,9 @@ const no_edits: []const zoxy.http.filter.AppliedHeaderEdit = &.{};
 pub fn main() void {
     var request_storage: parser.HeaderStorage = undefined;
     var response_storage: parser.HeaderStorage = undefined;
-    var path_scratch: [zoxy.constants.head_bytes_max]u8 = undefined;
-    var upstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
-    var downstream_head: [zoxy.constants.head_bytes_max]u8 = undefined;
+    var path_scratch: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
+    var upstream_head: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
+    var downstream_head: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
 
     var checksum: u64 = 0;
     var index: u64 = 0;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,11 +43,10 @@
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
         //
-        // Re-audit for 24da6d0 (§4, §5's head-buffer ring) — PENDING:
-        // zoxy-io/libxev#3 is open, and the PR that carries this pin stays
-        // a draft until that sign-off lands; what follows is the diff
-        // summary the audit reviews, not a record of one already done.
-        // One backend op
+        // Re-audit for 24da6d0 (§4, §5's head-buffer ring), signed off
+        // 2026-08-02 against zoxy-io/libxev#3 (standing open like the rest
+        // of the stack — the PR is the audit vehicle, the pin is the
+        // record). One backend op
         // (`recv_group`: prep mirrors std's buffer_selection recv arm), the
         // raw cqe flags kept on `Completion` beside `result_errno` with a
         // `bufferId` reader, and ENOBUFS surviving the recv mapping as

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,15 +32,31 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        // Audited fork: zoxy-io/libxev branch zoxy-op-errno = upstream
+        // Audited fork: zoxy-io/libxev branch zoxy-buffer-group = upstream
         // 9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf (the audited snapshot)
-        // plus three commits, each its own stacked PR:
+        // plus four commits, each its own stacked PR:
         //   c369817 expose io_uring setup flags through Options
         //   6bd950d expose the CQ depth (IORING_SETUP_CQSIZE) — the c10k
         //           lever
         //   b3d6b55 keep the raw errno on the Completion (zoxy-io/libxev#2)
+        //   24da6d0 recv_group — provided-buffer receives (zoxy-io/libxev#3)
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
+        //
+        // Re-audit for 24da6d0 (§4, §5's head-buffer ring) — PENDING:
+        // zoxy-io/libxev#3 is open, and the PR that carries this pin stays
+        // a draft until that sign-off lands; what follows is the diff
+        // summary the audit reviews, not a record of one already done.
+        // One backend op
+        // (`recv_group`: prep mirrors std's buffer_selection recv arm), the
+        // raw cqe flags kept on `Completion` beside `result_errno` with a
+        // `bufferId` reader, and ENOBUFS surviving the recv mapping as
+        // `error.NoBuffers`. io_uring only; no watcher or dynamic-API
+        // surface (a new op, not a new ReadBuffer arm, so the shared
+        // exhaustive switches stay untouched); registration and buffer
+        // returns stay caller-side via std against `loop.ring`. The test
+        // pins selection, exhaustion, syscall-free reuse, and that EOF
+        // consumes no buffer — the fact §5's no-leak-at-teardown rests on.
         //
         // Re-audit for b3d6b55: one `posix.E` field on `Completion`
         // defaulting to `.SUCCESS`, one assignment at the top of `invoke`
@@ -54,8 +70,8 @@
         // arms discard which errno failed, which is what left a c10k run
         // reporting 227,628 indistinguishable failures.
         .libxev = .{
-            .url = "git+https://github.com/zoxy-io/libxev#b3d6b55bfbea1de0401d11f69ad9755fed9a6144",
-            .hash = "libxev-0.0.0-86vtc6cnFACJYqPSG_os9Ea-nUgWmjAqi3CwCQGiFj2z",
+            .url = "git+https://github.com/zoxy-io/libxev#24da6d01bdc426cbbee045d7bfaf18843d0e6d2e",
+            .hash = "libxev-0.0.0-86vtczxOFAB_0IplaVvIkI3iUUo61wUtF10OMILaoVRG",
         },
         // Load generator, §9 Tier 0/1 only — never linked into the proxy
         // (no `src/` file imports it), so a bump moves what the benchmark

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -391,7 +391,17 @@ only by the loop thread:
    purpose: recv targets nobody reads may.
 3. **Upstream connections — `Pool(Upstream)` + per-endpoint idle lists.**
    Checked out by any request, parked on keep-alive, one shared pool for
-   the whole process (§3: the Pingora reuse win). **A parked upstream has
+   the whole process (§3: the Pingora reuse win). The slot carries ~48 B
+   of scalars; its head buffer — the request-head render target and
+   response-head accumulator — lives in its own pool
+   (`limits.upstream_head_buffers`), acquired with the slot and released
+   before the slot parks, so a parked origin connection holds a socket
+   and scalars, never 8 KiB of head. App-side `Pool(HeadBuffer)` rather
+   than the seam's kernel ring, because its first use is synchronous: a
+   render needs the bytes now, and a kernel-selected buffer only arrives
+   with a delivery. Exhaustion is the `l7_shed_upstream_head_buffers`
+   rung, with the ordinary keep-or-close rules — unlike the client ring,
+   this request was fully read. **A parked upstream has
    no armed op** — deliberately no per-connection poll, which would cost
    an in-flight op per idle upstream in the ring budget (§8) for a race
    that is already covered: the parked connection's deadline timer serves
@@ -447,8 +457,9 @@ a raised `RLIMIT_NOFILE`:
 |---|---|---|---|
 | conn slots | 1386 | 11466 | ~1.7 KiB state |
 | relay buffers | 1386 | 11466 | 2 × 4 KiB |
-| upstream slots | 1313 | 11466 | ~40 B state + 8 KiB head |
+| upstream slots | 1313 | 11466 | ~48 B state |
 | head buffers (ring) | = conn slots | 11466 | 8 KiB + 1 B |
+| upstream head buffers | = upstream slots | 11466 | 8 KiB + 8 B |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
 
 The access log (§8) adds one fixed reservation beside the pools — two
@@ -880,6 +891,7 @@ the loop thread.
 | head buffers | a client's first byte, before the parse | static `503`, then **always close** — the refused bytes are still unread in the socket, and a kept connection would shed them forever |
 | relay buffers (L7) | request admission on a kept-alive conn | static `503` from static memory, then keep or close per pressure |
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7), then keep or close per pressure / close (L4) |
+| upstream head buffers | beside the slot, as it is obtained | static `503`, then keep or close per pressure |
 | **origin capacity** — every endpoint at its `max_inflight` | endpoint pick | static `503` (L7) / close (L4) |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -458,9 +458,16 @@ a raised `RLIMIT_NOFILE`:
 | conn slots | 1386 | 11466 | ~1.7 KiB state |
 | relay buffers | 1386 | 11466 | 2 × 4 KiB |
 | upstream slots | 1313 | 11466 | ~48 B state |
-| head buffers (ring) | = conn slots | 11466 | 8 KiB + 1 B |
-| upstream head buffers | = upstream slots | 11466 | 8 KiB + 8 B |
+| head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
+| upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
+
+`head_buffer_bytes` defaults to 8 KiB and is the largest head accepted
+(oversize → 414/431, §7), with a 1 KiB floor and a 1 MiB ceiling: a size
+knob is operator-visible behaviour, not only memory. Three head-sized
+side buffers ride the same knob — the serving path's two
+canonicalization scratches and the health prober's response buffer — and
+appear in the banner as their own term.
 
 The access log (§8) adds one fixed reservation beside the pools — two
 staging buffers, 64 KiB together by default — and nothing at all when it
@@ -617,8 +624,9 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   [hparse](https://github.com/nikneym/hparse)** (pure Zig,
   SIMD-vectorized, never allocates or copies — picohttpparser-shaped
   API; "streaming" means detect-and-retry — partial input re-parses
-  from byte 0, bounded by `head_bytes_max`). Upstream was not adoptable
-  as-is; the fork cleared a recorded hardening gate before landing:
+  from byte 0, bounded by `limits.head_buffer_bytes`). Upstream was
+  not adoptable as-is; the fork cleared a recorded hardening gate
+  before landing:
   bounds-check the cursor (upstream dereferences one byte past
   the buffer on partial input — silent UB), accept HTAB in field values
   (RFC 9110), reject bare-LF line terminators (a smuggling ingredient),
@@ -769,9 +777,10 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   owning phase module at compile time.
 - **Resilience is minimal by design:** per-request and per-try deadlines
   (head-read gets its own deadline, so a slowloris meets the clock or
-  `head_bytes_max`, whichever comes first; each dial — the first try and
-  the replay's — runs under its own connect deadline); one free replay
-  of a request that hit a stale pooled connection — only when the
+  `limits.head_buffer_bytes`, whichever comes first; each dial — the
+  first try and the replay's — runs under its own connect deadline);
+  one free replay of a request that hit a stale pooled connection —
+  only when the
   connection was a *reused* checkout, no response byte was received, and
   the request leg never entered the body pump, so the whole try still
   sits byte-reconstructible in the head buffer. "May have begun
@@ -1212,9 +1221,9 @@ src/
   mem/
     Pool.zig          // Pool(T): startup alloc, intrusive free list
   net/
-    Conn.zig          // connection slot: state, completions, head buffer
+    Conn.zig          // connection slot: state, completions, head-ring claim
     relay.zig         // strict recv→send→recv relay (L4 + L7 bodies)
-    upstream.zig      // shared upstream pool + endpoint idle lists
+    upstream.zig      // shared upstream pool + endpoint idle lists + head pool
   http/
     parser.zig        // hparse wrapper: strictness + framing + chunked decoder
     render.zig        // §7 head rendering: hop-by-hop strip + close injection

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,7 +115,7 @@ not a resumed one.
   holds by construction — there is no second thread that could violate it.
 - **Minimal memory.** One shared pool sized for the global limit replaces
   N per-core pools each sized for a local worst case. Idle keep-alive
-  connections hold a slot and a head buffer, not relay buffers (§5) —
+  connections hold a slot — no relay buffers, no head buffer (§5) —
   memory follows *activity*, not connection count.
 - **Perfect connection reuse.** Pingora's headline win over NGINX was
   sharing upstream connections across all threads; the previous iteration
@@ -354,24 +354,41 @@ previous iteration paid that cost, and shared pools sized for concurrent
 *activity* rather than worst-case-per-core are the fix and the reason this
 iteration exists.
 
-Three shared pools, all owned and touched only by the loop thread:
+Three shared pools and one kernel-fronted ring, all owned and touched
+only by the loop thread:
 
 1. **Connection slots — `Pool(Conn)`.** One contiguous object per
    connection: state machine, embedded completions (one per overlappable
    op — the previous iteration grew a field per proven race — including
-   the timer-cancel completion, §4), the deadline timer, and a small
-   fixed **head buffer** (L7 request/response heads; idle on L4
-   connections, which relay through pool 2 only). Acquired at accept,
-   released at teardown once the slot's armed-op set is empty (release
-   rule below). Intrusive free list, LIFO reuse for cache warmth.
+   the timer-cancel completion, §4), and the deadline timer. Acquired at
+   accept, released at teardown once the slot's armed-op set is empty
+   (release rule below). Intrusive free list, LIFO reuse for cache
+   warmth.
 2. **Relay buffers — `Pool(RelayBuffer)`.** The large per-direction
    buffers for body/stream relaying, *decoupled from connection slots*.
    L7: acquired when a relay starts, **released when the connection goes
-   idle on keep-alive** — an idle connection costs a slot + head buffer
-   only. L4: acquired at accept, held for the connection's life (a recv
-   must always have a buffer posted). This decoupling is where shared
-   pools buy their memory win: buffers are sized for concurrent *relays*,
-   not for open connections.
+   idle on keep-alive** — an idle connection costs a slot only. L4:
+   acquired at accept, held for the connection's life (a relay recv must
+   always have a buffer posted). This decoupling is where shared pools
+   buy their memory win: buffers are sized for concurrent *relays*, not
+   for open connections.
+2b. **Head buffers — the provided-buffer ring (`limits.head_buffers`).**
+   The L7 request/response head buffers, decoupled from connection slots
+   by the same argument as the relay buffers — but where a relay recv
+   must carry a buffer, a head recv need not: the seam's `recvGroup`
+   (§4, single-shot buffer-select) arms with *no* buffer, and the kernel
+   binds one from the registered ring only when the client actually
+   speaks. Bound at the first byte of a request, returned at the
+   keep-alive turnaround, before a static response goes out, and at
+   teardown — so an idle connection holds no head bytes at all, an L4
+   connection never binds one, and the ring is sized for concurrent
+   *request heads*, not for open connections. Returning a buffer is a
+   tail bump, no syscall. The ring empty at a client's first byte is the
+   `l7_shed_head_buffers` rung (§8) — the one shed that always closes,
+   because the bytes it refused are still unread in the socket. The
+   server owns the in-use accounting (the kernel cannot report it) and
+   the lingering-close drain discards into one shared sink, aliasing on
+   purpose: recv targets nobody reads may.
 3. **Upstream connections — `Pool(Upstream)` + per-endpoint idle lists.**
    Checked out by any request, parked on keep-alive, one shared pool for
    the whole process (§3: the Pingora reuse win). **A parked upstream has
@@ -428,9 +445,10 @@ a raised `RLIMIT_NOFILE`:
 
 | pool | default | ceiling (c10k) | unit size |
 |---|---|---|---|
-| conn slots | 1386 | 11466 | ~1.7 KiB state + 8 KiB head |
+| conn slots | 1386 | 11466 | ~1.7 KiB state |
 | relay buffers | 1386 | 11466 | 2 × 4 KiB |
 | upstream slots | 1313 | 11466 | ~40 B state + 8 KiB head |
+| head buffers (ring) | = conn slots | 11466 | 8 KiB + 1 B |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
 
 The access log (§8) adds one fixed reservation beside the pools — two
@@ -439,8 +457,9 @@ is off. It is in the printed total, because §5's promise is that the
 total covers everything this process holds for its life, not only what is
 shaped like a pool. Roughly half a kilobyte of the conn-slot state above
 is its per-request capture: the method, host and path a line reports live
-in the head buffer, which the response head renders over (§7), so they
-have to be copied out while they are still there.
+in the head buffer, which the response head renders over (§7) and the
+turnaround returns to the ring, so they have to be copied out while they
+are still there.
 
 The config arena is in that total for the same reason — it is never
 freed — but it is the one term that is **measured rather than derived**,
@@ -561,7 +580,7 @@ accept → admit (slots? buffers?) → route by listener → connect upstream
 - Relay buffers (one per direction) are acquired at admission and held
   for the connection's life — a recv must always have a buffer posted —
   so `relay_buffers`, not connection slots, bounds concurrent L4
-  connections. The slot's head buffer is not used on the L4 path.
+  connections. An L4 connection never binds a head-ring buffer.
 - **Strict `recv → send → recv` per direction over one fixed buffer
   each.** The next chunk is never read until the current one is fully
   written, so a slow side stalls the fast side through TCP flow control
@@ -858,7 +877,8 @@ the loop thread.
 |---|---|---|
 | connection slots | accept completion | close immediately (SO_LINGER 0 → RST); accept stays armed |
 | relay buffers (L4) | accept admission | close immediately |
-| relay buffers (L7) | request admission on a kept-alive conn | static `503` from the head buffer, then keep or close per pressure |
+| head buffers | a client's first byte, before the parse | static `503`, then **always close** — the refused bytes are still unread in the socket, and a kept connection would shed them forever |
+| relay buffers (L7) | request admission on a kept-alive conn | static `503` from static memory, then keep or close per pressure |
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7), then keep or close per pressure / close (L4) |
 | **origin capacity** — every endpoint at its `max_inflight` | endpoint pick | static `503` (L7) / close (L4) |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
@@ -936,7 +956,12 @@ origin, not one this proxy can pick for them.
   pressure shortens parked-connection deadlines (and the sweep
   interval), reaping idle parked sockets so their slots free for fresh
   dials. Each bias sheds *idle* capacity before the wall must shed
-  *work*; each engage crossing has a counter.
+  *work*; each engage crossing has a counter. The head-buffer ring flips
+  the same flag on the same watermarks but drives no bias at all — an
+  idle connection holds no head buffer, so there is no idle occupancy a
+  timeout could evict; its flag and engage counter exist for the
+  operator, who sizes `limits.head_buffers` by the crossings before the
+  wall starts refusing.
 - **Metrics witness every shed.** Every rung has a counter, written only
   by the loop thread as a relaxed atomic — one writer, any number of
   readers. The admin plane reads them on the loop itself (§3: there is no

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -318,12 +318,17 @@ unmerged behind it, so the pin moves only after re-audit.
   against the tick would read 0 µs for every request served inside one
   completion batch. It costs two vDSO reads per logged request, against
   `now_ns`'s one per tick, and only when a deployment turns the log on.
-- **Plain ops only.** Multishot accept/recv, buffer rings, `send_zc`,
-  `splice` stay behind measurement — the previous iteration never became
-  CPU-bound without them, and this one is latency-bound with CPU
-  headroom. Each has since been evaluated; verdicts, revisit conditions,
-  and the measurements behind them live in
-  [`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md).
+- **Plain ops only.** Multishot accept/recv, `send_zc`, `splice` stay
+  behind measurement — the previous iteration never became CPU-bound
+  without them, and this one is latency-bound with CPU headroom. Each
+  has since been evaluated; verdicts, revisit conditions, and the
+  measurements behind them live in
+  [`IMPLEMENTATION_NOTES.md`](IMPLEMENTATION_NOTES.md). One graduation:
+  single-shot buffer-select — the buffer-ring mechanism without
+  multishot — carries the seam's `recvGroup` (§5's head-buffer ring),
+  adopted 2026-08-01 for density rather than throughput; the notes
+  record why that does not reopen the multishot closure. Every
+  completion still disarms.
 
 ## 5. Memory — shared pools, fixed at startup
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -368,6 +368,21 @@ What the build actually taught, for the next pooling change:
   (reset and EOF outrank selection). The whole no-leak-at-teardown story
   rests on that fact, which is why it is a test and not a comment.
 
+Measured (2026-08-02, Tier-1 bands, three runs each side vs `842a3e1`):
+no hop-overhead regression — keep-alive L7 p50 [+20, +24] µs against
+main's [+22, +23], close and large-body bands overlapping likewise.
+The gate that did fire was **flat-RSS**: the kernel consumes a buf_ring
+FIFO, so sustained load cycles through *every* registered buffer and
+faults the whole slab (measured: RSS 10.0 → 21.2 MiB, the slab's size
+exactly), where the old inline heads rode the conn pool's LIFO reuse
+and only the hot slots' pages ever faulted. The fix faults both slabs
+in at init — RSS now starts at the printed §5 budget (~31 MiB at the
+bench shape) and stays flat, which is what the budget promise wanted
+anyway. Two standing implications of the FIFO cycling: the head-write
+working set is the whole ring rather than a LIFO hot set (a cache
+argument for trading `head_buffers` down on small deployments), and any
+future "warm buffer" reasoning about the ring is wrong by construction.
+
 Deferred, deliberately: fuzz buffers exercise the 8 KiB default, not the
 1 MiB `head_buffer_bytes_max` the parser's guards now formally span —
 a capacity change, not new parsing logic, but worth a fuzz shape if the

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -292,6 +292,33 @@ submission-bound", below, 2026-07-28). Do not re-propose without a
 workload whose *measured* `cqes/wake` approaches 1; the shape of the
 workload is not the evidence, the batch depth is.
 
+## Single-shot buffer-select — adopted for density, not throughput (2026-08-01)
+
+The closure above stands on its axis, and this does not reopen it:
+multishot recv chased *syscalls*, the measured workload was not
+submission-bound, and nothing here changes that arithmetic. What
+returned is the buffer-group *mechanism* alone, for a problem the
+closure never priced: an idle L7 connection pins an 8 KiB head buffer
+because the recv armed while it idles must name a destination up front
+(#162 — head buffers are 62% of the default budget, held per connection
+rather than per active exchange). A single-shot `IOSQE_BUFFER_SELECT`
+recv — the fork's `recv_group` op, zoxy-io/libxev#3 — arms with no
+buffer; the kernel binds one from the registered ring only when bytes
+arrive, and returning it is a tail bump, no syscall. Op count per
+request is unchanged: the closure's "forfeits most of that win" was
+about the syscall win, which this deliberately does not chase.
+
+What the closure priced as the redesign cost is now owned outright: the
+buffer-group lifecycle and the ENOBUFS coupling live in the Io contract
+(`recvGroup` / `bufferGroupSlice` / `bufferGroupReturn`;
+`error.NoBuffers` is a §8 shed signal, never a retry), and SimIo models
+the group deterministically — lowest-free-id selection, exhaustion, and
+the no-consumption-on-EOF fact the fork's test pins against a real 6.18
+kernel. The §6 one-armed-recv discipline and XevIo's
+every-callback-disarms rule are unchanged; multishot stays closed on
+its own terms (do not re-propose without measured `cqes/wake`
+approaching 1).
+
 ## Pre-block spin — rejected (2026-07-12)
 
 Spinning before the loop blocks: p50 +15–25 µs *worse* and CPU ×2. The
@@ -357,7 +384,9 @@ itself. The durable "why" for each, so it is not re-chased.
   and **closed 2026-07-28** once the workload it was waiting for was
   measured. The syscall win does not pay for the relay redesign it
   demands; single-shot buffer-select would keep the strict §6 discipline
-  but forfeits most of that win.
+  but forfeits most of that win. Buffer-select has since been adopted
+  anyway — for memory density, a different axis; see "Single-shot
+  buffer-select" above. The multishot closure itself stands.
 - **`send_zc`** — rejected at the deliberate 4 KiB relay buffer. Below
   ~10–32 KiB the kernel copy is cheaper than page pinning, and the extra
   notification CQE per send doubles CQE consumption, eroding the CQ

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -319,6 +319,64 @@ every-callback-disarms rule are unchanged; multishot stays closed on
 its own terms (do not re-propose without measured `cqes/wake`
 approaching 1).
 
+## Head buffers left the slots (2026-08-02, #162)
+
+Before: 21.09 MiB of the 34.2 MiB default budget — 62% — was head
+buffers, inline in the conn and upstream slots, pinned for the *slot's*
+life rather than the exchange's. An idle keep-alive connection held
+8 KiB it needed only between first byte and turnaround; a parked origin
+connection held 8 KiB that was provably dead; an L4 connection held
+8 KiB the protocol cannot address. After: both heads are pooled and
+memory follows request heads in flight. Three knobs
+(`limits.head_buffers`, `upstream_head_buffers`, `head_buffer_bytes`)
+default to the never-shedding shapes, so out of the box nothing sheds
+and the total is unchanged — the wins are the idle/parked/L4 zeros and
+the operator's ability to trade the counts down and the size either way.
+
+The client side rides the seam's provided-buffer ring (`recvGroup`, the
+buffer-select note above): an idle connection's armed recv carries no
+buffer, the kernel binds one at the first byte, and the return is a
+tail bump. The upstream side is an app pool — its first use is a
+synchronous render, which a kernel ring cannot serve. Op count per
+request is unchanged; poll-first arming was designed, offered, and
+rejected for costing one SQE/CQE pair per request on a kernel-bound
+core.
+
+What the build actually taught, for the next pooling change:
+
+- **The shed's keep-or-close is decided by *where* the acquire sits.**
+  The upstream head acquire was planned at the render (`.l7_dialing`) —
+  and the directed test immediately showed those sheds always closing:
+  the §7 resync rule keeps only from `.l7_reading_head`. The acquire
+  moved beside the slot acquire, and the rung behaves like its
+  siblings. Place acquires where the ladder can still answer kindly.
+- **The client ring's rung is the one shed that precedes the parse**, so
+  it can pre-empt verdicts (400/414/501/403) that were provably
+  first-answer before — four sim script oracles and a DESIGN table row
+  had encoded that provability and failed honestly (seed 634). And it
+  must always close: the refused bytes are unread in the socket, and a
+  kept connection would re-arm onto them and shed the same request
+  forever (`respond` enforces the close at comptime).
+- **A delivery can carry a resource into a teardown.** The group-recv
+  completion racing `beginTeardown` arrives with a kernel-bound buffer
+  id; the early-return teardown path dropped it — an uncounted leak no
+  drain assert could see, because the bind was never recorded. The
+  `onUpstreamConnect` capture-then-release shape applies to every
+  resource a completion can hand a dying connection.
+- **EOF does not consume a provided buffer** — pinned by the fork's own
+  test against a real 6.18 kernel and mirrored in SimIo's check order
+  (reset and EOF outrank selection). The whole no-leak-at-teardown story
+  rests on that fact, which is why it is a test and not a comment.
+
+Deferred, deliberately: fuzz buffers exercise the 8 KiB default, not the
+1 MiB `head_buffer_bytes_max` the parser's guards now formally span —
+a capacity change, not new parsing logic, but worth a fuzz shape if the
+ceiling ever earns real traffic. The banner's "access log 0 KiB" nit
+(the log's 536 B/conn capture arrays living in the conn slots) also
+stays open: the LogState move was cut from #162's scope on measurement —
+its scalars are written unconditionally on both protocols, so moving
+them buys 40 B of stride for 14 hot-path guards.
+
 ## Pre-block spin — rejected (2026-07-12)
 
 Spinning before the loop blocks: p50 +15–25 µs *worse* and CPU ×2. The

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -629,6 +629,10 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
             .relay_buffers = 1,
             .upstream_slots = 1,
             .head_buffers = harness.head_buffers,
+            // Capacity 1: the first render engages the pressure flag, so
+            // the engage counter stays reachable even though the shed
+            // rung itself is relay-shadowed (see sim/main.zig uncovered).
+            .upstream_head_buffers = 1,
             .access_log_buffer_bytes = access_log_buffer_bytes,
         }
     else
@@ -650,6 +654,7 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
             .relay_buffers = if (harness.clean) 2 * clients_max else clients_max,
             .upstream_slots = 2 * clients_max,
             .head_buffers = harness.head_buffers,
+            .upstream_head_buffers = 2 * clients_max,
         };
     try harness.server.init(arena, &harness.io, &harness.config, options);
     try harness.server.start();

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -77,6 +77,11 @@ ended_count: u8,
 /// Clean seeds run without the adversary and with a well-behaved
 /// origin, so the L7 oracles demand exact golden outcomes.
 clean: bool,
+/// Decided before `io.init` (the ring the sim registers must equal the
+/// limit the server accounts against — Server.init asserts the match),
+/// consumed by `startServerAndOrigins` for the rest of the pool shape.
+force_exhaustion: bool,
+head_buffers: u32,
 end_timer_completion: SimIo.Completion,
 /// Virtual instant at which the HTTP origin stops listening mid-run, or
 /// 0 for never. Drawn on a fraction of checked-http adversarial seeds:
@@ -139,9 +144,25 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
     // exact outcome — a silently dropped 400 or a shed that should
     // not happen fails the seed instead of passing as a "cut".
     harness.clean = random.uintLessThan(u8, 4) == 0;
+    // A quarter of adversarial seeds shrink the pools to force the §8
+    // rungs. Drawn here rather than in `startServerAndOrigins` because
+    // the head-buffer ring is the Io backend's to register, and its size
+    // must be settled before the backend exists. 1–3 ring buffers, so
+    // across the sweep some seeds shed at the ring (1: a second
+    // concurrent head finds it empty) and others get far enough to shed
+    // at the relay rung instead (2–3: heads bind, the deeper rungs
+    // starve) — one size would shadow one rung or the other.
+    harness.force_exhaustion = !harness.clean and random.uintLessThan(u8, 4) == 0;
+    harness.head_buffers = if (harness.force_exhaustion)
+        1 + random.uintLessThan(u32, 3)
+    else
+        // The clean-seed watermark margin, same reasoning as the pools
+        // below in `startServerAndOrigins`.
+        2 * clients_max;
     try harness.io.init(arena, .{
         .seed = seed,
         .adversary = deriveAdversary(random, harness.clean),
+        .buffer_group_count = harness.head_buffers,
     });
     // Which cause the sim reports for every failure it injects (§8).
     // Production reads it off an errno; a virtual socket table has none,
@@ -583,8 +604,9 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
 fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: std.Random) !void {
     // A quarter of adversarial seeds shrink the pools to force the
     // §8 rungs; clean seeds keep ample pools so golden outcomes
-    // never meet a shed.
-    const force_exhaustion = !harness.clean and random.uintLessThan(u8, 4) == 0;
+    // never meet a shed. Decided in `setUp` (see `force_exhaustion`)
+    // because the ring size had to precede `io.init`.
+    const force_exhaustion = harness.force_exhaustion;
     // Adversarial seeds size the staging buffers at the floor — one
     // worst-case line each — so the buffer swap runs constantly and every
     // line meets a nearly-full buffer, against the default's hundred-line
@@ -601,9 +623,12 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
         zoxy.constants.access_log_buffer_bytes_min;
     const options: ServerSim.InitOptions = if (force_exhaustion)
         .{
-            .conn_slots = 1 + random.uintLessThan(u32, 2),
+            // head_buffers ≤ conn_slots is a Server.init precondition, so
+            // the slot draw starts at whatever the ring draw chose.
+            .conn_slots = harness.head_buffers + random.uintLessThan(u32, 2),
             .relay_buffers = 1,
             .upstream_slots = 1,
+            .head_buffers = harness.head_buffers,
             .access_log_buffer_bytes = access_log_buffer_bytes,
         }
     else
@@ -624,6 +649,7 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
             .conn_slots = 2 * clients_max,
             .relay_buffers = if (harness.clean) 2 * clients_max else clients_max,
             .upstream_slots = 2 * clients_max,
+            .head_buffers = harness.head_buffers,
         };
     try harness.server.init(arena, &harness.io, &harness.config, options);
     try harness.server.start();

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -219,7 +219,7 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 if (target[0] != '/') {
                     return true;
                 }
-                var canon_buf: [constants.head_bytes_max]u8 = undefined;
+                var canon_buf: [constants.head_buffer_bytes_default]u8 = undefined;
                 const canonical = parser.canonicalTarget(target, &canon_buf) catch {
                     return false;
                 };

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -247,24 +247,27 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     },
     .malformed_head = .{
         // A bare LF terminating the request line (§7 smuggling shape).
-        // The parse verdict precedes routing, so no §8 rung or dial
-        // failure can precede the 400.
+        // The parse verdict precedes routing, so no post-parse rung or
+        // dial failure can precede the 400 — but the §5 head ring gates
+        // the read *before* the parse, so its 503 can.
         .request = "GET /sim HTTP/1.1\nHost: sim\r\n\r\n",
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 400,
         .method = .get,
-        .allowed_statuses = &.{400},
+        .allowed_statuses = &.{ 400, 503 },
     },
     .oversize_uri = .{
         // The request line alone must overflow the proxy's 8 KiB head
-        // buffer with no newline in sight: 414, not 431.
+        // buffer with no newline in sight: 414, not 431. The §5 head
+        // ring gates the read before any byte accumulates, so its 503
+        // can precede the verdict.
         .request = "GET /" ++ ("a" ** 8500) ++ " HTTP/1.1\r\nHost: sim\r\n\r\n",
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 414,
         .method = .get,
-        .allowed_statuses = &.{414},
+        .allowed_statuses = &.{ 414, 503 },
     },
     .connect_method = .{
         // The 501 verdict precedes routing. The method context maps to
@@ -276,7 +279,8 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 501,
         .method = .get,
-        .allowed_statuses = &.{501},
+        // Only the §5 head ring's 503 precedes the parse the 501 rides on.
+        .allowed_statuses = &.{ 501, 503 },
     },
     .keepalive_pair = .{
         // The second GET is appended at run time, only after the first
@@ -327,15 +331,17 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     // §7 filter scripts: a distinct path per action so the listener's
     // rules fire only for these, never the others.
     .filter_reject = .{
-        // A reject is answered before any resource is acquired or origin
-        // dialed, so no §8 rung or dial failure can precede it — the
-        // only complete verdict is the 403.
+        // A reject is answered before any post-parse resource is
+        // acquired or origin dialed, so no such rung or dial failure can
+        // precede it — but the request must first be *read*, and the §5
+        // head ring gates that: its 503 is the one verdict that can
+        // arrive instead.
         .request = "GET /reject HTTP/1.1\r\nHost: sim\r\n\r\n",
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 403,
         .method = .get,
-        .allowed_statuses = &.{403},
+        .allowed_statuses = &.{ 403, 503 },
     },
     .filter_edit = .{
         // Routes and forwards like a plain GET, so the §8 rungs and a

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -180,8 +180,8 @@ comptime {
     assert(2 * forwarded_oversize_line.len + 2 > constants.forwarded_chain_bytes_max);
     // Both heads must reach the origin as heads, not as 414/431 verdicts:
     // the proxy's own cap is the ceiling either way.
-    assert(forwarded_inbound_head.len < constants.head_bytes_max);
-    assert(forwarded_oversize_head.len < constants.head_bytes_max);
+    assert(forwarded_inbound_head.len < constants.head_buffer_bytes_default);
+    assert(forwarded_oversize_head.len < constants.head_buffer_bytes_default);
 }
 
 /// Valid requests meet the canonical 200, the §8 rungs (503), an

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -217,6 +217,15 @@ const uncovered_ops = [_]struct { kind: SimIo.OpKind, reason: []const u8 }{
             "every serving path closes synchronously via closeNow — and the " ++
             "sweep configures no admin listener; src/admin_test.zig covers it",
     },
+    .{
+        // TEMPORARY: deleted by the next slice, which re-arms the proxy's
+        // idle head read as a recv_group against the §5 head-buffer ring
+        // and makes every http seed deliver it.
+        .kind = .recv_group,
+        .reason = "the seam carries it but the proxy does not arm it yet — " ++
+            "the head-buffer ring lands in the next slice; " ++
+            "src/io/contract_test.zig covers the op itself",
+    },
 };
 
 comptime {

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -140,6 +140,15 @@ const uncovered = [_]Uncovered{
             "exhausts the upstream pool directly",
     },
     .{
+        .name = "l7_shed_upstream_head_buffers",
+        .why = .unreached,
+        .reason = "same shadow as l7_shed_upstream_slots: the relay rung " ++
+            "answers first on every pool-starved seed, and reaching this " ++
+            "one besides needs two concurrent renders, which upstream_slots " ++
+            "= 1 rules out; src/http_proxy_test.zig exhausts the upstream " ++
+            "head pool directly",
+    },
+    .{
         .name = "l7_response_excess_sent",
         .why = .unreached,
         .reason = "no seed raises the adversary's recv cap to head_bytes_max, " ++

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -217,15 +217,6 @@ const uncovered_ops = [_]struct { kind: SimIo.OpKind, reason: []const u8 }{
             "every serving path closes synchronously via closeNow — and the " ++
             "sweep configures no admin listener; src/admin_test.zig covers it",
     },
-    .{
-        // TEMPORARY: deleted by the next slice, which re-arms the proxy's
-        // idle head read as a recv_group against the §5 head-buffer ring
-        // and makes every http seed deliver it.
-        .kind = .recv_group,
-        .reason = "the seam carries it but the proxy does not arm it yet — " ++
-            "the head-buffer ring lands in the next slice; " ++
-            "src/io/contract_test.zig covers the op itself",
-    },
 };
 
 comptime {

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -151,7 +151,7 @@ const uncovered = [_]Uncovered{
     .{
         .name = "l7_response_excess_sent",
         .why = .unreached,
-        .reason = "no seed raises the adversary's recv cap to head_bytes_max, " ++
+        .reason = "no seed raises the adversary's recv cap to head_buffer_bytes_default, " ++
             "so no origin delivery fills the head buffer; " ++
             "src/http_proxy_test.zig builds that delivery",
     },

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -42,6 +42,12 @@ pub fn Server(comptime IoType: type) type {
         /// The shared upstream connection pool (§3, §5): leased per L7
         /// exchange today; parking joins with keep-alive.
         upstreams: upstream_module.UpstreamPool(IoType),
+        /// The §5 upstream head buffers, pooled apart from the slots so a
+        /// parked connection holds a socket and ~48 B of slot, never 8 KiB
+        /// of head. App-side (not the seam's kernel ring) because the
+        /// acquire is synchronous: a render needs the bytes now.
+        upstream_head_buffers: Pool(upstream_module.HeadBuffer),
+        upstream_head_pressure: bool,
         /// Live L4 relayed connections per endpoint (§7), the other half
         /// of `upstream_module.Load`. The pool cannot hold this: an L4
         /// connection leases no upstream slot, so it is the server —
@@ -254,6 +260,8 @@ pub fn Server(comptime IoType: type) type {
             // endpoint-keyed table so they cannot disagree about a key.
             const keys = endpointKeysFor(config);
             try server.upstreams.init(arena, options.upstream_slots, keys);
+            assert(options.upstream_head_buffers <= options.upstream_slots);
+            try server.upstream_head_buffers.init(arena, options.upstream_head_buffers);
             server.l4_inflight = try arena.alloc(u16, keys.count);
             @memset(server.l4_inflight, 0);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
@@ -267,6 +275,7 @@ pub fn Server(comptime IoType: type) type {
             server.head_pressure = false;
             server.head_buffers_in_use = 0;
             server.head_buffers_capacity = options.head_buffers;
+            server.upstream_head_pressure = false;
             // Deliberately not zeroed: a discard sink's contents are never
             // read, the same argument the head buffers make (§5).
             server.drain_sink = undefined;
@@ -399,8 +408,10 @@ pub fn Server(comptime IoType: type) type {
             // conn is left to lease one, so the pool must be empty.
             assert(server.upstreams.isFullyReleased());
             // Every conn released its ring buffer on the way out, so the
-            // in-use count the server owns must have followed to zero.
+            // in-use count the server owns must have followed to zero —
+            // and every released or parked upstream let go of its head.
             assert(server.head_buffers_in_use == 0);
+            assert(server.upstream_head_buffers.isFullyReleased());
             server.io.stop();
         }
 
@@ -471,6 +482,7 @@ pub fn Server(comptime IoType: type) type {
                 server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
+                server.upstream_head_buffers.isFullyReleased() and
                 server.head_buffers_in_use == 0 and
                 server.admin.isQuiescent() and
                 server.access_log.isQuiescent() and
@@ -1125,6 +1137,18 @@ pub fn Server(comptime IoType: type) type {
             );
         }
 
+        fn updateUpstreamHeadPressure(server: *Self) void {
+            // Reachable only through an acquire or release, both of which
+            // imply a nonzero pool — the watermark math needs that.
+            assert(server.upstream_head_buffers.slots.len >= 1);
+            server.updatePressureFlag(
+                &server.upstream_head_pressure,
+                server.upstream_head_buffers.acquired_count,
+                @intCast(server.upstream_head_buffers.slots.len),
+                "upstream_head_pressure_engaged",
+            );
+        }
+
         fn updateHeadPressure(server: *Self) void {
             // Reachable only through a bind or return, both of which imply
             // a registered ring — so the capacity the watermark math needs
@@ -1178,6 +1202,8 @@ pub fn Server(comptime IoType: type) type {
                 .upstream_slots_capacity = server.upstreams.capacity(),
                 .head_buffers_in_use = server.head_buffers_in_use,
                 .head_buffers_capacity = server.head_buffers_capacity,
+                .upstream_head_buffers_in_use = server.upstream_head_buffers.acquired_count,
+                .upstream_head_buffers_capacity = server.upstream_head_buffers.capacity(),
                 .kernel_pressure_last_errno = server.last_pressure_errno,
                 .health_endpoints_checked = server.health.checked_count,
                 .health_endpoints_unhealthy = server.health.unhealthy_count,
@@ -1258,8 +1284,35 @@ pub fn Server(comptime IoType: type) type {
             // links would dangle), and at least this slot is leased.
             assert(!leased.parked);
             assert(server.upstreams.leasedCount() >= 1);
+            // A slot released mid-exchange — teardown, a static response,
+            // a stale replay — usually still holds its head buffer; one
+            // that never got one (the shed at its own head acquire) or
+            // released it at park arrives here empty-handed. One
+            // conditional chokepoint, so no release path can leak it.
+            if (leased.head_buffer != null) {
+                server.releaseUpstreamHeadBuffer(leased);
+            }
             server.upstreams.release(leased);
             server.updateUpstreamPressure();
+        }
+
+        /// The §5 upstream head-buffer pair: acquired at the request-head
+        /// render, released before the slot parks or with the slot itself.
+        /// Both sides recompute the watermark.
+        pub fn acquireUpstreamHeadBuffer(server: *Self) ?*upstream_module.HeadBuffer {
+            const head_buffer = server.upstream_head_buffers.acquire() orelse return null;
+            server.updateUpstreamHeadPressure();
+            return head_buffer;
+        }
+
+        pub fn releaseUpstreamHeadBuffer(
+            server: *Self,
+            leased: *upstream_module.UpstreamPool(IoType).Upstream,
+        ) void {
+            const head_buffer = leased.head_buffer orelse unreachable;
+            leased.head_buffer = null;
+            server.upstream_head_buffers.release(head_buffer);
+            server.updateUpstreamHeadPressure();
         }
 
         /// The idle timeout to apply now, shortened under downstream

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -74,6 +74,27 @@ pub fn Server(comptime IoType: type) type {
         relay_pressure: bool,
         conn_pressure: bool,
         upstream_pressure: bool,
+        /// The head-buffer ring's watermark flag (§8). Unlike the other
+        /// three it drives no timeout or keep-alive bias: an idle
+        /// connection holds no head buffer, so there is no idle occupancy
+        /// to evict — the only remedy for ring pressure is the shed rung
+        /// itself, and the flag exists for the gauge and the engage
+        /// counter an operator alerts on.
+        head_pressure: bool,
+        /// Ring buffers currently bound to connections: incremented at the
+        /// delivery that binds one, decremented by `returnHeadBuffer` —
+        /// the seam's kernel side cannot count for us, so the server is
+        /// the one owner of this number (§5). `head_buffers_capacity`
+        /// mirrors `limits.head_buffers`, asserted at init to equal the
+        /// group the Io backend actually registered.
+        head_buffers_in_use: u32,
+        head_buffers_capacity: u32,
+        /// The one shared lingering-close discard sink (§7): every
+        /// draining connection recvs into it concurrently, which is sound
+        /// precisely because no path reads it — bytes land, interleave,
+        /// and die. Inline rather than arena so it is part of no budget
+        /// term and can never be under-counted.
+        drain_sink: [constants.drain_sink_bytes]u8,
         /// Highest armed-op count any one connection has reached (§8):
         /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
         /// under runtime safety only (never in the shipped ReleaseFast
@@ -220,6 +241,11 @@ pub fn Server(comptime IoType: type) type {
             assert(options.relay_buffers >= 1);
             assert(options.upstream_slots >= 1);
             assert(options.relay_buffers <= options.conn_slots);
+            assert(options.head_buffers <= options.conn_slots);
+            // The ring the backend registered and the limit this server
+            // accounts against must be the same number, or the shed rung
+            // fires at a size no config names. Zero is the L4-only shape.
+            assert(io.bufferGroupCount() == options.head_buffers);
             server.io = io;
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
@@ -238,6 +264,12 @@ pub fn Server(comptime IoType: type) type {
             server.relay_pressure = false;
             server.conn_pressure = false;
             server.upstream_pressure = false;
+            server.head_pressure = false;
+            server.head_buffers_in_use = 0;
+            server.head_buffers_capacity = options.head_buffers;
+            // Deliberately not zeroed: a discard sink's contents are never
+            // read, the same argument the head buffers make (§5).
+            server.drain_sink = undefined;
             server.armed_ops_peak = 0;
             server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};
@@ -366,6 +398,9 @@ pub fn Server(comptime IoType: type) type {
             // beginDrain reaped every parked slot synchronously and no
             // conn is left to lease one, so the pool must be empty.
             assert(server.upstreams.isFullyReleased());
+            // Every conn released its ring buffer on the way out, so the
+            // in-use count the server owns must have followed to zero.
+            assert(server.head_buffers_in_use == 0);
             server.io.stop();
         }
 
@@ -436,6 +471,7 @@ pub fn Server(comptime IoType: type) type {
                 server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
+                server.head_buffers_in_use == 0 and
                 server.admin.isQuiescent() and
                 server.access_log.isQuiescent() and
                 server.health.isQuiescent();
@@ -722,6 +758,31 @@ pub fn Server(comptime IoType: type) type {
             server.updateRelayPressure();
         }
 
+        /// The ring pair (§5): the bind side is the seam's — the kernel
+        /// selects the buffer, `onHeadGroupRecv` reports it here — and the
+        /// return side hands the id back and clears the conn's claim, so a
+        /// double return dies in the seam's ownership assert rather than
+        /// as aliased receives. Both sides recompute the watermark.
+        pub fn noteHeadBufferBound(server: *Self) void {
+            assert(server.head_buffers_in_use < server.head_buffers_capacity);
+            server.head_buffers_in_use += 1;
+            server.updateHeadPressure();
+        }
+
+        pub fn returnHeadBuffer(server: *Self, conn: *ConnType) void {
+            assert(conn.head_buffer_id != ConnType.head_buffer_none);
+            assert(server.head_buffers_in_use >= 1);
+            server.io.bufferGroupReturn(conn.head_buffer_id);
+            conn.head_buffer_id = ConnType.head_buffer_none;
+            server.head_buffers_in_use -= 1;
+            server.updateHeadPressure();
+        }
+
+        /// The shared lingering-close discard target (§7) — see the field.
+        pub fn drainSink(server: *Self) []u8 {
+            return server.drain_sink[0..];
+        }
+
         /// The same pair for conn slots, with `admitConn` as its acquire
         /// side: pressure follows occupancy in both directions (§5, §8), so
         /// every slot return goes through here and the flag can never
@@ -861,6 +922,11 @@ pub fn Server(comptime IoType: type) type {
             if (conn.relay_buffer) |buffer| {
                 server.releaseRelayBuffer(buffer);
                 conn.relay_buffer = null;
+            }
+            // Same rule for the ring buffer: nothing armed references it
+            // (asserted above), so the return cannot race a landing recv.
+            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+                server.returnHeadBuffer(conn);
             }
             // The leased upstream slot rides the same release rule: its
             // socket (if any) was closed just above, so the slot is
@@ -1059,6 +1125,19 @@ pub fn Server(comptime IoType: type) type {
             );
         }
 
+        fn updateHeadPressure(server: *Self) void {
+            // Reachable only through a bind or return, both of which imply
+            // a registered ring — so the capacity the watermark math needs
+            // to be nonzero always is.
+            assert(server.head_buffers_capacity >= 1);
+            server.updatePressureFlag(
+                &server.head_pressure,
+                server.head_buffers_in_use,
+                server.head_buffers_capacity,
+                "head_pressure_engaged",
+            );
+        }
+
         /// Any pressure an *idle* downstream connection holds capacity
         /// against (§8): it pins a conn slot, and its next body relay
         /// claims a relay buffer. Drives only the idle-timeout division —
@@ -1097,6 +1176,8 @@ pub fn Server(comptime IoType: type) type {
                 .upstream_slots_leased = server.upstreams.leasedCount(),
                 .upstream_slots_parked = server.upstreams.parkedCount(),
                 .upstream_slots_capacity = server.upstreams.capacity(),
+                .head_buffers_in_use = server.head_buffers_in_use,
+                .head_buffers_capacity = server.head_buffers_capacity,
                 .kernel_pressure_last_errno = server.last_pressure_errno,
                 .health_endpoints_checked = server.health.checked_count,
                 .health_endpoints_unhealthy = server.health.unhealthy_count,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -282,6 +282,10 @@ pub fn Server(comptime IoType: type) type {
                 u8,
                 @as(usize, options.upstream_head_buffers) * options.head_buffer_bytes,
             );
+            // Faulted in at init like the client ring's slab (see
+            // XevIo.initBufferGroup): RSS is the printed §5 budget from
+            // the first tick, never a load-dependent climb.
+            @memset(upstream_head_slab, 0);
             for (server.upstream_head_buffers.slots, 0..) |*head_buffer, index| {
                 head_buffer.data =
                     upstream_head_slab[index * options.head_buffer_bytes ..][0..options.head_buffer_bytes];
@@ -294,6 +298,8 @@ pub fn Server(comptime IoType: type) type {
                 if (options.head_buffers >= 1) options.head_buffer_bytes else 0;
             server.target_scratch = try arena.alloc(u8, scratch_bytes);
             server.rewrite_scratch = try arena.alloc(u8, scratch_bytes);
+            @memset(server.target_scratch, 0);
+            @memset(server.rewrite_scratch, 0);
             assert(server.target_scratch.len + server.rewrite_scratch.len +
                 options.head_buffer_bytes == headScratchBytes(options));
             server.l4_inflight = try arena.alloc(u16, keys.count);

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -101,6 +101,17 @@ pub fn Server(comptime IoType: type) type {
         /// and die. Inline rather than arena so it is part of no budget
         /// term and can never be under-counted.
         drain_sink: [constants.drain_sink_bytes]u8,
+        /// The §7 canonicalization scratches for the serving path (the
+        /// balancer's `eligible_scratch` precedent): their length is the
+        /// config's `head_buffer_bytes`, and a runtime-length stack array
+        /// is exactly the dynamic allocation §5 forbids — allocated once
+        /// at init, reused per request. Two, not one: on the checkout
+        /// path the routed views still alias the target scratch while the
+        /// filter rewrite writes the other. Sound because the loop is
+        /// single-threaded and neither window suspends or re-enters.
+        /// Empty on an L4-only config, which never canonicalizes.
+        target_scratch: []u8,
+        rewrite_scratch: []u8,
         /// Highest armed-op count any one connection has reached (§8):
         /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
         /// under runtime safety only (never in the shipped ReleaseFast
@@ -248,10 +259,13 @@ pub fn Server(comptime IoType: type) type {
             assert(options.upstream_slots >= 1);
             assert(options.relay_buffers <= options.conn_slots);
             assert(options.head_buffers <= options.conn_slots);
-            // The ring the backend registered and the limit this server
-            // accounts against must be the same number, or the shed rung
-            // fires at a size no config names. Zero is the L4-only shape.
+            // The ring the backend registered and the limits this server
+            // accounts against must agree — count and unit size both — or
+            // the shed rung fires at a shape no config names. A zero
+            // count is the L4-only shape; the size holds regardless,
+            // because the health prober's buffer follows it too.
             assert(io.bufferGroupCount() == options.head_buffers);
+            assert(io.bufferGroupBytes() == options.head_buffer_bytes);
             server.io = io;
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
@@ -262,6 +276,26 @@ pub fn Server(comptime IoType: type) type {
             try server.upstreams.init(arena, options.upstream_slots, keys);
             assert(options.upstream_head_buffers <= options.upstream_slots);
             try server.upstream_head_buffers.init(arena, options.upstream_head_buffers);
+            // The pool's slab, wired once: `Pool` never touches `data`,
+            // so the wiring survives every acquire/release cycle.
+            const upstream_head_slab = try arena.alloc(
+                u8,
+                @as(usize, options.upstream_head_buffers) * options.head_buffer_bytes,
+            );
+            for (server.upstream_head_buffers.slots, 0..) |*head_buffer, index| {
+                head_buffer.data =
+                    upstream_head_slab[index * options.head_buffer_bytes ..][0..options.head_buffer_bytes];
+            }
+            // The serving path's canonicalization scratches (see the
+            // fields): sized only where a head can exist to canonicalize.
+            // `headScratchBytes` is the closed form the banner prints;
+            // asserting the sum here is what keeps the two from drifting.
+            const scratch_bytes: usize =
+                if (options.head_buffers >= 1) options.head_buffer_bytes else 0;
+            server.target_scratch = try arena.alloc(u8, scratch_bytes);
+            server.rewrite_scratch = try arena.alloc(u8, scratch_bytes);
+            assert(server.target_scratch.len + server.rewrite_scratch.len +
+                options.head_buffer_bytes == headScratchBytes(options));
             server.l4_inflight = try arena.alloc(u16, keys.count);
             @memset(server.l4_inflight, 0);
             server.listeners = try arena.alloc(ListenerState, config.listeners.len);
@@ -287,7 +321,7 @@ pub fn Server(comptime IoType: type) type {
             server.admin.init(server, config.admin_bind);
             server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
             try server.access_log.reserve(arena);
-            try server.health.init(arena, server, keys);
+            try server.health.init(arena, server, keys, options.head_buffer_bytes);
         }
 
         /// Override the admin/metrics bind before `start` — the simulator
@@ -571,8 +605,9 @@ pub fn Server(comptime IoType: type) type {
         /// already hold to be admitted at all. An L4 connection relays for
         /// its whole life, so a missing relay buffer is an admission-time
         /// shed (§8), counted before `admitted`; an idle L7 connection
-        /// holds a slot and head buffer only and acquires a buffer per body
-        /// leg (§5). The second divergence is `startProtocol`.
+        /// holds a slot only — its head buffer binds at the first byte,
+        /// its relay buffer per body leg (§5). The second divergence is
+        /// `startProtocol`.
         fn admit(server: *Self, state: *ListenerState, client_socket: IoType.Socket) void {
             assert(!server.draining);
             const conn = server.admitConn(client_socket) orelse return;
@@ -599,7 +634,7 @@ pub fn Server(comptime IoType: type) type {
         /// The first deadline that connection runs under: an L4 connection
         /// is dialing, so it gets the connect budget (§8); an L7 one is
         /// reading a head, so a slowloris meets the clock or
-        /// `head_bytes_max`, whichever comes first (§7).
+        /// `limits.head_buffer_bytes`, whichever comes first (§7).
         fn entryTimeoutMs(
             server: *const Self,
             protocol: config_module.Config.Listener.Protocol,
@@ -793,6 +828,16 @@ pub fn Server(comptime IoType: type) type {
         /// The shared lingering-close discard target (§7) — see the field.
         pub fn drainSink(server: *Self) []u8 {
             return server.drain_sink[0..];
+        }
+
+        /// The head-sized side buffers' closed form (§5): the two serving
+        /// scratches (only where a head can exist) plus the health
+        /// prober's response buffer (always). The budget banner prints
+        /// this; `init` asserts its allocations sum to it, so the printed
+        /// number cannot drift from what is actually reserved.
+        pub fn headScratchBytes(options: InitOptions) u64 {
+            const serving: u64 = if (options.head_buffers >= 1) 2 else 0;
+            return (serving + 1) * options.head_buffer_bytes;
         }
 
         /// The same pair for conn slots, with `admitConn` as its acquire

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -56,9 +56,12 @@ const Harness = struct {
         errdefer harness.arena_state.deinit();
         const arena = harness.arena_state.allocator();
 
+        // An http bed: ring on both sides of the seam, sized to the conn
+        // slots below (Server.init asserts the two agree).
         try harness.sim_io.init(arena, .{
             .seed = 1,
             .adversary = .{ .partial_io = false, .log_write_stall_ns = stall_ns },
+            .buffer_group_count = 4,
         });
         harness.endpoints = .{originAddress()};
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
@@ -81,6 +84,7 @@ const Harness = struct {
         try harness.server.init(arena, &harness.sim_io, &harness.config, .{
             .conn_slots = 4,
             .relay_buffers = 2,
+            .head_buffers = 4,
             .access_log_buffer_bytes = buffer_bytes,
         });
     }

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -85,6 +85,7 @@ const Harness = struct {
             .conn_slots = 4,
             .relay_buffers = 2,
             .head_buffers = 4,
+            .upstream_head_buffers = 4,
             .access_log_buffer_bytes = buffer_bytes,
         });
     }

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -54,7 +54,11 @@ const Harness = struct {
         errdefer harness.arena_state.deinit();
         const arena = harness.arena_state.allocator();
 
-        try harness.sim_io.init(arena, sim);
+        // An L4-only bed: no head-buffer ring on either side of the seam
+        // (Server.init asserts the two agree).
+        var sim_options = sim;
+        sim_options.buffer_group_count = 0;
+        try harness.sim_io.init(arena, sim_options);
         harness.endpoints = .{originAddress()};
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
         harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};

--- a/src/config.zig
+++ b/src/config.zig
@@ -91,6 +91,15 @@ pub const Config = struct {
         /// serves http without doing so dies on the seam's own assert
         /// rather than silently inheriting a production-sized ring.
         head_buffers: u32 = 0,
+        /// The §5 upstream head pool: how many exchanges may hold an
+        /// upstream head (the render-to-park window) at once. Parked
+        /// upstream connections hold none, so this bounds concurrent
+        /// *exchanges in their head phase*, not open origin connections.
+        /// The loader resolves an omitted field to upstream_slots (a
+        /// leased slot never needs more than one head — never sheds);
+        /// zero exactly when no listener speaks http, and the struct
+        /// default is the off state on the same terms as `head_buffers`.
+        upstream_head_buffers: u32 = 0,
         /// How many eighths of the io_uring completion queue the worst-case
         /// in-flight ops may fill (§8). Unlike the pool sizes this is not a
         /// shrink: ⅞ (the compiled default, the fill the ceiling is derived
@@ -313,6 +322,9 @@ pub const ValidationError = error{
     LimitHeadBuffersOutOfRange,
     LimitHeadBuffersOverConnSlots,
     LimitHeadBuffersWithoutHttpListener,
+    LimitUpstreamHeadBuffersOutOfRange,
+    LimitUpstreamHeadBuffersOverUpstreamSlots,
+    LimitUpstreamHeadBuffersWithoutHttpListener,
     LimitCqFillOutOfRange,
     LimitConnSlotsOverCqFill,
     LimitAccessLogBufferOutOfRange,
@@ -424,6 +436,11 @@ fn resolveLimits(
         conn_slots,
         http_listeners_count,
     );
+    const upstream_head_buffers = try resolveUpstreamHeadBuffers(
+        limits_json.upstream_head_buffers,
+        upstream_slots,
+        http_listeners_count,
+    );
     // The CQ fill is the one limit an operator tightens for headroom, not a
     // pool shrink (§8): a smaller fill demands a deeper ring for the same
     // conn slots. Range-check first, then reject a fill that — with these
@@ -452,6 +469,7 @@ fn resolveLimits(
         .relay_buffers = relay_buffers,
         .upstream_slots = upstream_slots,
         .head_buffers = head_buffers,
+        .upstream_head_buffers = upstream_head_buffers,
         .cq_fill_eighths = cq_fill_eighths,
         .access_log_buffer_bytes = access_log_buffer_bytes,
     };
@@ -482,6 +500,30 @@ fn resolveHeadBuffers(
     }
     assert(head_buffers <= conn_slots);
     return head_buffers;
+}
+
+/// The §5 upstream head pool, on `resolveHeadBuffers`'s exact terms with
+/// upstream slots as the ceiling: a leased slot never needs more than one
+/// head, so more heads than slots is waste stated as intent.
+fn resolveUpstreamHeadBuffers(
+    requested: ?u32,
+    upstream_slots: u32,
+    http_listeners_count: u32,
+) ValidationError!u32 {
+    assert(upstream_slots >= 1);
+    const upstream_head_buffers = requested orelse
+        (if (http_listeners_count >= 1) upstream_slots else 0);
+    if (upstream_head_buffers > upstream_slots) {
+        return error.LimitUpstreamHeadBuffersOverUpstreamSlots;
+    }
+    if (http_listeners_count == 0 and upstream_head_buffers >= 1) {
+        return error.LimitUpstreamHeadBuffersWithoutHttpListener;
+    }
+    if (http_listeners_count >= 1 and upstream_head_buffers == 0) {
+        return error.LimitUpstreamHeadBuffersOutOfRange;
+    }
+    assert(upstream_head_buffers <= upstream_slots);
+    return upstream_head_buffers;
 }
 
 fn resolveAccessLogBuffer(
@@ -585,6 +627,7 @@ pub const LimitsJson = struct {
     relay_buffers: ?u32 = null,
     upstream_slots: ?u32 = null,
     head_buffers: ?u32 = null,
+    upstream_head_buffers: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
     access_log_buffer_bytes: ?u32 = null,
 
@@ -615,6 +658,14 @@ pub const LimitsJson = struct {
                 "0 without one.",
             .minimum = 0,
             .maximum = constants.conn_slots_max,
+        },
+        .upstream_head_buffers = .{
+            .desc = "Upstream head buffers (bounds exchanges in their head " ++
+                "phase; parked origin connections hold none). Defaults to " ++
+                "upstream_slots; must be 1..upstream_slots with an http " ++
+                "listener, 0 without one.",
+            .minimum = 0,
+            .maximum = constants.upstream_slots_max,
         },
         .cq_fill_eighths = .{
             .desc = "Eighths of the io_uring completion queue the worst-case " ++
@@ -2575,8 +2626,10 @@ test "config: limits shrink pools below the ceilings, never past them" {
             \\ "limits":{"conn_slots":64,"head_buffers":16}}
         );
         // An http config follows conn slots when the ring is omitted and
-        // takes the operator's number when it is not.
+        // takes the operator's number when it is not; the upstream head
+        // pool follows upstream slots on the same terms.
         try std.testing.expectEqual(@as(u32, 16), parsed.limits.head_buffers);
+        try std.testing.expectEqual(constants.upstream_slots_default, parsed.limits.upstream_head_buffers);
     }
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
@@ -2634,6 +2687,14 @@ test "config: limits shrink pools below the ceilings, never past them" {
         "\"limits\":{\"head_buffers\":1}}");
     try expectParseError(error.LimitHeadBuffersOutOfRange, http_head ++ tail ++
         "\"limits\":{\"head_buffers\":0}}");
+    // The upstream head pool refuses the same three shapes against its
+    // own ceiling, the upstream slots.
+    try expectParseError(error.LimitUpstreamHeadBuffersOverUpstreamSlots, http_head ++ tail ++
+        "\"limits\":{\"upstream_slots\":2,\"upstream_head_buffers\":4}}");
+    try expectParseError(error.LimitUpstreamHeadBuffersWithoutHttpListener, head ++ tail ++
+        "\"limits\":{\"upstream_head_buffers\":1}}");
+    try expectParseError(error.LimitUpstreamHeadBuffersOutOfRange, http_head ++ tail ++
+        "\"limits\":{\"upstream_head_buffers\":0}}");
     // The CQ fill has its own range [min, max] in eighths; below or above
     // fails loudly, each distinct from the pool-size errors.
     try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":0}}");

--- a/src/config.zig
+++ b/src/config.zig
@@ -100,6 +100,15 @@ pub const Config = struct {
         /// zero exactly when no listener speaks http, and the struct
         /// default is the off state on the same terms as `head_buffers`.
         upstream_head_buffers: u32 = 0,
+        /// Bytes per head buffer, in both §5 head pools — and therefore
+        /// the largest request or response head this proxy accepts: an
+        /// oversize request head is 414/431, an oversize origin head
+        /// tears the exchange down (§7). Operator-visible behaviour, not
+        /// just a size, which is why it gets a floor (below it, ordinary
+        /// requests start dying) as well as a ceiling. May be raised as
+        /// well as lowered — the big-cookie/JWT case is the reason it
+        /// exists. Inert when both pools are zero (an L4-only config).
+        head_buffer_bytes: u32 = constants.head_buffer_bytes_default,
         /// How many eighths of the io_uring completion queue the worst-case
         /// in-flight ops may fill (§8). Unlike the pool sizes this is not a
         /// shrink: ⅞ (the compiled default, the fill the ceiling is derived
@@ -325,6 +334,7 @@ pub const ValidationError = error{
     LimitUpstreamHeadBuffersOutOfRange,
     LimitUpstreamHeadBuffersOverUpstreamSlots,
     LimitUpstreamHeadBuffersWithoutHttpListener,
+    LimitHeadBufferBytesOutOfRange,
     LimitCqFillOutOfRange,
     LimitConnSlotsOverCqFill,
     LimitAccessLogBufferOutOfRange,
@@ -346,18 +356,31 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     // any check inherits it.
     try validateTimeouts(&parsed.timeouts);
     const clusters = try resolveClusters(arena, &parsed.clusters, parsed.timeouts.connect_ms);
-    const listeners = try resolveListeners(arena, parsed.listeners, clusters);
-    const access_log_sink = try resolveAccessLogSink(parsed.access_log);
-    var http_listeners_count: u32 = 0;
-    for (listeners) |*listener| {
-        if (listener.protocol == .http) http_listeners_count += 1;
+    // Limits resolve before listeners, off the raw DTO counts: the route
+    // prefixes inside `resolveListeners` are gated against the resolved
+    // `head_buffer_bytes` — a prefix longer than the head can never
+    // match a parsed path, and belongs refused at load, not left to 404
+    // forever at runtime. The reorder moves precedences, pinned by
+    // tests: emptiness still outranks everything after the clusters
+    // (the limits resolver asserts a non-empty set, so the gate fires
+    // first here); a bad protocol string surfaces from the count below —
+    // before any bind or sink is looked at; and a bad bind, resolved
+    // last, now reports after a bad access-log sink.
+    if (parsed.listeners.len == 0) {
+        return error.ListenersEmpty;
     }
+    var http_listeners_count: u32 = 0;
+    for (parsed.listeners) |listener_json| {
+        if (try protocolOf(listener_json.protocol) == .http) http_listeners_count += 1;
+    }
+    const access_log_sink = try resolveAccessLogSink(parsed.access_log);
     const limits = try resolveLimits(
         &parsed.limits,
-        @intCast(listeners.len),
+        @intCast(parsed.listeners.len),
         http_listeners_count,
         access_log_sink != null,
     );
+    const listeners = try resolveListeners(arena, parsed.listeners, clusters, limits.head_buffer_bytes);
     const admin_bind = try resolveAdminBind(parsed.admin);
 
     assert(listeners.len >= 1);
@@ -441,6 +464,7 @@ fn resolveLimits(
         upstream_slots,
         http_listeners_count,
     );
+    const head_buffer_bytes = try resolveHeadBufferBytes(limits_json.head_buffer_bytes);
     // The CQ fill is the one limit an operator tightens for headroom, not a
     // pool shrink (§8): a smaller fill demands a deeper ring for the same
     // conn slots. Range-check first, then reject a fill that — with these
@@ -470,6 +494,7 @@ fn resolveLimits(
         .upstream_slots = upstream_slots,
         .head_buffers = head_buffers,
         .upstream_head_buffers = upstream_head_buffers,
+        .head_buffer_bytes = head_buffer_bytes,
         .cq_fill_eighths = cq_fill_eighths,
         .access_log_buffer_bytes = access_log_buffer_bytes,
     };
@@ -524,6 +549,23 @@ fn resolveUpstreamHeadBuffers(
     }
     assert(upstream_head_buffers <= upstream_slots);
     return upstream_head_buffers;
+}
+
+/// The head-buffer size (§5): a plain range, unlike its two count
+/// siblings — the size is a property of the pools and of the health
+/// prober's buffer, so it needs no http-listener coupling; an L4-only
+/// config's value still sizes the prober. The floor is behaviour, not
+/// memory: below it ordinary requests start dying as 414/431.
+fn resolveHeadBufferBytes(requested: ?u32) ValidationError!u32 {
+    const head_buffer_bytes = requested orelse constants.head_buffer_bytes_default;
+    if (head_buffer_bytes < constants.head_buffer_bytes_min or
+        head_buffer_bytes > constants.head_buffer_bytes_max)
+    {
+        return error.LimitHeadBufferBytesOutOfRange;
+    }
+    assert(head_buffer_bytes >= constants.head_buffer_bytes_min);
+    assert(head_buffer_bytes <= constants.head_buffer_bytes_max);
+    return head_buffer_bytes;
 }
 
 fn resolveAccessLogBuffer(
@@ -628,6 +670,7 @@ pub const LimitsJson = struct {
     upstream_slots: ?u32 = null,
     head_buffers: ?u32 = null,
     upstream_head_buffers: ?u32 = null,
+    head_buffer_bytes: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
     access_log_buffer_bytes: ?u32 = null,
 
@@ -666,6 +709,13 @@ pub const LimitsJson = struct {
                 "listener, 0 without one.",
             .minimum = 0,
             .maximum = constants.upstream_slots_max,
+        },
+        .head_buffer_bytes = .{
+            .desc = "Bytes per head buffer in both head pools — the largest " ++
+                "HTTP head accepted (oversize requests get 414/431). May be " ++
+                "raised for big-cookie/JWT traffic as well as lowered.",
+            .minimum = constants.head_buffer_bytes_min,
+            .maximum = constants.head_buffer_bytes_max,
         },
         .cq_fill_eighths = .{
             .desc = "Eighths of the io_uring completion queue the worst-case " ++
@@ -1273,6 +1323,7 @@ fn resolveListeners(
     arena: std.mem.Allocator,
     listeners_json: []const ListenerJson,
     clusters: []const Config.Cluster,
+    head_buffer_bytes: u32,
 ) ParseError![]const Config.Listener {
     assert(clusters.len >= 1);
     if (listeners_json.len == 0) {
@@ -1294,8 +1345,8 @@ fn resolveListeners(
         const protocol = try protocolOf(listener_json.protocol);
         listeners[index] = .{
             .bind_address = bind_address,
-            .routes = try resolveRoutes(arena, &listener_json, clusters, protocol),
-            .filters = try resolveFilters(arena, &listener_json, protocol),
+            .routes = try resolveRoutes(arena, &listener_json, clusters, protocol, head_buffer_bytes),
+            .filters = try resolveFilters(arena, &listener_json, protocol, head_buffer_bytes),
             .protocol = protocol,
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
         };
@@ -1352,6 +1403,7 @@ fn resolveFilters(
     arena: std.mem.Allocator,
     listener_json: *const ListenerJson,
     protocol: Config.Listener.Protocol,
+    head_buffer_bytes: u32,
 ) ParseError![]const filter.Rule {
     const filters_json = listener_json.filters orelse return &.{};
     // Any `filters` key on an l4 listener is a mistake — l4 relays bytes,
@@ -1367,8 +1419,8 @@ fn resolveFilters(
     var header_edits: u32 = 0;
     for (filters_json, rules) |rule_json, *rule| {
         rule.* = .{
-            .match = try resolveMatch(arena, &rule_json.match),
-            .actions = try resolveActions(arena, rule_json.actions),
+            .match = try resolveMatch(arena, &rule_json.match, head_buffer_bytes),
+            .actions = try resolveActions(arena, rule_json.actions, head_buffer_bytes),
         };
         header_edits += countHeaderEdits(rule.actions);
     }
@@ -1406,13 +1458,14 @@ fn countHeaderEdits(actions: []const filter.Action) u32 {
 fn resolveMatch(
     arena: std.mem.Allocator,
     match_json: *const MatchJson,
+    head_buffer_bytes: u32,
 ) ParseError!filter.Match {
     var match: filter.Match = .{};
     if (match_json.host) |host| {
         match.host = try validateRouteHost(host);
     }
     if (match_json.path_prefix) |prefix| {
-        try validateRoutePrefix(prefix);
+        try validateRoutePrefix(prefix, head_buffer_bytes);
         match.path_prefix = prefix;
     }
     if (match_json.method) |tokens| {
@@ -1476,6 +1529,7 @@ fn resolveHeaderMatches(
 fn resolveActions(
     arena: std.mem.Allocator,
     actions_json: []const ActionJson,
+    head_buffer_bytes: u32,
 ) ParseError![]const filter.Action {
     if (actions_json.len == 0) {
         return error.FilterActionsEmpty;
@@ -1483,13 +1537,13 @@ fn resolveActions(
     assert(actions_json.len >= 1); // Past the empty guard.
     const actions = try arena.alloc(filter.Action, actions_json.len);
     for (actions_json, actions) |action_json, *action| {
-        action.* = try resolveAction(&action_json);
+        action.* = try resolveAction(&action_json, head_buffer_bytes);
     }
     assert(actions.len == actions_json.len);
     return actions;
 }
 
-fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
+fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseError!filter.Action {
     // Exactly one action field carries the kind.
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
         @intFromBool(action_json.header_set != null) +
@@ -1517,8 +1571,8 @@ fn resolveAction(action_json: *const ActionJson) ParseError!filter.Action {
         return .{ .header_remove = name };
     }
     const rewrite = action_json.rewrite_prefix.?;
-    try validateRoutePrefix(rewrite.from);
-    try validateRoutePrefix(rewrite.to);
+    try validateRoutePrefix(rewrite.from, head_buffer_bytes);
+    try validateRoutePrefix(rewrite.to, head_buffer_bytes);
     return .{ .rewrite_prefix = .{ .from = rewrite.from, .to = rewrite.to } };
 }
 
@@ -1614,6 +1668,7 @@ fn resolveRoutes(
     listener_json: *const ListenerJson,
     clusters: []const Config.Cluster,
     protocol: Config.Listener.Protocol,
+    head_buffer_bytes: u32,
 ) ParseError![]const router.Route {
     const has_cluster = listener_json.cluster != null;
     const has_routes = listener_json.routes != null;
@@ -1638,7 +1693,7 @@ fn resolveRoutes(
     }
     const routes = try arena.alloc(router.Route, routes_json.len);
     for (routes_json, 0..) |route_json, index| {
-        try validateRoutePrefix(route_json.prefix);
+        try validateRoutePrefix(route_json.prefix, head_buffer_bytes);
         const host = if (route_json.host) |raw| try validateRouteHost(raw) else null;
         for (routes_json[0..index]) |previous| {
             // Earlier routes already passed validateRouteHost, so their raw
@@ -1703,15 +1758,24 @@ fn validateRouteHost(host: []const u8) ParseError![]const u8 {
 /// prefix that canonicalization would change (dot-segments, decodable or
 /// structure-changing escapes, a missing leading slash, a query) is
 /// rejected at load, not silently mismatched at request time.
-fn validateRoutePrefix(prefix: []const u8) ParseError!void {
+fn validateRoutePrefix(prefix: []const u8, head_buffer_bytes: u32) ParseError!void {
+    assert(head_buffer_bytes >= constants.head_buffer_bytes_min);
+    assert(head_buffer_bytes <= constants.head_buffer_bytes_max);
     if (prefix.len == 0 or prefix[0] != '/') {
         return error.RoutePrefixNotCanonical;
     }
-    if (prefix.len > constants.head_bytes_max) {
+    // Against the *resolved* size (`limits` resolves before listeners
+    // for exactly this): a prefix longer than the configured head can
+    // never match a parsed path, and belongs refused at load, not left
+    // to 404 forever at runtime.
+    if (prefix.len > head_buffer_bytes) {
         return error.RoutePrefixNotCanonical;
     }
-    var out: [constants.head_bytes_max]u8 = undefined;
-    const canonical = parser.canonicalTarget(prefix, &out) catch {
+    // Canonicalization only ever shrinks, so the compile-time ceiling on
+    // the runtime gate above bounds the scratch. Stack is fine here:
+    // this is the loader, not the serving path §5 constrains.
+    var out: [constants.head_buffer_bytes_max]u8 = undefined;
+    const canonical = parser.canonicalTarget(prefix, out[0..]) catch {
         return error.RoutePrefixNotCanonical;
     };
     if (canonical.query.len != 0 or !std.mem.eql(u8, canonical.path, prefix)) {
@@ -1771,7 +1835,13 @@ fn resolveHttpCheck(check: *const CheckJson) ParseError!Config.Cluster.Check.Htt
     if (path.len > constants.health_check_path_bytes_max) {
         return error.ClusterCheckPathTooLong;
     }
-    validateRoutePrefix(path) catch return error.ClusterCheckPathNotCanonical;
+    // The floor stands in for the resolved size here: clusters resolve
+    // before `limits`, and a probe path is already capped far below the
+    // smallest head buffer any config can choose (the comptime relation
+    // in constants.zig), so the tighter runtime gate can never bind.
+    comptime assert(constants.health_check_path_bytes_max < constants.head_buffer_bytes_min);
+    validateRoutePrefix(path, constants.head_buffer_bytes_min) catch
+        return error.ClusterCheckPathNotCanonical;
     if (check.host) |host| {
         if (host.len == 0 or host.len > constants.health_check_host_bytes_max) {
             return error.ClusterCheckHostInvalid;
@@ -2630,6 +2700,7 @@ test "config: limits shrink pools below the ceilings, never past them" {
         // pool follows upstream slots on the same terms.
         try std.testing.expectEqual(@as(u32, 16), parsed.limits.head_buffers);
         try std.testing.expectEqual(constants.upstream_slots_default, parsed.limits.upstream_head_buffers);
+        try std.testing.expectEqual(constants.head_buffer_bytes_default, parsed.limits.head_buffer_bytes);
     }
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
@@ -2695,6 +2766,29 @@ test "config: limits shrink pools below the ceilings, never past them" {
         "\"limits\":{\"upstream_head_buffers\":1}}");
     try expectParseError(error.LimitUpstreamHeadBuffersOutOfRange, http_head ++ tail ++
         "\"limits\":{\"upstream_head_buffers\":0}}");
+    // The size knob has a floor as well as a ceiling: below it ordinary
+    // requests start dying as 414/431, which is behaviour, not memory.
+    try expectParseError(error.LimitHeadBufferBytesOutOfRange, http_head ++ tail ++
+        "\"limits\":{\"head_buffer_bytes\":512}}");
+    try expectParseError(error.LimitHeadBufferBytesOutOfRange, http_head ++ tail ++
+        "\"limits\":{\"head_buffer_bytes\":2097152}}");
+    // The parse-order precedences the limits-before-listeners reorder
+    // moved, pinned deliberately (see `parse`): emptiness beats a bad
+    // sink; a bad protocol (even on a later listener) beats a bad bind
+    // on an earlier one, because the http count reads every protocol
+    // before any listener resolves.
+    try expectParseError(error.ListenersEmpty,
+        \\{"listeners":[],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1},
+        \\ "access_log":{"sink":"nonsense"}}
+    );
+    try expectParseError(error.ListenerProtocolUnknown,
+        \\{"listeners":[{"bind":"not-an-address","cluster":"a"},
+        \\               {"bind":"127.0.0.1:1","cluster":"a","protocol":"gopher"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
     // The CQ fill has its own range [min, max] in eighths; below or above
     // fails loudly, each distinct from the pool-size errors.
     try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":0}}");

--- a/src/config.zig
+++ b/src/config.zig
@@ -77,6 +77,20 @@ pub const Config = struct {
         conn_slots: u32 = constants.conn_slots_default,
         relay_buffers: u32 = constants.relay_buffers_default,
         upstream_slots: u32 = constants.upstream_slots_default,
+        /// The §5 head-buffer ring: how many request heads may be in
+        /// flight at once. Buffers bind only to connections with a head
+        /// actually arriving or held — idle keep-alive connections hold
+        /// none — so this is a concurrency limit, not a per-connection
+        /// cost. The loader resolves an omitted field to conn_slots
+        /// (every connection could be mid-head at once: never sheds, the
+        /// same worst-case memory the inline buffers used to pin); the
+        /// operator trades it down against the `l7_shed_head_buffers`
+        /// wall. Zero exactly when no listener speaks http. The *struct*
+        /// default is the off state, like `access_log_buffer_bytes`:
+        /// hand-built (test) configs opt in explicitly, and one that
+        /// serves http without doing so dies on the seam's own assert
+        /// rather than silently inheriting a production-sized ring.
+        head_buffers: u32 = 0,
         /// How many eighths of the io_uring completion queue the worst-case
         /// in-flight ops may fill (§8). Unlike the pool sizes this is not a
         /// shrink: ⅞ (the compiled default, the fill the ceiling is derived
@@ -296,6 +310,9 @@ pub const ValidationError = error{
     LimitRelayBuffersOutOfRange,
     LimitRelayBuffersOverConnSlots,
     LimitUpstreamSlotsOutOfRange,
+    LimitHeadBuffersOutOfRange,
+    LimitHeadBuffersOverConnSlots,
+    LimitHeadBuffersWithoutHttpListener,
     LimitCqFillOutOfRange,
     LimitConnSlotsOverCqFill,
     LimitAccessLogBufferOutOfRange,
@@ -319,9 +336,14 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     const clusters = try resolveClusters(arena, &parsed.clusters, parsed.timeouts.connect_ms);
     const listeners = try resolveListeners(arena, parsed.listeners, clusters);
     const access_log_sink = try resolveAccessLogSink(parsed.access_log);
+    var http_listeners_count: u32 = 0;
+    for (listeners) |*listener| {
+        if (listener.protocol == .http) http_listeners_count += 1;
+    }
     const limits = try resolveLimits(
         &parsed.limits,
         @intCast(listeners.len),
+        http_listeners_count,
         access_log_sink != null,
     );
     const admin_bind = try resolveAdminBind(parsed.admin);
@@ -372,9 +394,11 @@ fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddres
 fn resolveLimits(
     limits_json: *const LimitsJson,
     listeners_count: u32,
+    http_listeners_count: u32,
     access_log_on: bool,
 ) ValidationError!Config.Limits {
     assert(listeners_count >= 1);
+    assert(http_listeners_count <= listeners_count);
     // Omitted limits default to the lean out-of-box sizes, not the
     // compiled ceilings (§5): a small footprint unless the operator opts
     // up. relay buffers still follow conn slots when omitted (one buffer
@@ -395,6 +419,11 @@ fn resolveLimits(
     if (upstream_slots < 1 or upstream_slots > constants.upstream_slots_max) {
         return error.LimitUpstreamSlotsOutOfRange;
     }
+    const head_buffers = try resolveHeadBuffers(
+        limits_json.head_buffers,
+        conn_slots,
+        http_listeners_count,
+    );
     // The CQ fill is the one limit an operator tightens for headroom, not a
     // pool shrink (§8): a smaller fill demands a deeper ring for the same
     // conn slots. Range-check first, then reject a fill that — with these
@@ -417,13 +446,42 @@ fn resolveLimits(
         access_log_on,
     );
     assert(relay_buffers <= conn_slots);
+    assert(head_buffers <= conn_slots);
     return .{
         .conn_slots = conn_slots,
         .relay_buffers = relay_buffers,
         .upstream_slots = upstream_slots,
+        .head_buffers = head_buffers,
         .cq_fill_eighths = cq_fill_eighths,
         .access_log_buffer_bytes = access_log_buffer_bytes,
     };
+}
+
+/// The §5 head-buffer ring follows conn slots when omitted (every
+/// connection could be mid-head at once — never sheds), and is zero
+/// exactly when no listener speaks http: an L4-only deployment registers
+/// no ring, and one that asked for buffers it cannot use is told so. A
+/// ring an http deployment cannot bind from (zero) would shed every
+/// request, so that is rejected too, not defaulted around.
+fn resolveHeadBuffers(
+    requested: ?u32,
+    conn_slots: u32,
+    http_listeners_count: u32,
+) ValidationError!u32 {
+    assert(conn_slots >= 1);
+    const head_buffers = requested orelse
+        (if (http_listeners_count >= 1) conn_slots else 0);
+    if (head_buffers > conn_slots) {
+        return error.LimitHeadBuffersOverConnSlots;
+    }
+    if (http_listeners_count == 0 and head_buffers >= 1) {
+        return error.LimitHeadBuffersWithoutHttpListener;
+    }
+    if (http_listeners_count >= 1 and head_buffers == 0) {
+        return error.LimitHeadBuffersOutOfRange;
+    }
+    assert(head_buffers <= conn_slots);
+    return head_buffers;
 }
 
 fn resolveAccessLogBuffer(
@@ -526,6 +584,7 @@ pub const LimitsJson = struct {
     conn_slots: ?u32 = null,
     relay_buffers: ?u32 = null,
     upstream_slots: ?u32 = null,
+    head_buffers: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
     access_log_buffer_bytes: ?u32 = null,
 
@@ -548,6 +607,14 @@ pub const LimitsJson = struct {
             .desc = "Shared upstream connection slots.",
             .minimum = 1,
             .maximum = constants.upstream_slots_max,
+        },
+        .head_buffers = .{
+            .desc = "HTTP head buffers in the shared ring (bounds request heads " ++
+                "in flight; idle keep-alive connections hold none). Defaults " ++
+                "to conn_slots; must be 1..conn_slots with an http listener, " ++
+                "0 without one.",
+            .minimum = 0,
+            .maximum = constants.conn_slots_max,
         },
         .cq_fill_eighths = .{
             .desc = "Eighths of the io_uring completion queue the worst-case " ++
@@ -2493,8 +2560,34 @@ test "config: limits shrink pools below the ceilings, never past them" {
         try std.testing.expectEqual(@as(u32, 64), parsed.limits.conn_slots);
         try std.testing.expectEqual(@as(u32, 8), parsed.limits.relay_buffers);
         try std.testing.expectEqual(@as(u32, 8), parsed.limits.upstream_slots);
+        // An l4-only config registers no head-buffer ring.
+        try std.testing.expectEqual(@as(u32, 0), parsed.limits.head_buffers);
         // A tighter fill resolves verbatim when the pools leave room for it.
         try std.testing.expectEqual(@as(u32, 4), parsed.limits.cq_fill_eighths);
+    }
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state,
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1},
+            \\ "limits":{"conn_slots":64,"head_buffers":16}}
+        );
+        // An http config follows conn slots when the ring is omitted and
+        // takes the operator's number when it is not.
+        try std.testing.expectEqual(@as(u32, 16), parsed.limits.head_buffers);
+    }
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state,
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1},
+            \\ "limits":{"conn_slots":64}}
+        );
+        try std.testing.expectEqual(@as(u32, 64), parsed.limits.head_buffers);
     }
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
@@ -2509,6 +2602,7 @@ test "config: limits shrink pools below the ceilings, never past them" {
         try std.testing.expectEqual(constants.conn_slots_default, parsed.limits.conn_slots);
         try std.testing.expectEqual(constants.relay_buffers_default, parsed.limits.relay_buffers);
         try std.testing.expectEqual(constants.upstream_slots_default, parsed.limits.upstream_slots);
+        try std.testing.expectEqual(@as(u32, 0), parsed.limits.head_buffers);
         try std.testing.expectEqual(constants.cq_fill_eighths_default, parsed.limits.cq_fill_eighths);
     }
     const tail =
@@ -2529,6 +2623,17 @@ test "config: limits shrink pools below the ceilings, never past them" {
     // contradiction, not a derivable default.
     try expectParseError(error.LimitRelayBuffersOverConnSlots, head ++ tail ++
         "\"limits\":{\"conn_slots\":4,\"relay_buffers\":8}}");
+    // The head-buffer ring's three refusals (§5): more buffers than
+    // connections is waste stated as intent; any buffers without an http
+    // listener can never bind; an http listener with none would shed
+    // every request it is configured to serve.
+    const http_head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}],";
+    try expectParseError(error.LimitHeadBuffersOverConnSlots, http_head ++ tail ++
+        "\"limits\":{\"conn_slots\":4,\"head_buffers\":8}}");
+    try expectParseError(error.LimitHeadBuffersWithoutHttpListener, head ++ tail ++
+        "\"limits\":{\"head_buffers\":1}}");
+    try expectParseError(error.LimitHeadBuffersOutOfRange, http_head ++ tail ++
+        "\"limits\":{\"head_buffers\":0}}");
     // The CQ fill has its own range [min, max] in eighths; below or above
     // fails loudly, each distinct from the pool-size errors.
     try expectParseError(error.LimitCqFillOutOfRange, head ++ tail ++ "\"limits\":{\"cq_fill_eighths\":0}}");

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -851,6 +851,12 @@ pub const PoolSizes = struct {
     /// descriptor table (`bufferGroupDescriptorBytes`).
     head_buffers: u32,
     head_buffer_bytes: u64,
+    /// The §5 upstream head pool (`limits.upstream_head_buffers`; zero on
+    /// an L4-only config) and its unit size — `@sizeOf` the pool element,
+    /// so the intrusive free-list header rides along like every other
+    /// pool's.
+    upstream_head_buffers: u32,
+    upstream_head_buffer_bytes: u64,
 };
 
 /// What the access log reserves: nothing when it is off, both staging
@@ -875,7 +881,9 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     assert(sizes.upstream_slots <= upstream_slots_max);
     assert(sizes.conn_bytes > 0);
     assert(sizes.relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
-    assert(sizes.upstream_bytes >= head_bytes_max);
+    // Once 8 KiB of head, now scalars: the slot's head moved to the §5
+    // upstream head pool, whose own bound is asserted below.
+    assert(sizes.upstream_bytes > 0);
     // Either the log is off and costs nothing, or it holds exactly its two
     // buffers at a size the loader validated — never some third number.
     assert(sizes.access_log_bytes % access_log_buffers == 0);
@@ -886,12 +894,15 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
         @as(u64, access_log_buffers) * access_log_buffer_bytes_max);
     assert(sizes.head_buffers <= buffer_group_entries_max);
     assert(sizes.head_buffers == 0 or sizes.head_buffer_bytes >= 1);
+    assert(sizes.upstream_head_buffers <= sizes.upstream_slots);
+    assert(sizes.upstream_head_buffers == 0 or sizes.upstream_head_buffer_bytes >= head_bytes_max);
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
         sizes.access_log_bytes + sizes.endpoint_table_bytes +
         @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
-        bufferGroupDescriptorBytes(sizes.head_buffers);
+        bufferGroupDescriptorBytes(sizes.head_buffers) +
+        @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes;
     assert(total > 0);
     return total;
 }
@@ -920,7 +931,9 @@ test "pressure: relay watermarks have a hysteresis gap at every capacity" {
 test "budgets: memory total matches the closed form" {
     const conn_bytes: u64 = 10240;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
-    const upstream_bytes: u64 = head_bytes_max + 64;
+    // Scalars only since the head moved to its own pool (§5).
+    const upstream_bytes: u64 = 64;
+    const upstream_head_bytes: u64 = head_bytes_max + 8;
     // The endpoint-keyed tables (§7): like the access log, a reservation
     // that must move the total by exactly its own size and nothing else.
     const endpoint_tables: u64 = 4096;
@@ -944,7 +957,8 @@ test "budgets: memory total matches the closed form" {
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
         accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables +
-        head_ring;
+        head_ring +
+        @as(u64, upstream_slots_max) * upstream_head_bytes;
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
@@ -956,6 +970,8 @@ test "budgets: memory total matches the closed form" {
         .endpoint_table_bytes = endpoint_tables,
         .head_buffers = conn_slots_max,
         .head_buffer_bytes = head_bytes_max,
+        .upstream_head_buffers = upstream_slots_max,
+        .upstream_head_buffer_bytes = upstream_head_bytes,
     }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
@@ -967,9 +983,11 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(0),
         .endpoint_table_bytes = 0,
-        // The L4-only shape: no ring registered, no term at all.
+        // The L4-only shape: no ring, no upstream head pool, no terms.
         .head_buffers = 0,
         .head_buffer_bytes = head_bytes_max,
+        .upstream_head_buffers = 0,
+        .upstream_head_buffer_bytes = head_bytes_max,
     }));
     // An unconfigured access log reserves nothing (§5), and a configured
     // one reserves both buffers at whatever size it was given — the term

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -138,12 +138,36 @@ pub fn poolPressureOff(capacity: u32) u32 {
 /// configured idle timeout is already small.
 pub const pressure_idle_divisor: u32 = 4;
 
-/// Upper bound on one L7 request or response head, including the final
-/// CRLF — the size of a connection slot's head buffer (§5). A request
-/// head that cannot complete inside this budget is answered 414 (request
-/// line still open) or 431 (header section); an oversize origin response
-/// head tears the exchange down (§7).
-pub const head_bytes_max: u32 = 8 * 1024;
+/// The default upper bound on one L7 request or response head, including
+/// the final CRLF — the per-buffer size of both §5 head pools unless
+/// `limits.head_buffer_bytes` says otherwise. A request head that cannot
+/// complete inside the configured budget is answered 414 (request line
+/// still open) or 431 (header section); an oversize origin response head
+/// tears the exchange down (§7). The default stays 8 KiB deliberately:
+/// zoxy already accepts roughly half of HAProxy's ~15 KiB usable head,
+/// and shrinking further would reject heads its peers accept — the knob
+/// exists to *raise* for big-cookie/JWT deployments, and to lower only
+/// for operators who know their traffic.
+pub const head_buffer_bytes_default: u32 = 8 * 1024;
+
+/// The floor on `limits.head_buffer_bytes`. Below this, ordinary
+/// requests start dying as 414/431 — and it is what the comptime
+/// relations below hold against, so every derived buffer (the forwarded
+/// chain, the health probe) fits any size an operator may choose.
+pub const head_buffer_bytes_min: u32 = 1024;
+
+/// The ceiling on `limits.head_buffer_bytes` (the precedent is
+/// `access_log_buffer_bytes_max`: a size knob gets a sanity wall even
+/// where a count knob gets a relation). Also the widest head the parser
+/// layer must be prepared to see, whatever the config chose — its
+/// bounds-guarding asserts hold against this, not the default.
+pub const head_buffer_bytes_max: u32 = 1024 * 1024;
+
+comptime {
+    assert(head_buffer_bytes_min >= 1024);
+    assert(head_buffer_bytes_min <= head_buffer_bytes_default);
+    assert(head_buffer_bytes_default <= head_buffer_bytes_max);
+}
 
 /// Bounded per-head header array. Overflowing it is load, not malice: it
 /// maps to 431, distinguishable from malformed input's 400 (§7).
@@ -724,7 +748,6 @@ comptime {
     assert(connect_ms_default < idle_ms_default);
     assert(accept_retry_delay_ms >= 1);
     assert(pressure_idle_divisor >= 2);
-    assert(head_bytes_max >= 1024);
     assert(headers_max >= 8);
     assert(host_bytes_max >= 1);
     assert(upstream_slots_max >= 1);
@@ -771,9 +794,10 @@ comptime {
     // a write, and a third would be a queue nobody drains.
     assert(access_log_buffers == 2);
     // A carried chain plus the address appended to it must still leave a
-    // head that can be rendered; both are a small fraction of the buffer
-    // the whole head has to fit in.
-    assert(forwarded_value_bytes_max < head_bytes_max);
+    // head that can be rendered — inside the *smallest* head buffer an
+    // operator may configure, so the relation stays comptime while the
+    // size itself went runtime.
+    assert(forwarded_value_bytes_max < head_buffer_bytes_min);
     // The scratch must hold a bracketed IPv6 literal with its port, which
     // is what gets formatted before the port is stripped back off.
     assert(forwarded_client_bytes_max >= 47);
@@ -798,9 +822,10 @@ comptime {
     assert(health_check_host_bytes_max >= 1);
     assert(health_check_request_bytes_max >
         @as(u32, health_check_path_bytes_max) + health_check_host_bytes_max);
-    // A probe response is parsed by the same head parser the data path
-    // uses, so its buffer may never exceed what that parser accepts.
-    assert(health_check_request_bytes_max <= head_bytes_max);
+    // A probe request must fit the smallest head buffer an operator may
+    // configure — its response buffer follows `limits.head_buffer_bytes`
+    // at init, so only the request side needs a comptime floor.
+    assert(health_check_request_bytes_max <= head_buffer_bytes_min);
 }
 
 /// Total pool memory as a closed-form function of the *effective* pool
@@ -857,6 +882,12 @@ pub const PoolSizes = struct {
     /// pool's.
     upstream_head_buffers: u32,
     upstream_head_buffer_bytes: u64,
+    /// The head-sized side buffers (§5): the serving path's two
+    /// canonicalization scratches (present only where a head can exist)
+    /// and the health prober's response buffer (always). A fixed
+    /// reservation like the access log's, in the total on the same
+    /// promise; `main.zig` composes it to mirror `Server.init` exactly.
+    head_scratch_bytes: u64,
 };
 
 /// What the access log reserves: nothing when it is off, both staging
@@ -895,14 +926,18 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     assert(sizes.head_buffers <= buffer_group_entries_max);
     assert(sizes.head_buffers == 0 or sizes.head_buffer_bytes >= 1);
     assert(sizes.upstream_head_buffers <= sizes.upstream_slots);
-    assert(sizes.upstream_head_buffers == 0 or sizes.upstream_head_buffer_bytes >= head_bytes_max);
+    assert(sizes.upstream_head_buffers == 0 or
+        sizes.upstream_head_buffer_bytes >= head_buffer_bytes_min);
+    // At least the prober's one buffer, at least the smallest legal size.
+    assert(sizes.head_scratch_bytes >= head_buffer_bytes_min);
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
         sizes.access_log_bytes + sizes.endpoint_table_bytes +
         @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
         bufferGroupDescriptorBytes(sizes.head_buffers) +
-        @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes;
+        @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes +
+        sizes.head_scratch_bytes;
     assert(total > 0);
     return total;
 }
@@ -933,7 +968,7 @@ test "budgets: memory total matches the closed form" {
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes);
     // Scalars only since the head moved to its own pool (§5).
     const upstream_bytes: u64 = 64;
-    const upstream_head_bytes: u64 = head_bytes_max + 8;
+    const upstream_head_bytes: u64 = head_buffer_bytes_default + 8;
     // The endpoint-keyed tables (§7): like the access log, a reservation
     // that must move the total by exactly its own size and nothing else.
     const endpoint_tables: u64 = 4096;
@@ -946,19 +981,22 @@ test "budgets: memory total matches the closed form" {
     // page-granular and next-power-of-two, so a non-power-of-two count
     // pins the rounding too: 11466 → 16384 entries × 16 B = exactly 64
     // pages.
-    const head_ring: u64 = @as(u64, conn_slots_max) * (head_bytes_max + 1) +
+    const head_ring: u64 = @as(u64, conn_slots_max) * (head_buffer_bytes_default + 1) +
         bufferGroupDescriptorBytes(conn_slots_max);
     try std.testing.expectEqual(
         @as(u64, 16384) * 16,
         bufferGroupDescriptorBytes(conn_slots_max),
     );
     try std.testing.expectEqual(@as(u64, 0), bufferGroupDescriptorBytes(0));
+    // The side buffers: two serving scratches plus the prober's one.
+    const head_scratch: u64 = 3 * @as(u64, head_buffer_bytes_default);
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
         accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables +
         head_ring +
-        @as(u64, upstream_slots_max) * upstream_head_bytes;
+        @as(u64, upstream_slots_max) * upstream_head_bytes +
+        head_scratch;
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
@@ -969,11 +1007,14 @@ test "budgets: memory total matches the closed form" {
         .access_log_bytes = accessLogBytes(access_log_buffer_bytes_default),
         .endpoint_table_bytes = endpoint_tables,
         .head_buffers = conn_slots_max,
-        .head_buffer_bytes = head_bytes_max,
+        .head_buffer_bytes = head_buffer_bytes_default,
         .upstream_head_buffers = upstream_slots_max,
         .upstream_head_buffer_bytes = upstream_head_bytes,
+        .head_scratch_bytes = head_scratch,
     }));
-    const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
+    // The L4-only shape still carries the prober's one response buffer.
+    const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes +
+        head_buffer_bytes_default;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
@@ -983,11 +1024,13 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(0),
         .endpoint_table_bytes = 0,
-        // The L4-only shape: no ring, no upstream head pool, no terms.
+        // The L4-only shape: no ring, no upstream head pool, no scratch
+        // terms — but the prober's buffer is unconditional.
         .head_buffers = 0,
-        .head_buffer_bytes = head_bytes_max,
+        .head_buffer_bytes = head_buffer_bytes_default,
         .upstream_head_buffers = 0,
-        .upstream_head_buffer_bytes = head_bytes_max,
+        .upstream_head_buffer_bytes = head_buffer_bytes_default,
+        .head_scratch_bytes = head_buffer_bytes_default,
     }));
     // An unconfigured access log reserves nothing (§5), and a configured
     // one reserves both buffers at whatever size it was given — the term

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -491,6 +491,32 @@ pub const completion_queue_entries_max: u32 = 65536;
 /// two, only bounded by this.
 pub const buffer_group_entries_max: u32 = 1 << 15;
 
+comptime {
+    // Every head-buffer count a config can reach (`limits.head_buffers`
+    // ≤ conn_slots ≤ this ceiling) fits one registered group.
+    assert(conn_slots_max <= buffer_group_entries_max);
+}
+
+/// The buf_ring descriptor table behind the head-buffer ring (§5): one
+/// 16-byte `io_uring_buf` (ABI-fixed) per entry, entries the next power
+/// of two of the published count, mmapped page-granular. Zero when no
+/// ring is registered — an L4-only deployment.
+pub fn bufferGroupDescriptorBytes(head_buffers: u32) u64 {
+    assert(head_buffers <= buffer_group_entries_max);
+    if (head_buffers == 0) return 0;
+    const entries = std.math.ceilPowerOfTwo(u32, head_buffers) catch unreachable;
+    const bytes = std.mem.alignForward(u64, @as(u64, entries) * 16, 4096);
+    assert(bytes >= 4096);
+    return bytes;
+}
+
+/// One shared discard sink for every §7 lingering-close drain (the reads
+/// whose bytes are never looked at). Shared deliberately: with the head
+/// buffer returned before a static response goes out (§5), a reject storm
+/// must not need a buffer per draining connection, and recv targets whose
+/// contents nobody reads may alias.
+pub const drain_sink_bytes: u32 = 4 * 1024;
+
 /// §8 CQ fill: in-flight ring ops may occupy at most this many eighths of
 /// the completion queue; the rest stays free to absorb completion bursts.
 /// ⅞ is both the default and the largest fill a config may request — it is
@@ -818,6 +844,13 @@ pub const PoolSizes = struct {
     /// it from hardcoded widths would silently drift the moment one of
     /// them changed. `Server.endpointTableBytes` is the closed form.
     endpoint_table_bytes: u64,
+    /// The §5 head-buffer ring: how many buffers the deployment registered
+    /// (`limits.head_buffers`; zero on an L4-only config) and the unit
+    /// size of each. The total term is `count × (unit + 1)` — the slab
+    /// plus the seam's one ownership byte per buffer — plus the buf_ring
+    /// descriptor table (`bufferGroupDescriptorBytes`).
+    head_buffers: u32,
+    head_buffer_bytes: u64,
 };
 
 /// What the access log reserves: nothing when it is off, both staging
@@ -851,10 +884,14 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
             @as(u64, access_log_buffers) * access_log_buffer_bytes_min);
     assert(sizes.access_log_bytes <=
         @as(u64, access_log_buffers) * access_log_buffer_bytes_max);
+    assert(sizes.head_buffers <= buffer_group_entries_max);
+    assert(sizes.head_buffers == 0 or sizes.head_buffer_bytes >= 1);
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
-        sizes.access_log_bytes + sizes.endpoint_table_bytes;
+        sizes.access_log_bytes + sizes.endpoint_table_bytes +
+        @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
+        bufferGroupDescriptorBytes(sizes.head_buffers);
     assert(total > 0);
     return total;
 }
@@ -891,10 +928,23 @@ test "budgets: memory total matches the closed form" {
     // the access log on at the ceiling and off below it — the term is a
     // fixed reservation, so it must move the total by exactly its own size
     // and by nothing else.
+    // The head-buffer ring's term is count × (unit + 1) — the slab plus
+    // one ownership byte per buffer — plus the descriptor table, which is
+    // page-granular and next-power-of-two, so a non-power-of-two count
+    // pins the rounding too: 11466 → 16384 entries × 16 B = exactly 64
+    // pages.
+    const head_ring: u64 = @as(u64, conn_slots_max) * (head_bytes_max + 1) +
+        bufferGroupDescriptorBytes(conn_slots_max);
+    try std.testing.expectEqual(
+        @as(u64, 16384) * 16,
+        bufferGroupDescriptorBytes(conn_slots_max),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bufferGroupDescriptorBytes(0));
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
-        accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables;
+        accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables +
+        head_ring;
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
@@ -904,6 +954,8 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(access_log_buffer_bytes_default),
         .endpoint_table_bytes = endpoint_tables,
+        .head_buffers = conn_slots_max,
+        .head_buffer_bytes = head_bytes_max,
     }));
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
@@ -915,6 +967,9 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(0),
         .endpoint_table_bytes = 0,
+        // The L4-only shape: no ring registered, no term at all.
+        .head_buffers = 0,
+        .head_buffer_bytes = head_bytes_max,
     }));
     // An unconfigured access log reserves nothing (§5), and a configured
     // one reserves both buffers at whatever size it was given — the term

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -483,6 +483,14 @@ pub fn inFlightOps(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
 /// clamp) keep it out of reach.
 pub const completion_queue_entries_max: u32 = 65536;
 
+/// The widest provided-buffer group a ring can register (the seam's
+/// `recvGroup`, §5's head-buffer ring): a buf_ring's descriptor table is
+/// sized by a u16 power-of-two `entries` argument, so 1 << 15 is the
+/// largest capacity it can name. Fewer buffers than entries may be
+/// published — the operator's count is not itself forced to a power of
+/// two, only bounded by this.
+pub const buffer_group_entries_max: u32 = 1 << 15;
+
 /// §8 CQ fill: in-flight ring ops may occupy at most this many eighths of
 /// the completion queue; the rest stays free to absorb completion bursts.
 /// ⅞ is both the default and the largest fill a config may request — it is

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -28,6 +28,12 @@ pub const Counters = struct {
     relay_pressure_engaged: Value = Value.init(0),
     conn_pressure_engaged: Value = Value.init(0),
     upstream_pressure_engaged: Value = Value.init(0),
+    /// The head-buffer ring's crossing (§5, §8). Unlike the other three
+    /// this bias drives nothing — an idle connection holds no head
+    /// buffer, so there is no idle occupancy a timeout could evict — and
+    /// the counter is the alert an operator sizes `limits.head_buffers`
+    /// by, before the wall (`l7_shed_head_buffers`) starts refusing.
+    head_pressure_engaged: Value = Value.init(0),
     /// §8 rung: request/idle deadline fired → teardown.
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).
@@ -70,6 +76,12 @@ pub const Counters = struct {
     /// and the ratio to `accepted` is the churn signal.
     l7_shed_relay_buffers: Value = Value.init(0),
     l7_shed_upstream_slots: Value = Value.init(0),
+    /// §8 rung: a client spoke while the head-buffer ring was empty —
+    /// answered 503 and, uniquely among the sheds, *always* closed: the
+    /// request's bytes were never read (no buffer was ever bound), so a
+    /// kept connection would re-arm onto the same bytes and shed the same
+    /// request forever. `respond` enforces the close at comptime.
+    l7_shed_head_buffers: Value = Value.init(0),
     /// §8 requests answered 503 because every endpoint of their cluster
     /// was already carrying its configured `max_inflight`. Distinct from
     /// `l7_shed_upstream_slots` on purpose: that one says this proxy ran
@@ -269,6 +281,14 @@ pub const Counters = struct {
         /// in-use figure.
         upstream_slots_parked: u32,
         upstream_slots_capacity: u32,
+        /// Head-ring buffers bound to connections right now (§5). This is
+        /// the level whose wall answers `l7_shed_head_buffers`; with the
+        /// ring sized to its default (conn_slots) it cannot reach the
+        /// capacity, and the *gap* between this and `conn_slots_in_use`
+        /// is the density the ring buys — idle connections appear in the
+        /// conn level but not here.
+        head_buffers_in_use: u32,
+        head_buffers_capacity: u32,
         /// The raw errno of the most recent kernel-pressure failure, or 0
         /// for "none since start". A gauge, not a counter: the question is
         /// which errno is failing *now*, and the `kernel_pressure_*` cause
@@ -289,6 +309,7 @@ pub const Counters = struct {
         pub fn valid(gauges: *const Gauges) bool {
             if (gauges.conn_slots_in_use > gauges.conn_slots_capacity) return false;
             if (gauges.relay_buffers_in_use > gauges.relay_buffers_capacity) return false;
+            if (gauges.head_buffers_in_use > gauges.head_buffers_capacity) return false;
             if (gauges.health_endpoints_unhealthy > gauges.health_endpoints_checked) return false;
             const upstream_in_use = @as(u64, gauges.upstream_slots_leased) +
                 gauges.upstream_slots_parked;
@@ -541,6 +562,8 @@ const test_gauges: Counters.Gauges = .{
     .upstream_slots_leased = 5,
     .upstream_slots_parked = 11,
     .upstream_slots_capacity = 16,
+    .head_buffers_in_use = 2,
+    .head_buffers_capacity = 8,
     .kernel_pressure_last_errno = 105, // ENOBUFS on Linux
     .health_endpoints_checked = 4,
     .health_endpoints_unhealthy = 1,

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -34,6 +34,10 @@ pub const Counters = struct {
     /// the counter is the alert an operator sizes `limits.head_buffers`
     /// by, before the wall (`l7_shed_head_buffers`) starts refusing.
     head_pressure_engaged: Value = Value.init(0),
+    /// The upstream head pool's crossing, on the same no-bias terms: a
+    /// parked upstream holds no head buffer, so there is nothing idle to
+    /// evict — the alert for sizing `limits.upstream_head_buffers`.
+    upstream_head_pressure_engaged: Value = Value.init(0),
     /// §8 rung: request/idle deadline fired → teardown.
     deadline_expired: Value = Value.init(0),
     /// Upstream dial failed (refused/unreachable/canceled-by-teardown).
@@ -82,6 +86,15 @@ pub const Counters = struct {
     /// kept connection would re-arm onto the same bytes and shed the same
     /// request forever. `respond` enforces the close at comptime.
     l7_shed_head_buffers: Value = Value.init(0),
+    /// §8 rung: the upstream head pool was empty at the request-head
+    /// render — answered 503 with the ordinary keep-or-close rules (the
+    /// request was fully read and parsed, unlike the ring rung above).
+    /// Distinct from `l7_shed_upstream_slots` the way that one is
+    /// distinct from the endpoint cap: slots say the proxy ran out of
+    /// connections, this says it ran out of head staging — different
+    /// knobs (`upstream_slots` vs `upstream_head_buffers`), and an
+    /// operator widening the wrong one fixes nothing.
+    l7_shed_upstream_head_buffers: Value = Value.init(0),
     /// §8 requests answered 503 because every endpoint of their cluster
     /// was already carrying its configured `max_inflight`. Distinct from
     /// `l7_shed_upstream_slots` on purpose: that one says this proxy ran
@@ -289,6 +302,11 @@ pub const Counters = struct {
         /// conn level but not here.
         head_buffers_in_use: u32,
         head_buffers_capacity: u32,
+        /// Upstream head buffers held by exchanges right now (§5): the
+        /// render-to-park window, so with parking healthy this sits far
+        /// below the leased count — the gap is what the pool buys.
+        upstream_head_buffers_in_use: u32,
+        upstream_head_buffers_capacity: u32,
         /// The raw errno of the most recent kernel-pressure failure, or 0
         /// for "none since start". A gauge, not a counter: the question is
         /// which errno is failing *now*, and the `kernel_pressure_*` cause
@@ -310,6 +328,7 @@ pub const Counters = struct {
             if (gauges.conn_slots_in_use > gauges.conn_slots_capacity) return false;
             if (gauges.relay_buffers_in_use > gauges.relay_buffers_capacity) return false;
             if (gauges.head_buffers_in_use > gauges.head_buffers_capacity) return false;
+            if (gauges.upstream_head_buffers_in_use > gauges.upstream_head_buffers_capacity) return false;
             if (gauges.health_endpoints_unhealthy > gauges.health_endpoints_checked) return false;
             const upstream_in_use = @as(u64, gauges.upstream_slots_leased) +
                 gauges.upstream_slots_parked;
@@ -564,6 +583,8 @@ const test_gauges: Counters.Gauges = .{
     .upstream_slots_capacity = 16,
     .head_buffers_in_use = 2,
     .head_buffers_capacity = 8,
+    .upstream_head_buffers_in_use = 1,
+    .upstream_head_buffers_capacity = 6,
     .kernel_pressure_last_errno = 105, // ENOBUFS on Linux
     .health_endpoints_checked = 4,
     .health_endpoints_unhealthy = 1,

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -543,7 +543,7 @@ test "filter: rewritePath is a segment-correct prefix replacement" {
         try std.testing.expectEqualStrings(case.want, got);
         // The result must be what canonicalization would produce — the join
         // yields canonical output directly, no second pass.
-        var canon: [constants.head_bytes_max]u8 = undefined;
+        var canon: [constants.head_buffer_bytes_default]u8 = undefined;
         const recanon = try parser.canonicalTarget(got, &canon);
         try std.testing.expectEqualStrings(got, recanon.path);
     }

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -9,7 +9,7 @@
 //! into caller-owned storage over the linear head buffer, and "streaming"
 //! is detect-and-retry — a partial head returns `error.Incomplete` and the
 //! caller re-parses from byte 0 once more bytes arrive, bounded by
-//! `constants.head_bytes_max`.
+//! `limits.head_buffer_bytes`.
 //!
 //! The §7 fork hardening gate is fully cleared at the current pin: the
 //! fork rejects bare-LF line terminators itself (CRLF only) and parses
@@ -311,7 +311,7 @@ pub fn parseRequestHead(
     head_is_full: bool,
     headers_storage: *HeaderStorage,
 ) HeadError!RequestHead {
-    assert(head.len <= constants.head_bytes_max);
+    assert(head.len <= constants.head_buffer_bytes_max);
     if (head_is_full) {
         assert(head.len >= 1);
     }
@@ -360,7 +360,7 @@ pub fn parseResponseHead(
     headers_storage: *HeaderStorage,
     request_method: Method,
 ) HeadError!ResponseHead {
-    assert(head.len <= constants.head_bytes_max);
+    assert(head.len <= constants.head_buffer_bytes_max);
     // The proxy rejects CONNECT before dialing (§7 keeps tunnels out), so
     // a CONNECT response is unrepresentable here.
     assert(request_method != .connect);
@@ -782,7 +782,7 @@ fn analyzeHeaders(
 fn scanConnectionTokens(value: []const u8, analysis: *HeaderAnalysis) void {
     // The value is a slice of the parsed head (an empty value is legal:
     // `Connection:` with nothing after it), so it is head-buffer bounded.
-    assert(value.len <= constants.head_bytes_max);
+    assert(value.len <= constants.head_buffer_bytes_max);
     var tokens = std.mem.splitScalar(u8, value, ',');
     while (tokens.next()) |raw_token| {
         const token = std.mem.trim(u8, raw_token, " \t");
@@ -906,7 +906,11 @@ pub const CanonicalTarget = struct {
 /// never disagree about which resource a request names.
 pub fn canonicalTarget(
     target: []const u8,
-    out: *[constants.head_bytes_max]u8,
+    /// Caller-owned decode target, at least `target.len` wide — a slice
+    /// now that head sizes are the config's (`limits.head_buffer_bytes`):
+    /// the callers own buffers of that runtime size, and decoding only
+    /// ever shrinks, so the length relation is the whole contract.
+    out: []u8,
 ) error{Malformed}!CanonicalTarget {
     // validateTarget admitted only origin-form here; asterisk-form and
     // CONNECT never route by path and stay with the caller.
@@ -985,7 +989,7 @@ fn decodeTargetPath(path: []const u8, out: []u8) error{Malformed}!u32 {
 fn collapseDotSegments(bytes: []u8) error{Malformed}!u32 {
     assert(bytes.len >= 1);
     assert(bytes[0] == '/');
-    assert(bytes.len <= constants.head_bytes_max);
+    assert(bytes.len <= constants.head_buffer_bytes_max);
     var read: u32 = 0;
     var write: u32 = 0;
     while (read < bytes.len) {
@@ -1685,7 +1689,7 @@ test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
 
 fn fuzzParserInputs(context: void, smith: *std.testing.Smith) !void {
     _ = context;
-    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    var input_buffer: [constants.head_buffer_bytes_default]u8 = undefined;
     const input_len = smith.slice(&input_buffer);
     assert(input_len <= input_buffer.len);
     const input = input_buffer[0..input_len];
@@ -1767,7 +1771,7 @@ test "canonicalTarget: table of canonical forms and rejects" {
         .{ .target = "/./..", .path = null },
     };
     for (cases) |case| {
-        var out: [constants.head_bytes_max]u8 = undefined;
+        var out: [constants.head_buffer_bytes_default]u8 = undefined;
         const result = canonicalTarget(case.target, &out);
         if (case.path) |expected_path| {
             const canonical = try result;
@@ -1782,9 +1786,9 @@ test "canonicalTarget: table of canonical forms and rejects" {
 test "canonicalTarget: canonicalization is idempotent" {
     const targets = [_][]const u8{ "/a/../b", "/caf%c3%a9", "//a/./b%7e", "/a/b/.." };
     for (targets) |target| {
-        var out: [constants.head_bytes_max]u8 = undefined;
+        var out: [constants.head_buffer_bytes_default]u8 = undefined;
         const first = try canonicalTarget(target, &out);
-        var out_again: [constants.head_bytes_max]u8 = undefined;
+        var out_again: [constants.head_buffer_bytes_default]u8 = undefined;
         const second = try canonicalTarget(first.path, &out_again);
         try std.testing.expectEqualStrings(first.path, second.path);
         try std.testing.expectEqual(@as(usize, 0), second.query.len);
@@ -1802,12 +1806,12 @@ test "fuzz: canonicalTarget rejects or emits the canonical form" {
 
 fn fuzzCanonicalTarget(context: void, smith: *std.testing.Smith) !void {
     _ = context;
-    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    var input_buffer: [constants.head_buffer_bytes_default]u8 = undefined;
     input_buffer[0] = '/';
     const tail_len = smith.slice(input_buffer[1..]);
     const input = input_buffer[0 .. 1 + tail_len];
 
-    var out: [constants.head_bytes_max]u8 = undefined;
+    var out: [constants.head_buffer_bytes_default]u8 = undefined;
     // Reject-or-canonical, no third outcome: a reject ends the case.
     const canonical = canonicalTarget(input, &out) catch return;
     // Rooted, never grown, and the split covers the input.
@@ -1820,7 +1824,7 @@ fn fuzzCanonicalTarget(context: void, smith: *std.testing.Smith) !void {
     assert(!std.mem.endsWith(u8, canonical.path, "/.."));
     assert(!std.mem.endsWith(u8, canonical.path, "/."));
     // The canonical form is its own canonical form.
-    var out_again: [constants.head_bytes_max]u8 = undefined;
+    var out_again: [constants.head_buffer_bytes_default]u8 = undefined;
     const again = try canonicalTarget(canonical.path, &out_again);
     assert(std.mem.eql(u8, again.path, canonical.path));
     assert(again.query.len == 0);

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -139,16 +139,17 @@ pub fn Proxy(comptime IoType: type) type {
         /// upstream head content states its precondition.
         fn upstreamHeadBytes(upstream: *UpstreamType) []u8 {
             assert(upstream.head_buffer != null);
-            return upstream.head_buffer.?.bytes[0..];
+            return upstream.head_buffer.?.data;
         }
 
         /// Where a head continuation read lands: the free space after what
         /// has already accumulated in the bound buffer.
         fn headRecvBuffer(server: *ServerType, conn: *ConnType) []u8 {
+            const bytes = headBytes(server, conn);
             // Parsing turns a full buffer into an oversize verdict before
             // we ever get here, so there is always room to read into.
-            assert(conn.head_len < constants.head_bytes_max);
-            return headBytes(server, conn)[conn.head_len..];
+            assert(conn.head_len < bytes.len);
+            return bytes[conn.head_len..];
         }
 
         /// Account for bytes that became head bytes. Named because a
@@ -159,10 +160,12 @@ pub fn Proxy(comptime IoType: type) type {
         /// more head bytes than there is room for — a decrypted record is up
         /// to 16 KiB against an 8 KiB head — fills what fits, records the
         /// surplus, and lets `parseAndDispatch` answer it. Handing an overrun
-        /// to this function is a bug, and asserts as one.
-        fn fillHead(conn: *ConnType, appended: u32) void {
+        /// to this function is a bug, and asserts as one. `capacity` is the
+        /// bound buffer's own length, passed because the size is the
+        /// config's now, not this file's to name.
+        fn fillHead(conn: *ConnType, appended: u32, capacity: usize) void {
             assert(appended >= 1);
-            assert(conn.head_len + appended <= constants.head_bytes_max);
+            assert(conn.head_len + appended <= capacity);
             conn.head_len += appended;
         }
 
@@ -256,7 +259,7 @@ pub fn Proxy(comptime IoType: type) type {
             // deadline must report the time it spent doing it (§8).
             server.beginLogRequest(conn);
             conn.log.bytes_in += bound.len;
-            fillHead(conn, bound.len);
+            fillHead(conn, bound.len, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
         }
 
@@ -285,7 +288,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.head_buffer_id != ConnType.head_buffer_none);
             assert(conn.head_len >= 1);
             conn.log.bytes_in += received;
-            fillHead(conn, received);
+            fillHead(conn, received, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
         }
 
@@ -294,8 +297,9 @@ pub fn Proxy(comptime IoType: type) type {
         /// static reject; a valid head → routing.
         fn parseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            const head = headBytes(server, conn)[0..conn.head_len];
-            const head_is_full = conn.head_len == constants.head_bytes_max;
+            const bytes = headBytes(server, conn);
+            const head = bytes[0..conn.head_len];
+            const head_is_full = conn.head_len == bytes.len;
 
             var storage: parser.HeaderStorage = undefined;
             const request = parser.parseRequestHead(head, head_is_full, &storage) catch |err| switch (err) {
@@ -338,7 +342,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn requestKeys(
             request: *const parser.RequestHead,
-            scratch: *[constants.head_bytes_max]u8,
+            scratch: []u8,
             host_scratch: *[constants.host_bytes_max]u8,
         ) error{BadPath}!RequestKeys {
             assert(request.target.len >= 1);
@@ -373,7 +377,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn targetViews(
             request: *const parser.RequestHead,
-            scratch: *[constants.head_bytes_max]u8,
+            scratch: []u8,
         ) error{BadPath}!TargetViews {
             assert(request.target.len >= 1);
             if (request.target[0] != '/') {
@@ -426,7 +430,7 @@ pub fn Proxy(comptime IoType: type) type {
             request: *const parser.RequestHead,
             views: *const TargetViews,
             host_scratch: *[constants.host_bytes_max]u8,
-            rewrite_scratch: *[constants.head_bytes_max]u8,
+            rewrite_scratch: []u8,
             edit_buffer: *[constants.header_edits_max]filter.AppliedHeaderEdit,
         ) error{Oversize}!Forwarded {
             const base = views.forward;
@@ -559,10 +563,15 @@ pub fn Proxy(comptime IoType: type) type {
             // §7: canonicalize the host and path once, then apply filters
             // and routing to that one view before acquiring any resource,
             // so a bad path, a policy reject, or an unrouted host/path is
-            // answered cheaply.
-            var scratch: [constants.head_bytes_max]u8 = undefined;
+            // answered cheaply. The target scratch is the server's (§5):
+            // its length is the config's `head_buffer_bytes` now, and a
+            // runtime-length stack array is exactly the dynamic allocation
+            // §5 forbids. Sound because uses never overlap — the loop is
+            // single-threaded, and the window (through routing into the
+            // checkout path's render) neither suspends nor re-enters.
+            const scratch = server.target_scratch;
             var host_scratch: [constants.host_bytes_max]u8 = undefined;
-            const keys = requestKeys(request, &scratch, &host_scratch) catch {
+            const keys = requestKeys(request, scratch, &host_scratch) catch {
                 captureTarget(conn, null, request.target);
                 return respond(server, conn, 400, "l7_bad_request");
             };
@@ -771,12 +780,12 @@ pub fn Proxy(comptime IoType: type) type {
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
             // Only this path pays for canonicalization twice, and it has
-            // to: routeRequest's scratch died with its frame at the dial.
-            // The scratch lives here so the views outlive the call.
-            var scratch: [constants.head_bytes_max]u8 = undefined;
+            // to: routeRequest's use of the shared scratch ended with its
+            // frame at the dial — which is also why reusing the same
+            // server-owned scratch here cannot overlap it.
             // Same bytes routeRequest already canonicalized, so this cannot
             // fail — the §7 single-source-of-truth rule again.
-            const views = targetViews(&request, &scratch) catch unreachable;
+            const views = targetViews(&request, server.target_scratch) catch unreachable;
             renderRequestAndStartLegs(server, conn, &request, &views);
         }
 
@@ -811,14 +820,16 @@ pub fn Proxy(comptime IoType: type) type {
             // the forwarded path and any header edits, against the same
             // canonical view the reject/route phase used.
             var host_scratch: [constants.host_bytes_max]u8 = undefined;
-            var rewrite_scratch: [constants.head_bytes_max]u8 = undefined;
             var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
+            // The rewrite scratch is the server's, distinct from the
+            // target scratch: on the checkout path the routed views still
+            // alias that one while the rewrite runs.
             const plan = planForward(
                 conn,
                 request,
                 views,
                 &host_scratch,
-                &rewrite_scratch,
+                server.rewrite_scratch,
                 &edit_buffer,
             ) catch {
                 // A rewritten path too long to forward: the §7 oversize
@@ -831,7 +842,7 @@ pub fn Proxy(comptime IoType: type) type {
             // connection is a parking candidate (§5), and stripping the
             // client's Connection header already made persistence the wire
             // default.
-            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, &upstream.head_buffer.?.bytes) catch {
+            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, upstreamHeadBytes(upstream)) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
@@ -1189,7 +1200,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.response_leg == .awaiting_head);
             const upstream = conn.upstream.?;
-            assert(upstream.head_len < constants.head_bytes_max);
+            assert(upstream.head_len < upstreamHeadBytes(upstream).len);
             conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.recv(
                 conn.upstream_socket.?,
@@ -1222,7 +1233,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(received >= 1);
             const upstream = conn.upstream.?;
             upstream.head_len += received;
-            assert(upstream.head_len <= constants.head_bytes_max);
+            assert(upstream.head_len <= upstreamHeadBytes(upstream).len);
             parseResponseAndDispatch(server, conn);
         }
 
@@ -1234,7 +1245,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             const upstream = conn.upstream.?;
             const head = upstreamHeadBytes(upstream)[0..upstream.head_len];
-            const head_is_full = upstream.head_len == constants.head_bytes_max;
+            const head_is_full = upstream.head_len == upstreamHeadBytes(upstream).len;
 
             var storage: parser.HeaderStorage = undefined;
             const response = parser.parseResponseHead(
@@ -1334,7 +1345,7 @@ pub fn Proxy(comptime IoType: type) type {
             const rendered = render.renderResponseHead(
                 response,
                 !keep_downstream,
-                headBytes(server, conn)[0..constants.head_bytes_max],
+                headBytes(server, conn),
             ) catch {
                 upstreamFailed(server, conn);
                 return;
@@ -1356,7 +1367,7 @@ pub fn Proxy(comptime IoType: type) type {
             // round trip per response. The fallback writes the head, then
             // the excess from upstream.head as the channel's next write.
             var head_write_len: u32 = @intCast(rendered.len);
-            if (rendered.len + feed.consumed <= constants.head_bytes_max) {
+            if (rendered.len + feed.consumed <= headBytes(server, conn).len) {
                 @memcpy(
                     headBytes(server, conn)[rendered.len..][0..feed.consumed],
                     excess[0..feed.consumed],
@@ -2186,7 +2197,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// message ended mid-chunk; the rest is pipelined data, dropped
         /// while every exchange closes its connection.
         fn feedFraming(framing: *Framing, bytes: []const u8) FeedResult {
-            assert(bytes.len <= constants.head_bytes_max);
+            assert(bytes.len <= constants.head_buffer_bytes_max);
             switch (framing.*) {
                 .none => return .{ .consumed = 0, .done = true, .malformed = false },
                 .content_length => |*remaining| {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -90,7 +90,8 @@ pub fn Proxy(comptime IoType: type) type {
         pub fn start(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
             assert(conn.head_len == 0);
-            armHeadRecv(server, conn);
+            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            armHeadGroupRecv(server, conn);
         }
 
         // -- the head-fill seam: the *request* head (§4, §7) --
@@ -123,13 +124,21 @@ pub fn Proxy(comptime IoType: type) type {
         // Such a source records the overrun and lets the dispatch answer it,
         // rather than deciding first and growing a second copy of the ladder.
 
-        /// Where a head read lands: the free space after what has already
-        /// accumulated.
-        fn headRecvBuffer(conn: *ConnType) []u8 {
+        /// The head bytes this connection holds — the ring buffer bound at
+        /// the delivery that started the request (§5). Asserting the hold
+        /// here means every read of head content states its precondition.
+        fn headBytes(server: *ServerType, conn: *ConnType) []u8 {
+            assert(conn.head_buffer_id != ConnType.head_buffer_none);
+            return server.io.bufferGroupSlice(conn.head_buffer_id);
+        }
+
+        /// Where a head continuation read lands: the free space after what
+        /// has already accumulated in the bound buffer.
+        fn headRecvBuffer(server: *ServerType, conn: *ConnType) []u8 {
             // Parsing turns a full buffer into an oversize verdict before
             // we ever get here, so there is always room to read into.
             assert(conn.head_len < constants.head_bytes_max);
-            return conn.head[conn.head_len..];
+            return headBytes(server, conn)[conn.head_len..];
         }
 
         /// Account for bytes that became head bytes. Named because a
@@ -147,11 +156,31 @@ pub fn Proxy(comptime IoType: type) type {
             conn.head_len += appended;
         }
 
+        /// The idle arm (§5): a recv that carries no buffer. Fresh
+        /// connections and kept-alive turnarounds both wait here, holding
+        /// nothing — the ring binds a buffer only when the client actually
+        /// speaks.
+        fn armHeadGroupRecv(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            assert(conn.head_len == 0);
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.recvGroup(
+                conn.client_socket,
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onHeadGroupRecv,
+            );
+        }
+
+        /// The continuation arm: the head is partway parsed, the buffer is
+        /// bound, read the rest into it (§7 detect-and-retry).
         fn armHeadRecv(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
             // Resolved before the arm, so the source's own bound is checked
             // before any state changes.
-            const into = headRecvBuffer(conn);
+            const into = headRecvBuffer(server, conn);
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
@@ -163,6 +192,64 @@ pub fn Proxy(comptime IoType: type) type {
             );
         }
 
+        fn onHeadGroupRecv(conn: *ConnType, result: Io.RecvGroupError!Io.GroupRecv) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                // The teardown raced the client's first byte (§5): the
+                // kernel may already have bound a ring buffer for the
+                // delivery, and dropping it here would leak that buffer
+                // for the process's life — uncounted, so no drain assert
+                // could ever notice. Straight back to the ring, not
+                // through `returnHeadBuffer`: the bind was never recorded,
+                // so there is no in-use count to decrement. The same
+                // capture-then-release shape `onUpstreamConnect` uses for
+                // a socket that arrived into a teardown.
+                if (result) |bound| {
+                    server.io.bufferGroupReturn(bound.buffer_id);
+                } else |_| {}
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l7_reading_head);
+            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            const bound = result catch |err| switch (err) {
+                error.NoBuffers => {
+                    // The client spoke and the ring is empty: §8's newest
+                    // work sheds. `respond` force-closes this counter at
+                    // comptime (its `may_keep`) — the unread bytes sit in
+                    // the socket, and a kept connection would re-arm onto
+                    // them and shed the same request forever.
+                    respond(server, conn, 503, "l7_shed_head_buffers");
+                    return;
+                },
+                else => {
+                    // A client that closes or resets before speaking simply
+                    // leaves — there is nothing to answer, and (pinned by
+                    // the seam's contract) no buffer was consumed for it.
+                    // The witness filters internally: only Unexpected
+                    // (kernel pressure) is counted.
+                    server.witnessKernelPressure(.recv, err);
+                    server.beginTeardown(conn);
+                    return;
+                },
+            };
+            assert(bound.len >= 1);
+            conn.head_buffer_id = bound.buffer_id;
+            server.noteHeadBufferBound();
+            // A request begins with its first byte, and only with a byte:
+            // started here rather than before the unwrap above, because
+            // the read that ends an *idle* kept-alive connection completes
+            // in this same callback with EOF, and starting a request there
+            // would owe the log a line for a request nobody made. Nor at
+            // the parse: a slowloris that dribbles for the whole head-read
+            // deadline must report the time it spent doing it (§8).
+            server.beginLogRequest(conn);
+            conn.log.bytes_in += bound.len;
+            fillHead(conn, bound.len);
+            parseAndDispatch(server, conn);
+        }
+
         fn onHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
             conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
@@ -172,25 +259,21 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assert(conn.state == .l7_reading_head);
             const received = result catch |err| {
-                // A client that closes or resets before finishing its head
-                // simply leaves — there is nothing to answer. The §7
-                // head-read deadline handles the slowloris that stalls
-                // instead of closing. The witness filters internally: only
-                // Unexpected (kernel pressure) is counted, so orderly
-                // EndOfStream/Reset pass through it uncounted.
+                // A client that closes or resets mid-head simply leaves —
+                // there is nothing to answer. The §7 head-read deadline
+                // handles the slowloris that stalls instead of closing.
+                // The witness filters internally: only Unexpected (kernel
+                // pressure) is counted, so orderly EndOfStream/Reset pass
+                // through it uncounted.
                 server.witnessKernelPressure(.recv, err);
                 server.beginTeardown(conn);
                 return;
             };
             assert(received >= 1);
-            // A request begins with its first byte, and only with a byte:
-            // started here rather than before the unwrap above, because
-            // the read that ends an *idle* kept-alive connection completes
-            // in this same callback with EOF, and starting a request there
-            // would owe the log a line for a request nobody made. Nor at
-            // the parse: a slowloris that dribbles for the whole head-read
-            // deadline must report the time it spent doing it (§8).
-            server.beginLogRequest(conn);
+            // The request already began at the group delivery that bound
+            // the buffer; this is more of the same head.
+            assert(conn.head_buffer_id != ConnType.head_buffer_none);
+            assert(conn.head_len >= 1);
             conn.log.bytes_in += received;
             fillHead(conn, received);
             parseAndDispatch(server, conn);
@@ -201,7 +284,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// static reject; a valid head → routing.
         fn parseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            const head = conn.head[0..conn.head_len];
+            const head = headBytes(server, conn)[0..conn.head_len];
             const head_is_full = conn.head_len == constants.head_bytes_max;
 
             var storage: parser.HeaderStorage = undefined;
@@ -645,7 +728,7 @@ pub fn Proxy(comptime IoType: type) type {
             // bytes are the single source of truth), so a failure here is
             // an invariant violation, not an input condition.
             const request = parser.parseRequestHead(
-                conn.head[0..conn.head_len],
+                headBytes(server, conn)[0..conn.head_len],
                 false,
                 &storage,
             ) catch unreachable;
@@ -851,7 +934,7 @@ pub fn Proxy(comptime IoType: type) type {
             // (§7). Once the response recv is armed that op is gone, and an
             // op is never canceled (§5) — so a malformed body found later
             // can only tear down. Checking here keeps the 400 reachable.
-            const excess = conn.head[conn.l7.request_head_len..conn.head_len];
+            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.head_len];
             const feed = feedFraming(&conn.l7.request_framing, excess);
             if (feed.malformed) {
                 respond(server, conn, 400, "l7_bad_request");
@@ -874,7 +957,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_head);
             assert(!feed.malformed);
-            const excess = conn.head[conn.l7.request_head_len..conn.head_len];
+            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.head_len];
             if (feed.consumed < excess.len) {
                 conn.l7.client_pipelined = true;
             }
@@ -897,7 +980,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
-                direction.pending(conn.head[base..]),
+                direction.pending(headBytes(server, conn)[base..]),
                 &conn.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -1210,7 +1293,7 @@ pub fn Proxy(comptime IoType: type) type {
             const rendered = render.renderResponseHead(
                 response,
                 !keep_downstream,
-                &conn.head,
+                headBytes(server, conn)[0..constants.head_bytes_max],
             ) catch {
                 upstreamFailed(server, conn);
                 return;
@@ -1232,9 +1315,9 @@ pub fn Proxy(comptime IoType: type) type {
             // round trip per response. The fallback writes the head, then
             // the excess from upstream.head as the channel's next write.
             var head_write_len: u32 = @intCast(rendered.len);
-            if (rendered.len + feed.consumed <= conn.head.len) {
+            if (rendered.len + feed.consumed <= constants.head_bytes_max) {
                 @memcpy(
-                    conn.head[rendered.len..][0..feed.consumed],
+                    headBytes(server, conn)[rendered.len..][0..feed.consumed],
                     excess[0..feed.consumed],
                 );
                 head_write_len = @intCast(rendered.len + feed.consumed);
@@ -1251,7 +1334,7 @@ pub fn Proxy(comptime IoType: type) type {
             // separate fact, and `outcome` stays `aborted` until
             // `finishExchange` earns `ok` (§8).
             conn.log.status = response.status;
-            armClientWrite(server, conn, conn.head[0..head_write_len], .response_excess);
+            armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .response_excess);
         }
 
         // -- the client-write channel (§7, §8) --
@@ -1577,13 +1660,21 @@ pub fn Proxy(comptime IoType: type) type {
             // (§8). The captures are left in place: their lengths are what
             // gate every read, and this zeroes those.
             assert(conn.log.emitted or conn.log.started_wall_ns == 0);
+            // The request's head buffer goes back to the ring before the
+            // idle wait begins — an idle connection holds no head bytes
+            // (§5). Conditional because the static-response path already
+            // returned it (`releaseForStaticResponse`); the completed-
+            // exchange path still holds it here.
+            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+                server.returnHeadBuffer(conn);
+            }
             conn.head_len = 0;
             conn.l7 = .{};
             conn.log.reset();
             conn.directions = .{ .{}, .{} };
             conn.state = .l7_reading_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
-            armHeadRecv(server, conn);
+            armHeadGroupRecv(server, conn);
         }
 
         /// Whether an expired exchange can still be answered 504 (§8): no
@@ -1706,7 +1797,7 @@ pub fn Proxy(comptime IoType: type) type {
             // be fed again on the fresh try.
             var storage: parser.HeaderStorage = undefined;
             const request = parser.parseRequestHead(
-                conn.head[0..conn.head_len],
+                headBytes(server, conn)[0..conn.head_len],
                 false,
                 &storage,
             ) catch unreachable;
@@ -1811,10 +1902,10 @@ pub fn Proxy(comptime IoType: type) type {
         /// Everything a static response no longer needs, returned before
         /// the answer goes out rather than at teardown (§5, §8).
         ///
-        /// The relay buffer: the response and its lingering drain
-        /// read/write only conn.head, so a reject or 503 storm holding
-        /// buffers for the whole drain window would pin the L4 admissions
-        /// those buffers gate. The upstream slot: a still-attached one — a
+        /// The relay buffer: the response comes from static memory and the
+        /// lingering drain discards into the shared sink, so a reject or
+        /// 503 storm holding buffers for the whole drain window would pin
+        /// the L4 admissions those buffers gate. The upstream slot: a still-attached one — a
         /// failed dial with no socket, an oversize-after-edit reject, a
         /// malformed body — would otherwise ride the same window. Both
         /// data ops are free at every caller, so nothing is armed on the
@@ -1822,6 +1913,18 @@ pub fn Proxy(comptime IoType: type) type {
         fn releaseForStaticResponse(server: *ServerType, conn: *ConnType) void {
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
+            // The head buffer too: the answer is static memory and the
+            // lingering drain discards into the shared sink, so nothing
+            // past this point reads or writes head bytes — and a reject
+            // storm holding ring buffers for its drain windows would
+            // starve the very requests the 503s are protecting. Conditional
+            // because the NoBuffers rung answers without ever holding one.
+            // `head_len` deliberately survives the return: it is a count,
+            // not buffer content, and the §7 resync rule still reads it to
+            // decide keep-or-close; `beginNextRequest` zeroes it.
+            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+                server.returnHeadBuffer(conn);
+            }
             if (conn.relay_buffer) |buffer| {
                 server.releaseRelayBuffer(buffer);
                 conn.relay_buffer = null;
@@ -1884,7 +1987,14 @@ pub fn Proxy(comptime IoType: type) type {
             // honors apply here (§7, §8): the client's own ask, the drain,
             // and relay pressure — a proxy shedding buffers should not also
             // be holding connections open for their next request.
-            const keep = staticResponseResyncable(conn) and
+            // The head-shed rung can never keep, structurally: nothing was
+            // read (the ring was empty, so no buffer was ever bound), the
+            // request's bytes wait unread in the socket, and a kept
+            // connection would re-arm onto those same bytes and shed them
+            // forever. Comptime, so the resync rule — whose asserts require
+            // at least one byte read — is never consulted on that rung.
+            const may_keep = comptime !std.mem.eql(u8, counter, "l7_shed_head_buffers");
+            const keep = may_keep and staticResponseResyncable(conn) and
                 conn.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();
@@ -1927,6 +2037,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
+            if (std.mem.eql(u8, counter, "l7_shed_head_buffers")) return .shed;
             // A capped endpoint is a shed like any other from the
             // client's side: the request was refused to protect the
             // origin, and the line should read the same as the rungs
@@ -1944,8 +2055,9 @@ pub fn Proxy(comptime IoType: type) type {
         fn resumeAfterStaticResponse(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_responding);
             assert(conn.client_write.pending.len == 0);
-            // `respond` frees both before the send, so a kept connection
-            // carries nothing into its next request (§5).
+            // `respond` frees all three before the send, so a kept
+            // connection carries nothing into its next request (§5).
+            assert(conn.head_buffer_id == ConnType.head_buffer_none);
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
@@ -1981,11 +2093,16 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn armDrainRecv(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_draining_request);
-            // The head buffer is scratch now — recv into it and discard.
+            // The head buffer went back to the ring with the rest of the
+            // static response's holdings, so the discard lands in the
+            // server's one shared sink — recv targets whose contents
+            // nobody reads may alias, and a reject storm drains through
+            // 4 KiB total instead of 8 KiB per draining connection (§5).
+            assert(conn.head_buffer_id == ConnType.head_buffer_none);
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
-                conn.head[0..],
+                server.drainSink(),
                 &conn.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -81,6 +81,7 @@ fn bareAddress(
 pub fn Proxy(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
+    const UpstreamType = @import("../net/upstream.zig").UpstreamPool(IoType).Upstream;
     const Framing = ConnType.Framing;
 
     return struct {
@@ -130,6 +131,15 @@ pub fn Proxy(comptime IoType: type) type {
         fn headBytes(server: *ServerType, conn: *ConnType) []u8 {
             assert(conn.head_buffer_id != ConnType.head_buffer_none);
             return server.io.bufferGroupSlice(conn.head_buffer_id);
+        }
+
+        /// The upstream head bytes this exchange holds (§5): acquired at
+        /// the request-head render, released before the slot parks or
+        /// with the slot. Asserting the claim here means every read of
+        /// upstream head content states its precondition.
+        fn upstreamHeadBytes(upstream: *UpstreamType) []u8 {
+            assert(upstream.head_buffer != null);
+            return upstream.head_buffer.?.bytes[0..];
         }
 
         /// Where a head continuation read lands: the free space after what
@@ -627,6 +637,12 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream = parked;
                 conn.upstream_socket = parked.socket;
                 parked.head_len = 0;
+                // A parked slot released its head buffer before parking;
+                // the exchange re-acquires here, still in
+                // `.l7_reading_head` so a shed keeps (the checked-out
+                // socket is closed with the slot — the shed costs a
+                // parked origin connection, not a client one).
+                if (!acquireUpstreamHeadOrShed(server, conn)) return;
                 conn.l7.upstream_was_reused = true;
                 conn.state = .l7_dialing;
                 // No await happened: this runs in the same callback as the
@@ -640,6 +656,26 @@ pub fn Proxy(comptime IoType: type) type {
             dialUpstream(server, conn, pick);
         }
 
+        /// Acquire the exchange's upstream head buffer (§5) — the render
+        /// target and response-head accumulator — or shed. Called at the
+        /// two places a slot is obtained, deliberately *before* the state
+        /// leaves `.l7_reading_head` on the request path: the resync rule
+        /// keeps a shed connection only from there, and this rung earns
+        /// the same keep its slot sibling gets. (The §7 replay re-dials
+        /// from `.l7_exchanging`, where a shed closes — the stream is
+        /// mid-exchange and cannot be trusted kept.) On the shed path
+        /// `respond` has already released the slot the caller just
+        /// obtained, so the caller only returns.
+        fn acquireUpstreamHeadOrShed(server: *ServerType, conn: *ConnType) bool {
+            const upstream = conn.upstream.?;
+            assert(upstream.head_buffer == null);
+            upstream.head_buffer = server.acquireUpstreamHeadBuffer() orelse {
+                respond(server, conn, 503, "l7_shed_upstream_head_buffers");
+                return false;
+            };
+            return true;
+        }
+
         /// Acquire a fresh slot and dial `pick` under the per-try connect
         /// deadline (§8) — shared by the first try (`routeRequest`) and
         /// the §7 stale replay (`beginReplay`), so both tries dial
@@ -651,6 +687,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.upstream = server.acquireUpstream(conn.cluster_index, pick.endpoint_index) orelse {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
+            if (!acquireUpstreamHeadOrShed(server, conn)) return;
             // The slot is held, so this try really is going to this
             // endpoint — whether or not the dial ends up succeeding. A
             // replay overwrites it, naming the endpoint that served (§7).
@@ -766,6 +803,10 @@ pub fn Proxy(comptime IoType: type) type {
             assert(views.forward.path.len >= 1);
             assert(views.match.len >= 1);
             const upstream = conn.upstream.?;
+            // Acquired back when the slot was obtained (`acquireUpstreamHeadOrShed`),
+            // while the state still allowed a kept shed; by render time it
+            // is a held invariant, not a question.
+            assert(upstream.head_buffer != null);
             // Apply the listener's filters (empty when none): a rewrite of
             // the forwarded path and any header edits, against the same
             // canonical view the reject/route phase used.
@@ -790,7 +831,7 @@ pub fn Proxy(comptime IoType: type) type {
             // connection is a parking candidate (§5), and stripping the
             // client's Connection header already made persistence the wire
             // default.
-            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, &upstream.head) catch {
+            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, &upstream.head_buffer.?.bytes) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
@@ -894,7 +935,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
-                conn.upstream.?.head[l7.request_head_sent..l7.rendered_request_len],
+                upstreamHeadBytes(conn.upstream.?)[l7.request_head_sent..l7.rendered_request_len],
                 &conn.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -1152,7 +1193,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.recv(
                 conn.upstream_socket.?,
-                upstream.head[upstream.head_len..],
+                upstreamHeadBytes(upstream)[upstream.head_len..],
                 &conn.op_data_upstream_to_client.completion,
                 ConnType,
                 conn,
@@ -1192,7 +1233,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn parseResponseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             const upstream = conn.upstream.?;
-            const head = upstream.head[0..upstream.head_len];
+            const head = upstreamHeadBytes(upstream)[0..upstream.head_len];
             const head_is_full = upstream.head_len == constants.head_bytes_max;
 
             var storage: parser.HeaderStorage = undefined;
@@ -1239,7 +1280,7 @@ pub fn Proxy(comptime IoType: type) type {
             const upstream = conn.upstream.?;
             var storage: parser.HeaderStorage = undefined;
             const response = parser.parseResponseHead(
-                upstream.head[0..upstream.head_len],
+                upstreamHeadBytes(upstream)[0..upstream.head_len],
                 false,
                 &storage,
                 conn.l7.request_method,
@@ -1303,7 +1344,7 @@ pub fn Proxy(comptime IoType: type) type {
 
             // Feed the framing tracker over the body excess that arrived
             // coalesced with the head.
-            const excess = upstream.head[response.head_len..upstream.head_len];
+            const excess = upstreamHeadBytes(upstream)[response.head_len..upstream.head_len];
             const feed = feedFraming(&conn.l7.response_framing, excess);
             if (feed.malformed) {
                 upstreamFailed(server, conn);
@@ -1453,7 +1494,7 @@ pub fn Proxy(comptime IoType: type) type {
             armClientWrite(
                 server,
                 conn,
-                conn.upstream.?.head[base..][0..excess_len],
+                upstreamHeadBytes(conn.upstream.?)[base..][0..excess_len],
                 .response_body,
             );
         }
@@ -1592,6 +1633,12 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             const upstream = conn.upstream.?;
             assert(!upstream.parked);
+            // The exchange's head bytes go back before the slot parks
+            // (§5): the response leg is settled, so the client-write
+            // channel no longer references them — asserted, because the
+            // excess write sends straight from this buffer.
+            assert(conn.client_write.pending.len == 0);
+            server.releaseUpstreamHeadBuffer(upstream);
             server.upstreams.park(upstream);
             upstream.deadline_ns = server.io.nowNs() +
                 @as(u64, server.parkedTimeoutMs()) * std.time.ns_per_ms;
@@ -2038,6 +2085,7 @@ pub fn Proxy(comptime IoType: type) type {
             if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_head_buffers")) return .shed;
+            if (std.mem.eql(u8, counter, "l7_shed_upstream_head_buffers")) return .shed;
             // A capped endpoint is a shed like any other from the
             // client's side: the request was refused to protect the
             // origin, and the line should read the same as the rungs

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -395,8 +395,8 @@ const testing = std.testing;
 /// Fuzz/test staging: normalization can grow a head (a missing space
 /// after `:` is rendered back, one byte per header), so the oracle
 /// buffer carries slack; the production staging area is exactly
-/// `head_bytes_max` and overflowing it is the 431/teardown verdict.
-const oracle_buffer_bytes = constants.head_bytes_max + @as(u32, constants.headers_max) + 64;
+/// `head_buffer_bytes_default` and overflowing it is the 431/teardown verdict.
+const oracle_buffer_bytes = constants.head_buffer_bytes_default + @as(u32, constants.headers_max) + 64;
 
 test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const head = "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-Nominated\r\n" ++
@@ -466,27 +466,27 @@ test "render: an edit that overflows the buffer is Oversize" {
     );
 }
 
-test "render: the edited oracle skips a head that grows past head_bytes_max" {
+test "render: the edited oracle skips a head that grows past head_buffer_bytes_default" {
     // Regression: `parseRequestHead`'s first statement asserts
-    // `head.len <= head_bytes_max`, so an edited head rendered past that
+    // `head.len <= head_buffer_bytes_default`, so an edited head rendered past that
     // ceiling (into the slack oracle buffer) would trip that assert before
     // any error could surface — a panic reachable under `--fuzz`. The oracle
     // guards on `rendered.len`; this input, a source exactly at the ceiling
     // with a no-space colon (render re-adds ": ", +1 byte) plus the fixed
     // edits, is guaranteed over it. Without the guard the call panics.
-    var source: [constants.head_bytes_max]u8 = undefined;
+    var source: [constants.head_buffer_bytes_default]u8 = undefined;
     const prefix = "GET / HTTP/1.1\r\nHost: a\r\nX:";
     @memcpy(source[0..prefix.len], prefix);
     // Pad the value so the whole head, including the terminating CRLF, is
-    // exactly head_bytes_max bytes.
-    const value_end = constants.head_bytes_max - "\r\n\r\n".len;
+    // exactly head_buffer_bytes_default bytes.
+    const value_end = constants.head_buffer_bytes_default - "\r\n\r\n".len;
     @memset(source[prefix.len..value_end], 'x');
     @memcpy(source[value_end..], "\r\n\r\n");
 
-    // The source is legal (head.len == head_bytes_max is within the limit).
+    // The source is legal (head.len == head_buffer_bytes_default is within the limit).
     var storage: parser.HeaderStorage = undefined;
     const parsed = try parser.parseRequestHead(&source, false, &storage);
-    try testing.expectEqual(@as(u32, constants.head_bytes_max), parsed.head_len);
+    try testing.expectEqual(@as(u32, constants.head_buffer_bytes_default), parsed.head_len);
     // Confirm the edited render genuinely crosses the ceiling — otherwise
     // this test would exercise nothing. (The edit set mirrors the oracle's.)
     const edits = [_]filter.AppliedHeaderEdit{
@@ -496,7 +496,7 @@ test "render: the edited oracle skips a head that grows past head_bytes_max" {
     };
     var render_buf: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, &render_buf);
-    try testing.expect(rendered.len > constants.head_bytes_max);
+    try testing.expect(rendered.len > constants.head_buffer_bytes_default);
     // Must return cleanly instead of panicking in the reparse precondition.
     checkRequestRenderEdited(&source);
 }
@@ -629,7 +629,7 @@ fn checkRequestRender(input: []const u8) void {
     // Mirror the routeRequest gate (§7): an origin-form target that will
     // not canonicalize is a 400 and never reaches the renderer; OPTIONS
     // asterisk-form has no path and forwards verbatim.
-    var scratch: [constants.head_bytes_max]u8 = undefined;
+    var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
     const target: parser.CanonicalTarget = if (request.target[0] == '/')
         (parser.canonicalTarget(request.target, &scratch) catch return)
     else
@@ -638,12 +638,12 @@ fn checkRequestRender(input: []const u8) void {
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = renderRequestHead(&request, target, &.{}, false, null, &buffer) catch unreachable;
 
-    // The oracle buffer carries slack past `head_bytes_max` so normalization
+    // The oracle buffer carries slack past `head_buffer_bytes_default` so normalization
     // growth never truncates the comparison; production renders into an
-    // exactly-`head_bytes_max` buffer and 431s anything larger. A head that
+    // exactly-`head_buffer_bytes_default` buffer and 431s anything larger. A head that
     // grew past that ceiling here is that oversize verdict — not a reparse
     // input, and past the parser's own size precondition — so stop before it.
-    if (rendered.len > constants.head_bytes_max) {
+    if (rendered.len > constants.head_buffer_bytes_default) {
         return;
     }
     var reparse_storage: parser.HeaderStorage = undefined;
@@ -679,7 +679,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
     if (request.method == .connect) {
         return;
     }
-    var scratch: [constants.head_bytes_max]u8 = undefined;
+    var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
     const target: parser.CanonicalTarget = if (request.target[0] == '/')
         (parser.canonicalTarget(request.target, &scratch) catch return)
     else
@@ -695,13 +695,13 @@ fn checkRequestRenderEdited(input: []const u8) void {
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = renderRequestHead(&request, target, &edits, false, null, &buffer) catch return;
 
-    // The appended edits can push an already-large head past `head_bytes_max`
+    // The appended edits can push an already-large head past `head_buffer_bytes_default`
     // — the oversize-after-edits verdict (431 in production, which renders
-    // into an exactly-`head_bytes_max` buffer). Past that ceiling the head is
+    // into an exactly-`head_buffer_bytes_default` buffer). Past that ceiling the head is
     // not a reparse input and would trip the parser's size precondition, so
     // stop; a reparse miss below is then only the benign headers-count
     // overflow (source at `headers_max` plus the appended lines).
-    if (rendered.len > constants.head_bytes_max) {
+    if (rendered.len > constants.head_buffer_bytes_default) {
         return;
     }
     var reparse_storage: parser.HeaderStorage = undefined;
@@ -745,7 +745,7 @@ test "fuzz: parse-render-reparse keeps routing and framing intact" {
 
 fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
     _ = context;
-    var input_buffer: [constants.head_bytes_max]u8 = undefined;
+    var input_buffer: [constants.head_buffer_bytes_default]u8 = undefined;
     const input_len = smith.slice(&input_buffer);
     assert(input_len <= input_buffer.len);
     const input = input_buffer[0..input_len];
@@ -771,7 +771,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
     if (request.method == .connect) {
         return;
     }
-    var scratch: [constants.head_bytes_max]u8 = undefined;
+    var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
     const target: parser.CanonicalTarget = if (request.target[0] == '/')
         (parser.canonicalTarget(request.target, &scratch) catch return)
     else
@@ -790,7 +790,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
         forwarded_for,
         &buffer,
     ) catch return;
-    if (rendered.len > constants.head_bytes_max) {
+    if (rendered.len > constants.head_buffer_bytes_default) {
         return;
     }
     var reparse_storage: parser.HeaderStorage = undefined;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -487,6 +487,9 @@ const Http1Bed = struct {
         conn_slots: u32 = 4,
         relay_buffers: u32 = 2,
         upstream_slots: u32 = 2,
+        /// The §5 head-buffer ring; null follows conn_slots (never
+        /// sheds), a number drives the `l7_shed_head_buffers` rung.
+        head_buffers: ?u32 = null,
         /// The §6 absolute age cap; 0 (the default) disables it. A cap the
         /// exchange outlives clamps every stored deadline to it, so a
         /// re-based target can already be in the past.
@@ -536,7 +539,15 @@ const Http1Bed = struct {
         if (options.inbox_bytes) |bytes| {
             adversary.inbox_bytes = bytes;
         }
-        try bed.sim_io.init(arena, .{ .seed = options.seed, .adversary = adversary });
+        // One number on both sides (§5): the ring the sim registers is
+        // the limit the server accounts against — Server.init asserts
+        // the match, so a bed cannot drift them apart.
+        const head_buffers = options.head_buffers orelse options.conn_slots;
+        try bed.sim_io.init(arena, .{
+            .seed = options.seed,
+            .adversary = adversary,
+            .buffer_group_count = head_buffers,
+        });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
@@ -562,6 +573,7 @@ const Http1Bed = struct {
             .conn_slots = options.conn_slots,
             .relay_buffers = options.relay_buffers,
             .upstream_slots = options.upstream_slots,
+            .head_buffers = head_buffers,
             .access_log_buffer_bytes = if (options.access_log)
                 constants.access_log_buffer_bytes_default
             else
@@ -1148,6 +1160,64 @@ test "l7: an upstream-slot shed keeps the connection, and the client's ask decid
     // the churn loop.
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("accepted"));
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("admitted"));
+    try bed.expectDrained();
+}
+
+test "l7: a head-ring shed answers 503 and always closes" {
+    // The §5 rung that precedes the parse: the client spoke while every
+    // ring buffer was bound. Unlike every other shed this one can never
+    // keep — the request's bytes were never read (no buffer was ever
+    // bound), so a kept connection would re-arm onto the same bytes and
+    // shed the same request forever. `respond` enforces the close at
+    // comptime; this pins the wire truth of both halves: the 503, and
+    // the announced close that follows it.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 61,
+        .head_buffers = 1,
+        .origin_mute = true,
+    });
+    defer bed.tearDown();
+
+    // client binds the single ring buffer and holds it (a mute origin
+    // keeps its exchange open); client2 arrives to an empty ring.
+    bed.client.drain_on_finish = false;
+    bed.client2.send_delay_ms = 100;
+    bed.client2.request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_shed_head_buffers"));
+    try bed.expectDrained();
+}
+
+test "l7: keep-alive returns the head buffer between requests" {
+    // The §5 headline: an idle keep-alive connection holds no head
+    // bytes. Observed through the watermark counter rather than a
+    // mid-run probe: with a one-buffer ring every bind engages the
+    // pressure flag (the high watermark of capacity 1 is 1) and every
+    // return clears it, so two sequential keep-alive requests on one
+    // connection must count exactly two engages. A ring buffer held
+    // across the idle gap would count one — and shed the second
+    // request besides, which the zero shed count rules out.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 62,
+        .origin_response = response,
+        .head_buffers = 1,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_head_buffers"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("head_pressure_engaged"));
     try bed.expectDrained();
 }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -59,7 +59,7 @@ const HttpClient = struct {
     /// Twice the proxy's head buffer: a response that fills that buffer and
     /// then grows in the render exceeds it, and the separate-excess scenario
     /// needs the whole response in one place to compare against.
-    receive_buffer: [2 * constants.head_bytes_max]u8 = undefined,
+    receive_buffer: [2 * constants.head_buffer_bytes_default]u8 = undefined,
     received_len: u32 = 0,
     outcome: Outcome = .pending,
 
@@ -493,6 +493,8 @@ const Http1Bed = struct {
         /// The §5 upstream head pool; null follows upstream_slots (never
         /// sheds), a number drives `l7_shed_upstream_head_buffers`.
         upstream_head_buffers: ?u32 = null,
+        /// Bytes per head buffer — the configured largest-accepted head.
+        head_buffer_bytes: u32 = constants.head_buffer_bytes_default,
         /// The §6 absolute age cap; 0 (the default) disables it. A cap the
         /// exchange outlives clamps every stored deadline to it, so a
         /// re-based target can already be in the past.
@@ -550,6 +552,7 @@ const Http1Bed = struct {
             .seed = options.seed,
             .adversary = adversary,
             .buffer_group_count = head_buffers,
+            .buffer_group_bytes = options.head_buffer_bytes,
         });
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
@@ -578,6 +581,7 @@ const Http1Bed = struct {
             .upstream_slots = options.upstream_slots,
             .head_buffers = head_buffers,
             .upstream_head_buffers = options.upstream_head_buffers orelse options.upstream_slots,
+            .head_buffer_bytes = options.head_buffer_bytes,
             .access_log_buffer_bytes = if (options.access_log)
                 constants.access_log_buffer_bytes_default
             else
@@ -774,14 +778,14 @@ test "l7: a head that fits on arrival but not after forwarding is 431" {
     // accepted, rejected only when the proxy renders what it will forward
     // (#87).
     {
-        // An added header pushes an exactly-`head_bytes_max` head over.
+        // An added header pushes an exactly-`head_buffer_bytes_default` head over.
         const rules = [_]filter.Rule{.{
             .match = .{ .path_prefix = "/api" },
             .actions = &.{.{ .header_add = .{ .name = "X-Trace", .value = "on" } }},
         }};
         const prefix = "GET /api HTTP/1.1\r\nHost: o\r\nX-Pad: ";
         const suffix = "\r\n\r\n";
-        var request: [constants.head_bytes_max]u8 = undefined;
+        var request: [constants.head_buffer_bytes_default]u8 = undefined;
         @memcpy(request[0..prefix.len], prefix);
         @memset(request[prefix.len..][0 .. request.len - prefix.len - suffix.len], 'p');
         @memcpy(request[request.len - suffix.len ..][0..suffix.len], suffix);
@@ -1262,6 +1266,38 @@ test "l7: an upstream head-pool shed keeps the connection like any post-parse ru
     try bed.expectDrained();
 }
 
+test "l7: the configured head size is the accepted head size" {
+    // The §5 size knob is behaviour, not just memory: at 1024 bytes a
+    // request line that would sail through the 8 KiB default dies as the
+    // 414 the smaller buffer makes of it, and an ordinary GET still fits.
+    // The oversize half proves the wall moved down with the config; the
+    // ordinary half proves it did not move below what it promises.
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 64,
+        .origin_response = response,
+        .head_buffer_bytes = constants.head_buffer_bytes_min,
+    });
+    defer bed.tearDown();
+
+    // 1100 path bytes: past the 1024 buffer with no newline in sight —
+    // the request line alone overflows, which is the 414 shape.
+    const oversize = "GET /" ++ ("a" ** 1100) ++ " HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.send_delay_ms = 50;
+    bed.client2.request = oversize;
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /ok HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
+    try std.testing.expect(std.mem.startsWith(u8, bed.client.response(), "HTTP/1.1 200 OK"));
+    try bed.expectDrained();
+}
+
 test "l7: kernel pressure on a socket option is witnessed per op, on both sockets" {
     // A fresh L7 exchange sets TCP_NODELAY twice: once on the accepted
     // client socket (`Server` admission) and once on the dialled upstream
@@ -1723,18 +1759,18 @@ test "l7: a coalesced excess too large to ride the rendered head is written sepa
     // injection then grows the render past it and the excess cannot ride
     // along — it leaves as a second write straight from upstream.head (§7).
     // Sizes derive from the bound rather than being spelled out, so a change
-    // to `head_bytes_max` fails here loudly instead of quietly sliding the
+    // to `head_buffer_bytes_default` fails here loudly instead of quietly sliding the
     // scenario off the branch it exists to cover (#77).
     const injected_len = "Connection: close\r\n".len;
     const body_len = 42;
-    const head_len: usize = constants.head_bytes_max - body_len;
+    const head_len: usize = constants.head_buffer_bytes_default - body_len;
     const prefix = std.fmt.comptimePrint(
         "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nX-Pad: ",
         .{body_len},
     );
     const suffix = "\r\n\r\n";
 
-    var response_bytes: [constants.head_bytes_max]u8 = undefined;
+    var response_bytes: [constants.head_buffer_bytes_default]u8 = undefined;
     @memcpy(response_bytes[0..prefix.len], prefix);
     @memset(response_bytes[prefix.len..][0 .. head_len - prefix.len - suffix.len], 'p');
     @memcpy(response_bytes[head_len - suffix.len ..][0..suffix.len], suffix);
@@ -1799,7 +1835,7 @@ test "l7: the coalesced excess in the shape production delivers it" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 12,
-        .inbox_bytes = constants.head_bytes_max,
+        .inbox_bytes = constants.head_buffer_bytes_default,
         .origin_response = &response_bytes,
     });
     defer bed.tearDown();
@@ -1919,13 +1955,13 @@ test "l7: an origin response head the proxy cannot parse is 502" {
         try bed.expectDrained();
     }
     {
-        // A head that never terminates. It accumulates to `head_bytes_max`
+        // A head that never terminates. It accumulates to `head_buffer_bytes_default`
         // over several reads, and the parser turns the last Incomplete into
         // the oversize verdict rather than asking for a read that has
         // nowhere to land.
         const unterminated = "HTTP/1.1 200 OK\r\nX-Pad: ";
         const response = unterminated ++
-            ("p" ** (constants.head_bytes_max - unterminated.len));
+            ("p" ** (constants.head_buffer_bytes_default - unterminated.len));
 
         var bed: Http1Bed = undefined;
         try bed.setUp(std.testing.allocator, .{ .seed = 8, .origin_response = response });
@@ -1951,7 +1987,7 @@ test "l7: an origin head that no longer fits once the close is injected is 502" 
     // like any other upstream failure — 502, not a truncated response (#87).
     const prefix = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nX-Pad: ";
     const suffix = "\r\n\r\n";
-    var response_bytes: [constants.head_bytes_max]u8 = undefined;
+    var response_bytes: [constants.head_buffer_bytes_default]u8 = undefined;
     @memcpy(response_bytes[0..prefix.len], prefix);
     @memset(
         response_bytes[prefix.len..][0 .. response_bytes.len - prefix.len - suffix.len],
@@ -3253,14 +3289,14 @@ test "l7: an oversize inbound chain fails safe to the observed peer, and is coun
         .seed = 43,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
         .forwarded = .append,
-        .inbox_bytes = constants.head_bytes_max,
+        .inbox_bytes = constants.head_buffer_bytes_default,
     });
     defer bed.tearDown();
 
     // One address repeated past `forwarded_chain_bytes_max`.
     const hop = "10.0.0.1, ";
     const hops = @divFloor(constants.forwarded_chain_bytes_max, hop.len) + 2;
-    var request: [constants.head_bytes_max]u8 = undefined;
+    var request: [constants.head_buffer_bytes_default]u8 = undefined;
     var writer = std.Io.Writer.fixed(&request);
     try writer.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Forwarded-For: ");
     for (0..hops) |_| try writer.writeAll(hop);

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -490,6 +490,9 @@ const Http1Bed = struct {
         /// The §5 head-buffer ring; null follows conn_slots (never
         /// sheds), a number drives the `l7_shed_head_buffers` rung.
         head_buffers: ?u32 = null,
+        /// The §5 upstream head pool; null follows upstream_slots (never
+        /// sheds), a number drives `l7_shed_upstream_head_buffers`.
+        upstream_head_buffers: ?u32 = null,
         /// The §6 absolute age cap; 0 (the default) disables it. A cap the
         /// exchange outlives clamps every stored deadline to it, so a
         /// re-based target can already be in the past.
@@ -574,6 +577,7 @@ const Http1Bed = struct {
             .relay_buffers = options.relay_buffers,
             .upstream_slots = options.upstream_slots,
             .head_buffers = head_buffers,
+            .upstream_head_buffers = options.upstream_head_buffers orelse options.upstream_slots,
             .access_log_buffer_bytes = if (options.access_log)
                 constants.access_log_buffer_bytes_default
             else
@@ -1218,6 +1222,43 @@ test "l7: keep-alive returns the head buffer between requests" {
 
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_head_buffers"));
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("head_pressure_engaged"));
+    try bed.expectDrained();
+}
+
+test "l7: an upstream head-pool shed keeps the connection like any post-parse rung" {
+    // The §5 upstream head pool's wall, distinct from the slot wall: two
+    // slots free, one head buffer — the first exchange holds it from the
+    // moment its slot was obtained (a mute origin never lets it park), so
+    // the second request gets a slot and sheds at the head acquire right
+    // beside it. Unlike the client-side ring rung this request was fully
+    // read and parsed, so the ordinary keep-or-close rules apply — pinned
+    // the same way the slot-shed test pins them: two requests answered on
+    // one connection, the close spelling honoring the client's own ask.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 63,
+        .upstream_slots = 2,
+        .upstream_head_buffers = 1,
+        .origin_mute = true,
+    });
+    defer bed.tearDown();
+
+    bed.client.drain_on_finish = false;
+    bed.client2.send_delay_ms = 100;
+    bed.client2.request = "GET /one HTTP/1.1\r\nHost: o\r\n\r\n";
+    bed.client2.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_relay_buffers"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_head_buffers"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_upstream_slots"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_shed_upstream_head_buffers"));
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n" ++
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client2.response(),
+    );
     try bed.expectDrained();
 }
 

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -646,6 +646,12 @@ pub fn bufferGroupSlice(io: *SimIo, buffer_id: u16) []u8 {
     return io.group_slab[@as(usize, buffer_id) * io.group_bytes ..][0..io.group_bytes];
 }
 
+/// The group's capacity — what a caller's own in-use accounting must
+/// agree with, asserted at the composition site rather than trusted.
+pub fn bufferGroupCount(io: *const SimIo) u32 {
+    return io.group_count;
+}
+
 /// Give a selected buffer back to the group. Sync and syscall-free in
 /// production (a buf_ring tail bump); here it is the flag flip the sim's
 /// leak assertions watch.

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -139,6 +139,16 @@ sink_overflow_bytes: u32,
 pending_log_write_errors: u8,
 /// The ephemeral port the next simulated client connects from.
 next_client_port: u16,
+/// The provided-buffer group (§5): one slab, a free flag per buffer, and
+/// the in-use count the asserts ride on. Selection happens at delivery
+/// time — an armed `recv_group` holds nothing — mirroring the kernel's
+/// buf_ring, with lowest-free-id in place of the kernel's own choice so
+/// the schedule stays a pure function of the seed.
+group_slab: []u8,
+group_free: []bool,
+group_count: u32,
+group_bytes: u32,
+group_in_use: u32,
 
 const blackholed_addresses_max: u8 = 4;
 const connect_error_addresses_max: u8 = 4;
@@ -185,6 +195,13 @@ pub const Options = struct {
     /// Print pending-op forensics when a deadlock is detected. Tests
     /// that deliberately provoke a deadlock turn this off.
     dump_on_deadlock: bool = true,
+    /// The provided-buffer group `recvGroup` selects from — the simulated
+    /// twin of the io_uring buf_ring (§5's head-buffer ring). Selection is
+    /// deterministic (lowest free id), so a seed replays the same buffer
+    /// assignments. Defaults wide enough that no scenario sheds unless it
+    /// asks to: one buffer per possible socket, production-sized.
+    buffer_group_count: u32 = sockets_max,
+    buffer_group_bytes: u32 = constants.head_bytes_max,
 };
 
 pub const Socket = packed struct(u32) {
@@ -214,6 +231,7 @@ pub const OpKind = enum(u8) {
     accept,
     connect,
     recv,
+    recv_group,
     send,
     close,
     log_write,
@@ -227,6 +245,7 @@ const Op = union(OpKind) {
     accept: struct { listener_index: u16 },
     connect: struct { address: std.Io.net.IpAddress, fate: ConnectFate, canceled: bool },
     recv: struct { socket: Socket, buffer: []u8 },
+    recv_group: struct { socket: Socket },
     send: struct { socket: Socket, bytes: []const u8 },
     close: struct { socket: Socket },
     log_write: struct { bytes: []const u8 },
@@ -241,6 +260,7 @@ const Result = union(enum) {
     accept: Io.AcceptError!Socket,
     connect: Io.ConnectError!Socket,
     recv: Io.RecvError!u32,
+    recv_group: Io.RecvGroupError!Io.GroupRecv,
     send: Io.SendError!u32,
     close: void,
     log_write: Io.LogWriteError!u32,
@@ -393,6 +413,13 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     // wider than the backing array would index past it.
     assert(options.adversary.inbox_bytes >= 1);
     assert(options.adversary.inbox_bytes <= inbox_bytes_max);
+    // A zero-buffer group is a scenario choice (an L4-only world arms no
+    // recv_group); a zero-byte buffer is never anything but a bug. The
+    // count ceiling is the kernel twin's own (buf_ring entries are a u16
+    // power of two), stated here so ids stay u16 and the slab multiply
+    // below cannot overflow before it widens.
+    assert(options.buffer_group_bytes >= 1);
+    assert(options.buffer_group_count <= constants.buffer_group_entries_max);
 
     io.listeners = try arena.alloc(ListenerEntry, listeners_max);
     io.pending = try arena.alloc(*Completion, pending_ops_max);
@@ -422,6 +449,15 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.sink_overflow_bytes = 0;
     io.pending_log_write_errors = 0;
     io.next_client_port = client_port_base;
+    io.group_slab = try arena.alloc(
+        u8,
+        @as(usize, options.buffer_group_count) * options.buffer_group_bytes,
+    );
+    io.group_free = try arena.alloc(bool, options.buffer_group_count);
+    @memset(io.group_free, true);
+    io.group_count = options.buffer_group_count;
+    io.group_bytes = options.buffer_group_bytes;
+    io.group_in_use = 0;
     assert(io.sockets.isFullyReleased());
 }
 
@@ -577,6 +613,48 @@ pub fn recv(
         .callback = erasedResult(Userdata, .recv, callback),
     };
     io.enqueue(completion);
+}
+
+/// A recv that carries no buffer (§5's head-buffer ring): the group binds
+/// one at delivery time, or answers `error.NoBuffers` if it cannot. The
+/// armed op itself holds nothing — that is the entire point.
+pub fn recvGroup(
+    io: *SimIo,
+    socket: Socket,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.RecvGroupError!Io.GroupRecv) void,
+) void {
+    assert(completion.state == .dead);
+    assert(io.group_count >= 1);
+    _ = io.socketEntry(socket);
+    completion.* = .{
+        .op = .{ .recv_group = .{ .socket = socket } },
+        .userdata = userdata,
+        .callback = erasedResult(Userdata, .recv_group, callback),
+    };
+    io.enqueue(completion);
+}
+
+/// The bytes behind a `GroupRecv.buffer_id`, valid until returned.
+pub fn bufferGroupSlice(io: *SimIo, buffer_id: u16) []u8 {
+    assert(buffer_id < io.group_count);
+    // Only the holder of an id may read it, and the simulator can enforce
+    // what the kernel-backed twin cannot observe.
+    assert(!io.group_free[buffer_id]);
+    return io.group_slab[@as(usize, buffer_id) * io.group_bytes ..][0..io.group_bytes];
+}
+
+/// Give a selected buffer back to the group. Sync and syscall-free in
+/// production (a buf_ring tail bump); here it is the flag flip the sim's
+/// leak assertions watch.
+pub fn bufferGroupReturn(io: *SimIo, buffer_id: u16) void {
+    assert(buffer_id < io.group_count);
+    assert(!io.group_free[buffer_id]);
+    assert(io.group_in_use >= 1);
+    io.group_free[buffer_id] = true;
+    io.group_in_use -= 1;
 }
 
 pub fn send(
@@ -979,6 +1057,10 @@ fn dumpPendingOps(io: *const SimIo) void {
                 "  recv socket={d} gen={d}\n",
                 .{ op.socket.index, op.socket.generation },
             ),
+            .recv_group => |op| std.debug.print(
+                "  recv_group socket={d} gen={d}\n",
+                .{ op.socket.index, op.socket.generation },
+            ),
             .send => |op| std.debug.print(
                 "  send socket={d} gen={d} len={d}\n",
                 .{ op.socket.index, op.socket.generation, op.bytes.len },
@@ -1037,6 +1119,14 @@ fn opReady(io: *SimIo, completion: *Completion) bool {
             break :ready entry.kernel_pressure or entry.reset or entry.inbox.count > 0 or
                 entry.read_shutdown or entry.fin_received;
         },
+        // Readiness is the socket's, never the group's: the kernel twin
+        // waits for data with an empty group too, and reports NoBuffers
+        // only when bytes actually arrive to an empty one.
+        .recv_group => |op| ready: {
+            const entry = io.socketEntry(op.socket);
+            break :ready entry.kernel_pressure or entry.reset or entry.inbox.count > 0 or
+                entry.read_shutdown or entry.fin_received;
+        },
         .send => |op| ready: {
             const entry = io.socketEntry(op.socket);
             if (entry.kernel_pressure or entry.reset or
@@ -1082,6 +1172,7 @@ fn deliverOne(io: *SimIo, completion: *Completion) void {
             .connect = if (op.canceled) error.Canceled else io.finishConnect(op.address, op.fate),
         },
         .recv => |op| .{ .recv = io.finishRecv(op.socket, op.buffer) },
+        .recv_group => |op| .{ .recv_group = io.finishRecvGroup(op.socket) },
         .send => |op| .{ .send = io.finishSend(op.socket, op.bytes) },
         .log_write => |op| .{ .log_write = io.finishLogWrite(op.bytes) },
         .close => |op| close: {
@@ -1199,6 +1290,52 @@ fn finishRecv(io: *SimIo, socket: Socket, buffer: []u8) Io.RecvError!u32 {
     }
     assert(entry.read_shutdown or entry.fin_received);
     return error.EndOfStream;
+}
+
+/// `finishRecv` with the buffer bound at delivery instead of at arm — the
+/// order of the checks is the contract: reset and EOF outrank selection,
+/// so a dying socket never consumes a buffer (the kernel behaves the same;
+/// the fork's test pins it).
+fn finishRecvGroup(io: *SimIo, socket: Socket) Io.RecvGroupError!Io.GroupRecv {
+    const entry = io.socketEntry(socket);
+    if (entry.kernel_pressure) {
+        // Transient op failure: consume the flag, leave the socket usable.
+        entry.kernel_pressure = false;
+        io.recordPressure();
+        return error.Unexpected;
+    }
+    if (entry.reset) {
+        return error.Reset;
+    }
+    if (entry.inbox.count > 0 and !entry.read_shutdown) {
+        const buffer_id = io.groupPickFree() orelse return error.NoBuffers;
+        const buffer = io.bufferGroupSlice(buffer_id);
+        const available: u32 = @min(@as(u32, @intCast(buffer.len)), entry.inbox.count);
+        const n = io.partialLen(available);
+        const popped = entry.inbox.pop(buffer[0..n]);
+        assert(popped == n);
+        assert(n >= 1);
+        return .{ .len = n, .buffer_id = buffer_id };
+    }
+    assert(entry.read_shutdown or entry.fin_received);
+    return error.EndOfStream;
+}
+
+/// Lowest free id, or null on exhaustion. Lowest rather than random on
+/// purpose: buffer assignment stays a pure function of the seed's
+/// schedule, so it cannot fork a trace on its own.
+fn groupPickFree(io: *SimIo) ?u16 {
+    assert(io.group_in_use <= io.group_count);
+    for (io.group_free, 0..) |free, index| {
+        if (free) {
+            io.group_free[index] = false;
+            io.group_in_use += 1;
+            assert(io.group_in_use <= io.group_count);
+            return @intCast(index);
+        }
+    }
+    assert(io.group_in_use == io.group_count);
+    return null;
 }
 
 fn finishSend(io: *SimIo, socket: Socket, bytes: []const u8) Io.SendError!u32 {
@@ -1463,6 +1600,12 @@ fn traceMix(io: *SimIo, completion: *const Completion, result: *const Result) vo
     io.mix(@intFromEnum(result.*));
     const detail: u64 = switch (result.*) {
         .recv => |r| if (r) |n| n else |err| 1000 + @intFromError(err),
+        // Both halves matter to a trace: the same bytes landing in a
+        // different buffer is a different schedule.
+        .recv_group => |r| if (r) |g|
+            (@as(u64, g.buffer_id) << 32) | g.len
+        else |err|
+            11000 + @intFromError(err),
         .send => |r| if (r) |n| n else |err| 2000 + @intFromError(err),
         .accept => |r| if (r) |s| @as(u32, @bitCast(s)) else |err| 3000 + @intFromError(err),
         .connect => |r| if (r) |s| @as(u32, @bitCast(s)) else |err| 4000 + @intFromError(err),

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -24,11 +24,12 @@ const SimIo = @This();
 const sockets_max: u16 = 1024;
 const listeners_max: u16 = 32;
 const accept_queue_max: u16 = 64;
-/// The widest a scenario may open a socket ring. Sized to the head buffer
-/// so a scenario can reproduce a production-shaped delivery — one read
-/// filling `conn.head`/`upstream.head` outright — which a narrower ring
-/// makes unrepresentable whatever the seed.
-const inbox_bytes_max: u32 = constants.head_bytes_max;
+/// The widest a scenario may open a socket ring. The simulator's own
+/// 8 KiB rather than the production head size — which is the config's
+/// now (`limits.head_buffer_bytes`) — matching the *default* head
+/// buffer, so a scenario can still reproduce a production-shaped
+/// delivery: one read filling a default-sized head buffer outright.
+const inbox_bytes_max: u32 = 8 * 1024;
 /// What a scenario gets unless it asks for more. Half the head buffer, so
 /// a head larger than it still arrives in pieces by default and the §7
 /// detect-and-retry re-parse keeps being exercised.
@@ -38,7 +39,9 @@ comptime {
     assert(inbox_bytes_default <= inbox_bytes_max);
     // The default must stay narrower than a head buffer, or every scenario
     // silently loses the piecewise head arrival it covers today.
-    assert(inbox_bytes_default < constants.head_bytes_max);
+    assert(inbox_bytes_default < inbox_bytes_max);
+    // The whole-head delivery stays representable at the default size.
+    assert(inbox_bytes_max >= constants.head_buffer_bytes_default);
 }
 /// The simulator's own in-flight-op bound (§9), derived from *its*
 /// listener limit rather than production's — which no longer has one, so
@@ -201,7 +204,7 @@ pub const Options = struct {
     /// assignments. Defaults wide enough that no scenario sheds unless it
     /// asks to: one buffer per possible socket, production-sized.
     buffer_group_count: u32 = sockets_max,
-    buffer_group_bytes: u32 = constants.head_bytes_max,
+    buffer_group_bytes: u32 = constants.head_buffer_bytes_default,
 };
 
 pub const Socket = packed struct(u32) {
@@ -650,6 +653,11 @@ pub fn bufferGroupSlice(io: *SimIo, buffer_id: u16) []u8 {
 /// agree with, asserted at the composition site rather than trusted.
 pub fn bufferGroupCount(io: *const SimIo) u32 {
     return io.group_count;
+}
+
+/// One buffer's size, on the same asserted-not-trusted terms.
+pub fn bufferGroupBytes(io: *const SimIo) u32 {
+    return io.group_bytes;
 }
 
 /// Give a selected buffer back to the group. Sync and syscall-free in

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -456,6 +456,8 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
         u8,
         @as(usize, options.buffer_group_count) * options.buffer_group_bytes,
     );
+    // Zeroed for symmetry with the kernel twin's init-time fault-in.
+    @memset(io.group_slab, 0);
     io.group_free = try arena.alloc(bool, options.buffer_group_count);
     @memset(io.group_free, true);
     io.group_count = options.buffer_group_count;

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -681,6 +681,12 @@ fn sliceForId(io: *XevIo, buffer_id: u16) []u8 {
     return io.group_slab[@as(usize, buffer_id) * io.group_bytes ..][0..io.group_bytes];
 }
 
+/// The group's capacity — what a caller's own in-use accounting must
+/// agree with, asserted at the composition site rather than trusted.
+pub fn bufferGroupCount(io: *const XevIo) u32 {
+    return io.group_count;
+}
+
 /// Give a selected buffer back to the group: on io_uring two stores and an
 /// atomic tail bump — no syscall — republishing the id to the kernel; on
 /// the emulation, a push onto the free stack.

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -162,6 +162,12 @@ fn initBufferGroup(io: *XevIo, arena: std.mem.Allocator, count: u32, bytes: u32)
     assert(bytes >= 1);
     assert(count <= constants.buffer_group_entries_max);
     io.group_slab = try arena.alloc(u8, @as(usize, count) * bytes);
+    // Fault the whole slab in now: the kernel consumes the ring FIFO, so
+    // under sustained load every registered buffer gets written — pages a
+    // LIFO pool would never touch. Zeroing at init makes RSS the printed
+    // §5 budget from the first tick instead of a load-dependent climb the
+    // bench's flat-RSS gate (rightly) refuses.
+    @memset(io.group_slab, 0);
     io.group_checked_out = try arena.alloc(bool, count);
     @memset(io.group_checked_out, false);
     io.group_count = count;

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -27,6 +27,14 @@ const XevIo = @This();
 /// perform the blocking syscall; completion callbacks still run on the
 /// loop thread, so the single-threaded discipline holds.
 const needs_thread_pool = xev.backend == .kqueue;
+/// Whether the provided-buffer group is the kernel's (a registered
+/// buf_ring the fork's `recv_group` op selects from) or an app-side
+/// emulation. Only io_uring has the real thing; everywhere else the
+/// buffer binds at arm time — correct and testable on the macOS dev box,
+/// but the idle-socket density win is the io_uring deployment's alone.
+const uses_buf_ring = xev.backend == .io_uring;
+/// The one buffer group this backend registers (§5's head-buffer ring).
+const buffer_group_id: u16 = 0;
 
 /// The access-log sink (§8): the process's own stdout, inherited, never
 /// opened here. Config names the sink by enum and this is the only value
@@ -50,6 +58,25 @@ listeners_count: u16,
 /// the same callback — the loop is single-threaded and callbacks do not
 /// nest, so "most recent" is "the one being delivered".
 last_pressure: Io.Pressure,
+/// The provided-buffer group's slab: `group_count × group_bytes`, arena-
+/// allocated at init. On io_uring every buffer is published to the
+/// registered buf_ring and the kernel owns selection; the app touches the
+/// ring again only to return an id (a tail bump, no syscall).
+group_slab: []u8,
+group_count: u32,
+group_bytes: u32,
+group_br: if (uses_buf_ring) ?*align(std.heap.page_size_min) linux.io_uring_buf_ring else void,
+group_mask: if (uses_buf_ring) u16 else void,
+/// Emulation only (non-io_uring): the free ids as a stack, filled so the
+/// pop order starts at 0 — the same lowest-first shape SimIo picks, so a
+/// test reading ids behaves alike over all three backends.
+group_free: if (uses_buf_ring) void else []u16,
+group_free_len: if (uses_buf_ring) void else u32,
+/// True from the delivery that handed an id out until its return — on
+/// both arms. The kernel cannot observe a double return (it would just
+/// republish the id and let two receives alias one buffer, silently), so
+/// the seam tracks ownership itself and makes the corruption an assert.
+group_checked_out: []bool,
 
 pub const Socket = enum(i32) { _ };
 
@@ -88,6 +115,12 @@ pub fn init(
     /// table. Every admin-enabled deployment hits it, and nothing in the
     /// test suite would: `Server(XevIo)` is instantiated only by main.
     configured_listeners: u32,
+    /// The provided-buffer group (§5's head-buffer ring): how many
+    /// buffers, how wide each. Zero count is a group nobody registered —
+    /// legal, and what an L4-only deployment gets; arming `recvGroup`
+    /// against it is asserted misuse.
+    buffer_group_count: u32,
+    buffer_group_bytes: u32,
 ) !void {
     assert(configured_listeners <= std.math.maxInt(u16) - constants.admin_listeners);
     const listeners = configured_listeners + constants.admin_listeners;
@@ -115,9 +148,61 @@ pub fn init(
     io.signal_mask = std.atomic.Value(u8).init(0);
     io.signal_callback = null;
     io.signal_userdata = null;
+    try io.initBufferGroup(arena, buffer_group_count, buffer_group_bytes);
     // cached_now is undefined until the first tick; ops armed before
     // run() (accepts, timers at startup) must see a sane clock.
     io.loop.update_now();
+}
+
+/// Set up the provided-buffer group: slab from the arena, published to a
+/// kernel buf_ring on io_uring, to the app-side free stack elsewhere.
+/// Split from `init` the way `initLoop` is — for the length limit, and
+/// because the two backends' setup shares nothing but the slab.
+fn initBufferGroup(io: *XevIo, arena: std.mem.Allocator, count: u32, bytes: u32) !void {
+    assert(bytes >= 1);
+    assert(count <= constants.buffer_group_entries_max);
+    io.group_slab = try arena.alloc(u8, @as(usize, count) * bytes);
+    io.group_checked_out = try arena.alloc(bool, count);
+    @memset(io.group_checked_out, false);
+    io.group_count = count;
+    io.group_bytes = bytes;
+    if (comptime uses_buf_ring) {
+        io.group_br = null;
+        io.group_mask = 0;
+        if (count == 0) return;
+        const entries: u16 = @intCast(std.math.ceilPowerOfTwo(u32, count) catch unreachable);
+        const br = linux.IoUring.setup_buf_ring(
+            io.loop.ring.fd,
+            entries,
+            buffer_group_id,
+            .{ .inc = false },
+        ) catch |err| switch (err) {
+            // EINVAL with known-good arguments: the kernel predates
+            // IORING_REGISTER_PBUF_RING (5.19). No silent downgrade — a
+            // deployment that asked for head buffers gets the density it
+            // asked for or a refusal it can read at startup.
+            error.ArgumentsInvalid => return error.BufferRingUnsupported,
+            else => return err,
+        };
+        linux.IoUring.buf_ring_init(br);
+        io.group_mask = linux.IoUring.buf_ring_mask(entries);
+        var index: u16 = 0;
+        while (index < count) : (index += 1) {
+            linux.IoUring.buf_ring_add(br, io.sliceForId(index), index, io.group_mask, index);
+        }
+        linux.IoUring.buf_ring_advance(br, @intCast(count));
+        io.group_br = br;
+    } else {
+        io.group_free = try arena.alloc(u16, count);
+        var index: u32 = 0;
+        // Filled descending so the stack pops lowest-first — the same
+        // shape SimIo picks, so a test reading ids behaves alike over
+        // every backend.
+        while (index < count) : (index += 1) {
+            io.group_free[index] = @intCast(count - 1 - index);
+        }
+        io.group_free_len = count;
+    }
 }
 
 /// Build the event loop with zoxy's ring discipline (§3, §4, §8). Split
@@ -181,6 +266,12 @@ fn initLoop(cq_entries: u32, thread_pool: ?*xev.ThreadPool) !xev.Loop {
 
 /// Test-only teardown; production never exits except through drain.
 pub fn deinit(io: *XevIo) void {
+    if (comptime uses_buf_ring) {
+        if (io.group_br) |br| {
+            const entries: u16 = @intCast(std.math.ceilPowerOfTwo(u32, io.group_count) catch unreachable);
+            linux.IoUring.free_buf_ring(io.loop.ring.fd, br, entries, buffer_group_id);
+        }
+    }
     for (io.listeners[0..io.listeners_count]) |*entry| {
         assert(!entry.open or entry.armed_accept == null);
         if (entry.open) {
@@ -444,6 +535,171 @@ pub fn recv(
             return .disarm;
         }
     }).adapter);
+}
+
+/// A recv that carries no buffer (§5's head-buffer ring). On io_uring the
+/// fork's `recv_group` op lets the kernel bind one at delivery time; on
+/// other backends the free stack binds one here at arm time — same
+/// contract, no density win, which only the io_uring deployment claims.
+pub fn recvGroup(
+    io: *XevIo,
+    socket: Socket,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.RecvGroupError!Io.GroupRecv) void,
+) void {
+    assert(io.group_count >= 1);
+    if (comptime uses_buf_ring) {
+        assert(io.group_br != null);
+        completion.* = .{
+            .op = .{ .recv_group = .{
+                .fd = @intFromEnum(socket),
+                .group_id = buffer_group_id,
+                .max_len = io.group_bytes,
+            } },
+            .userdata = userdata,
+            .callback = (struct {
+                fn adapter(
+                    context: ?*anyopaque,
+                    loop: *xev.Loop,
+                    inner: *xev.Completion,
+                    result: xev.Result,
+                ) xev.CallbackAction {
+                    const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+                    io_inner.recordPressure(inner);
+                    const typed: *Userdata = @ptrCast(@alignCast(context.?));
+                    callback(typed, if (result.recv_group) |n| ok: {
+                        // Bytes delivered ⇒ the kernel selected a buffer
+                        // and said so in the cqe flags; trust its word
+                        // over any assumption (the fork pins this).
+                        const id = inner.bufferId() orelse unreachable;
+                        assert(n >= 1);
+                        assert(!io_inner.group_checked_out[id]);
+                        io_inner.group_checked_out[id] = true;
+                        break :ok Io.GroupRecv{ .len = @intCast(n), .buffer_id = id };
+                    } else |err| switch (err) {
+                        error.EOF => error.EndOfStream,
+                        error.ConnectionResetByPeer => error.Reset,
+                        error.Canceled => error.Canceled,
+                        error.NoBuffers => error.NoBuffers,
+                        else => error.Unexpected,
+                    });
+                    return .disarm;
+                }
+            }).adapter,
+        };
+        io.loop.add(completion);
+    } else {
+        io.recvGroupEmulated(socket, completion, Userdata, userdata, callback);
+    }
+}
+
+/// The non-io_uring arm of `recvGroup`: bind a free buffer now and issue a
+/// classic recv into it; with none free, deliver NoBuffers through a
+/// zero-delay timer so exhaustion still arrives as a completion, never
+/// re-entrantly from inside the arm call.
+fn recvGroupEmulated(
+    io: *XevIo,
+    socket: Socket,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.RecvGroupError!Io.GroupRecv) void,
+) void {
+    if (io.group_free_len == 0) {
+        io.timer.run(&io.loop, completion, 0, Userdata, userdata, (struct {
+            fn adapter(
+                context: ?*Userdata,
+                loop: *xev.Loop,
+                timer_completion: *xev.Completion,
+                result: xev.Timer.RunError!void,
+            ) xev.CallbackAction {
+                _ = loop;
+                _ = timer_completion;
+                result catch @panic("zero-delay timer failed");
+                callback(context.?, error.NoBuffers);
+                return .disarm;
+            }
+        }).adapter);
+        return;
+    }
+    io.group_free_len -= 1;
+    const id = io.group_free[io.group_free_len];
+    const tcp = xev.TCP.initFd(@intFromEnum(socket));
+    tcp.read(&io.loop, completion, .{ .slice = io.sliceForId(id) }, Userdata, userdata, (struct {
+        fn adapter(
+            context: ?*Userdata,
+            loop: *xev.Loop,
+            read_completion: *xev.Completion,
+            tcp_inner: xev.TCP,
+            read_buffer: xev.ReadBuffer,
+            result: xev.ReadError!usize,
+        ) xev.CallbackAction {
+            const io_inner: *XevIo = @fieldParentPtr("loop", loop);
+            io_inner.recordPressure(read_completion);
+            _ = tcp_inner;
+            // The id rides back in the buffer itself: its offset in the
+            // slab is the id, so nothing per-op has to store it.
+            const bound: u16 = @intCast(@divExact(
+                @intFromPtr(read_buffer.slice.ptr) - @intFromPtr(io_inner.group_slab.ptr),
+                io_inner.group_bytes,
+            ));
+            callback(context.?, if (result) |n| ok: {
+                assert(n >= 1);
+                assert(!io_inner.group_checked_out[bound]);
+                io_inner.group_checked_out[bound] = true;
+                break :ok Io.GroupRecv{ .len = @intCast(n), .buffer_id = bound };
+            } else |err| refund: {
+                // No bytes ⇒ no consumption, matching the kernel twin:
+                // the buffer goes back before the error is delivered.
+                io_inner.group_free[io_inner.group_free_len] = bound;
+                io_inner.group_free_len += 1;
+                // anyerror: kqueue's ReadError has no ConnectionResetByPeer.
+                break :refund switch (@as(anyerror, err)) {
+                    error.EOF => error.EndOfStream,
+                    error.ConnectionResetByPeer => error.Reset,
+                    error.Canceled => error.Canceled,
+                    else => error.Unexpected,
+                };
+            });
+            return .disarm;
+        }
+    }).adapter);
+}
+
+/// The bytes behind a `GroupRecv.buffer_id`, valid until returned.
+pub fn bufferGroupSlice(io: *XevIo, buffer_id: u16) []u8 {
+    // Only the holder of a delivered id may read it — the same ownership
+    // assert SimIo makes, backed here by the seam's own tracking.
+    assert(io.group_checked_out[buffer_id]);
+    return io.sliceForId(buffer_id);
+}
+
+fn sliceForId(io: *XevIo, buffer_id: u16) []u8 {
+    assert(buffer_id < io.group_count);
+    return io.group_slab[@as(usize, buffer_id) * io.group_bytes ..][0..io.group_bytes];
+}
+
+/// Give a selected buffer back to the group: on io_uring two stores and an
+/// atomic tail bump — no syscall — republishing the id to the kernel; on
+/// the emulation, a push onto the free stack.
+pub fn bufferGroupReturn(io: *XevIo, buffer_id: u16) void {
+    assert(buffer_id < io.group_count);
+    // A double return would republish the id and let two receives alias
+    // one buffer — corruption the kernel delivers silently, so it must
+    // die here instead.
+    assert(io.group_checked_out[buffer_id]);
+    io.group_checked_out[buffer_id] = false;
+    if (comptime uses_buf_ring) {
+        const br = io.group_br orelse unreachable;
+        linux.IoUring.buf_ring_add(br, io.sliceForId(buffer_id), buffer_id, io.group_mask, 0);
+        linux.IoUring.buf_ring_advance(br, 1);
+    } else {
+        assert(io.group_free_len < io.group_count);
+        io.group_free[io.group_free_len] = buffer_id;
+        io.group_free_len += 1;
+    }
 }
 
 pub fn send(

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -687,6 +687,11 @@ pub fn bufferGroupCount(io: *const XevIo) u32 {
     return io.group_count;
 }
 
+/// One buffer's size, on the same asserted-not-trusted terms.
+pub fn bufferGroupBytes(io: *const XevIo) u32 {
+    return io.group_bytes;
+}
+
 /// Give a selected buffer back to the group: on io_uring two stores and an
 /// atomic tail bump — no syscall — republishing the id to the kernel; on
 /// the emulation, a push onto the free stack.

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -70,12 +70,23 @@ const init_attempts_max: u8 = 5;
 /// implicitly: contract tests bind a handful of sockets, so a small fixed
 /// reservation covers every scenario here.
 const listeners_reserved: u32 = 8;
+/// Every test ring registers a small provided-buffer group, sized so the
+/// group tests can exhaust it on purpose while the rest never notice it.
+const buffer_group_count: u32 = 2;
+const buffer_group_bytes: u32 = 512;
 
 fn initTestIo(xev_io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
     var attempt: u8 = 1;
     while (true) : (attempt += 1) {
         assert(attempt <= init_attempts_max);
-        if (XevIo.init(xev_io, arena, cq_entries, listeners_reserved)) |_| {
+        if (XevIo.init(
+            xev_io,
+            arena,
+            cq_entries,
+            listeners_reserved,
+            buffer_group_count,
+            buffer_group_bytes,
+        )) |_| {
             return;
         } else |err| {
             if (err != error.SystemResources) return err;
@@ -297,6 +308,193 @@ test "contract: echo on XevIo over real loopback" {
     try scenario.start(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
     try xev_io.run();
     try scenario.verify();
+}
+
+/// The provided-buffer group contract, one story over any backend: a
+/// group-recv binds a buffer only when data arrives; a mid-message
+/// continuation is a classic recv into the bound buffer; exhaustion is
+/// `NoBuffers` delivered as a completion; a returned buffer is selectable
+/// again; and EOF consumes nothing. Driven under the SimIo adversary
+/// (splits every delivery) and over XevIo's real loopback alike.
+fn GroupContract(comptime IoType: type) type {
+    Io.assertIoInterface(IoType);
+    return struct {
+        io: *IoType,
+        accept_completion: IoType.Completion = .{},
+        connect_completion: IoType.Completion = .{},
+        op_completion: IoType.Completion = .{},
+        accepted: ?IoType.Socket = null,
+        connected: ?IoType.Socket = null,
+        sent: ?u32 = null,
+        group: ?(Io.RecvGroupError!Io.GroupRecv) = null,
+        classic: ?(Io.RecvError!u32) = null,
+
+        const Contract = @This();
+        const payload = "0123456789abcdefghijklmnopqrstuvwxyz-ok!";
+
+        fn onAccept(c: *Contract, result: Io.AcceptError!IoType.Socket) void {
+            c.accepted = result catch null;
+        }
+        fn onConnect(c: *Contract, result: Io.ConnectError!IoType.Socket) void {
+            c.connected = result catch null;
+        }
+        fn onSend(c: *Contract, result: Io.SendError!u32) void {
+            c.sent = result catch 0;
+        }
+        fn onGroup(c: *Contract, result: Io.RecvGroupError!Io.GroupRecv) void {
+            c.group = result;
+        }
+        fn onClassic(c: *Contract, result: Io.RecvError!u32) void {
+            c.classic = result;
+        }
+
+        fn pair(c: *Contract, listener: IoType.Listener) !struct { IoType.Socket, IoType.Socket } {
+            c.accepted = null;
+            c.connected = null;
+            c.accept_completion = .{};
+            c.connect_completion = .{};
+            c.io.accept(listener, &c.accept_completion, Contract, c, onAccept);
+            c.io.connect(
+                c.io.listenerAddress(listener),
+                &c.connect_completion,
+                Contract,
+                c,
+                onConnect,
+            );
+            try c.io.run();
+            return .{
+                c.connected orelse return error.ConnectNeverCompleted,
+                c.accepted orelse return error.AcceptNeverCompleted,
+            };
+        }
+
+        /// Send the whole payload, looping on the short writes both the
+        /// adversary and a real kernel may deal.
+        fn sendAll(c: *Contract, socket: IoType.Socket) !void {
+            var offset: u32 = 0;
+            while (offset < payload.len) {
+                c.sent = null;
+                c.op_completion = .{};
+                c.io.send(socket, payload[offset..], &c.op_completion, Contract, c, onSend);
+                try c.io.run();
+                const n = c.sent orelse return error.SendNeverCompleted;
+                if (n == 0) return error.SendFailed;
+                offset += n;
+            }
+        }
+
+        /// Group-recv the payload's first bytes, then continue with
+        /// classic recvs into the bound buffer — the §5 head-read shape.
+        fn recvWholePayload(c: *Contract, socket: IoType.Socket) !u16 {
+            c.group = null;
+            c.op_completion = .{};
+            c.io.recvGroup(socket, &c.op_completion, Contract, c, onGroup);
+            try c.io.run();
+            const first = try (c.group orelse return error.RecvNeverCompleted);
+            try std.testing.expect(first.len >= 1);
+            const buffer = c.io.bufferGroupSlice(first.buffer_id);
+            var total: u32 = first.len;
+            while (total < payload.len) {
+                c.classic = null;
+                c.op_completion = .{};
+                c.io.recv(socket, buffer[total..], &c.op_completion, Contract, c, onClassic);
+                try c.io.run();
+                total += try (c.classic orelse return error.RecvNeverCompleted);
+            }
+            try std.testing.expectEqualSlices(u8, payload, buffer[0..payload.len]);
+            return first.buffer_id;
+        }
+
+        /// One armed group-recv, one delivery, whatever it carries.
+        fn recvOnce(c: *Contract, socket: IoType.Socket) !Io.RecvGroupError!Io.GroupRecv {
+            c.group = null;
+            c.op_completion = .{};
+            c.io.recvGroup(socket, &c.op_completion, Contract, c, onGroup);
+            try c.io.run();
+            return c.group orelse return error.RecvNeverCompleted;
+        }
+    };
+}
+
+/// The story needs a group of exactly two 512-byte buffers — what the
+/// XevIo test harness registers, and what the SimIo variant passes.
+fn runGroupContract(comptime IoType: type, io: *IoType) !void {
+    const Contract = GroupContract(IoType);
+    var c: Contract = .{ .io = io };
+    const listener = try io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
+
+    // Selection, and the classic-recv continuation into the bound buffer.
+    const client_a, const server_a = try c.pair(listener);
+    try c.sendAll(client_a);
+    const id_a = try c.recvWholePayload(server_a);
+
+    // Second delivery binds the other buffer; the group is now empty.
+    const client_b, const server_b = try c.pair(listener);
+    try c.sendAll(client_b);
+    const id_b = try c.recvWholePayload(server_b);
+    try std.testing.expect(id_a != id_b);
+
+    // Exhaustion: data waiting, group empty — NoBuffers as a completion.
+    const client_c, const server_c = try c.pair(listener);
+    try c.sendAll(client_c);
+    try std.testing.expectError(error.NoBuffers, try c.recvOnce(server_c));
+
+    // Return one buffer and the same bytes deliver into it: with exactly
+    // one buffer in the group, every backend must select it.
+    io.bufferGroupReturn(id_a);
+    const retry = try (try c.recvOnce(server_c));
+    try std.testing.expectEqual(id_a, retry.buffer_id);
+    try std.testing.expect(retry.len >= 1);
+    io.bufferGroupReturn(retry.buffer_id);
+    io.bufferGroupReturn(id_b);
+
+    // EOF consumes nothing: after the peer closes, both buffers must
+    // still be selectable — two concurrent data deliveries prove it.
+    io.closeNow(client_a);
+    const eof = try c.recvOnce(server_a);
+    try std.testing.expectError(error.EndOfStream, eof);
+    try c.sendAll(client_b);
+    const after_b = try (try c.recvOnce(server_b));
+    try c.sendAll(client_c);
+    const after_c = try (try c.recvOnce(server_c));
+    try std.testing.expect(after_b.buffer_id != after_c.buffer_id);
+    io.bufferGroupReturn(after_b.buffer_id);
+    io.bufferGroupReturn(after_c.buffer_id);
+
+    io.closeNow(server_a);
+    for ([_]IoType.Socket{ client_b, server_b, client_c, server_c }) |socket| {
+        io.closeNow(socket);
+    }
+    io.listenClose(listener);
+}
+
+test "contract: the provided-buffer group on SimIo under the adversary" {
+    var seed: u64 = 1;
+    while (seed <= 10) : (seed += 1) {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+
+        var sim_io: SimIo = undefined;
+        try sim_io.init(arena_state.allocator(), .{
+            .seed = seed,
+            .adversary = .{ .partial_io = true, .connect_delay_ns_max = 5_000_000 },
+            .buffer_group_count = 2,
+            .buffer_group_bytes = 512,
+        });
+        try runGroupContract(SimIo, &sim_io);
+        try std.testing.expect(sim_io.sockets.isFullyReleased());
+        try std.testing.expectEqual(@as(u32, 0), sim_io.group_in_use);
+    }
+}
+
+test "contract: the provided-buffer group on XevIo over real loopback" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var xev_io: XevIo = undefined;
+    try initTestIo(&xev_io, arena_state.allocator(), 0);
+    defer xev_io.deinit();
+    try runGroupContract(XevIo, &xev_io);
 }
 
 test "contract: XevIo requests a nonzero IORING_SETUP_CQSIZE depth" {
@@ -794,7 +992,8 @@ test "xevio: the listener table reserves a slot for the admin listener" {
 
     var xev_io: XevIo = undefined;
     // One configured listener; capacity must be that plus the admin slot.
-    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1);
+    // No buffer group — the zero-count arm must also keep init working.
+    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1, 0, 1);
     defer xev_io.deinit();
 
     const loopback = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0");

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -25,6 +25,8 @@
 //!   bufferGroupReturn(io, buffer_id) void              (sync; no syscall)
 //!   bufferGroupCount(io) u32                           (sync; the group's
 //!       capacity — what the caller's own accounting must agree with)
+//!   bufferGroupBytes(io) u32                           (sync; one buffer's
+//!       size — what the caller's own limits must agree with)
 //!   send(io, socket, bytes, c, U, u, cb(u, SendError!u32))
 //!   close(io, socket, c, U, u, cb(u))
 //!   logWrite(io, bytes, c, U, u, cb(u, LogWriteError!u32))   (§8 access log)
@@ -204,6 +206,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "bufferGroupSlice",
             "bufferGroupReturn",
             "bufferGroupCount",
+            "bufferGroupBytes",
             "send",
             "close",
             "logWrite",

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -17,6 +17,12 @@
 //!       pending connect — a black-holed dial must still reach a terminal
 //!       completion or its slot could never be released, §5)
 //!   recv(io, socket, buffer, c, U, u, cb(u, RecvError!u32))
+//!   recvGroup(io, socket, c, U, u, cb(u, RecvGroupError!GroupRecv))
+//!       (a recv that carries no buffer: the backend binds one from its
+//!       provided-buffer group only when data arrives, so an armed idle
+//!       socket pins no memory — §5's head-buffer ring rides on this)
+//!   bufferGroupSlice(io, buffer_id) []u8               (sync; the bytes)
+//!   bufferGroupReturn(io, buffer_id) void              (sync; no syscall)
 //!   send(io, socket, bytes, c, U, u, cb(u, SendError!u32))
 //!   close(io, socket, c, U, u, cb(u))
 //!   logWrite(io, bytes, c, U, u, cb(u, LogWriteError!u32))   (§8 access log)
@@ -77,6 +83,28 @@ pub const RecvError = error{
     EndOfStream,
     Reset,
     Canceled,
+    Unexpected,
+};
+
+/// What a `recvGroup` delivers on success: the byte count and which of the
+/// backend's provided buffers the bytes landed in. The id is the caller's
+/// claim ticket — `bufferGroupSlice` to read, `bufferGroupReturn` to give
+/// it back — and stays valid until returned.
+pub const GroupRecv = struct {
+    len: u32,
+    buffer_id: u16,
+};
+
+/// `RecvError` plus the one failure a bufferless receive exists to report.
+pub const RecvGroupError = error{
+    EndOfStream,
+    Reset,
+    Canceled,
+    /// Data arrived and the buffer group was empty. Backpressure, not a
+    /// fault: the bytes are still in the socket, and the §8 answer is a
+    /// shed — a caller that instead re-arms without returning a buffer
+    /// first spins on the same bytes forever.
+    NoBuffers,
     Unexpected,
 };
 
@@ -170,6 +198,9 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "connect",
             "connectCancel",
             "recv",
+            "recvGroup",
+            "bufferGroupSlice",
+            "bufferGroupReturn",
             "send",
             "close",
             "logWrite",

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -23,6 +23,8 @@
 //!       socket pins no memory — §5's head-buffer ring rides on this)
 //!   bufferGroupSlice(io, buffer_id) []u8               (sync; the bytes)
 //!   bufferGroupReturn(io, buffer_id) void              (sync; no syscall)
+//!   bufferGroupCount(io) u32                           (sync; the group's
+//!       capacity — what the caller's own accounting must agree with)
 //!   send(io, socket, bytes, c, U, u, cb(u, SendError!u32))
 //!   close(io, socket, c, U, u, cb(u))
 //!   logWrite(io, bytes, c, U, u, cb(u, LogWriteError!u32))   (§8 access log)
@@ -201,6 +203,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "recvGroup",
             "bufferGroupSlice",
             "bufferGroupReturn",
+            "bufferGroupCount",
             "send",
             "close",
             "logWrite",

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,7 +112,9 @@ pub fn main(init: std.process.Init) !void {
     try ensureFdBudget(fds_required);
     try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
 
-    try global_io.init(arena, cq_entries, listeners_count);
+    // Buffer group zero until the head-buffer ring's limits knob lands:
+    // no group is registered and nothing arms against one.
+    try global_io.init(arena, cq_entries, listeners_count, 0, zoxy.constants.head_bytes_max);
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
     try server.start();

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,14 +112,14 @@ pub fn main(init: std.process.Init) !void {
     try ensureFdBudget(fds_required);
     try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
 
-    // The ring is the config's to size (§5); Server.init asserts its own
-    // accounting against the same number.
+    // The ring is the config's to size (§5), count and unit both;
+    // Server.init asserts its own accounting against the same numbers.
     try global_io.init(
         arena,
         cq_entries,
         listeners_count,
         config.limits.head_buffers,
-        zoxy.constants.head_bytes_max,
+        config.limits.head_buffer_bytes,
     );
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
@@ -282,6 +282,37 @@ fn ensureFdBudget(fds_required: u32) !void {
     try std.posix.setrlimit(.NOFILE, limits);
 }
 
+/// The §5 pool-size vector for the effective config — split from
+/// `printBudgets` for the length limit, and so the composition reads as
+/// one thing: every term the closed form takes, sourced from the limit
+/// or `@sizeOf` that owns it.
+fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
+    const limits = config.limits;
+    const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
+    // The head-sized side buffers (§5): Server owns the closed form and
+    // asserts its own allocations against it, so printing it here cannot
+    // drift from what init actually reserves.
+    const head_scratch_bytes = ServerXev.headScratchBytes(limits);
+    assert(head_scratch_bytes >= limits.head_buffer_bytes);
+    return .{
+        .conn_slots = limits.conn_slots,
+        .conn_bytes = @sizeOf(ServerXev.ConnType),
+        .relay_buffers = limits.relay_buffers,
+        .relay_buffer_pair_bytes = @sizeOf(zoxy.RelayBuffer),
+        .upstream_slots = limits.upstream_slots,
+        .upstream_bytes = @sizeOf(UpstreamType),
+        .access_log_bytes = zoxy.constants.accessLogBytes(limits.access_log_buffer_bytes),
+        .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
+        .head_buffers = limits.head_buffers,
+        .head_buffer_bytes = limits.head_buffer_bytes,
+        .upstream_head_buffers = limits.upstream_head_buffers,
+        // The pool element (the free-list header and the slab slice) plus
+        // its share of the slab itself.
+        .upstream_head_buffer_bytes = @sizeOf(zoxy.UpstreamHeadBuffer) + limits.head_buffer_bytes,
+        .head_scratch_bytes = head_scratch_bytes,
+    };
+}
+
 fn printBudgets(
     io: std.Io,
     config: *const zoxy.config.Config,
@@ -294,7 +325,6 @@ fn printBudgets(
     config_arena_bytes: u64,
 ) !void {
     const constants = zoxy.constants;
-    const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
     // Every budget reflects the *effective* config (§5, §8): the config may
     // shrink the pools, the fd demand, and the requested ring below the
     // compiled ceilings, and all three are shown as actually sized.
@@ -306,24 +336,12 @@ fn printBudgets(
     );
     const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
     const endpoint_stride = ServerXev.endpointKeysFor(config).stride;
+    const sizes = poolSizesFor(config);
     // §5's promise is that the printed total covers everything this
     // process holds for its life. The config arena qualifies — it is
     // never freed — so it joins the total even though it is the one term
     // measured rather than derived from constants.
-    const memory_total = constants.memoryBytesTotal(&.{
-        .conn_slots = limits.conn_slots,
-        .conn_bytes = @sizeOf(ServerXev.ConnType),
-        .relay_buffers = limits.relay_buffers,
-        .relay_buffer_pair_bytes = @sizeOf(zoxy.RelayBuffer),
-        .upstream_slots = limits.upstream_slots,
-        .upstream_bytes = @sizeOf(UpstreamType),
-        .access_log_bytes = access_log_bytes,
-        .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
-        .head_buffers = limits.head_buffers,
-        .head_buffer_bytes = constants.head_bytes_max,
-        .upstream_head_buffers = limits.upstream_head_buffers,
-        .upstream_head_buffer_bytes = @sizeOf(zoxy.UpstreamHeadBuffer),
-    }) + config_arena_bytes;
+    const memory_total = constants.memoryBytesTotal(&sizes) + config_arena_bytes;
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
     const writer = &file_writer.interface;
@@ -334,7 +352,8 @@ fn printBudgets(
         \\budgets (DESIGN.md §5/§8; closed-form except where marked):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
-        \\          + upstream head buffers {d} x {d} B + access log {d} KiB
+        \\          + upstream head buffers {d} x {d} B + head scratch {d} B
+        \\          + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
@@ -350,14 +369,15 @@ fn printBudgets(
         limits.relay_buffers,
         @sizeOf(zoxy.RelayBuffer),
         limits.upstream_slots,
-        @sizeOf(UpstreamType),
+        sizes.upstream_bytes,
         limits.head_buffers,
         // The +1 ownership byte stays out of the banner's per-unit figure;
         // the closed-form total above carries it.
-        constants.head_bytes_max,
+        limits.head_buffer_bytes,
         constants.bufferGroupDescriptorBytes(limits.head_buffers),
         limits.upstream_head_buffers,
-        @sizeOf(zoxy.UpstreamHeadBuffer),
+        sizes.upstream_head_buffer_bytes,
+        sizes.head_scratch_bytes,
         access_log_bytes / 1024,
         ServerXev.endpointTableBytes(config),
         config.clusters.len,

--- a/src/main.zig
+++ b/src/main.zig
@@ -321,6 +321,8 @@ fn printBudgets(
         .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
         .head_buffers = limits.head_buffers,
         .head_buffer_bytes = constants.head_bytes_max,
+        .upstream_head_buffers = limits.upstream_head_buffers,
+        .upstream_head_buffer_bytes = @sizeOf(zoxy.UpstreamHeadBuffer),
     }) + config_arena_bytes;
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
@@ -332,7 +334,7 @@ fn printBudgets(
         \\budgets (DESIGN.md §5/§8; closed-form except where marked):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
-        \\          + access log {d} KiB
+        \\          + upstream head buffers {d} x {d} B + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
@@ -354,6 +356,8 @@ fn printBudgets(
         // the closed-form total above carries it.
         constants.head_bytes_max,
         constants.bufferGroupDescriptorBytes(limits.head_buffers),
+        limits.upstream_head_buffers,
+        @sizeOf(zoxy.UpstreamHeadBuffer),
         access_log_bytes / 1024,
         ServerXev.endpointTableBytes(config),
         config.clusters.len,

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,9 +112,15 @@ pub fn main(init: std.process.Init) !void {
     try ensureFdBudget(fds_required);
     try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
 
-    // Buffer group zero until the head-buffer ring's limits knob lands:
-    // no group is registered and nothing arms against one.
-    try global_io.init(arena, cq_entries, listeners_count, 0, zoxy.constants.head_bytes_max);
+    // The ring is the config's to size (§5); Server.init asserts its own
+    // accounting against the same number.
+    try global_io.init(
+        arena,
+        cq_entries,
+        listeners_count,
+        config.limits.head_buffers,
+        zoxy.constants.head_bytes_max,
+    );
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
     try server.start();
@@ -313,6 +319,8 @@ fn printBudgets(
         .upstream_bytes = @sizeOf(UpstreamType),
         .access_log_bytes = access_log_bytes,
         .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
+        .head_buffers = limits.head_buffers,
+        .head_buffer_bytes = constants.head_bytes_max,
     }) + config_arena_bytes;
     var buffer: [1024]u8 = undefined;
     var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
@@ -323,7 +331,8 @@ fn printBudgets(
         \\zoxy {s}{s}
         \\budgets (DESIGN.md §5/§8; closed-form except where marked):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
-        \\          + upstream slots {d} x {d} B + access log {d} KiB
+        \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
+        \\          + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
@@ -340,6 +349,11 @@ fn printBudgets(
         @sizeOf(zoxy.RelayBuffer),
         limits.upstream_slots,
         @sizeOf(UpstreamType),
+        limits.head_buffers,
+        // The +1 ownership byte stays out of the banner's per-unit figure;
+        // the closed-form total above carries it.
+        constants.head_bytes_max,
+        constants.bufferGroupDescriptorBytes(limits.head_buffers),
         access_log_bytes / 1024,
         ServerXev.endpointTableBytes(config),
         config.clusters.len,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -254,17 +254,23 @@ pub fn Conn(comptime IoType: type) type {
         birth_ns: u64,
         armed: Armed,
         directions: [2]DirectionState,
-        /// L7 request/response head bytes accumulate here across recv
-        /// retries (§5, §7); idle on L4 connections, which relay through
-        /// the relay buffer only. Parsing is detect-and-retry from byte 0
-        /// (§7), so these bytes stay the single source of truth: nothing
-        /// parsed is stored across callbacks, and a re-parse after an
-        /// await costs one bounded scan instead of 2 KiB of per-slot
-        /// header storage. Deliberately not zeroed at admission — bytes
-        /// past `head_len` are never read.
-        head: [constants.head_bytes_max]u8,
-        /// Bytes of `head` filled so far; the head's end is found by
-        /// parsing, the body (or a pipelined next head) follows it.
+        /// The §5 head-ring buffer this connection holds, or
+        /// `head_buffer_none`. Bound by the seam at the delivery that
+        /// starts a request (`recvGroup`) and returned at the keep-alive
+        /// turnaround, before a static response goes out, or at teardown —
+        /// so an idle connection holds no head bytes at all, and an L4
+        /// connection never binds one. The bytes live in the ring's slab
+        /// (`bufferGroupSlice`); everything the old inline array promised
+        /// still holds of them: request/response head accumulates across
+        /// recv retries, parsing is detect-and-retry from byte 0 (§7), the
+        /// buffer's content stays the single source of truth while held,
+        /// and nothing zeroes it — bytes past `head_len` are never read.
+        head_buffer_id: u16,
+        /// Bytes of the held head buffer filled so far; the head's end is
+        /// found by parsing, the body (or a pipelined next head) follows
+        /// it. A count, not content: it survives the buffer's return at a
+        /// static response, because the §7 resync rule still reads it to
+        /// decide keep-or-close; `beginNextRequest` zeroes it.
         head_len: u32,
         /// The client-directed write in flight, if any (§7, §8) — see
         /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
@@ -326,6 +332,16 @@ pub fn Conn(comptime IoType: type) type {
         op_deadline_cancel: Op,
 
         const Self = @This();
+
+        /// "This connection holds no head-ring buffer." Out of range by
+        /// construction: a group never publishes more than
+        /// `buffer_group_entries_max` ids, and the comptime check below
+        /// keeps the sentinel above every real one.
+        pub const head_buffer_none: u16 = std.math.maxInt(u16);
+
+        comptime {
+            assert(constants.buffer_group_entries_max <= head_buffer_none);
+        }
 
         pub const State = enum(u8) {
             // L4 relay states.
@@ -546,6 +562,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.birth_ns = server.io.nowNs();
             conn.armed = .{};
             conn.directions = .{ .{}, .{} };
+            conn.head_buffer_id = head_buffer_none;
             conn.head_len = 0;
             conn.client_write = .{};
             conn.cluster_index = cluster_index;

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -83,10 +83,12 @@ pub fn Checker(comptime IoType: type) type {
         request: [constants.health_check_request_bytes_max]u8,
         request_len: u32,
         request_sent: u32,
-        /// The response head as it accumulates. Sized to what the data
-        /// path's own parser accepts, so a head this proxy would forward
-        /// is never one the probe rejects for being too big.
-        response: [constants.head_bytes_max]u8,
+        /// The response head as it accumulates. Sized at init to what the
+        /// data path's own parser accepts (`limits.head_buffer_bytes`),
+        /// so a head this proxy would forward is never one the probe
+        /// rejects for being too big — a relation that followed the size
+        /// into the config.
+        response: []u8,
         response_len: u32,
         armed: Armed,
         /// Ops a cancel was already spent on (never `.cancel` itself):
@@ -148,9 +150,14 @@ pub fn Checker(comptime IoType: type) type {
             arena: std.mem.Allocator,
             server: *ServerType,
             keys: upstream.EndpointKeys,
+            /// The probe's response buffer size — `limits.head_buffer_bytes`,
+            /// so the probe accepts exactly the heads the data path does.
+            response_bytes: u32,
         ) error{OutOfMemory}!void {
             assert(keys.count >= 1);
+            assert(response_bytes >= constants.head_buffer_bytes_min);
             checker.server = server;
+            checker.response = try arena.alloc(u8, response_bytes);
             checker.healthy = try arena.alloc(bool, keys.count);
             checker.fail_streaks = try arena.alloc(u8, keys.count);
             checker.ok_streaks = try arena.alloc(u8, keys.count);

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -609,7 +609,11 @@ const Harness = struct {
         errdefer bed.arena_state.deinit();
         const arena = bed.arena_state.allocator();
 
-        try bed.io.init(arena, options.sim);
+        // An L4-only bed: no head-buffer ring on either side of the seam
+        // (Server.init asserts the two agree).
+        var sim_options = options.sim;
+        sim_options.buffer_group_count = 0;
+        try bed.io.init(arena, sim_options);
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -46,7 +46,12 @@ const idle_none: u32 = std.math.maxInt(u32);
 pub const HeadBuffer = struct {
     pool_next: u32,
     generation: u32,
-    bytes: [constants.head_bytes_max]u8,
+    /// Into the pool's one slab, wired at `Server.init` right after the
+    /// pool itself and never touched again — `Pool` only ever writes the
+    /// two header fields above, so the wiring survives every
+    /// acquire/release. `limits.head_buffer_bytes` long: the size is the
+    /// config's, which is why this is a slice and not an array.
+    data: []u8,
 };
 
 pub const EndpointKeys = struct {

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -36,6 +36,19 @@ const idle_none: u32 = std.math.maxInt(u32);
 /// on the pick path, and the waste is bounded by the config the operator
 /// wrote — the same trade the fixed arrays made, minus the part that had
 /// nothing to do with this deployment.
+/// One §5 upstream head buffer: the render target for an outgoing request
+/// head and the accumulator for the origin's response head — one buffer
+/// deliberately serving both, in sequence (the response leg asserts the
+/// request's use is over before it starts). Pooled app-side rather than
+/// through the seam's kernel ring because its first use is synchronous:
+/// a render needs the bytes now, and a kernel-selected buffer only
+/// arrives with a delivery. `Pool(HeadBuffer)` supplies the free list.
+pub const HeadBuffer = struct {
+    pool_next: u32,
+    generation: u32,
+    bytes: [constants.head_bytes_max]u8,
+};
+
 pub const EndpointKeys = struct {
     /// Entries per cluster: the largest endpoint count any one cluster
     /// declares. At least 1, so a key is always addressable.
@@ -78,9 +91,9 @@ pub fn UpstreamPool(comptime IoType: type) type {
         const Self = @This();
 
         /// One upstream connection slot (§5 pool 3): identity, socket,
-        /// idle links, the idle deadline, and the head buffer response
-        /// heads are parsed into and rendered upstream heads are staged
-        /// in. The dial and data-op completions live on the owning
+        /// idle links, the idle deadline, and a claim on the head buffer
+        /// response heads are parsed into and rendered upstream heads are
+        /// staged in. The dial and data-op completions live on the owning
         /// `Conn`, one field per proven race (the Conn precedent).
         pub const Upstream = struct {
             pool_next: u32,
@@ -93,10 +106,17 @@ pub fn UpstreamPool(comptime IoType: type) type {
             parked: bool,
             idle_next: u32,
             idle_prev: u32,
-            head: [constants.head_bytes_max]u8,
-            /// Valid prefix of `head` while it accumulates a response
-            /// head; the rendered upstream request head tracks its own
-            /// length in the owning connection instead.
+            /// The §5 upstream head buffer this exchange holds, acquired
+            /// at the request-head render and released before the slot
+            /// parks — a parked connection holds a socket and this slot's
+            /// scalars, never 8 KiB of head. Null outside that window.
+            head_buffer: ?*HeadBuffer,
+            /// Valid prefix of the held head buffer while it accumulates
+            /// a response head; the rendered upstream request head tracks
+            /// its own length in the owning connection instead. A count,
+            /// not content: §7 replay eligibility reads it (and requires
+            /// zero) without caring what the buffer holds, and checkout
+            /// zeroes it on a slot whose buffer is long since released.
             head_len: u32,
             /// Absolute idle deadline while parked (§5): a parked
             /// connection holds no armed op, so the Server's single sweep
@@ -139,6 +159,7 @@ pub fn UpstreamPool(comptime IoType: type) type {
             upstream.parked = false;
             upstream.idle_next = idle_none;
             upstream.idle_prev = idle_none;
+            upstream.head_buffer = null;
             upstream.head_len = 0;
             upstream.deadline_ns = 0;
             const key = pool.keys.key(cluster_index, endpoint_index);
@@ -153,6 +174,10 @@ pub fn UpstreamPool(comptime IoType: type) type {
         /// likely to still be open and cache-warm).
         pub fn park(pool: *Self, upstream: *Upstream) void {
             assert(!upstream.parked);
+            // Parking with the head buffer still claimed is the leak §5's
+            // whole upstream story exists to prevent: the caller releases
+            // it first, and a parked slot provably holds no head bytes.
+            assert(upstream.head_buffer == null);
             assert(upstream.idle_next == idle_none);
             assert(upstream.idle_prev == idle_none);
             const index = pool.slot_pool.indexOf(upstream);

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,6 +23,7 @@ pub const http = struct {
 pub const Io = @import("io/io.zig");
 pub const Pool = @import("mem/Pool.zig").Pool;
 pub const RelayBuffer = @import("net/relay.zig").RelayBuffer;
+pub const UpstreamHeadBuffer = @import("net/upstream.zig").HeadBuffer;
 pub const UpstreamPool = @import("net/upstream.zig").UpstreamPool;
 pub const Server = @import("Server.zig").Server;
 pub const shed = @import("shed.zig");

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -242,7 +242,12 @@ pub const TestBed = struct {
         errdefer bed.arena_state.deinit();
         const arena = bed.arena_state.allocator();
 
-        try bed.sim_io.init(arena, options.sim);
+        // One number on both sides (§5): the ring the sim registers is
+        // the limit the server accounts against — Server.init asserts the
+        // match, so a bed cannot drift them apart.
+        var sim_options = options.sim;
+        sim_options.buffer_group_count = options.server.head_buffers;
+        try bed.sim_io.init(arena, sim_options);
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};


### PR DESCRIPTION
Closes #162 — levers 2 and 3. Five commits, one per slice, each `zig build ci`-green and tiger-style-reviewed.

> **Draft, gated on zoxy-io/libxev#3.** The final commit moves the libxev pin to the fork's `zoxy-buffer-group` head (`24da6d0`) — a fourth stacked commit adding a `recv_group` op (provided-buffer receives). The zon's audit-trail comment carries the diff summary and is marked PENDING; this PR converts from draft only after that re-audit lands. CI here runs green against the fetched pin.

## What

Head buffers were 21.09 MiB of the 34.2 MiB default budget — 62% — inline in the conn and upstream slots, pinned per *connection*. Now both are pooled and memory follows *request heads in flight*:

- **Client side — a kernel provided-buffer ring** (`IOSQE_BUFFER_SELECT` via the fork op, surfaced as the seam's `recvGroup`). An idle connection's armed recv carries no buffer; the kernel binds one at the client's first byte; the return at turnaround is a tail bump, no syscall. **Zero extra ring ops per request** (poll-first was designed, offered, and rejected for costing one SQE/CQE on a kernel-bound core).
- **Upstream side — an app-side `Pool(HeadBuffer)`**, acquired beside the slot, released before the slot parks. A parked origin connection holds a socket and ~48 B of scalars.
- **Three knobs**: `head_buffers` (default `conn_slots` — never sheds), `upstream_head_buffers` (default `upstream_slots`), `head_buffer_bytes` (default 8192, floor 1024, ceiling 1 MiB — the floor is behaviour: below it ordinary requests die as 414/431; the raise is the big-cookie/JWT case). L4-only configs get zero of everything.
- **Two new §8 rungs**: `l7_shed_head_buffers` (the one shed that precedes the parse, and the one shed that *always closes* — the refused bytes are unread in the socket, and a kept connection would re-arm onto them forever; enforced at comptime) and `l7_shed_upstream_head_buffers` (ordinary keep-or-close — the request was fully read). Pressure flags and gauges for both pools, deliberately bias-free: idle holds nothing, so there is nothing idle to evict.

Conn slot: 9,904 B → 1,712 B. Upstream slot: 8,232 B → 48 B. At the defaults nothing sheds and the total is unchanged — the wins are the idle/parked/L4 zeros and the knobs.

## Verified live (real io_uring, nginx origin)

An open idle keep-alive connection scrapes `head_buffers_in_use 0` with `conn_slots_in_use 1`; the parked upstream scrapes 0 too. A 3000-byte URI dies 414 at a configured 2048 while ordinary requests serve. SIGTERM drains clean through the new all-returned asserts. The banner:

```
memory  total 665 KiB = conn slots 64 x 1712 B + relay buffers 64 x 8200 B
        + upstream slots 32 x 48 B + head buffers 8 x 2048 B (+ ring 4096 B)
        + upstream head buffers 8 x 2072 B + head scratch 6144 B
```

## What the reviews caught (per-slice, all fixed in-slice)

- Buffer rings were a **closed verdict** (the multishot note) — reconciled explicitly: the closure stands on the syscall axis; buffer-select graduates on density, the axis it never priced.
- A teardown racing the client's first byte **leaked the kernel-bound buffer uncounted** — capture-then-release, the `onUpstreamConnect` shape.
- The upstream acquire at the render **always closed its sheds** (the resync rule keeps only from `.l7_reading_head`) — moved beside the slot acquire; sim seed 634 independently caught four script oracles encoding the now-false "no rung precedes the parse".
- A double `bufferGroupReturn` would alias two receives onto one buffer **silently, kernel-side** — the seam tracks per-id ownership and asserts.

Plus: the sim census both-ways rule drove the harness sizing (1–3 ring buffers on force-exhaustion seeds so the head rung and the relay rung both stay reachable), and the config loader now resolves limits before listeners so route prefixes are gated against the *resolved* head size at load.

## Not in scope

The LogState/capture-array move was cut on measurement (its scalars are written unconditionally on both protocols; 40 B of stride for 14 hot-path guards), and fuzz shapes still exercise the 8 KiB default rather than the 1 MiB ceiling — both recorded in IMPLEMENTATION_NOTES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)