### PR TITLE
Access log file sink, SIGHUP rotation, and the banner's move to stderr

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -257,11 +257,45 @@ fn drainChild(
     assert(label.len > 0);
     assert(running.*);
     try std.posix.kill(child.id.?, .TERM);
+    // A child whose stderr this harness piped (the banner gate) writes
+    // its drain-time counter dump there: forward it to the run log for
+    // the band review, reading to EOF *before* the reap — the read is
+    // what observes the exit, and `wait` may tear the pipe down.
+    if (child.stderr != null) forwardStderr(io, child);
     const term = try child.wait(io);
     running.* = false;
     const drained_cleanly = term == .exited and term.exited == 0;
     std.debug.print("{s} drain: {s}\n", .{ label, if (drained_cleanly) "clean exit" else "UNCLEAN" });
     return drained_cleanly;
+}
+
+/// Pump the child's piped stderr into this process's own until EOF. The
+/// child has been told to exit, so EOF is guaranteed; the cap is misuse
+/// insurance (a chatty child), not a liveness need.
+fn forwardStderr(io: Io, child: *const std.process.Child) void {
+    assert(child.stderr != null);
+    const chunks_max: u32 = 128;
+    var read_buffer: [8192]u8 = undefined;
+    var file_reader = child.stderr.?.reader(io, &read_buffer);
+    var forwarded: u64 = 0;
+    var chunk_index: u32 = 0;
+    while (chunk_index < chunks_max) : (chunk_index += 1) {
+        var chunk: [8192]u8 = undefined;
+        const read = file_reader.interface.readSliceShort(&chunk) catch |err| {
+            // Surfaced, not gated: the dump is band-review context, and a
+            // torn pipe must not turn a finished run red — but it must
+            // say so, or a missing dump reads as a zoxy bug.
+            std.debug.print("bench: child stderr unreadable ({t})\n", .{err});
+            return;
+        };
+        if (read == 0) return;
+        assert(read <= chunk.len);
+        forwarded += read;
+        std.debug.print("{s}", .{chunk[0..read]});
+    }
+    std.debug.print("bench: child stderr still open after {d} KiB forwarded; giving up\n", .{
+        forwarded / 1024,
+    });
 }
 
 /// The §9 overload scenario: offered load ≫ capacity against a zoxy
@@ -449,14 +483,14 @@ const Banner = struct {
     head_buffers: u64,
 };
 
-/// Read the banner off the child's piped stdout, forward it verbatim to
+/// Read the banner off the child's piped stderr, forward it verbatim to
 /// the run log (bug reports paste the banner; the pipe must not eat it),
 /// and parse the two numbers the RSS gates need. Bounded by the banner's
 /// own shape — it ends at the "  config  " line — so a child that dies
 /// first or prints something else is a setup failure surfaced here.
 fn readBanner(io: Io, child: *const std.process.Child) !Banner {
     assert(child.id != null);
-    assert(child.stdout != null);
+    assert(child.stderr != null);
     const banner_lines_max: u32 = 32;
     const total_prefix = "  memory  total ";
     // "+ head buffers" cannot match the upstream line, which spells
@@ -464,7 +498,7 @@ fn readBanner(io: Io, child: *const std.process.Child) !Banner {
     const ring_marker = "+ head buffers ";
     const last_line_prefix = "  config  ";
     var read_buffer: [4096]u8 = undefined;
-    var file_reader = child.stdout.?.reader(io, &read_buffer);
+    var file_reader = child.stderr.?.reader(io, &read_buffer);
     const reader = &file_reader.interface;
     var banner: Banner = .{ .total_kb = 0, .head_buffers = 0 };
     var line_index: u32 = 0;
@@ -780,14 +814,16 @@ fn spawnZoxy(
     , .{ zoxy_port, zoxy_http_port, origin_address });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
-    // stdout is piped so `readBanner` can gate on the §5 total. Only the
-    // banner ever crosses it: this config keeps the access log off, and
-    // the drain-time counter dump goes to stderr — a stdout sink here
-    // would eventually fill the pipe and block the proxy under test.
+    // stderr is piped so `readBanner` can gate on the §5 total (the
+    // banner is diagnostics, and zoxy keeps stdout for the access log's
+    // `stdout` sink). Between the banner and the drain nothing else
+    // lands there, and the drain-time counter dump — a few KiB against a
+    // 64 KiB pipe — is forwarded into the run log by `drainChild`, so
+    // the band review keeps it and the pipe can never fill.
     return std.process.spawn(io, .{
         .argv = &.{ zoxy_path, config_path },
-        .stdout = .pipe,
-        .stderr = .inherit,
+        .stdout = .inherit,
+        .stderr = .pipe,
     }) catch |err| {
         std.debug.print("bench: could not spawn {s} ({t}); run `zig build` first\n", .{
             zoxy_path,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -62,6 +62,8 @@ Non-goals (deliberate, recorded so they are decisions rather than drift):
 - Config reload. Config is parse-once immutable (§5); a change is a
   process restart — consistent with process-per-port scale-out (§3). Hot
   restart / drain-to-successor is out of scope for the same reason.
+  SIGHUP is therefore free for the conventional log-rotation meaning and
+  carries only that (§8): reopen the access log's file sink.
 - Dynamic DNS for upstreams. Cluster endpoints are static socket
   addresses resolved once at config load (§7); re-resolution waits for a
   demonstrated need.
@@ -457,7 +459,7 @@ a raised `RLIMIT_NOFILE`:
 |---|---|---|---|
 | conn slots | 1386 | 11466 | ~1.7 KiB state |
 | relay buffers | 1386 | 11466 | 2 × 4 KiB |
-| upstream slots | 1312 | 11466 | ~48 B state |
+| upstream slots | 1311 | 11466 | ~48 B state |
 | head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
 | upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
@@ -508,7 +510,7 @@ recorded there.
 The *defaults* are not pinned to each other, and deliberately: the
 out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than
 by admission (matching 1386 would cost 4168 fds), so the upstream default
-sits at 1312 — the largest value that still stays strictly under that
+sits at 1311 — the largest value that still stays strictly under that
 line with the access log's possible file sink counted (§8; naming a log
 file is not tuning, so the lean promise holds with one) — rather than at
 the conn default. An L4 deployment never touches
@@ -1003,11 +1005,26 @@ origin, not one this proxy can pick for them.
   sink is `stdout` (inherited, no fd of its own, piped wherever the
   operator already sends this process's output) or `file` with a `path`:
   opened once at startup — append-only, created if absent, never
-  truncated, one fd in `fdsRequired`'s budget — and held for the
-  process's life. Append-only is what makes an external copy-truncate
+  truncated, two fds in `fdsRequired`'s budget (held + the reopen
+  transient below). Append-only is what makes an external copy-truncate
   rotation (logrotate) safe: every write lands at the current end,
-  wherever a rotation just put it. In-place reopen-on-SIGHUP is a
-  tracked issue, not a shipped feature. Whichever sink, it
+  wherever a rotation just put it. Move-based rotation is served by
+  **SIGHUP**, which reopens the configured path: the new fd opens
+  *first* — a rotation that cannot open its file keeps the old fd and
+  counts `access_log_reopen_failed`, because a failed rotation must not
+  destroy a working log — and the swap happens only between sink
+  writes, never under one (a pending reopen waits for the in-flight
+  write's completion, and every line accepted after the signal lands in
+  the new file). The reopen itself is two synchronous syscalls on the
+  loop — a priced exception to the never-block rule, accepted because
+  rotation is operator-paced and rare where the async alternative is a
+  fork op against a closed union (§4); a log directory that can *hang*
+  (dead NFS) stalls the loop at rotation time, which is a deployment
+  problem, not a proxy one. A successful reopen also heals a `broken`
+  sink: what broke was the fd the rotation just replaced. On a `stdout` sink — or
+  no log at all — SIGHUP is a no-op, and that is the signal's *only*
+  meaning: zoxy does not reload config (§1 non-goal — the §5 pools are
+  startup-fixed, so a config change is a restart). Whichever sink, it
   writes one JSON object per line: one per HTTP exchange (including every
   reject, request-level shed and verdict) and one per L4 connection,
   carrying the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -457,7 +457,7 @@ a raised `RLIMIT_NOFILE`:
 |---|---|---|---|
 | conn slots | 1386 | 11466 | ~1.7 KiB state |
 | relay buffers | 1386 | 11466 | 2 × 4 KiB |
-| upstream slots | 1313 | 11466 | ~48 B state |
+| upstream slots | 1312 | 11466 | ~48 B state |
 | head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
 | upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | **pool memory** | **~34 MiB** | **~288 MiB** | |
@@ -508,8 +508,10 @@ recorded there.
 The *defaults* are not pinned to each other, and deliberately: the
 out-of-box shape is bounded by the stock 4096 `RLIMIT_NOFILE` rather than
 by admission (matching 1386 would cost 4168 fds), so the upstream default
-sits at 1313 — the largest value that still stays strictly under that
-line — rather than at the conn default. An L4 deployment never touches
+sits at 1312 — the largest value that still stays strictly under that
+line with the access log's possible file sink counted (§8; naming a log
+file is not tuning, so the lean promise holds with one) — rather than at
+the conn default. An L4 deployment never touches
 the upstream pool at all — an L4 dial holds no upstream slot. A
 deployment that means to fill its conn pool raises both together through
 `limits`.
@@ -997,7 +999,15 @@ origin, not one this proxy can pick for them.
   how often; an access log says *which request*, and that is what an
   operator needs when one client is being served badly and the aggregates
   look fine. Optional — a config `access_log` block names a sink, and
-  absent it the whole feature reserves nothing and reads no clock — it
+  absent it the whole feature reserves nothing and reads no clock. The
+  sink is `stdout` (inherited, no fd of its own, piped wherever the
+  operator already sends this process's output) or `file` with a `path`:
+  opened once at startup — append-only, created if absent, never
+  truncated, one fd in `fdsRequired`'s budget — and held for the
+  process's life. Append-only is what makes an external copy-truncate
+  rotation (logrotate) safe: every write lands at the current end,
+  wherever a rotation just put it. In-place reopen-on-SIGHUP is a
+  tracked issue, not a shipped feature. Whichever sink, it
   writes one JSON object per line: one per HTTP exchange (including every
   reject, request-level shed and verdict) and one per L4 connection,
   carrying the
@@ -1025,11 +1035,11 @@ origin, not one this proxy can pick for them.
   the honest one: under a shed storm the log would be the highest-volume
   thing in the process, so the lines an operator most wanted would be the
   first the drop rung took.
-  **A log line must never stall the data path.** The sink is a pipe the
-  operator owns, so it can block for arbitrarily long, and a proxy that
-  waited on it would hand every client's latency to whatever reads its
-  logs. So the write is a ring op like every other (§4) with at most one
-  in flight — one entry in the ring budget, reserved unconditionally —
+  **A log line must never stall the data path.** The sink is a pipe or a
+  filesystem the operator owns, so it can block for arbitrarily long, and
+  a proxy that waited on it would hand every client's latency to whatever
+  reads its logs. So the write is a ring op like every other (§4) with
+  at most one in flight — one ring-budget entry, reserved unconditionally —
   lines accumulate in a second staging buffer while it is out, the two
   swap when it lands, and **a line that does not fit is dropped and
   counted.** That is this section's own rule applied to logging: the

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -180,6 +180,19 @@ const uncovered = [_]Uncovered{
         .reason = "the harness never calls injectLogWriteError; " ++
             "src/access_log_test.zig covers the stop-and-witness",
     },
+    .{
+        .name = "access_log_reopened",
+        .why = .unreached,
+        .reason = "the sweep's sink is stdout and no script injects SIGHUP; " ++
+            "src/access_log_test.zig drives the rotation swap",
+    },
+    .{
+        .name = "access_log_reopen_failed",
+        .why = .unreached,
+        .reason = "same as access_log_reopened, plus injectLogReopenError " ++
+            "is a directed-test control; src/access_log_test.zig covers " ++
+            "the keep-the-old-sink arm",
+    },
 };
 
 comptime {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -427,6 +427,7 @@ pub fn Server(comptime IoType: type) type {
                     const snapshot = server.gauges();
                     server.counters.dump(&snapshot);
                 },
+                .reopen_log => server.access_log.requestReopen(),
             }
         }
 

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -289,8 +289,15 @@ pub fn AccessLog(comptime IoType: type) type {
         /// a transient — the ring already absorbed every would-block — so
         /// retrying would spend a syscall per line forever to lose the
         /// same lines. Every subsequent record counts as dropped, so the
-        /// gap is visible in the metrics the log stopped narrating.
+        /// gap is visible in the metrics the log stopped narrating. The
+        /// one way back is a successful SIGHUP reopen (§8 rotation): the
+        /// broken thing was the *old* fd, and a fresh one is a fresh
+        /// verdict.
         broken: bool,
+        /// A SIGHUP arrived while a write was in flight (§8 rotation):
+        /// the swap happens at that write's completion, never under it —
+        /// the fd being closed must not be one the ring still holds.
+        reopen_pending: bool,
         completion: IoType.Completion,
 
         const Self = @This();
@@ -319,6 +326,7 @@ pub fn AccessLog(comptime IoType: type) type {
             log.flush_sent = 0;
             log.writing = false;
             log.broken = false;
+            log.reopen_pending = false;
             log.completion = .{};
             assert(log.isQuiescent());
         }
@@ -415,6 +423,10 @@ pub fn AccessLog(comptime IoType: type) type {
                 log.flush_len = 0;
                 log.flush_sent = 0;
                 log.staging_len = 0;
+                // A SIGHUP that raced the failing write still gets its
+                // rotation — and a successful one heals the break, since
+                // what broke was the fd it just replaced (§8).
+                if (log.reopen_pending) log.performReopen();
                 log.server.maybeStopAfterDrain();
                 return;
             };
@@ -427,10 +439,55 @@ pub fn AccessLog(comptime IoType: type) type {
             }
             log.flush_len = 0;
             log.flush_sent = 0;
+            // The deferred rotation happens before the next flush arms,
+            // so every line accepted after the SIGHUP lands in the new
+            // file — the boundary an operator's rotation tooling expects.
+            if (log.reopen_pending) log.performReopen();
             log.maybeFlush();
             // The drain stops the loop only once the sink is quiet, so the
             // completion that empties it is the one that has to re-check.
             log.server.maybeStopAfterDrain();
+        }
+
+        /// SIGHUP (§8 rotation): reopen the `file` sink at its configured
+        /// path. On any other sink — stdout, or no log at all — the
+        /// signal is a no-op, not an error: an operator's blanket
+        /// `killall -HUP` must not hurt a deployment that has nothing to
+        /// rotate. The swap itself waits for the in-flight write, if any.
+        pub fn requestReopen(log: *Self) void {
+            const sink = log.sink orelse return;
+            if (sink != .file) return;
+            // A configured sink always has staging (the loader's
+            // one-number rule) — the invariant that makes the reopen
+            // worth anything: lines have somewhere to wait out the swap.
+            assert(log.buffer_bytes >= 1);
+            log.reopen_pending = true;
+            if (log.writing) return;
+            log.performReopen();
+        }
+
+        /// The swap, between writes by construction (§8 rotation): open
+        /// new first, so failure keeps the old fd and the lines keep
+        /// landing where they already were — counted, not fatal. Success
+        /// also heals a `broken` sink: what broke was the old fd, and
+        /// the replacement gets its own verdict.
+        fn performReopen(log: *Self) void {
+            assert(!log.writing);
+            assert(log.reopen_pending);
+            assert(log.sink != null);
+            log.reopen_pending = false;
+            log.server.io.logReopen() catch {
+                log.server.counters.increment("access_log_reopen_failed");
+                return;
+            };
+            log.server.counters.increment("access_log_reopened");
+            if (log.broken) {
+                // Every line since the break was counted as a drop and
+                // nothing staged (`record` refuses while broken), so the
+                // fresh fd starts clean.
+                assert(log.staging_len == 0);
+                log.broken = false;
+            }
         }
 
         /// Quiescent for the drain-stop gate (§8): nothing in flight and

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -5,8 +5,9 @@
 //! entry, both closed-form in `constants.zig` like every other budget.
 //!
 //! **A log line never blocks the loop, and never queues without bound.**
-//! Those two rules are the whole design. The sink is a pipe the operator
-//! owns, so it can stall for arbitrarily long, and a proxy that waits for
+//! Those two rules are the whole design. The sink — stdout piped wherever
+//! the operator sends it, or the append-only file the config named (§8) —
+//! can stall for arbitrarily long, and a proxy that waits for
 //! it would hand every client's latency to whatever is reading its logs.
 //! So the write is a ring op with at most one in flight, lines accumulate
 //! in the *other* buffer while it is out, the buffers swap when it lands,

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -52,6 +52,18 @@ const Harness = struct {
         buffer_bytes: u32,
         stall_ns: u64,
     ) !void {
+        try harness.setUpWithSink(gpa, buffer_bytes, stall_ns, .stdout);
+    }
+
+    /// The reopen tests need the `file` arm — SIGHUP is a no-op on any
+    /// other sink. SimIo opens nothing, so the path is never touched.
+    fn setUpWithSink(
+        harness: *Harness,
+        gpa: std.mem.Allocator,
+        buffer_bytes: u32,
+        stall_ns: u64,
+        sink: config_module.Config.AccessLogSink,
+    ) !void {
         harness.arena_state = std.heap.ArenaAllocator.init(gpa);
         errdefer harness.arena_state.deinit();
         const arena = harness.arena_state.allocator();
@@ -79,7 +91,7 @@ const Harness = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
-            .access_log_sink = if (buffer_bytes == 0) null else .stdout,
+            .access_log_sink = if (buffer_bytes == 0) null else sink,
         };
         try harness.server.init(arena, &harness.sim_io, &harness.config, .{
             .conn_slots = 4,
@@ -285,4 +297,164 @@ test "access log: an unflushed line keeps the drain from stopping the loop" {
     try testing.expect(harness.server.access_log.isQuiescent());
     try testing.expect(harness.server.isIdle());
     try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+}
+
+test "access log: SIGHUP reopens an idle file sink immediately" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        0,
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    // Nothing in flight: the swap needs no completion to wait for.
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopened"));
+    try testing.expectEqual(@as(u32, 1), harness.sim_io.log_reopen_count);
+
+    // The sink still works after the swap.
+    harness.emit(0);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+}
+
+test "access log: SIGHUP under an in-flight write swaps at its completion" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        1_000_000, // The write stalls, so the signal races it.
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    harness.emit(0);
+    try testing.expect(!harness.server.access_log.isQuiescent());
+    harness.server.access_log.requestReopen();
+    // Deferred: the fd under the armed write must not be closed (§8).
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_reopened"));
+    try testing.expectEqual(@as(u32, 0), harness.sim_io.log_reopen_count);
+
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopened"));
+    try testing.expectEqual(@as(u32, 1), harness.sim_io.log_reopen_count);
+    // The line that was in flight landed before the swap; nothing lost.
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+    try testing.expect(harness.server.access_log.isQuiescent());
+}
+
+test "access log: SIGHUP on a stdout sink is a no-op" {
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, constants.access_log_buffer_bytes_min, 0);
+    defer harness.tearDown();
+
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_reopened"));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_reopen_failed"));
+    try testing.expectEqual(@as(u32, 0), harness.sim_io.log_reopen_count);
+}
+
+test "access log: a failed reopen keeps the old sink working" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        0,
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    harness.sim_io.injectLogReopenError();
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopen_failed"));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_reopened"));
+
+    // The old fd was never closed: lines keep landing where they were.
+    harness.emit(0);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+}
+
+test "access log: a successful reopen heals a broken sink" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        0,
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    // Break the sink the §8 way: a write fails, the log stops, drops count.
+    harness.sim_io.injectLogWriteError();
+    harness.emit(0);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_write_failed"));
+    harness.emit(1);
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_dropped"));
+
+    // Rotation replaces the broken fd; the replacement gets its own verdict.
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopened"));
+    harness.emit(2);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+    // The heal is exact: the drop count did not move again.
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_dropped"));
+    try testing.expect(harness.server.access_log.isQuiescent());
+}
+
+test "access log: SIGHUP racing the failing write still rotates and heals" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        1_000_000, // In flight when both the failure and the signal land.
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    harness.sim_io.injectLogWriteError();
+    harness.emit(0);
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_reopened"));
+
+    // The write fails, marks the sink broken — and the pending rotation
+    // fires right there, healing it in the same completion (§8).
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_write_failed"));
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopened"));
+
+    harness.emit(1);
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), lineCount(harness.sim_io.sinkBytes()));
+    try testing.expectEqual(@as(u64, 0), harness.counter("access_log_dropped"));
+}
+
+test "access log: repeated SIGHUPs under one write collapse to one swap" {
+    var harness: Harness = undefined;
+    try harness.setUpWithSink(
+        testing.allocator,
+        constants.access_log_buffer_bytes_min,
+        1_000_000,
+        .{ .file = "/virtual/access.log" },
+    );
+    defer harness.tearDown();
+
+    harness.emit(0);
+    // An operator's rotation script and a stray `killall -HUP` in the
+    // same window: the flag is idempotent, so the write's completion
+    // performs exactly one swap — the file both signals meant.
+    harness.server.access_log.requestReopen();
+    harness.server.access_log.requestReopen();
+    try testing.expectEqual(@as(u32, 0), harness.sim_io.log_reopen_count);
+
+    try harness.drainSink();
+    try testing.expectEqual(@as(u64, 1), harness.counter("access_log_reopened"));
+    try testing.expectEqual(@as(u32, 1), harness.sim_io.log_reopen_count);
+    try testing.expect(harness.server.access_log.isQuiescent());
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -63,14 +63,28 @@ pub const Config = struct {
     /// is configured — the log stays off and reserves nothing.
     access_log_sink: ?AccessLogSink = null,
 
-    /// Where the access log writes (§8). An enum with one arm today
-    /// because there is one sink: the process's own stdout, inherited
-    /// rather than opened, so the log costs no file descriptor and carries
-    /// no rotation story of its own — an operator pipes it wherever they
-    /// already send this process's output. Named rather than made a bare
-    /// boolean so a second sink is a new arm, not a new field.
-    pub const AccessLogSink = enum(u1) {
+    /// Where the access log writes (§8). `stdout` is the process's own
+    /// standard output, inherited rather than opened, so it costs no file
+    /// descriptor and carries no rotation story of its own — an operator
+    /// pipes it wherever they already send this process's output. `file`
+    /// is a path the io backend opens once at startup — append-only,
+    /// created if absent, never truncated — costing exactly one fd
+    /// (`fdsRequired`); append-only is what keeps an external
+    /// copy-truncate rotation safe, every write landing at the current
+    /// end wherever a rotation just put it. A tagged union so the arm
+    /// that needs a parameter carries it, and the arms stay the closed
+    /// set the schema names (`AccessLogSinkKind`).
+    pub const AccessLogSink = union(AccessLogSinkKind) {
         stdout,
+        file: []const u8,
+    };
+
+    /// The sink names the config may spell — split from `AccessLogSink`
+    /// because the schema renders (and the parser matches) bare names,
+    /// and only the resolved union carries a payload.
+    pub const AccessLogSinkKind = enum(u1) {
+        stdout,
+        file,
     };
 
     pub const Limits = struct {
@@ -341,6 +355,8 @@ pub const ValidationError = error{
     LimitAccessLogBufferWithoutSink,
     AdminBindInvalid,
     AccessLogSinkUnknown,
+    AccessLogPathMissing,
+    AccessLogPathOnStdout,
 };
 
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
@@ -403,13 +419,32 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
 /// Resolve the optional access log (§8): absent means off — no staging
 /// buffers reserved, no lines emitted. A present block names its sink from
 /// a closed set, so an unknown value fails at load rather than silently
-/// logging somewhere the operator did not ask for.
+/// logging somewhere the operator did not ask for; `path` is required by
+/// exactly the sink that uses it. Both mismatches are rejected, not
+/// ignored — the `ClusterCheckHttpFieldOnTcp` rule, one block over: a
+/// field the named sink cannot honor describes a config the operator
+/// misread, and this proxy does not start on those.
 fn resolveAccessLogSink(
     access_log_json: ?AccessLogJson,
 ) ValidationError!?Config.AccessLogSink {
     const access_log = access_log_json orelse return null;
-    return std.meta.stringToEnum(Config.AccessLogSink, access_log.sink) orelse
-        error.AccessLogSinkUnknown;
+    const kind = std.meta.stringToEnum(Config.AccessLogSinkKind, access_log.sink) orelse
+        return error.AccessLogSinkUnknown;
+    switch (kind) {
+        .stdout => {
+            if (access_log.path != null) return error.AccessLogPathOnStdout;
+            return .stdout;
+        },
+        .file => {
+            const path = access_log.path orelse return error.AccessLogPathMissing;
+            // Empty is missing, not "a file named nothing": openat would
+            // reject it later and worse — at startup's end, not load time.
+            if (path.len == 0) return error.AccessLogPathMissing;
+            // The postcondition `openLogSinkFd` (main) leans on.
+            assert(path.len >= 1);
+            return .{ .file = path };
+        },
+    }
 }
 
 /// Resolve the optional admin/metrics listener (§8):
@@ -639,6 +674,7 @@ pub const ConfigJson = struct {
 
 pub const AccessLogJson = struct {
     sink: []const u8,
+    path: ?[]const u8 = null,
 
     pub const schema_doc =
         "Optional access log. When present, zoxy writes one JSON object per " ++
@@ -647,8 +683,15 @@ pub const AccessLogJson = struct {
         "than allowed to block the event loop when the sink cannot keep up.";
     pub const schema_fields = .{
         .sink = .{
-            .desc = "Where lines are written. `stdout` is the process's own standard output.",
-            .enum_type = Config.AccessLogSink,
+            .desc = "Where lines are written. `stdout` is the process's own standard " ++
+                "output; `file` appends to `path`.",
+            .enum_type = Config.AccessLogSinkKind,
+        },
+        .path = .{
+            .desc = "File the `file` sink appends to: created if absent, opened " ++
+                "append-only at startup (one extra fd), never truncated — so a " ++
+                "copy-truncate rotation is safe. Required by `sink:\"file\"`, " ++
+                "rejected beside `stdout`, which cannot use it.",
         },
     };
 };
@@ -3102,8 +3145,12 @@ const fuzz_seed_json =
     \\ "timeouts":{"connect_ms":5000,"idle_ms":60000,"drain_deadline_ms":10000,
     \\ "max_lifetime_ms":300000,"request_ms":30000,"health_interval_ms":2000},
     \\ "limits":{"conn_slots":64,"relay_buffers":32,"upstream_slots":32},
-    \\ "access_log":{"sink":"stdout"},"admin":{"bind":"127.0.0.1:9901"}}
+    \\ "access_log":{"sink":"file","path":"/var/log/zoxy.log"},
+    \\ "admin":{"bind":"127.0.0.1:9901"}}
 ;
+// The `file` arm here, `stdout` in `example_json` beside it: between the
+// two corpus entries the mutator sees every sink spelling, including the
+// `path` key only one of them may carry.
 
 test "config: the fuzz seed carrying every block parses" {
     // It is a corpus entry, so it has to be a *valid* config — an
@@ -3172,7 +3219,25 @@ test "config: the access-log block resolves a sink, absent leaves it off" {
             &arena_state,
             head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\"}}",
         );
-        try std.testing.expectEqual(Config.AccessLogSink.stdout, parsed.access_log_sink.?);
+        try std.testing.expect(parsed.access_log_sink.? == .stdout);
+        try std.testing.expectEqual(
+            constants.access_log_buffer_bytes_default,
+            parsed.limits.access_log_buffer_bytes,
+        );
+    }
+    // A file sink carries its path through to the resolved union.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ tail ++ ",\"access_log\":{\"sink\":\"file\",\"path\":\"/var/log/zoxy.log\"}}",
+        );
+        try std.testing.expect(parsed.access_log_sink.? == .file);
+        try std.testing.expectEqualStrings(
+            "/var/log/zoxy.log",
+            parsed.access_log_sink.?.file,
+        );
         try std.testing.expectEqual(
             constants.access_log_buffer_bytes_default,
             parsed.limits.access_log_buffer_bytes,
@@ -3198,9 +3263,21 @@ test "config: the access-log block resolves a sink, absent leaves it off" {
     );
     // The block is strict like every other: `sink` required, extras rejected.
     try expectParseError(error.MissingField, head ++ tail ++ ",\"access_log\":{}}");
+    // `path` belongs to exactly the sink that uses it: beside `stdout` it
+    // describes something that cannot happen, and a `file` sink without
+    // one (or with an empty one) names no file at all. The
+    // `ClusterCheckHttpFieldOnTcp` rule, applied here.
     try expectParseError(
-        error.UnknownField,
+        error.AccessLogPathOnStdout,
         head ++ tail ++ ",\"access_log\":{\"sink\":\"stdout\",\"path\":\"/tmp/x\"}}",
+    );
+    try expectParseError(
+        error.AccessLogPathMissing,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"file\"}}",
+    );
+    try expectParseError(
+        error.AccessLogPathMissing,
+        head ++ tail ++ ",\"access_log\":{\"sink\":\"file\",\"path\":\"\"}}",
     );
     // A buffer below one worst-case line would drop lines it had room for,
     // which is the one thing a drop must never mean; above the ceiling is

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -652,10 +652,12 @@ pub fn fdsRequired(
     assert(upstream_slots <= upstream_slots_max);
     assert(listeners <= std.math.maxInt(u16));
     // Zero or one: the config names at most one sink, and only its `file`
-    // arm opens anything.
+    // arm opens anything. Each file sink costs its held fd plus one
+    // transient during a SIGHUP reopen — the new fd opens before the old
+    // one closes, so a failed rotation keeps a working log (§8).
     assert(access_log_files <= 1);
     return 3 + 1 + 1 + (listeners + admin_listeners) +
-        2 * conn_slots + 1 + admin_conns + upstream_slots + 1 + access_log_files;
+        2 * conn_slots + 1 + admin_conns + upstream_slots + 1 + 2 * access_log_files;
 }
 
 /// Default effective pool sizes when the config omits a `limits` block: a
@@ -685,20 +687,21 @@ pub const relay_buffers_default: u32 = conn_slots_default;
 /// `conn_slots_max`), because the out-of-box shape is bounded by the
 /// stock 4096 `RLIMIT_NOFILE` rather than by admission: matching 1386
 /// would put the default at 4168 fds, over that line, for capacity an
-/// unconfigured proxy is not there to serve. 1312 is the largest value
+/// unconfigured proxy is not there to serve. 1311 is the largest value
 /// that still clears that line — `fdsRequired(conn_slots_default, x, 1, 1)`
-/// is `2783 + x` (the health probe's reserved fd and the access log's
-/// possible file sink both included: naming a log file is not *tuning*,
-/// so the lean promise must hold with one), and that must stay strictly
-/// under 4096 (the out-of-box budget stays *under* the stock limit, not
-/// flush against it), so `4096 - 2783 - 1 = 1312` — the default leans as
-/// far toward `conn_slots_default` as the stock fd budget allows. An L4
+/// is `2784 + x` (the health probe's reserved fd and the access log's
+/// possible file sink both included, the sink at its SIGHUP-reopen worst
+/// of two fds: naming a log file is not *tuning*, so the lean promise
+/// must hold with one), and that must stay strictly under 4096 (the
+/// out-of-box budget stays *under* the stock limit, not flush against
+/// it), so `4096 - 2784 - 1 = 1311` — the default leans as far toward
+/// `conn_slots_default` as the stock fd budget allows. An L4
 /// deployment never leases from this pool at all — an L4 dial reads its
 /// `leased_counts` for the P2C draw and holds no slot. A deployment that
 /// means to fill its conn pool raises both together in `limits` — which
 /// is what the ceilings exist to permit and what the c10k benchmark
 /// configuration does.
-pub const upstream_slots_default: u32 = 1312;
+pub const upstream_slots_default: u32 = 1311;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -1067,9 +1070,10 @@ test "budgets: c10k ceiling fd count needs a raised NOFILE" {
         @as(u32, 34407),
         fdsRequired(conn_slots_max, upstream_slots_max, 0, 0),
     );
-    // A file sink is exactly one fd, at the ceiling as everywhere.
+    // A file sink is two fds — held plus the SIGHUP-reopen transient —
+    // at the ceiling as everywhere.
     try std.testing.expectEqual(
-        @as(u32, 34408),
+        @as(u32, 34409),
         fdsRequired(conn_slots_max, upstream_slots_max, 0, 1),
     );
     try std.testing.expect(fdsRequired(conn_slots_max, upstream_slots_max, 0, 1) <= 65536);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -632,7 +632,9 @@ pub const completion_queue_entries: u32 =
 /// transient just-accepted fd an admission decision is pending on + one
 /// socket per in-flight admin scrape + one socket per parked upstream,
 /// which belongs to no connection + the one socket the in-flight health
-/// probe may hold while dialing (§7). Closed form so `ensureFdBudget` can
+/// probe may hold while dialing (§7) + the access log's file sink when the
+/// config names one (§8 — the `stdout` sink is one of the three stdio
+/// descriptors already counted). Closed form so `ensureFdBudget` can
 /// check the *effective* size against RLIMIT_NOFILE; the admin and
 /// health-probe reservations are fixed.
 ///
@@ -640,12 +642,20 @@ pub const completion_queue_entries: u32 =
 /// the listener term makes this a property of a config, not of this file.
 /// `ensureFdBudget` was always the real gate — it compares this against
 /// the actual RLIMIT_NOFILE — and it is now the only one.
-pub fn fdsRequired(conn_slots: u32, upstream_slots: u32, listeners: u32) u32 {
+pub fn fdsRequired(
+    conn_slots: u32,
+    upstream_slots: u32,
+    listeners: u32,
+    access_log_files: u32,
+) u32 {
     assert(conn_slots <= conn_slots_max);
     assert(upstream_slots <= upstream_slots_max);
     assert(listeners <= std.math.maxInt(u16));
+    // Zero or one: the config names at most one sink, and only its `file`
+    // arm opens anything.
+    assert(access_log_files <= 1);
     return 3 + 1 + 1 + (listeners + admin_listeners) +
-        2 * conn_slots + 1 + admin_conns + upstream_slots + 1;
+        2 * conn_slots + 1 + admin_conns + upstream_slots + 1 + access_log_files;
 }
 
 /// Default effective pool sizes when the config omits a `limits` block: a
@@ -675,19 +685,20 @@ pub const relay_buffers_default: u32 = conn_slots_default;
 /// `conn_slots_max`), because the out-of-box shape is bounded by the
 /// stock 4096 `RLIMIT_NOFILE` rather than by admission: matching 1386
 /// would put the default at 4168 fds, over that line, for capacity an
-/// unconfigured proxy is not there to serve. 1313 is the largest value
-/// that still clears that line — `fdsRequired(conn_slots_default, x, 1)`
-/// is `2782 + x` (the health probe's reserved fd included), and that must
-/// stay strictly under 4096 (the out-of-box budget stays *under* the
-/// stock limit, not flush against it), so `4096 - 2782 - 1 = 1313` — the
-/// default leans as far toward
-/// `conn_slots_default` as the stock fd budget allows. An L4
+/// unconfigured proxy is not there to serve. 1312 is the largest value
+/// that still clears that line — `fdsRequired(conn_slots_default, x, 1, 1)`
+/// is `2783 + x` (the health probe's reserved fd and the access log's
+/// possible file sink both included: naming a log file is not *tuning*,
+/// so the lean promise must hold with one), and that must stay strictly
+/// under 4096 (the out-of-box budget stays *under* the stock limit, not
+/// flush against it), so `4096 - 2783 - 1 = 1312` — the default leans as
+/// far toward `conn_slots_default` as the stock fd budget allows. An L4
 /// deployment never leases from this pool at all — an L4 dial reads its
 /// `leased_counts` for the P2C draw and holds no slot. A deployment that
 /// means to fill its conn pool raises both together in `limits` — which
 /// is what the ceilings exist to permit and what the c10k benchmark
 /// configuration does.
-pub const upstream_slots_default: u32 = 1313;
+pub const upstream_slots_default: u32 = 1312;
 
 comptime {
     assert(std.math.isPowerOfTwo(ring_entries));
@@ -1052,8 +1063,16 @@ test "budgets: c10k ceiling fd count needs a raised NOFILE" {
     // the ceiling must raise RLIMIT_NOFILE (systemd LimitNOFILE / ulimit).
     // `ensureFdBudget` checks the *effective* size against the real limit
     // at startup (§8); this pins the ceiling closed form.
-    try std.testing.expectEqual(@as(u32, 34407), fdsRequired(conn_slots_max, upstream_slots_max, 0));
-    try std.testing.expect(fdsRequired(conn_slots_max, upstream_slots_max, 0) <= 65536);
+    try std.testing.expectEqual(
+        @as(u32, 34407),
+        fdsRequired(conn_slots_max, upstream_slots_max, 0, 0),
+    );
+    // A file sink is exactly one fd, at the ceiling as everywhere.
+    try std.testing.expectEqual(
+        @as(u32, 34408),
+        fdsRequired(conn_slots_max, upstream_slots_max, 0, 1),
+    );
+    try std.testing.expect(fdsRequired(conn_slots_max, upstream_slots_max, 0, 1) <= 65536);
     // The out-of-box side of this is pinned by "the default deployment is
     // lean" below, not restated here.
 }
@@ -1062,7 +1081,9 @@ test "budgets: the default deployment is lean" {
     // The out-of-box config (no `limits` block) starts under a routine
     // 4096 NOFILE and asks the kernel for a shallow ring, not the c10k
     // ceiling — operators opt up through `limits` (§5). One listener.
-    try std.testing.expect(fdsRequired(conn_slots_default, upstream_slots_default, 1) < 4096);
+    // With the one file sink a config can name included: the lean line
+    // holds whether or not the access log writes to a file.
+    try std.testing.expect(fdsRequired(conn_slots_default, upstream_slots_default, 1, 1) < 4096);
     try std.testing.expect(
         completionQueueDepthFor(conn_slots_default, upstream_slots_default, 1, cq_fill_eighths_default) <
             completion_queue_entries,

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -228,6 +228,17 @@ pub const Counters = struct {
     /// things at once: some already-accepted lines never reached the sink,
     /// and every line since has been counted as dropped.
     access_log_write_failed: Value = Value.init(0),
+    /// SIGHUP rotations of the `file` sink that took (§8): the old fd
+    /// closed between writes, the path reopened, and — when the sink had
+    /// been marked broken — the break healed, because what broke was the
+    /// fd this rotation just replaced.
+    access_log_reopened: Value = Value.init(0),
+    /// SIGHUP rotations that could not open the path (§8). The old fd is
+    /// kept and lines keep landing where they already were: a failed
+    /// rotation must not destroy a working log. Rising alongside a
+    /// rotation schedule means the log directory has a problem the
+    /// rotation tooling is not reporting.
+    access_log_reopen_failed: Value = Value.init(0),
     /// §8 L4 connections closed because every endpoint of their cluster
     /// was already carrying its configured `max_inflight`. An L4 listener
     /// has no way to say "try later", so the ladder's L4 answer applies:

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -140,6 +140,10 @@ sink_overflow_bytes: u32,
 /// a real broken pipe takes, which a virtual sink would otherwise never
 /// exercise (§9) — the same argument `pending_set_option_errors` makes.
 pending_log_write_errors: u8,
+/// One-shot `logReopen` failures (§8 rotation), same shape as the write
+/// errors above; and how many reopens succeeded, for scenario oracles.
+pending_log_reopen_errors: u8,
+log_reopen_count: u32,
 /// The ephemeral port the next simulated client connects from.
 next_client_port: u16,
 /// The provided-buffer group (§5): one slab, a free flag per buffer, and
@@ -451,6 +455,8 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.sink_len = 0;
     io.sink_overflow_bytes = 0;
     io.pending_log_write_errors = 0;
+    io.pending_log_reopen_errors = 0;
+    io.log_reopen_count = 0;
     io.next_client_port = client_port_base;
     io.group_slab = try arena.alloc(
         u8,
@@ -760,6 +766,27 @@ pub fn nowWallNs(io: *const SimIo) u64 {
 pub fn injectLogWriteError(io: *SimIo) void {
     assert(io.pending_log_write_errors < std.math.maxInt(u8));
     io.pending_log_write_errors += 1;
+}
+
+/// Reopen the file sink (§8 rotation). The virtual sink has no inode to
+/// rotate, so success is a counted no-op — what the scenario observes is
+/// the *caller's* sequencing (swap only between writes, heal on success,
+/// keep-old on failure), which is the part worth simulating. Sync like
+/// the kernel twin.
+pub fn logReopen(io: *SimIo) Io.LogReopenError!void {
+    if (io.pending_log_reopen_errors >= 1) {
+        io.pending_log_reopen_errors -= 1;
+        return error.Unexpected;
+    }
+    assert(io.log_reopen_count < std.math.maxInt(u32));
+    io.log_reopen_count += 1;
+}
+
+/// Targeted scenario control: the next `logReopen` fails, driving the
+/// keep-the-old-sink path (§8 rotation).
+pub fn injectLogReopenError(io: *SimIo) void {
+    assert(io.pending_log_reopen_errors < std.math.maxInt(u8));
+    io.pending_log_reopen_errors += 1;
 }
 
 /// Everything the server wrote to the sink, for the §9 oracle.

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -47,9 +47,13 @@ loop: xev.Loop,
 timer: xev.Timer,
 notifier: xev.Async,
 /// Where `logWrite` sends its bytes (§8): `log_sink_stdout`, or the file
-/// fd the caller obtained from `openLogSink`. Held for the process's
-/// life, closed by exit like the stdio it stands beside.
+/// fd the caller obtained from `openLogSink`. Held until `logReopen`
+/// swaps it or the process exits — never closed under a write, which is
+/// what the access log's swap-between-completions discipline guarantees.
 log_sink_fd: posix.fd_t,
+/// The path behind a `file` sink, or null for stdout — what `logReopen`
+/// opens again at rotation (§8). Config-arena memory, process lifetime.
+log_sink_path: ?[]const u8,
 thread_pool: if (needs_thread_pool) xev.ThreadPool else void,
 notifier_completion: xev.Completion,
 signal_mask: std.atomic.Value(u8),
@@ -130,10 +134,16 @@ pub fn init(
     /// the fd `openLogSink` returned. A parameter rather than opened here
     /// so the caller owning the config error report also owns the path.
     log_sink_fd: posix.fd_t,
+    /// The path that fd came from — non-null exactly for a `file` sink —
+    /// kept so `logReopen` can open it again at rotation (§8).
+    log_sink_path: ?[]const u8,
 ) !void {
     assert(configured_listeners <= std.math.maxInt(u16) - constants.admin_listeners);
     // Stdout or a real opened file — never a sentinel, never closed-over.
     assert(log_sink_fd >= 0);
+    // The path travels with exactly the fd that came from it: a file
+    // sink's fd without its path would make `logReopen` unanswerable.
+    assert((log_sink_path != null) == (log_sink_fd != log_sink_stdout));
     const listeners = configured_listeners + constants.admin_listeners;
     assert(listeners >= 1);
     if (comptime needs_thread_pool) {
@@ -155,6 +165,7 @@ pub fn init(
     io.listeners = try arena.alloc(ListenerEntry, listeners);
     io.listeners_count = 0;
     io.log_sink_fd = log_sink_fd;
+    io.log_sink_path = log_sink_path;
     io.last_pressure = Io.Pressure.none;
     io.notifier_completion = .{};
     io.signal_mask = std.atomic.Value(u8).init(0);
@@ -798,6 +809,34 @@ pub fn openLogSink(path: []const u8) !posix.fd_t {
     }, 0o644);
 }
 
+/// Reopen the `file` sink at its configured path (§8 rotation): open the
+/// new fd *first* — on failure the old one stays and the caller keeps
+/// writing where lines were already landing — then close the old and
+/// swap. Legal only between log writes: the caller (the access log's
+/// swap-between-completions discipline) is what guarantees no in-flight
+/// op holds the fd being closed. Asking this of a stdout sink is
+/// asserted misuse — stdout has no path to reopen.
+///
+/// Deliberately synchronous on the live loop, unlike every data-path op
+/// and unlike the rule `logWrite` states below — a priced exception, not
+/// an oversight: rotation is operator-initiated and rare (per day, not
+/// per request), the pair costs two metadata syscalls on the filesystem
+/// the operator chose for their logs, and the async alternative is a
+/// fork op (`IORING_OP_OPENAT` — the op union is closed, §4 pin policy)
+/// plus a swap state machine, bought for an event that happens less
+/// often than a health probe. What the trade accepts: a log directory on
+/// a *hung* filesystem (NFS with a dead server) stalls the loop for the
+/// open's duration at rotation time. An operator whose log directory can
+/// hang has a deployment problem no proxy can absorb.
+pub fn logReopen(io: *XevIo) Io.LogReopenError!void {
+    const path = io.log_sink_path orelse unreachable;
+    assert(io.log_sink_fd != log_sink_stdout);
+    const new_fd = openLogSink(path) catch return error.Unexpected;
+    assert(new_fd >= 0);
+    closeFd(io.log_sink_fd);
+    io.log_sink_fd = new_fd;
+}
+
 /// Write one batch of access-log bytes to the sink (§8). A ring op, not a
 /// direct `write`: the sink is whatever the operator pointed stdout at, or
 /// a file on whatever filesystem they named, and a pipe whose reader has
@@ -1165,6 +1204,9 @@ fn onNotifierWake(
     }
     if (mask & signalBit(.dump_counters) != 0) {
         callback(io.signal_userdata, .dump_counters);
+    }
+    if (mask & signalBit(.reopen_log) != 0) {
+        callback(io.signal_userdata, .reopen_log);
     }
     // The internal signal wait is the one legitimate `.rearm`: an eventfd
     // read has no stale-time hazard, unlike timers.

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -36,15 +36,20 @@ const uses_buf_ring = xev.backend == .io_uring;
 /// The one buffer group this backend registers (§5's head-buffer ring).
 const buffer_group_id: u16 = 0;
 
-/// The access-log sink (§8): the process's own stdout, inherited, never
-/// opened here. Config names the sink by enum and this is the only value
-/// it can name today, so the fd budget is unchanged — stdout is already
-/// one of the three stdio descriptors `fdsRequired` reserves.
-const log_sink_fd: posix.fd_t = 1;
+/// The access-log sink's `stdout` arm (§8): the process's own stdout,
+/// inherited, never opened and never closed — already one of the three
+/// stdio descriptors `fdsRequired` reserves, so it costs nothing. The
+/// `file` arm is `openLogSink`'s fd instead, counted by `fdsRequired`'s
+/// `access_log_files` term.
+pub const log_sink_stdout: posix.fd_t = 1;
 
 loop: xev.Loop,
 timer: xev.Timer,
 notifier: xev.Async,
+/// Where `logWrite` sends its bytes (§8): `log_sink_stdout`, or the file
+/// fd the caller obtained from `openLogSink`. Held for the process's
+/// life, closed by exit like the stdio it stands beside.
+log_sink_fd: posix.fd_t,
 thread_pool: if (needs_thread_pool) xev.ThreadPool else void,
 notifier_completion: xev.Completion,
 signal_mask: std.atomic.Value(u8),
@@ -121,8 +126,14 @@ pub fn init(
     /// against it is asserted misuse.
     buffer_group_count: u32,
     buffer_group_bytes: u32,
+    /// The §8 access-log sink `logWrite` targets: `log_sink_stdout`, or
+    /// the fd `openLogSink` returned. A parameter rather than opened here
+    /// so the caller owning the config error report also owns the path.
+    log_sink_fd: posix.fd_t,
 ) !void {
     assert(configured_listeners <= std.math.maxInt(u16) - constants.admin_listeners);
+    // Stdout or a real opened file — never a sentinel, never closed-over.
+    assert(log_sink_fd >= 0);
     const listeners = configured_listeners + constants.admin_listeners;
     assert(listeners >= 1);
     if (comptime needs_thread_pool) {
@@ -143,6 +154,7 @@ pub fn init(
     errdefer io.timer.deinit();
     io.listeners = try arena.alloc(ListenerEntry, listeners);
     io.listeners_count = 0;
+    io.log_sink_fd = log_sink_fd;
     io.last_pressure = Io.Pressure.none;
     io.notifier_completion = .{};
     io.signal_mask = std.atomic.Value(u8).init(0);
@@ -765,10 +777,32 @@ pub fn send(
     }).adapter);
 }
 
+/// Open the §8 access log's `file` sink: append-only, created if absent,
+/// never truncated. `O_APPEND` rather than a positioned write, for two
+/// reasons that both bite later if skipped: the ring's write op targets
+/// the fd's own position (the fork submits offset −1), and append-only is
+/// what makes an external copy-truncate rotation safe — every write lands
+/// at the current end, wherever a rotation just put it. Standalone and
+/// synchronous: one open at startup before the loop exists, under
+/// src/io/ because fds are made only here (§4's boundary); the caller
+/// owns the error report, since it owns the path the operator wrote.
+pub fn openLogSink(path: []const u8) !posix.fd_t {
+    assert(path.len >= 1);
+    // 0644: the operator's tooling reads the log; only this process
+    // writes it. The umask tightens it further if the deployment says so.
+    return posix.openat(posix.AT.FDCWD, path, .{
+        .ACCMODE = .WRONLY,
+        .CREAT = true,
+        .APPEND = true,
+        .CLOEXEC = true,
+    }, 0o644);
+}
+
 /// Write one batch of access-log bytes to the sink (§8). A ring op, not a
-/// direct `write`: the sink is whatever the operator pointed stdout at, and
-/// a pipe whose reader has stalled would block the whole loop for as long
-/// as it stays stalled — the one thing this proxy must never do. Through
+/// direct `write`: the sink is whatever the operator pointed stdout at, or
+/// a file on whatever filesystem they named, and a pipe whose reader has
+/// stalled — or a disk that is busy — would block the whole loop for as
+/// long as it stays stalled, the one thing this proxy must never do. Through
 /// the ring the kernel punts a would-block write to its own worker and the
 /// loop keeps serving; the caller's staging buffer absorbs the interval and
 /// drops when it cannot (§8's ladder, applied to logging).
@@ -784,7 +818,7 @@ pub fn logWrite(
     comptime callback: fn (*Userdata, Io.LogWriteError!u32) void,
 ) void {
     assert(bytes.len >= 1);
-    const file = xev.File.initFd(log_sink_fd);
+    const file = xev.File.initFd(io.log_sink_fd);
     file.write(&io.loop, completion, .{ .slice = bytes }, Userdata, userdata, (struct {
         fn adapter(
             context: ?*Userdata,

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -87,6 +87,7 @@ fn initTestIo(xev_io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
             buffer_group_count,
             buffer_group_bytes,
             XevIo.log_sink_stdout,
+            null,
         )) |_| {
             return;
         } else |err| {
@@ -994,7 +995,7 @@ test "xevio: the listener table reserves a slot for the admin listener" {
     var xev_io: XevIo = undefined;
     // One configured listener; capacity must be that plus the admin slot.
     // No buffer group — the zero-count arm must also keep init working.
-    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1, 0, 1, XevIo.log_sink_stdout);
+    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1, 0, 1, XevIo.log_sink_stdout, null);
     defer xev_io.deinit();
 
     const loopback = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0");

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -86,6 +86,7 @@ fn initTestIo(xev_io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
             listeners_reserved,
             buffer_group_count,
             buffer_group_bytes,
+            XevIo.log_sink_stdout,
         )) |_| {
             return;
         } else |err| {
@@ -993,7 +994,7 @@ test "xevio: the listener table reserves a slot for the admin listener" {
     var xev_io: XevIo = undefined;
     // One configured listener; capacity must be that plus the admin slot.
     // No buffer group — the zero-count arm must also keep init working.
-    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1, 0, 1);
+    try XevIo.init(&xev_io, arena_state.allocator(), 0, 1, 0, 1, XevIo.log_sink_stdout);
     defer xev_io.deinit();
 
     const loopback = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0");

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -30,6 +30,8 @@
 //!   send(io, socket, bytes, c, U, u, cb(u, SendError!u32))
 //!   close(io, socket, c, U, u, cb(u))
 //!   logWrite(io, bytes, c, U, u, cb(u, LogWriteError!u32))   (§8 access log)
+//!   logReopen(io) LogReopenError!void                   (sync; §8 rotation,
+//!       file sink only — swap the sink fd between writes, never under one)
 //!   timerStart(io, c, delay_ns, U, u, cb(u, TimerError!void))
 //!   timerCancel(io, timer_c, cancel_c, U, u, cb(u))     (the one legal cancel)
 //!   signalWait(io, U, u, cb(u, Signal))                 (persistent waiter)
@@ -53,6 +55,11 @@ pub const XevIo = @import("XevIo.zig");
 pub const Signal = enum(u8) {
     terminate,
     dump_counters,
+    /// SIGHUP: reopen the access log's file sink (§8 rotation). This is
+    /// the *only* meaning SIGHUP carries — zoxy does not reload config
+    /// (§1 non-goal: the §5 pools are startup-fixed, so a config change
+    /// is a restart), and claiming the signal for the log says so.
+    reopen_log,
 };
 
 pub const ShutdownHow = enum(u8) {
@@ -139,6 +146,15 @@ pub const LogWriteError = error{
     Unexpected,
 };
 
+/// The file sink's reopen failing (§8 rotation). One error for the same
+/// reason `LogWriteError` has one: there is exactly one response — keep
+/// the old fd, count `access_log_reopen_failed`, and keep writing where
+/// the lines were already landing. A reopen can only be asked of a
+/// `file` sink; the backends assert that, they do not error on it.
+pub const LogReopenError = error{
+    Unexpected,
+};
+
 pub const SetOptionError = error{
     Unexpected,
 };
@@ -210,6 +226,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "send",
             "close",
             "logWrite",
+            "logReopen",
             "timerStart",
             "timerCancel",
             "signalWait",

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,11 @@ pub fn main(init: std.process.Init) !void {
         config.limits.head_buffers,
         config.limits.head_buffer_bytes,
         log_sink_fd,
+        // The path rides beside its fd so SIGHUP can reopen it (§8).
+        if (config.access_log_sink) |sink| switch (sink) {
+            .stdout => null,
+            .file => |path| path,
+        } else null,
     );
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
@@ -267,6 +272,8 @@ const help_text =
     \\Signals:
     \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0.
     \\  SIGUSR1           Dump counters to stderr.
+    \\  SIGHUP            Reopen the access log's file sink (rotation).
+    \\                    No other meaning: config changes are a restart.
     \\
 ;
 
@@ -468,6 +475,7 @@ fn installSignalHandlers() void {
     std.posix.sigaction(.TERM, &action, null);
     std.posix.sigaction(.INT, &action, null);
     std.posix.sigaction(.USR1, &action, null);
+    std.posix.sigaction(.HUP, &action, null);
     // A proxy must not die because something downstream of it went away.
     // The access log writes to a pipe the operator owns (§8), and a `write`
     // to a pipe with no reader raises SIGPIPE, whose default action is to
@@ -491,6 +499,7 @@ fn onRawSignal(signal_number: std.posix.SIG) callconv(.c) void {
     const signal: zoxy.Io.Signal = switch (signal_number) {
         .TERM, .INT => .terminate,
         .USR1 => .dump_counters,
+        .HUP => .reopen_log,
         else => return,
     };
     global_io.notifySignalFromHandler(signal);

--- a/src/main.zig
+++ b/src/main.zig
@@ -90,7 +90,7 @@ pub fn main(init: std.process.Init) !void {
     const config = try readConfig(init.io, arena, config_path);
     const config_arena_bytes = init.arena.queryCapacity() - arena_before;
 
-    const cq_entries = try resolveBudgets(init.io, &config, config_arena_bytes);
+    const cq_entries = try resolveBudgets(&config, config_arena_bytes);
     const log_sink_fd = try openLogSinkFd(&config);
 
     // The ring is the config's to size (§5), count and unit both;
@@ -123,7 +123,6 @@ pub fn main(init: std.process.Init) !void {
 /// fd one, prints the banner, and returns the CQ depth the ring must be
 /// created with.
 fn resolveBudgets(
-    io: std.Io,
     config: *const zoxy.config.Config,
     config_arena_bytes: u64,
 ) !u32 {
@@ -149,7 +148,7 @@ fn resolveBudgets(
     // pools, the ring, and the fd demand all fit what the constants proved.
     assert(cq_entries <= zoxy.constants.completion_queue_entries);
     try ensureFdBudget(fds_required);
-    try printBudgets(io, config, fds_required, cq_entries, config_arena_bytes);
+    printBudgets(config, fds_required, cq_entries, config_arena_bytes);
     return cq_entries;
 }
 
@@ -267,7 +266,7 @@ const help_text =
     \\
     \\Signals:
     \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0.
-    \\  SIGUSR1           Dump counters to stdout.
+    \\  SIGUSR1           Dump counters to stderr.
     \\
 ;
 
@@ -354,8 +353,14 @@ fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
     };
 }
 
+/// The §5 banner, to **stderr**: the banner is diagnostics, and stdout
+/// belongs to the data an operator may point there — the access log's
+/// `stdout` sink must stay one uncontaminated JSON line per event.
+/// Stderr is where the counter dump already goes, and via the same
+/// `std.debug.print` plain-write path, so the two interleave whole-lines
+/// even when both land in one redirected file (a positional writer here
+/// would be silently overwritten by the dump's shared-offset writes).
 fn printBudgets(
-    io: std.Io,
     config: *const zoxy.config.Config,
     fds_required: u32,
     cq_entries: u32,
@@ -364,7 +369,7 @@ fn printBudgets(
     /// it is whatever the operator's config file needed — which is
     /// exactly why it is reported rather than derived.
     config_arena_bytes: u64,
-) !void {
+) void {
     const constants = zoxy.constants;
     // Every budget reflects the *effective* config (§5, §8): the config may
     // shrink the pools, the fd demand, and the requested ring below the
@@ -376,19 +381,49 @@ fn printBudgets(
         @intCast(config.listeners.len),
     );
     const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
-    const endpoint_stride = ServerXev.endpointKeysFor(config).stride;
     const sizes = poolSizesFor(config);
     // §5's promise is that the printed total covers everything this
     // process holds for its life. The config arena qualifies — it is
     // never freed — so it joins the total even though it is the one term
     // measured rather than derived from constants.
     const memory_total = constants.memoryBytesTotal(&sizes) + config_arena_bytes;
-    var buffer: [1024]u8 = undefined;
-    var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
-    const writer = &file_writer.interface;
+    // A banner that could print a zero total or zero fd demand would be
+    // reporting a proxy that reserved nothing — the closed form broke.
+    assert(memory_total > 0);
+    assert(fds_required > 0);
+    printMemoryBanner(config, &sizes, memory_total, access_log_bytes, config_arena_bytes);
+    std.debug.print(
+        \\  fds     {d} required (asserted against RLIMIT_NOFILE)
+        \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
+        \\  config  {d} listener(s), {d} cluster(s), access log {s}
+        \\
+    , .{
+        fds_required,
+        constants.ring_entries,
+        cq_entries,
+        in_flight,
+        config.listeners.len,
+        config.clusters.len,
+        if (config.access_log_sink) |sink| @tagName(sink) else "off",
+    });
+}
+
+/// The banner's version and memory lines — the §5 closed form itemized.
+/// Split from `printBudgets` for the length limit; the two prints are
+/// sequential same-thread writes to stderr, so nothing interleaves.
+fn printMemoryBanner(
+    config: *const zoxy.config.Config,
+    sizes: *const zoxy.constants.PoolSizes,
+    memory_total: u64,
+    access_log_bytes: u64,
+    config_arena_bytes: u64,
+) void {
+    assert(memory_total > 0);
+    assert(config.listeners.len >= 1);
+    const limits = config.limits;
     // The version leads, because this banner is what a bug report pastes
     // and `--version` is what it does not think to run.
-    try writer.print(
+    std.debug.print(
         \\zoxy {s}{s}
         \\budgets (DESIGN.md §5/§8; closed-form except where marked):
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
@@ -397,9 +432,6 @@ fn printBudgets(
         \\          + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + config arena {d} KiB (measured, not closed-form)
-        \\  fds     {d} required (asserted against RLIMIT_NOFILE)
-        \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
-        \\  config  {d} listener(s), {d} cluster(s), access log {s}
         \\
     , .{
         build_options.version,
@@ -415,24 +447,16 @@ fn printBudgets(
         // The +1 ownership byte stays out of the banner's per-unit figure;
         // the closed-form total above carries it.
         limits.head_buffer_bytes,
-        constants.bufferGroupDescriptorBytes(limits.head_buffers),
+        zoxy.constants.bufferGroupDescriptorBytes(limits.head_buffers),
         limits.upstream_head_buffers,
         sizes.upstream_head_buffer_bytes,
         sizes.head_scratch_bytes,
         access_log_bytes / 1024,
         ServerXev.endpointTableBytes(config),
         config.clusters.len,
-        endpoint_stride,
+        ServerXev.endpointKeysFor(config).stride,
         config_arena_bytes / 1024,
-        fds_required,
-        constants.ring_entries,
-        cq_entries,
-        in_flight,
-        config.listeners.len,
-        config.clusters.len,
-        if (config.access_log_sink) |sink| @tagName(sink) else "off",
     });
-    try writer.flush();
 }
 
 fn installSignalHandlers() void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -90,36 +90,18 @@ pub fn main(init: std.process.Init) !void {
     const config = try readConfig(init.io, arena, config_path);
     const config_arena_bytes = init.arena.queryCapacity() - arena_before;
 
-    // fds and the ring are sized to the *effective* config, not the
-    // compiled ceilings (§5, §8): a lean deployment neither demands the
-    // c10k RLIMIT_NOFILE nor asks the kernel for a 65536-deep ring.
-    const listeners_count: u32 = @intCast(config.listeners.len);
-    const fds_required = zoxy.constants.fdsRequired(
-        config.limits.conn_slots,
-        config.limits.upstream_slots,
-        listeners_count,
-    );
-    const cq_entries = zoxy.constants.completionQueueDepthFor(
-        config.limits.conn_slots,
-        config.limits.upstream_slots,
-        listeners_count,
-        config.limits.cq_fill_eighths,
-    );
-    // The effective config never exceeds the compiled ceilings (§8): the
-    // pools, the ring, and the fd demand all fit what the constants proved.
-
-    assert(cq_entries <= zoxy.constants.completion_queue_entries);
-    try ensureFdBudget(fds_required);
-    try printBudgets(init.io, &config, fds_required, cq_entries, config_arena_bytes);
+    const cq_entries = try resolveBudgets(init.io, &config, config_arena_bytes);
+    const log_sink_fd = try openLogSinkFd(&config);
 
     // The ring is the config's to size (§5), count and unit both;
     // Server.init asserts its own accounting against the same numbers.
     try global_io.init(
         arena,
         cq_entries,
-        listeners_count,
+        @intCast(config.listeners.len),
         config.limits.head_buffers,
         config.limits.head_buffer_bytes,
+        log_sink_fd,
     );
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
@@ -132,6 +114,65 @@ pub fn main(init: std.process.Init) !void {
     assert(server.isIdle());
     const gauges = server.gauges();
     server.counters.dump(&gauges);
+}
+
+/// The §5/§8 startup budget gauntlet: fds and the ring are sized to the
+/// *effective* config, not the compiled ceilings — a lean deployment
+/// neither demands the c10k RLIMIT_NOFILE nor asks the kernel for a
+/// 65536-deep ring. Derives both demands, raises RLIMIT_NOFILE to the
+/// fd one, prints the banner, and returns the CQ depth the ring must be
+/// created with.
+fn resolveBudgets(
+    io: std.Io,
+    config: *const zoxy.config.Config,
+    config_arena_bytes: u64,
+) !u32 {
+    const listeners_count: u32 = @intCast(config.listeners.len);
+    assert(listeners_count >= 1);
+    const access_log_files: u32 = if (config.access_log_sink) |sink|
+        @intFromBool(sink == .file)
+    else
+        0;
+    const fds_required = zoxy.constants.fdsRequired(
+        config.limits.conn_slots,
+        config.limits.upstream_slots,
+        listeners_count,
+        access_log_files,
+    );
+    const cq_entries = zoxy.constants.completionQueueDepthFor(
+        config.limits.conn_slots,
+        config.limits.upstream_slots,
+        listeners_count,
+        config.limits.cq_fill_eighths,
+    );
+    // The effective config never exceeds the compiled ceilings (§8): the
+    // pools, the ring, and the fd demand all fit what the constants proved.
+    assert(cq_entries <= zoxy.constants.completion_queue_entries);
+    try ensureFdBudget(fds_required);
+    try printBudgets(io, config, fds_required, cq_entries, config_arena_bytes);
+    return cq_entries;
+}
+
+/// The §8 access-log sink as the fd `XevIo` will write: the inherited
+/// stdout, or the file the config named — opened here, before the loop
+/// exists, so a path that cannot open stops the process while the banner
+/// above still names what it tried. The seam owns the syscall
+/// (`XevIo.openLogSink`); the error report is this caller's, because the
+/// path is the operator's own text.
+fn openLogSinkFd(config: *const zoxy.config.Config) !@TypeOf(XevIo.log_sink_stdout) {
+    const sink = config.access_log_sink orelse return XevIo.log_sink_stdout;
+    switch (sink) {
+        .stdout => return XevIo.log_sink_stdout,
+        .file => |path| {
+            // The loader rejected an empty path at parse (§8), so a
+            // failure here is the filesystem's answer, not a config shape.
+            assert(path.len >= 1);
+            return XevIo.openLogSink(path) catch |err| {
+                std.debug.print("zoxy: cannot open access log '{s}': {t}\n", .{ path, err });
+                return err;
+            };
+        },
+    }
 }
 
 /// Read and parse the config file, or say on stderr why it cannot be.


### PR DESCRIPTION
Three slices, one arc: the access log learns to write to a file, rotation works both ways, and stdout becomes a stream an operator can actually consume.

## 1. `"sink": "file"` + `"path"` (b621a3e)

Opens once at startup — append-only, created if absent, never truncated — and holds the fd for the process's life. `O_APPEND` is load-bearing twice: the fork submits the ring write at the fd's own position (offset −1), and it's what makes logrotate `copytruncate` safe. Validation follows the health-check precedent: `path` required by exactly the sink that uses it (`AccessLogPathMissing`), rejected beside the one that can't (`AccessLogPathOnStdout`). The schema names kinds via a new plain `AccessLogSinkKind`; only the resolved union carries the payload. `fdsRequired` gains its `access_log_files` term — naming a log file is not tuning, so the lean out-of-box promise absorbs it.

## 2. Banner → stderr (2f728ad)

The banner is diagnostics; stdout is the one stream an operator may point data at. With `sink: "stdout"` the log must be one uncontaminated JSON line per event — verified in a smoke: stdout carries nothing else. Diagnostics now share stderr with the counter dump via the same plain-write path, which also dissolves a real footgun: the old positional writer's banner was silently overwritten by the dump when both streams were redirected to one file. The bench's banner gate follows the pipe, and the drain forwards the piped stderr so the band review keeps the counter dump. (Also fixes `--help`'s claim that SIGUSR1 dumps to stdout — it never did.)

## 3. SIGHUP reopen (9ee5012, closes #167)

Move-based rotation: SIGHUP reopens the configured path, and that is the signal's *only* meaning — config reload is now a recorded §1 non-goal (startup-fixed pools ⇒ restart), which frees the conventional signal for the conventional job. The swap rides the sink's at-most-one-write discipline (`reopen_pending` fires at the in-flight write's completion — the ring never holds the fd being closed), opens new-before-closing-old so a failed rotation keeps a working log, and a successful one heals a `broken` sink. The reopen is two synchronous syscalls on the live loop — a priced, documented exception to the never-block rule (the async route is a fork op against the closed union, for an operator-paced event). The file-sink fd term becomes 2 (held + transient), rederiving `upstream_slots_default` 1313 → 1311 across the arc.

## Validation

- `zig build ci` (unit + 4096-seed sim, census extended with reasons), `zig fmt`, schema tool — green on every slice.
- Full Tier-1 bench run green with the stderr banner gate (bands overlap, RSS window 18.8 → 21.1 MiB under the 35.2 MiB ceiling, counter dump present in the run log via the new forward).
- Seven directed reopen tests (idle/deferred swap, failure-race heal, double-signal collapse, keep-old, heal, stdout no-op) plus config/fd-budget test updates.
- Live smokes: JSON lines land and append across restart; `mv` + SIGHUP moves new lines to a fresh file (`access_log_reopened 1`); `chmod 000` + SIGHUP keeps the old fd receiving (`access_log_reopen_failed 1`); bad path stops startup naming the path; per-slice tiger-style reviews applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)