### PR TITLE
PROXY protocol receive: hash routing learns the real client behind an LB (#142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ without inspecting them; `http` runs the HTTP/1.1 reverse proxy.
 ]
 ```
 
-Up to 8 listeners. Each is bound with `SO_REUSEPORT`, so running several
-zoxy processes on the same port is the supported way to use more than one
-core. Every connection — accepted and upstream alike — gets `TCP_NODELAY`
-unconditionally: Nagle plus delayed ACK costs a reused keep-alive connection
-a hard 40 ms stall, which is not worth a config knob.
+Listener count is bounded by your config's own ring and fd budgets,
+checked at startup, not by a compiled ceiling. Each is bound with
+`SO_REUSEPORT`, so running several zoxy processes on the same port is
+the supported way to use more than one core. Every connection —
+accepted and upstream alike — gets `TCP_NODELAY` unconditionally:
+Nagle plus delayed ACK costs a reused keep-alive connection a hard
+40 ms stall, which is not worth a config knob.
 
 ### Routing
 
@@ -170,6 +172,12 @@ prefix of an IPv6 one, so stickiness survives privacy-address rotation.
 The tradeoff is inherent to hashing on client address: NAT hides many clients
 behind one address, and one heavy client cannot be split. Prefer `p2c` where
 even load matters more than stickiness.
+
+The key is the *observed* client address, so behind another proxy or LB
+every connection carries that machine's address and the whole cluster
+hashes to one endpoint. See
+[Learning who the client is](#learning-who-the-client-is-proxy-protocol)
+for how an `l4` listener recovers the real client.
 
 ### Health checks
 
@@ -257,6 +265,49 @@ isn't. `zoxy_forwarded_chain_dropped` counts that.
 Filters may not set `X-Forwarded-For`; the loader rejects it. A filter
 can only write a constant, so it would pin one fixed address to every
 client — which looks like forwarding and is the opposite of it.
+
+### Learning who the client is (PROXY protocol)
+
+The mirror problem: put a load balancer in front of zoxy and *zoxy* sees
+only the balancer. That breaks more than logging — `pick: "hash"` keys
+on the client address, so behind an LB every connection hashes alike and
+the whole fleet lands on one endpoint. An `l4` listener can instead
+require each connection to open with a PROXY protocol header (v1 or v2 —
+what AWS NLB, GCP and HAProxy emit) announcing the real client:
+
+```json
+{
+    "bind": "0.0.0.0:5432",
+    "protocol": "l4",
+    "cluster": "postgres",
+    "proxy_protocol": { "mode": "require" }
+}
+```
+
+**`require` is the only mode, on purpose.** A listener that accepted a
+header *when one happens to show up* would let any client that can reach
+it choose its own address — and with it its own sticky backend and its
+own access-log lines. The PROXY protocol spec forbids that of receivers,
+and HAProxy gates the same feature behind an explicit `accept-proxy` for
+the same reason. So a `require` listener closes any connection that does
+not open with a valid header: it is unusable by anything except the
+proxy configured in front of it, which is the point. Turn it on only
+where the listener is reachable exclusively through that proxy.
+
+What the header announces is what zoxy believes everywhere the client
+address is consumed: the hash pick, the access log's `client` field. A
+header that announces nothing — v1 `UNKNOWN`, v2 `LOCAL`, the shapes a
+balancer's own health checks arrive in — is accepted and keeps the
+observed peer. Headers are size-capped at 512 bytes (v2 TLVs within the
+cap are skipped; a declared length past it is refused at once), and
+header bytes never count toward the log's `bytes_in` — only payload
+does.
+
+`zoxy_l4_proxy_header_accepted` and `zoxy_l4_proxy_header_invalid`
+count the verdicts; a rising `invalid` means something that is not the
+configured proxy is reaching the listener — exactly what the mode
+exists to refuse. `http` listeners reject the block for now: the L7
+receive phase does not exist yet.
 
 ### Filters
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -594,11 +594,15 @@ Rules:
 The minimal proxy:
 
 ```
-accept → admit (slots? buffers?) → route by listener → connect upstream
+accept → admit (slots? buffers?) → route by listener
+       → [require? read PROXY header] → connect upstream
        → bidirectional relay → teardown on either EOF/error/deadline
 ```
 
-- A listener is bound to a cluster in config; no parsing, no inspection.
+- A listener is bound to a cluster in config; no parsing, no inspection
+  *of the payload*. The one exception is opt-in and runs ahead of it: a
+  `proxy_protocol` listener consumes one bounded PROXY-protocol header
+  before the dial (below), and after that the relay is as blind as ever.
 - Relay buffers (one per direction) are acquired at admission and held
   for the connection's life — a recv must always have a buffer posted —
   so `relay_buffers`, not connection slots, bounds concurrent L4
@@ -612,6 +616,41 @@ accept → admit (slots? buffers?) → route by listener → connect upstream
 - Half-close is honored (`shutdown` propagates FIN); the connection ends
   when both directions have drained or the deadline fires.
 - Idle timeout and max-lifetime ride the single deadline timer.
+- **Receiving PROXY protocol** (`"proxy_protocol": { "mode": "require" }`,
+  #142). Behind another proxy the observed peer is that proxy, and the
+  client address is a *routing input* — §7's `hash` keys on it, so an LB
+  in front does not merely blur the logs, it collapses the whole fleet
+  onto one endpoint. A `require` listener demands every connection open
+  with a PROXY protocol header (v1 or v2 — what AWS NLB, GCP and HAProxy
+  emit) announcing the real client, parsed before the dial because the
+  dial consumes the address. The trust shape is `forwarded`'s (§7),
+  inverted to the receive side: per listener, no default, and **no
+  sniffing arm** — a listener that accepted a header only when one shows
+  up would let any client choose the address that routing, the access
+  log, and the origin then believe, which the spec forbids of receivers.
+  `require` therefore closes any connection that does not open with a
+  valid header, making the listener unusable by anything but the proxy
+  configured in front of it — that is the point. A header that announces
+  nothing (v1 `UNKNOWN`, v2 `LOCAL` — how a fronting balancer's own
+  health checks arrive) is accepted and keeps the observed peer.
+  Mechanically the phase costs nothing new: it stages in the relay
+  buffer's client→upstream half (held since admission, idle until the
+  relay starts), runs under the connect budget — the fronting proxy
+  speaks immediately after connecting, and the hand-over's fresh dial
+  deadline then only ever moves *later*, which the lazy timer absorbs
+  without a rebase (§4) — re-parses from byte 0 per delivery against a
+  parser whose verdicts are monotonic (a prefix of a valid header is
+  never `invalid`), and enters the relay with any coalesced payload
+  pre-staged as the first send. The header is bounded by
+  `proxy_header_bytes_max` (512: admits both specs' largest fixed
+  address blocks and real TLVs — the v2 length field is the peer's
+  number, the cap is ours) and never counts toward `bytes_in`; the
+  verdicts are `l4_proxy_header_accepted` / `l4_proxy_header_invalid`,
+  the latter deliberately outside the `shed_` gate identity because the
+  connection was admitted before it could be judged (§9). IPv4-mapped
+  IPv6 announcements unwrap to the IPv4 address they are — the accept
+  path's own normalization — so one client hashes one way however its
+  address was conveyed.
 
 ## 7. L7 data path — HTTP/1.1 reverse proxy
 
@@ -853,6 +892,11 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   clients of the flapping endpoint, who are already affected by it.
   And source-IP hashing balances by *client*, not by request: NAT puts
   many clients on one address, and one heavy client cannot be split.
+  It also balances by the *observed* client: behind another proxy every
+  connection carries that proxy's address, so the key is one value and
+  the whole cluster hashes to a single endpoint — stickiness inverted,
+  not degraded. `proxy_protocol` on the listener (§6) is what makes
+  `source_ip` mean the real client there.
 - **Active health checks** are per-cluster opt-in (a `check` block —
   HAProxy's model) so a request is not routed to an endpoint known to be
   down:
@@ -1253,6 +1297,7 @@ src/
     Pool.zig          // Pool(T): startup alloc, intrusive free list
   net/
     Conn.zig          // connection slot: state, completions, head-ring claim
+    proxy_protocol.zig // PROXY v1/v2 header parse: pure, total, monotonic (§6)
     relay.zig         // strict recv→send→recv relay (L4 + L7 bodies)
     upstream.zig      // shared upstream pool + endpoint idle lists + head pool
   http/

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -33,6 +33,8 @@ const assert = std.debug.assert;
 const Harness = @This();
 
 const clients_max: u8 = 6;
+/// "203.0.113.255:65535" is 19 bytes; the slack is headroom, not hope.
+const announced_bytes_max: u8 = 32;
 /// Virtual time from scenario start after which stuck work is force-ended.
 const scenario_end_ns: u64 = 2_000_000_000;
 /// The slowest §7 probe pacing a non-outage seed may draw. Named so the
@@ -70,6 +72,14 @@ origin: Origin,
 origin_http: HttpOrigin,
 clients: [clients_max]EchoClient,
 l7_clients: [clients_max]HttpClient,
+/// The #142 gate drawn for the l4 listener; `populateClients` reads it
+/// to decide whether its clients open with headers.
+proxy_protocol_l4: ?zoxy.config.Config.Listener.ProxyProtocol,
+/// Per-L4-client address its header announced (len 0 = none): distinct
+/// per client, so `verifyAccessLog` can demand the log states each one
+/// on clean seeds — presence is attribution.
+l4_announced: [clients_max][announced_bytes_max]u8,
+l4_announced_len: [clients_max]u8,
 l4_count: u8,
 l7_count: u8,
 clients_count: u8,
@@ -417,6 +427,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     };
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
+    harness.proxy_protocol_l4 = deriveProxyProtocol(random);
     harness.wireListeners(deriveForwarded(random));
     harness.config = .{
         .listeners = &harness.listener_configs,
@@ -574,6 +585,21 @@ fn deriveForwarded(random: std.Random) ?zoxy.config.Config.Listener.Forwarded {
     };
 }
 
+/// The #142 receive gate on the l4 listener: a third of seeds require a
+/// PROXY header, clean seeds included — the phase is deterministic, so a
+/// clean seed's headers always complete and the golden oracles gain the
+/// accept path, while adversarial seeds split headers across deliveries
+/// and cut them mid-read. Like `deriveForwarded`, the mode alone is not
+/// coverage: what the clients *send* decides which verdict fires, and
+/// `deriveProxyHeader` scripts that spread — including no header at all,
+/// which is the refusal `require` exists to make.
+fn deriveProxyProtocol(random: std.Random) ?zoxy.config.Config.Listener.ProxyProtocol {
+    if (random.uintLessThan(u8, 3) == 0) {
+        return .require;
+    }
+    return null;
+}
+
 fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
     harness.filters_http = .{
         .{
@@ -590,7 +616,12 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
         },
     };
     harness.listener_configs = .{
-        .{ .bind_address = bindAddress(), .routes = &harness.routes_l4, .protocol = .l4 },
+        .{
+            .bind_address = bindAddress(),
+            .routes = &harness.routes_l4,
+            .protocol = .l4,
+            .proxy_protocol = harness.proxy_protocol_l4,
+        },
         .{
             .bind_address = httpBindAddress(),
             .routes = &harness.routes_http,
@@ -680,6 +711,7 @@ fn populateClients(harness: *Harness, random: std.Random) void {
     harness.ended_count = 0;
     harness.clients = @splat(.{});
     harness.l7_clients = @splat(.{});
+    harness.l4_announced_len = @splat(0);
     var index: u8 = 0;
     while (index < harness.clients_count) : (index += 1) {
         if (random.boolean()) {
@@ -695,17 +727,102 @@ fn populateClients(harness: *Harness, random: std.Random) void {
             client.context = harness;
         } else {
             const client = &harness.clients[harness.l4_count];
+            const l4_index = harness.l4_count;
             harness.l4_count += 1;
             var token: [l4.token_bytes_max]u8 = undefined;
             const token_len = 1 + random.uintLessThan(u8, l4.token_bytes_max);
             random.bytes(token[0..token_len]);
             const silent = random.uintLessThan(u8, 5) == 0;
-            client.prepare(&harness.io, bindAddress(), token[0..token_len], silent);
+            // A silent client sends nothing, header included: on a
+            // require-listener it is the connect-budget reap's fodder,
+            // and drawing it a header it would never send would teach
+            // `verifyAccessLog` to demand an announcement that never
+            // crossed the wire.
+            var prefix_buffer: [l4.prefix_bytes_max]u8 = undefined;
+            const prefix = if (silent)
+                ""
+            else
+                harness.deriveProxyHeader(random, l4_index, &prefix_buffer);
+            client.prepare(
+                &harness.io,
+                bindAddress(),
+                token[0..token_len],
+                prefix,
+                silent,
+            );
             client.on_ended = clientEndedHook;
             client.context = harness;
         }
     }
     assert(harness.l4_count + harness.l7_count == harness.clients_count);
+}
+
+/// The header an L4 client opens with when the listener requires one
+/// (#142), or "" — the gate off, or one draw in six sending nothing so
+/// the sweep reaches the refusal too (the random token then opens the
+/// stream, and `require` closes on its first byte; the rare token that
+/// happens to open like a header meets the connect-budget reap instead).
+/// The spread covers both spec versions and both verdict families:
+/// announcing headers (v1 TCP4, v2 INET) carry a per-client distinct
+/// address that is recorded for the clean-seed log oracle, and
+/// non-announcing ones (v1 UNKNOWN, v2 LOCAL) are the health-check shape
+/// that must keep the observed peer.
+fn deriveProxyHeader(
+    harness: *Harness,
+    random: std.Random,
+    l4_index: u8,
+    buffer: *[l4.prefix_bytes_max]u8,
+) []const u8 {
+    assert(l4_index < clients_max);
+    assert(harness.l4_announced_len[l4_index] == 0);
+    if (harness.proxy_protocol_l4 == null) {
+        return "";
+    }
+    const octet: u8 = l4_index + 1;
+    const port: u16 = 40_000 + @as(u16, l4_index);
+    switch (random.uintLessThan(u8, 6)) {
+        0 => return "",
+        1 => return "PROXY UNKNOWN\r\n",
+        2 => {
+            // v2 LOCAL: a fronting proxy's health check.
+            @memcpy(buffer[0..16], "\r\n\r\n\x00\r\nQUIT\n" ++ "\x20\x00\x00\x00");
+            return buffer[0..16];
+        },
+        3 => {
+            // v2 PROXY INET announcing 203.0.113.<octet>:<port>.
+            @memcpy(buffer[0..16], "\r\n\r\n\x00\r\nQUIT\n" ++ "\x21\x11\x00\x0c");
+            buffer[16..20].* = .{ 203, 0, 113, octet };
+            buffer[20..24].* = .{ 10, 0, 0, 1 };
+            std.mem.writeInt(u16, buffer[24..26], port, .big);
+            std.mem.writeInt(u16, buffer[26..28], 443, .big);
+            harness.recordAnnounced(l4_index, octet, port);
+            return buffer[0..28];
+        },
+        else => {
+            // v1 TCP4, the same announcement in text.
+            const line = std.fmt.bufPrint(
+                buffer,
+                "PROXY TCP4 203.0.113.{d} 10.0.0.1 {d} 443\r\n",
+                .{ octet, port },
+            ) catch unreachable; // 46 bytes at most, into 64.
+            harness.recordAnnounced(l4_index, octet, port);
+            return line;
+        },
+    }
+}
+
+fn recordAnnounced(harness: *Harness, l4_index: u8, octet: u8, port: u16) void {
+    assert(l4_index < clients_max);
+    const text = std.fmt.bufPrint(
+        &harness.l4_announced[l4_index],
+        "203.0.113.{d}:{d}",
+        .{ octet, port },
+    ) catch unreachable; // 19 bytes at most, into announced_bytes_max.
+    // The shortest form is "203.0.113.1:40000"; anything outside the
+    // template's range means the format string drifted from the record.
+    assert(text.len >= 17);
+    assert(text.len <= 19);
+    harness.l4_announced_len[l4_index] = @intCast(text.len);
 }
 
 pub fn startClients(harness: *Harness) void {
@@ -851,6 +968,35 @@ fn verifyAccessLog(harness: *Harness) !void {
         // silent clients (`sim/l4.zig` draws some) owe a line, theirs
         // reporting `bytes_in: 0`.
         if (tally.l4 != harness.l4_count) return error.AccessLogL4LinesDiverged;
+        try harness.verifyAnnouncedClients(sink);
+    }
+}
+
+/// #142, clean seeds only: a client that announced an address via its
+/// PROXY header must be logged *as* that address — the same field the §7
+/// hash pick keys on, so this is the sweep's witness that the header is
+/// believed, not merely consumed (reverting the one believe-the-header
+/// line fails seed 20 here). Adversarial seeds are excluded because a cut
+/// mid-header rightly logs the observed peer; that a clean seed's header
+/// always completes ahead of any drawn deadline is the same pacing
+/// argument the clean-abort check above rests on. The addresses are
+/// distinct per client, so presence is attribution.
+fn verifyAnnouncedClients(harness: *const Harness, sink: []const u8) !void {
+    assert(harness.clean);
+    assert(harness.l4_count <= clients_max);
+    var l4_index: u8 = 0;
+    while (l4_index < harness.l4_count) : (l4_index += 1) {
+        const announced_len = harness.l4_announced_len[l4_index];
+        if (announced_len == 0) continue;
+        var needle_buffer: [announced_bytes_max + 11]u8 = undefined;
+        const needle = std.fmt.bufPrint(
+            &needle_buffer,
+            "\"client\":\"{s}\"",
+            .{harness.l4_announced[l4_index][0..announced_len]},
+        ) catch unreachable; // The key wrapper is exactly 11 bytes.
+        if (std.mem.indexOf(u8, sink, needle) == null) {
+            return error.AccessLogAnnouncedClientMissing;
+        }
     }
 }
 

--- a/sim/l4.zig
+++ b/sim/l4.zig
@@ -5,6 +5,12 @@
 //! oracle). Integrity invariant: every byte received must be a prefix of
 //! the token sent — the proxy may cut a stream short, but it must never
 //! corrupt or reorder it.
+//!
+//! A client may open with a scripted prefix ahead of the token — the
+//! PROXY protocol header a `proxy_protocol` listener requires (#142).
+//! The prefix is never part of the echo expectation: a proxy that
+//! relayed header bytes to the origin fails the integrity oracle as an
+//! overrun or corruption, with no #142-specific check needed.
 
 const std = @import("std");
 
@@ -15,6 +21,9 @@ const Io = zoxy.Io;
 const assert = std.debug.assert;
 
 pub const token_bytes_max: u8 = 48;
+/// Fits every header shape the harness scripts (#142): the longest is a
+/// v1 TCP4 line at 46 bytes; v2 LOCAL and INET are 16 and 28.
+pub const prefix_bytes_max: u8 = 64;
 
 /// A verify-time verdict over everything the client received.
 pub const ClientError = error{
@@ -38,6 +47,11 @@ pub fn Client(comptime IoType: type) type {
         send_completion: IoType.Completion = .{},
         token: [token_bytes_max]u8 = undefined,
         token_len: u8 = 0,
+        /// Sent ahead of the token — a PROXY protocol header (#142) for
+        /// `proxy_protocol` scenarios; empty for everyone else.
+        prefix: [prefix_bytes_max]u8 = undefined,
+        prefix_len: u8 = 0,
+        prefix_sent: u8 = 0,
         receive_buffer: [token_bytes_max]u8 = undefined,
         /// Once the echo is complete, the recv waiting on the FIN lands
         /// here; any byte that arrives is an integrity violation.
@@ -63,15 +77,19 @@ pub fn Client(comptime IoType: type) type {
             io: *IoType,
             address: std.Io.net.IpAddress,
             token: []const u8,
+            prefix: []const u8,
             silent: bool,
         ) void {
             assert(token.len >= 1);
             assert(token.len <= token_bytes_max);
+            assert(prefix.len <= prefix_bytes_max);
             client.io = io;
             client.address = address;
             client.silent = silent;
             @memcpy(client.token[0..token.len], token);
             client.token_len = @intCast(token.len);
+            @memcpy(client.prefix[0..prefix.len], prefix);
+            client.prefix_len = @intCast(prefix.len);
         }
 
         pub fn begin(client: *Self) void {
@@ -99,12 +117,19 @@ pub fn Client(comptime IoType: type) type {
         }
 
         fn armSend(client: *Self) void {
-            assert(client.sent_len < client.token_len);
             assert(!client.send_pending);
             client.send_pending = true;
+            // The prefix goes first, then the token — two cursors, one
+            // send in flight, resumed from whichever is still short.
+            const bytes = if (client.prefix_sent < client.prefix_len)
+                client.prefix[client.prefix_sent..client.prefix_len]
+            else blk: {
+                assert(client.sent_len < client.token_len);
+                break :blk client.token[client.sent_len..client.token_len];
+            };
             client.io.send(
                 client.socket,
-                client.token[client.sent_len..client.token_len],
+                bytes,
                 &client.send_completion,
                 Self,
                 client,
@@ -119,11 +144,20 @@ pub fn Client(comptime IoType: type) type {
                 client.settleIfTerminal();
                 return;
             };
-            client.sent_len += sent;
-            assert(client.sent_len <= client.token_len);
+            if (client.prefix_sent < client.prefix_len) {
+                // A send never spans the cursor seam: it was armed on the
+                // prefix alone, so the credit is the prefix's.
+                client.prefix_sent += @intCast(sent);
+                assert(client.prefix_sent <= client.prefix_len);
+            } else {
+                client.sent_len += sent;
+                assert(client.sent_len <= client.token_len);
+            }
             if (client.recv_terminal) {
                 client.settleIfTerminal();
-            } else if (client.sent_len < client.token_len) {
+            } else if (client.prefix_sent < client.prefix_len or
+                client.sent_len < client.token_len)
+            {
                 client.armSend();
             }
         }

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -193,6 +193,20 @@ const uncovered = [_]Uncovered{
             "is a directed-test control; src/access_log_test.zig covers " ++
             "the keep-the-old-sink arm",
     },
+    .{
+        .name = "l4_proxy_header_accepted",
+        .why = .unreached,
+        .reason = "no sweep listener requires PROXY protocol yet — the #142 " ++
+            "receive-phase scripts are the next slice; " ++
+            "src/server_test.zig drives the accept path meanwhile",
+    },
+    .{
+        .name = "l4_proxy_header_invalid",
+        .why = .unreached,
+        .reason = "same gap as l4_proxy_header_accepted: no require-mode " ++
+            "listener in the sweep until the #142 scripts land; " ++
+            "src/server_test.zig drives the reject path meanwhile",
+    },
 };
 
 comptime {

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -193,20 +193,6 @@ const uncovered = [_]Uncovered{
             "is a directed-test control; src/access_log_test.zig covers " ++
             "the keep-the-old-sink arm",
     },
-    .{
-        .name = "l4_proxy_header_accepted",
-        .why = .unreached,
-        .reason = "no sweep listener requires PROXY protocol yet — the #142 " ++
-            "receive-phase scripts are the next slice; " ++
-            "src/server_test.zig drives the accept path meanwhile",
-    },
-    .{
-        .name = "l4_proxy_header_invalid",
-        .why = .unreached,
-        .reason = "same gap as l4_proxy_header_accepted: no require-mode " ++
-            "listener in the sweep until the #142 scripts land; " ++
-            "src/server_test.zig drives the reject path meanwhile",
-    },
 };
 
 comptime {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -25,6 +25,7 @@ const Pool = @import("mem/Pool.zig").Pool;
 const proxy = @import("http/proxy.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
+const proxy_protocol = @import("net/proxy_protocol.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
 const upstream_module = @import("net/upstream.zig");
@@ -632,7 +633,14 @@ pub fn Server(comptime IoType: type) type {
                 .http => null,
             };
             server.finishAdmission(conn, client_socket, buffer, state);
-            server.startProtocol(conn, state.protocol);
+            if (state.proxy_protocol != null) {
+                // The loader rejects the block on an http listener, so a
+                // non-null here can only be an l4 one (#142).
+                assert(state.protocol == .l4);
+                server.startProxyHeaderPhase(conn);
+            } else {
+                server.startProtocol(conn, state.protocol);
+            }
         }
 
         /// The state a protocol's connection starts serving in, in one
@@ -668,10 +676,10 @@ pub fn Server(comptime IoType: type) type {
         /// fork happens after the handshake rather than at accept.
         ///
         /// It takes the protocol as an argument rather than reading it off
-        /// the slot deliberately: on this branch the second caller does not
-        /// exist, and a field with one writer and one reader would be state
-        /// kept for a caller that is not here (§1). The phase that needs to
-        /// recall a connection's protocol is the one that should decide how.
+        /// the slot deliberately: a field with one writer and one reader
+        /// would be state kept for the caller's convenience (§1), and both
+        /// callers — admission, and the PROXY-header phase's hand-over
+        /// (#142) — know the protocol without asking.
         ///
         /// The state and deadline stores are idempotent at admission — the
         /// tail below set exactly these values from the same protocol, and
@@ -680,12 +688,17 @@ pub fn Server(comptime IoType: type) type {
         /// between the two writes — and they are load-bearing for a
         /// hand-over, which arrives in whatever state its phase ran in.
         /// Keeping them here is what makes both callers a single call.
+        ///
+        /// No `!draining` assert, deliberately: admission's path asserts
+        /// it at `admit`, but a hand-over may legally complete mid-drain —
+        /// an admitted connection finishing its work is exactly what the
+        /// drain waits for (§8), so the phase proceeds to the dial and the
+        /// drain timer bounds it like any other straggler.
         fn startProtocol(
             server: *Self,
             conn: *ConnType,
             protocol: config_module.Config.Listener.Protocol,
         ) void {
-            assert(!server.draining);
             assert(!conn.isTearingDown());
             // The one timer this connection ever arms is already armed
             // (§4: a state transition only ever *stores* a new deadline).
@@ -860,6 +873,128 @@ pub fn Server(comptime IoType: type) type {
         fn releaseConn(server: *Self, conn: *ConnType) void {
             server.conns.release(conn);
             server.updateConnPressure();
+        }
+
+        /// Enter the §6 PROXY-protocol receive phase (#142) on an admitted
+        /// L4 connection: read the fronting proxy's header before the dial,
+        /// because the dial consumes `client_address` (the hash pick, §7)
+        /// and the header is what makes that the real client. Runs under
+        /// the connect budget `finishAdmission` already stored — the
+        /// fronting proxy speaks immediately after connecting, so a silent
+        /// peer is reaped on a dial-scale clock, and the hand-over's fresh
+        /// connect deadline only ever moves *later*, which the lazily
+        /// re-armed timer absorbs without a rebase (§4).
+        fn startProxyHeaderPhase(server: *Self, conn: *ConnType) void {
+            assert(!conn.isTearingDown());
+            assert(conn.state == .connecting);
+            assert(conn.relay_buffer != null);
+            assert(conn.armed.deadline);
+            assert(conn.head_len == 0);
+            conn.state = .l4_reading_proxy_header;
+            server.armProxyHeaderRecv(conn);
+        }
+
+        /// One recv into the staging window past what has accumulated.
+        /// The window ends at the cap, not the buffer: a header the cap
+        /// rejects should be rejected by the parser's verdict, never by
+        /// outreading the staging the §5 budget assigned this phase.
+        fn armProxyHeaderRecv(server: *Self, conn: *ConnType) void {
+            assert(conn.state == .l4_reading_proxy_header);
+            assert(conn.relay_buffer != null);
+            assert(conn.head_len < constants.proxy_header_bytes_max);
+            const staging = conn.relay_buffer.?
+                .client_to_upstream[0..constants.proxy_header_bytes_max];
+            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            server.io.recv(
+                conn.client_socket,
+                staging[conn.head_len..],
+                &conn.op_data_client_to_upstream.completion,
+                ConnType,
+                conn,
+                onProxyHeaderRecv,
+            );
+        }
+
+        /// Accumulate and re-judge from byte 0 (detect-and-retry, §7's
+        /// discipline): the parser's verdicts are monotonic, so a partial
+        /// header reads `need_more` until its last byte lands.
+        fn onProxyHeaderRecv(conn: *ConnType, result: Io.RecvError!u32) void {
+            const server = conn.server;
+            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            if (conn.isTearingDown()) {
+                server.continueTeardown(conn);
+                return;
+            }
+            assert(conn.state == .l4_reading_proxy_header);
+            const received = result catch |err| {
+                if (err == error.EndOfStream) {
+                    // A peer that hangs up mid-header was not the
+                    // configured proxy; same verdict as garbage bytes.
+                    server.counters.increment("l4_proxy_header_invalid");
+                } else {
+                    server.witnessKernelPressure(.recv, err);
+                }
+                server.beginTeardown(conn);
+                return;
+            };
+            assert(received >= 1);
+            conn.head_len += received;
+            assert(conn.head_len <= constants.proxy_header_bytes_max);
+            const staged = conn.relay_buffer.?.client_to_upstream[0..conn.head_len];
+            const parsed = proxy_protocol.parse(staged);
+            switch (parsed) {
+                .need_more => server.armProxyHeaderRecv(conn),
+                .invalid => {
+                    server.counters.increment("l4_proxy_header_invalid");
+                    server.beginTeardown(conn);
+                },
+                .ok => |*header| server.finishProxyHeader(conn, header),
+            }
+        }
+
+        /// The hand-over (#142): believe the header, stage any coalesced
+        /// payload as the relay's opening debt, and start the protocol —
+        /// `startProtocol`'s anticipated second caller.
+        fn finishProxyHeader(
+            server: *Self,
+            conn: *ConnType,
+            header: *const proxy_protocol.Header,
+        ) void {
+            assert(conn.state == .l4_reading_proxy_header);
+            assert(header.bytes_len >= 1);
+            assert(header.bytes_len <= conn.head_len);
+            server.counters.increment("l4_proxy_header_accepted");
+            // Null keeps the observed peer (LOCAL/UNKNOWN, §6): the
+            // fronting proxy's own health checks arrive that way.
+            if (header.client) |client| {
+                conn.client_address = client;
+            }
+            const leftover_len = conn.head_len - header.bytes_len;
+            if (leftover_len >= 1) {
+                // Payload the last recv delivered behind the header. Move
+                // it to the buffer's start and frame it as the client→
+                // upstream direction's debt; `Relay.start` enters the
+                // pump mid-cycle on exactly this state.
+                const staging = &conn.relay_buffer.?.client_to_upstream;
+                std.mem.copyForwards(
+                    u8,
+                    staging[0..leftover_len],
+                    staging[header.bytes_len..conn.head_len],
+                );
+                // The payload is client bytes that crossed the wire — the
+                // access log's `bytes_in` unit (§8) — which the relay's
+                // own counting will never see; the header is metadata the
+                // origin never receives, so it stays uncounted.
+                conn.log.bytes_in += leftover_len;
+                const direction = &conn.directions[
+                    @intFromEnum(ConnType.Direction.client_to_upstream)
+                ];
+                assert(direction.phase == .idle);
+                direction.phase = .receiving;
+                direction.owe(leftover_len);
+            }
+            conn.head_len = 0;
+            server.startProtocol(conn, .l4);
         }
 
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
@@ -1569,8 +1704,9 @@ pub fn Server(comptime IoType: type) type {
         /// timely response from the upstream — a connect that never
         /// completes is exactly that) via the one connect cancel outside
         /// teardown; a refused dial keeps its prompt 502. Every other
-        /// state (L4, head read's slowloris, the static-response drain, a
-        /// pending verdict) tears down as before.
+        /// state (L4 — its PROXY-header read included, whose silent peer
+        /// this is the reaper for — head read's slowloris, the
+        /// static-response drain, a pending verdict) tears down as before.
         fn expireDeadline(server: *Self, conn: *ConnType) void {
             assert(!conn.isTearingDown());
             assert(!conn.armed.deadline); // Delivered; re-armed only below.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -179,6 +179,11 @@ pub fn Server(comptime IoType: type) type {
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
             forwarded: ?config_module.Config.Listener.Forwarded,
+            /// The listener's PROXY protocol expectation (#142, null =
+            /// first bytes are payload). Read at admission only — the
+            /// receive phase is entered before the connection has any
+            /// state of its own — so nothing is copied onto the conn.
+            proxy_protocol: ?config_module.Config.Listener.ProxyProtocol,
             /// Copied from config so admission forks without reaching back
             /// through the listener index (§6, §7).
             protocol: config_module.Config.Listener.Protocol,
@@ -354,6 +359,7 @@ pub fn Server(comptime IoType: type) type {
                     .routes = listener_config.routes,
                     .filters = listener_config.filters,
                     .forwarded = listener_config.forwarded,
+                    .proxy_protocol = listener_config.proxy_protocol,
                     .protocol = listener_config.protocol,
                     .accepting = false,
                 };

--- a/src/config.zig
+++ b/src/config.zig
@@ -162,6 +162,13 @@ pub const Config = struct {
         /// the same cluster may be reachable from an edge listener that
         /// must not trust an inbound chain and an internal one that must.
         forwarded: ?Forwarded = null,
+        /// Whether every connection on this listener must open with a
+        /// PROXY protocol header announcing the real client (§6, #142),
+        /// or null to treat first bytes as payload — the behavior of
+        /// every config predating this. Per listener, like `forwarded`
+        /// and for the same reason: it states what sits in front of this
+        /// socket. `l4` only until the L7 receive phase exists.
+        proxy_protocol: ?ProxyProtocol = null,
 
         /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
         /// `http` runs the HTTP/1.1 reverse-proxy state machine. The
@@ -187,6 +194,22 @@ pub const Config = struct {
             /// only where every hop in front is one you control —
             /// anywhere else it is the forgery above, appended to.
             append,
+        };
+
+        /// What a listener expecting PROXY protocol does about it
+        /// (#142). One arm today; a closed enum rather than a bool
+        /// (`HashKey`'s shape) so a CIDR-gated variant is a new arm
+        /// rather than a new mechanism. There is deliberately no arm
+        /// that *sniffs*: a listener accepting header-or-raw-bytes lets
+        /// any client choose the address that routing (`pick: hash`
+        /// keys on `client_address`, §7) and the access log then
+        /// believe, which is why the spec forbids it of receivers.
+        pub const ProxyProtocol = enum(u1) {
+            /// Every connection must open with a valid v1 or v2 header;
+            /// anything else is closed. This makes the listener
+            /// unusable by anything except the proxy configured in
+            /// front of it — that is the point.
+            require,
         };
     };
 
@@ -320,6 +343,8 @@ pub const ValidationError = error{
     ListenerL4Filters,
     ListenerL4Forwarded,
     ListenerForwardedModeUnknown,
+    ListenerHttpProxyProtocol,
+    ListenerProxyProtocolModeUnknown,
     FilterMethodEmpty,
     FilterMethodUnknown,
     FilterHeaderMatchKind,
@@ -790,6 +815,9 @@ pub const ListenerJson = struct {
     /// Optional §7 client-address forwarding; absent leaves the header
     /// untouched. HTTP-only — an l4 relay has no header to carry it.
     forwarded: ?ForwardedJson = null,
+    /// Optional PROXY protocol expectation (#142); absent treats first
+    /// bytes as payload. L4-only until the L7 receive phase exists.
+    proxy_protocol: ?ProxyProtocolJson = null,
 
     pub const schema_doc =
         "One accepting socket. Exactly one of `cluster` or `routes` selects " ++
@@ -812,6 +840,11 @@ pub const ListenerJson = struct {
             .desc = "Tell the origin the client's address via X-Forwarded-For " ++
                 "(http listeners only); absent leaves the header untouched.",
         },
+        .proxy_protocol = .{
+            .desc = "Expect a PROXY protocol header (v1 or v2) ahead of every " ++
+                "connection's payload (l4 listeners only); absent treats first " ++
+                "bytes as payload.",
+        },
     };
 };
 
@@ -830,6 +863,26 @@ pub const ForwardedJson = struct {
                 "(use at the edge). append: extend the inbound chain with the observed " ++
                 "peer (use only when every hop in front is trusted).",
             .enum_type = Config.Listener.Forwarded,
+        },
+    };
+};
+
+pub const ProxyProtocolJson = struct {
+    mode: []const u8,
+
+    pub const schema_doc =
+        "Whether this listener expects the proxy in front of it to announce " ++
+        "each client with a PROXY protocol header. There is no sniffing mode " ++
+        "— accepting a header only when one shows up would let any client " ++
+        "pick the address that routing and logging then believe — and `mode` " ++
+        "is stated even with one value today, so future modes extend a " ++
+        "vocabulary rather than change what absence means.";
+    pub const schema_fields = .{
+        .mode = .{
+            .desc = "require: every connection must open with a valid v1 or v2 " ++
+                "header; anything else is closed. Only meaningful when the " ++
+                "listener is reachable exclusively through the fronting proxy.",
+            .enum_type = Config.Listener.ProxyProtocol,
         },
     };
 };
@@ -1251,11 +1304,11 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// block below runs `assert_meta_matches` on each at comptime, so the
 /// metadata cannot drift from the fields whether or not the emitter builds.
 pub const dto_types = .{
-    ConfigJson,    ListenerJson,    RouteJson,    FilterJson,
-    MatchJson,     HeaderMatchJson, ActionJson,   HeaderEditJson,
-    RewriteJson,   ClusterJson,     TimeoutsJson, LimitsJson,
-    AdminJson,     AccessLogJson,   CheckJson,    ClusterHashJson,
-    ForwardedJson,
+    ConfigJson,    ListenerJson,      RouteJson,    FilterJson,
+    MatchJson,     HeaderMatchJson,   ActionJson,   HeaderEditJson,
+    RewriteJson,   ClusterJson,       TimeoutsJson, LimitsJson,
+    AdminJson,     AccessLogJson,     CheckJson,    ClusterHashJson,
+    ForwardedJson, ProxyProtocolJson,
 };
 
 comptime {
@@ -1392,6 +1445,7 @@ fn resolveListeners(
             .filters = try resolveFilters(arena, &listener_json, protocol, head_buffer_bytes),
             .protocol = protocol,
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
+            .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
         };
     }
 
@@ -1937,6 +1991,23 @@ fn resolveForwarded(
     }
     return std.meta.stringToEnum(Config.Listener.Forwarded, forwarded.mode) orelse
         error.ListenerForwardedModeUnknown;
+}
+
+/// Resolve a listener's PROXY protocol expectation (#142): absent is
+/// off, and a block on an `http` listener is rejected rather than
+/// ignored — the L7 path has no receive phase yet, so accepting the
+/// config would state a trust boundary nothing enforces, the exact
+/// silent hole the option exists to close.
+fn resolveProxyProtocol(
+    proxy_protocol_json: ?ProxyProtocolJson,
+    protocol: Config.Listener.Protocol,
+) ValidationError!?Config.Listener.ProxyProtocol {
+    const proxy_protocol = proxy_protocol_json orelse return null;
+    if (protocol == .http) {
+        return error.ListenerHttpProxyProtocol;
+    }
+    return std.meta.stringToEnum(Config.Listener.ProxyProtocol, proxy_protocol.mode) orelse
+        error.ListenerProxyProtocolModeUnknown;
 }
 
 /// The closed pick-policy vocabulary; anything else is its own error so
@@ -3491,6 +3562,50 @@ test "config: the forwarded block resolves a mode, and is http-only" {
     try expectParseError(
         error.MissingField,
         head ++ ",\"protocol\":\"http\",\"forwarded\":{}" ++ tail,
+    );
+}
+
+test "config: the proxy_protocol block resolves a mode, and is l4-only" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"";
+    const tail = "}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // Absent: first bytes are payload — every config predating this.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ tail);
+        try std.testing.expect(parsed.listeners[0].proxy_protocol == null);
+    }
+    // The one mode resolves, on the defaulted protocol and stated l4 alike.
+    inline for (.{ "", ",\"protocol\":\"l4\"" }) |protocol_field| {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ protocol_field ++ ",\"proxy_protocol\":{\"mode\":\"require\"}" ++ tail,
+        );
+        try std.testing.expectEqual(
+            Config.Listener.ProxyProtocol.require,
+            parsed.listeners[0].proxy_protocol.?,
+        );
+    }
+    // The L7 path has no receive phase yet, so a block there would state
+    // a trust boundary nothing enforces — rejected, not ignored.
+    try expectParseError(
+        error.ListenerHttpProxyProtocol,
+        head ++ ",\"protocol\":\"http\",\"proxy_protocol\":{\"mode\":\"require\"}" ++ tail,
+    );
+    // The mode vocabulary is closed and `mode` is required; sniffing
+    // ("optional") is deliberately not in it — a listener that accepts
+    // header-or-raw-bytes lets any client choose its own address.
+    try expectParseError(
+        error.ListenerProxyProtocolModeUnknown,
+        head ++ ",\"proxy_protocol\":{\"mode\":\"optional\"}" ++ tail,
+    );
+    try expectParseError(
+        error.MissingField,
+        head ++ ",\"proxy_protocol\":{}" ++ tail,
     );
 }
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -111,6 +111,17 @@ pub const relay_buffers_max: u32 = conn_slots_max;
 /// this proxy targets.
 pub const relay_buffer_bytes: u32 = 4 * 1024;
 
+/// Most bytes a PROXY protocol header may occupy before the listener
+/// rejects the peer (#142). The bound is ours, not the spec's: a v2
+/// header declares its own length in a u16, and that number is chosen by
+/// a peer whose trustworthiness is exactly what the header has not yet
+/// established. 512 admits every fixed address block the spec defines —
+/// the largest, AF_UNIX, is 216 bytes after the 16-byte prelude — plus
+/// the TLVs real senders append (AWS NLB's VPCE id); v1 bounds itself at
+/// 107. Must fit the relay buffer, where the receive phase stages the
+/// header and whatever payload arrived coalesced behind it.
+pub const proxy_header_bytes_max: u32 = 512;
+
 /// §8 "watermarks before walls": each pool flips a pressure flag before
 /// it hits the wall so the proxy sheds *idle* capacity before it must
 /// shed *work*: relay or conn pressure shortens idle timeouts, relay
@@ -730,6 +741,12 @@ comptime {
     assert(inFlightOps(conn_slots_max, upstream_slots_max, 0) <= completion_queue_entries);
     assert(conn_slots_max - 1 <= std.math.maxInt(u16));
     assert(relay_buffer_bytes >= 512);
+    // The PROXY header stages in the relay buffer's client→upstream half
+    // and must admit the largest header either spec version allows
+    // (v2's 16-byte prelude + AF_UNIX's 216-byte block; v1's 107 line).
+    assert(proxy_header_bytes_max <= relay_buffer_bytes);
+    assert(proxy_header_bytes_max >= 16 + 216);
+    assert(proxy_header_bytes_max >= 107);
     assert(clusters_min >= 1);
     // The §8 cap ceiling is the largest load one endpoint can carry: one
     // L7 lease per upstream slot plus one L4 charge per conn slot, since

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -254,6 +254,20 @@ pub const Counters = struct {
     /// count means someone is sending chains no real topology produces,
     /// which is worth knowing.
     forwarded_chain_dropped: Value = Value.init(0),
+    /// §6 PROXY protocol receive (#142): connections a `proxy_protocol`
+    /// listener closed because the peer's opening bytes were not a valid
+    /// header — malformed, over `proxy_header_bytes_max`, or EOF
+    /// mid-header. Deliberately **not** `shed_`-prefixed, on
+    /// `l4_shed_endpoint_inflight`'s exact reasoning: the connection was
+    /// admitted before its header could be judged, so it counts in the
+    /// flow identity as an ordinary completion. A rising count means
+    /// something other than the configured fronting proxy is reaching a
+    /// listener whose mode exists to refuse exactly that.
+    l4_proxy_header_invalid: Value = Value.init(0),
+    /// Headers a `proxy_protocol` listener accepted, address-bearing or
+    /// not — `LOCAL` and `UNKNOWN` keep the observed peer, and a
+    /// fronting proxy's health checks arrive exactly that way (§6).
+    l4_proxy_header_accepted: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -270,7 +270,11 @@ pub fn Conn(comptime IoType: type) type {
         /// found by parsing, the body (or a pipelined next head) follows
         /// it. A count, not content: it survives the buffer's return at a
         /// static response, because the §7 resync rule still reads it to
-        /// decide keep-or-close; `beginNextRequest` zeroes it.
+        /// decide keep-or-close; `beginNextRequest` zeroes it. The
+        /// `l4_reading_proxy_header` phase (#142) counts the same way
+        /// over its own staging — the relay buffer's client→upstream
+        /// half — and zeroes it at hand-over, so the relay starts clean
+        /// and the L7 meaning is never mixed with the L4 one.
         head_len: u32,
         /// The client-directed write in flight, if any (§7, §8) — see
         /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
@@ -345,6 +349,13 @@ pub fn Conn(comptime IoType: type) type {
 
         pub const State = enum(u8) {
             // L4 relay states.
+            /// Reading the PROXY protocol header a `proxy_protocol`
+            /// listener requires (#142), staged in the relay buffer's
+            /// client→upstream half and accumulated in `head_len`.
+            /// Runs *before* `.connecting`, necessarily: the dial
+            /// consumes `client_address` (the hash pick, §7), and the
+            /// header is what makes that address the real client's.
+            l4_reading_proxy_header,
             connecting,
             relaying,
             // L7 states (§7): `l7_reading_head` accumulates and re-parses
@@ -377,6 +388,7 @@ pub fn Conn(comptime IoType: type) type {
         /// `beginTeardown` is a legal transition.
         pub fn isLive(conn: *const Self) bool {
             return switch (conn.state) {
+                .l4_reading_proxy_header,
                 .connecting,
                 .relaying,
                 .l7_reading_head,

--- a/src/net/proxy_protocol.zig
+++ b/src/net/proxy_protocol.zig
@@ -1,0 +1,591 @@
+//! PROXY protocol (v1 and v2) header parsing for the receive path
+//! (#142): a listener configured to sit behind another proxy learns the
+//! real client from a header that proxy prepends, because the kernel's
+//! peer address is the proxy's own — and `client_address` is a routing
+//! input (`pick: hash`, §7), not just a log field, so the observed peer
+//! would pin every client to one endpoint.
+//!
+//! Parsing is pure and total: bytes in, verdict out, no I/O, no
+//! allocation, no third outcome (the §9 fuzz oracle below). The caller
+//! accumulates bytes and re-parses from byte 0 on every delivery —
+//! detect-and-retry, the same discipline as the HTTP head parser — so the
+//! verdicts are monotonic by contract: a strict prefix of a header that
+//! parses (or may yet parse) is always `.need_more`, never `.invalid`. A
+//! transient `.invalid` would tear down a connection whose next segment
+//! completed the header.
+//!
+//! **Deliberately not here: the decision to look for a header at all.**
+//! Accepting one from an arbitrary peer would let any client choose its
+//! own sticky backend and forge every access-log line about itself, so
+//! the spec forbids sniffing and this parser is only ever consulted on a
+//! listener whose config states the peer is trusted — the same
+//! per-listener trust statement `forwarded` settled (§7).
+//!
+//! `client == null` on a successful parse means "keep the observed peer":
+//! v1 `UNKNOWN`, v2 `LOCAL`, and every valid non-TCP family land there.
+//! Health checks from the fronting proxy arrive exactly this way, so
+//! treating them as errors would take the listener down.
+//!
+//! Spec: https://www.haproxy.org/download/2.9/doc/proxy-protocol.txt
+
+const std = @import("std");
+const constants = @import("../constants.zig");
+
+const assert = std.debug.assert;
+
+/// The verdict on a byte prefix. `need_more` never asks past
+/// `constants.proxy_header_bytes_max` (asserted in `parse`), so the
+/// accumulating caller needs no bound of its own.
+pub const Parsed = union(enum) {
+    need_more,
+    invalid,
+    ok: Header,
+};
+
+/// A complete header: who the fronting proxy says connected, and how many
+/// bytes the header occupies — the relayed payload starts at `bytes_len`.
+pub const Header = struct {
+    /// The announced client, or null to keep the observed peer (v1
+    /// `UNKNOWN`, v2 `LOCAL`, valid non-TCP families). An IPv4-mapped
+    /// IPv6 announcement unwraps to the IPv4 address it is, the same
+    /// normalization the accept path applies (`XevIo.addressOf`) — one
+    /// client must hash one way however its address was conveyed.
+    client: ?std.Io.net.IpAddress,
+    bytes_len: u32,
+};
+
+/// The shortest parse any input can complete: v1's "PROXY UNKNOWN\r\n"
+/// (v2's minimum is the 16-byte prelude).
+const header_bytes_min: u32 = 15;
+
+const v1_signature = "PROXY ";
+/// Spec: a v1 line, CRLF included, never exceeds 107 bytes (the
+/// worst-case TCP6 line). Longer without a CRLF is not a v1 header.
+const v1_line_bytes_max: u32 = 107;
+
+const v2_signature = "\r\n\r\n\x00\r\nQUIT\n";
+/// Signature, version/command byte, family/protocol byte, u16 length.
+const v2_prelude_bytes: u32 = 16;
+
+const V1Family = enum { tcp4, tcp6 };
+
+comptime {
+    assert(v1_signature.len == 6);
+    assert(v2_signature.len == 12);
+    assert(header_bytes_min == "PROXY UNKNOWN\r\n".len);
+    assert(v2_prelude_bytes == v2_signature.len + 4);
+    // Byte 0 discriminates the two versions.
+    assert(v1_signature[0] != v2_signature[0]);
+    // The cap admits every maximal fixed-size header either version
+    // defines; rejecting one the spec allows would be a config trap.
+    assert(v1_line_bytes_max <= constants.proxy_header_bytes_max);
+    assert(v2_prelude_bytes + 216 <= constants.proxy_header_bytes_max);
+}
+
+/// Judge `bytes` as the start of a PROXY protocol header. Callable on any
+/// prefix of the client's stream, any number of times.
+pub fn parse(bytes: []const u8) Parsed {
+    const parsed = parseAny(bytes);
+    switch (parsed) {
+        // What `need_more` promises the accumulating caller: the answer
+        // always arrives within the cap, so a buffer sized by it and a
+        // loop bounded by it both suffice.
+        .need_more => assert(bytes.len < constants.proxy_header_bytes_max),
+        .invalid => {},
+        .ok => |header| {
+            assert(header.bytes_len >= header_bytes_min);
+            assert(header.bytes_len <= bytes.len);
+            assert(header.bytes_len <= constants.proxy_header_bytes_max);
+        },
+    }
+    return parsed;
+}
+
+fn parseAny(bytes: []const u8) Parsed {
+    if (bytes.len == 0) {
+        return .need_more;
+    }
+    if (bytes[0] == v2_signature[0]) {
+        return parseV2(bytes);
+    }
+    if (bytes[0] == v1_signature[0]) {
+        return parseV1(bytes);
+    }
+    // Negative space: neither version starts this way, and no suffix can
+    // repair byte 0 — invalid now rather than after 107 more bytes.
+    assert(bytes[0] != v1_signature[0]);
+    assert(bytes[0] != v2_signature[0]);
+    return .invalid;
+}
+
+fn parseV1(bytes: []const u8) Parsed {
+    assert(bytes.len >= 1);
+    assert(bytes[0] == v1_signature[0]);
+    const window = bytes[0..@min(bytes.len, v1_line_bytes_max)];
+    const line_end = std.mem.indexOf(u8, window, "\r\n") orelse {
+        if (bytes.len >= v1_line_bytes_max) {
+            return .invalid;
+        }
+        // No terminator yet. Wait only while the bytes present are still
+        // a prefix of the one legal opening; "PROXA" can never recover.
+        const signature_window = bytes[0..@min(bytes.len, v1_signature.len)];
+        if (!std.mem.startsWith(u8, v1_signature, signature_window)) {
+            return .invalid;
+        }
+        return .need_more;
+    };
+    const line = window[0..line_end];
+    if (!std.mem.startsWith(u8, line, v1_signature)) {
+        return .invalid;
+    }
+    assert(line_end + 2 <= v1_line_bytes_max);
+    const bytes_len: u32 = @intCast(line_end + 2);
+    var tokens = std.mem.splitScalar(u8, line[v1_signature.len..], ' ');
+    const family_token = tokens.first();
+    if (std.mem.eql(u8, family_token, "UNKNOWN")) {
+        // Spec: for UNKNOWN the receiver ignores everything up to the
+        // CRLF. The fronting proxy saw a family it cannot describe (a
+        // health check's UNIX socket, say); the observed peer stands.
+        return .{ .ok = .{ .client = null, .bytes_len = bytes_len } };
+    }
+    if (std.mem.eql(u8, family_token, "TCP4")) {
+        return parseV1Proxy(.tcp4, &tokens, bytes_len);
+    }
+    if (std.mem.eql(u8, family_token, "TCP6")) {
+        return parseV1Proxy(.tcp6, &tokens, bytes_len);
+    }
+    return .invalid;
+}
+
+/// The four address fields of a TCP4/TCP6 line: exactly four more tokens
+/// separated by single spaces (an empty token — doubled, leading, or
+/// trailing space — fails address or port parsing), then the line ends.
+fn parseV1Proxy(
+    family: V1Family,
+    tokens: *std.mem.SplitIterator(u8, .scalar),
+    bytes_len: u32,
+) Parsed {
+    assert(bytes_len >= header_bytes_min);
+    assert(bytes_len <= v1_line_bytes_max);
+    const source_address = tokens.next() orelse return .invalid;
+    const destination_address = tokens.next() orelse return .invalid;
+    const source_port_token = tokens.next() orelse return .invalid;
+    const destination_port_token = tokens.next() orelse return .invalid;
+    if (tokens.next() != null) {
+        return .invalid;
+    }
+    const source_port = parsePort(source_port_token) orelse return .invalid;
+    const destination_port = parsePort(destination_port_token) orelse return .invalid;
+    const client = parseV1Address(family, source_address, source_port) orelse
+        return .invalid;
+    // The destination is this proxy; validated — parse-or-reject admits
+    // no half-checked header — and discarded.
+    _ = parseV1Address(family, destination_address, destination_port) orelse
+        return .invalid;
+    return .{ .ok = .{ .client = client, .bytes_len = bytes_len } };
+}
+
+/// Spec-strict decimal port: one to five digits, no leading zero, at most
+/// 65535. Stricter than the address parsers need to be because nothing
+/// here delegates it.
+fn parsePort(token: []const u8) ?u16 {
+    if (token.len == 0) {
+        return null;
+    }
+    if (token.len > 5) {
+        return null;
+    }
+    if (token.len > 1) {
+        if (token[0] == '0') {
+            return null;
+        }
+    }
+    assert(token.len >= 1);
+    assert(token.len <= 5);
+    var value: u32 = 0;
+    for (token) |char| {
+        if (char < '0') return null;
+        if (char > '9') return null;
+        value = value * 10 + (char - '0');
+    }
+    assert(value <= 99999);
+    if (value > std.math.maxInt(u16)) {
+        return null;
+    }
+    return @intCast(value);
+}
+
+fn parseV1Address(
+    family: V1Family,
+    token: []const u8,
+    port: u16,
+) ?std.Io.net.IpAddress {
+    switch (family) {
+        .tcp4 => {
+            // `Ip4Address.parse` is the strictness delegate: it rejects
+            // leading zeros, short octet counts, and trailing bytes.
+            const address = std.Io.net.Ip4Address.parse(token, port) catch return null;
+            assert(token.len >= 7);
+            return .{ .ip4 = address };
+        },
+        .tcp6 => {
+            // Every IPv6 text form contains ':' and no IPv4 form does;
+            // requiring it rejects a spec-violating v4 literal on a
+            // TCP6 line.
+            if (std.mem.findScalar(u8, token, ':') == null) {
+                return null;
+            }
+            const address = std.Io.net.IpAddress.parse(token, port) catch return null;
+            assert(address.getPort() == port);
+            // `parse` keeps a mapped `::ffff:a.b.c.d` as IPv6; unwrap it
+            // to the IPv4 address it is — see `Header.client`.
+            return switch (address) {
+                .ip4 => address,
+                .ip6 => |ip6| std.Io.net.IpAddress.fromIp6(ip6),
+            };
+        },
+    }
+}
+
+fn parseV2(bytes: []const u8) Parsed {
+    assert(bytes.len >= 1);
+    assert(bytes[0] == v2_signature[0]);
+    if (bytes.len < v2_signature.len) {
+        if (!std.mem.startsWith(u8, v2_signature, bytes)) {
+            return .invalid;
+        }
+        return .need_more;
+    }
+    if (!std.mem.startsWith(u8, bytes, v2_signature)) {
+        return .invalid;
+    }
+    if (bytes.len < v2_prelude_bytes) {
+        return .need_more;
+    }
+    // Byte 12: protocol version (must be 2) and command.
+    const version_command = bytes[12];
+    if (version_command >> 4 != 0x2) {
+        return .invalid;
+    }
+    const command = version_command & 0x0F;
+    if (command > 0x1) { // 0x0 LOCAL, 0x1 PROXY; the rest are unassigned.
+        return .invalid;
+    }
+    // Byte 13: address family and transport protocol. The spec is
+    // explicit that values past the assigned ones "must be rejected as
+    // invalid by receivers" — rejection here is mandated, not a choice.
+    const family = bytes[13] >> 4;
+    const protocol = bytes[13] & 0x0F;
+    if (family > 0x3) { // UNSPEC, INET, INET6, UNIX.
+        return .invalid;
+    }
+    if (protocol > 0x2) { // UNSPEC, STREAM, DGRAM.
+        return .invalid;
+    }
+    assert(family <= 0x3);
+    assert(protocol <= 0x2);
+    const block_len: u32 = std.mem.readInt(u16, bytes[14..16], .big);
+    const total_len = v2_prelude_bytes + block_len;
+    // The declared length is the peer's number; the cap is ours. Judged
+    // before waiting, so an oversize header is rejected at byte 16 rather
+    // than trusted to fill a buffer it never fits.
+    if (total_len > constants.proxy_header_bytes_max) {
+        return .invalid;
+    }
+    if (command == 0x1) {
+        // A PROXY announcement must cover its family's address block;
+        // anything past the block is TLVs, consumed and discarded.
+        if (block_len < v2AddressBytes(family)) {
+            return .invalid;
+        }
+    }
+    if (bytes.len < total_len) {
+        return .need_more;
+    }
+    assert(total_len >= v2_prelude_bytes);
+    const client = if (command == 0x1)
+        v2Address(family, protocol, bytes[v2_prelude_bytes..total_len])
+    else
+        null;
+    return .{ .ok = .{ .client = client, .bytes_len = total_len } };
+}
+
+/// The fixed address-block size a PROXY command must carry per family:
+/// source and destination addresses, then source and destination ports.
+fn v2AddressBytes(family: u8) u32 {
+    assert(family <= 0x3);
+    return switch (family) {
+        0x0 => 0, // UNSPEC carries whatever it likes; none of it is read.
+        0x1 => 4 + 4 + 2 + 2,
+        0x2 => 16 + 16 + 2 + 2,
+        0x3 => 108 + 108, // AF_UNIX paths; no ports.
+        else => unreachable, // Asserted above; families stop at 0x3.
+    };
+}
+
+/// The announced client of a validated PROXY command, or null to keep
+/// the observed peer: only a TCP (STREAM) family conveys a peer this
+/// TCP listener can mean anything by. UNSPEC, UNIX, and DGRAM are
+/// valid statements — just not about a client we can route.
+fn v2Address(family: u8, protocol: u8, block: []const u8) ?std.Io.net.IpAddress {
+    assert(family <= 0x3);
+    assert(protocol <= 0x2);
+    if (protocol != 0x1) {
+        return null;
+    }
+    switch (family) {
+        0x1 => {
+            assert(block.len >= v2AddressBytes(0x1));
+            return .{ .ip4 = .{
+                .bytes = block[0..4].*,
+                .port = std.mem.readInt(u16, block[8..10], .big),
+            } };
+        },
+        0x2 => {
+            assert(block.len >= v2AddressBytes(0x2));
+            // `fromIp6` unwraps an IPv4-mapped announcement — see
+            // `Header.client` for why the normalization matters.
+            return std.Io.net.IpAddress.fromIp6(.{
+                .bytes = block[0..16].*,
+                .port = std.mem.readInt(u16, block[32..34], .big),
+                .flow = 0,
+                .interface = .none,
+            });
+        },
+        else => return null, // 0x0 UNSPEC, 0x3 UNIX.
+    }
+}
+
+// -- tests ---------------------------------------------------------------
+
+const testing = std.testing;
+
+fn clientEql(a: ?std.Io.net.IpAddress, b: ?std.Io.net.IpAddress) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.?.eql(&b.?);
+}
+
+/// The invariants any input must satisfy — the same oracle unit vectors
+/// and the fuzzer share, so a pinned case checks everything fuzz would.
+fn checkParse(input: []const u8) void {
+    const parsed = parse(input);
+    if (parsed == .ok) {
+        // Bytes past the header cannot have contributed to the verdict:
+        // the header alone must parse to the very same answer.
+        const alone = parse(input[0..parsed.ok.bytes_len]);
+        assert(alone == .ok);
+        assert(alone.ok.bytes_len == parsed.ok.bytes_len);
+        assert(clientEql(alone.ok.client, parsed.ok.client));
+    }
+    // Monotonicity, the accumulate-and-retry contract (module header):
+    // while an input has not been judged `.invalid`, every strict prefix
+    // of the bytes that led to the verdict must read `.need_more`.
+    if (parsed != .invalid) {
+        const limit: usize = switch (parsed) {
+            .ok => |header| header.bytes_len,
+            else => input.len,
+        };
+        assert(limit <= input.len);
+        var prefix_len: usize = 0;
+        while (prefix_len < limit) : (prefix_len += 1) {
+            assert(parse(input[0..prefix_len]) == .need_more);
+        }
+    }
+}
+
+fn expectClient(input: []const u8, expected: ?std.Io.net.IpAddress, expected_len: u32) !void {
+    checkParse(input);
+    const parsed = parse(input);
+    try testing.expect(parsed == .ok);
+    try testing.expectEqual(expected_len, parsed.ok.bytes_len);
+    try testing.expect(clientEql(expected, parsed.ok.client));
+}
+
+fn expectVerdict(input: []const u8, expected: std.meta.Tag(Parsed)) !void {
+    checkParse(input);
+    try testing.expectEqual(expected, @as(std.meta.Tag(Parsed), parse(input)));
+}
+
+const client_v4: std.Io.net.IpAddress =
+    .{ .ip4 = .{ .bytes = .{ 198, 51, 100, 1 }, .port = 56324 } };
+
+test "proxy protocol v1: the spec's own lines parse to their clients" {
+    try expectClient("PROXY TCP4 198.51.100.1 203.0.113.9 56324 443\r\n", client_v4, 47);
+    // The spec's worst-case TCP4 line, all fields maximal.
+    try expectClient(
+        "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n",
+        .{ .ip4 = .{ .bytes = .{ 255, 255, 255, 255 }, .port = 65535 } },
+        56,
+    );
+    try expectClient(
+        "PROXY TCP6 2001:db8::1 ::1 56324 443\r\n",
+        .{ .ip6 = .{
+            .bytes = .{ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+            .port = 56324,
+            .flow = 0,
+            .interface = .none,
+        } },
+        38,
+    );
+    // Payload behind the header is not the parser's to judge.
+    try expectClient("PROXY UNKNOWN\r\nGET / HTTP/1.0\r\n\r\n", null, 15);
+    try expectClient("PROXY UNKNOWN ignored junk fields\r\n", null, 35);
+}
+
+test "proxy protocol v1: a mapped announcement hashes as the IPv4 client it is" {
+    const parsed = parse("PROXY TCP6 ::ffff:198.51.100.1 ::1 56324 443\r\n");
+    try testing.expect(parsed == .ok);
+    try testing.expect(parsed.ok.client.? == .ip4);
+    try testing.expect(clientEql(client_v4, parsed.ok.client));
+}
+
+test "proxy protocol v1: incomplete lines wait, hopeless ones do not" {
+    try expectVerdict("", .need_more);
+    try expectVerdict("P", .need_more);
+    try expectVerdict("PROXY", .need_more);
+    try expectVerdict("PROXY TCP4 198.51.100.1", .need_more);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 56324 443\r", .need_more);
+    // Byte 0 can already condemn a stream; so can a broken signature.
+    try expectVerdict("QROXY TCP4", .invalid);
+    try expectVerdict("PROXA", .invalid);
+    try expectVerdict("proxy TCP4 198.51.100.1 203.0.113.9 56324 443\r\n", .invalid);
+}
+
+test "proxy protocol v1: the 107-byte line bound is exact" {
+    // "PROXY UNKNOWN " + filler + CRLF: UNKNOWN ignores the filler, so
+    // the only judgment left is the length's.
+    const line_105 = "PROXY UNKNOWN " ++ ("x" ** 91) ++ "\r\n";
+    comptime assert(line_105.len == 107);
+    try expectClient(line_105, null, 107);
+    const line_108 = "PROXY UNKNOWN " ++ ("x" ** 92) ++ "\r\n";
+    comptime assert(line_108.len == 108);
+    try expectVerdict(line_108, .invalid);
+    // 107 bytes and still no CRLF: no v1 line can be forming.
+    try expectVerdict("PROXY UNKNOWN " ++ ("x" ** 93), .invalid);
+}
+
+test "proxy protocol v1: field discipline is strict" {
+    // Doubled space, missing field, trailing space, extra field.
+    try expectVerdict("PROXY TCP4  198.51.100.1 203.0.113.9 56324 443\r\n", .invalid);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 56324\r\n", .invalid);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 56324 443 \r\n", .invalid);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 56324 443 7\r\n", .invalid);
+    try expectVerdict("PROXY\r\n", .invalid);
+    try expectVerdict("PROXY TCP5 198.51.100.1 203.0.113.9 56324 443\r\n", .invalid);
+    // Ports: leading zero, overflow, empty, non-digit.
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 056324 443\r\n", .invalid);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 65536 443\r\n", .invalid);
+    try expectVerdict("PROXY TCP4 198.51.100.1 203.0.113.9 56324 4a3\r\n", .invalid);
+    // Family/address mismatch, both directions.
+    try expectVerdict("PROXY TCP4 2001:db8::1 203.0.113.9 56324 443\r\n", .invalid);
+    try expectVerdict("PROXY TCP6 198.51.100.1 ::1 56324 443\r\n", .invalid);
+    // A non-canonical IPv4 octet (leading zero) is the delegate's call.
+    try expectVerdict("PROXY TCP4 198.051.100.1 203.0.113.9 56324 443\r\n", .invalid);
+    // Port 0 is within the spec's stated range.
+    try expectClient(
+        "PROXY TCP4 198.51.100.1 203.0.113.9 0 443\r\n",
+        .{ .ip4 = .{ .bytes = .{ 198, 51, 100, 1 }, .port = 0 } },
+        43,
+    );
+}
+
+const v2_local_min = v2_signature ++ "\x20\x00\x00\x00";
+const v2_proxy_inet = v2_signature ++ "\x21\x11\x00\x0c" ++
+    "\xc6\x33\x64\x01" ++ "\xcb\x00\x71\x09" ++ "\xdc\x04" ++ "\x01\xbb";
+
+test "proxy protocol v2: the binary form parses to its client" {
+    comptime assert(v2_proxy_inet.len == 28);
+    try expectClient(v2_proxy_inet, client_v4, 28);
+    // TLVs ride behind the address block inside the declared length.
+    const with_tlv = v2_signature ++ "\x21\x11\x00\x11" ++
+        "\xc6\x33\x64\x01" ++ "\xcb\x00\x71\x09" ++ "\xdc\x04" ++ "\x01\xbb" ++
+        "\x04\x00\x02\xab\xcd";
+    try expectClient(with_tlv, client_v4, 33);
+    // Payload behind the declared length is untouched.
+    try expectClient(v2_proxy_inet ++ "GET / HTTP/1.0\r\n", client_v4, 28);
+    // INET6 with a mapped source unwraps to the IPv4 client (one client,
+    // one hash, however conveyed).
+    const mapped = v2_signature ++ "\x21\x21\x00\x24" ++
+        ("\x00" ** 10) ++ "\xff\xff" ++ "\xc6\x33\x64\x01" ++
+        ("\x00" ** 15) ++ "\x01" ++ "\xdc\x04" ++ "\x01\xbb";
+    comptime assert(mapped.len == 52);
+    try expectClient(mapped, client_v4, 52);
+}
+
+test "proxy protocol v2: LOCAL and non-TCP families keep the observed peer" {
+    try expectClient(v2_local_min, null, 16);
+    // LOCAL with a block: skipped whole.
+    try expectClient(v2_signature ++ "\x20\x00\x00\x03" ++ "abc", null, 19);
+    // PROXY over UNSPEC, DGRAM, and UNIX: valid statements about peers
+    // this TCP listener cannot route by.
+    try expectClient(v2_signature ++ "\x21\x00\x00\x00", null, 16);
+    const dgram = v2_signature ++ "\x21\x12\x00\x0c" ++ ("\x00" ** 12);
+    try expectClient(dgram, null, 28);
+    const unix = v2_signature ++ "\x21\x31\x00\xd8" ++ ("\x00" ** 216);
+    comptime assert(unix.len == 232);
+    try expectClient(unix, null, 232);
+}
+
+test "proxy protocol v2: truncations wait, corruption does not" {
+    try expectVerdict("\r", .need_more);
+    try expectVerdict(v2_signature[0..7], .need_more);
+    try expectVerdict(v2_signature, .need_more);
+    try expectVerdict(v2_signature ++ "\x21\x11", .need_more);
+    try expectVerdict(v2_proxy_inet[0..20], .need_more);
+    // A corrupt signature byte, and each rejected nibble.
+    try expectVerdict("\r\n\r\n\x00\r\nQUIT\x00" ++ "\x21\x11\x00\x0c", .invalid);
+    try expectVerdict(v2_signature ++ "\x11\x11\x00\x0c", .invalid); // version 1
+    try expectVerdict(v2_signature ++ "\x22\x11\x00\x0c", .invalid); // command 2
+    try expectVerdict(v2_signature ++ "\x21\x41\x00\x0c", .invalid); // family 4
+    try expectVerdict(v2_signature ++ "\x21\x13\x00\x0c", .invalid); // protocol 3
+    // A PROXY announcement too short for its family's addresses.
+    try expectVerdict(v2_signature ++ "\x21\x11\x00\x0b", .invalid);
+    try expectVerdict(v2_signature ++ "\x21\x21\x00\x0c", .invalid);
+}
+
+test "proxy protocol v2: the declared length meets the cap at byte 16" {
+    // 16 + 496 lands exactly on the cap; one more is rejected — before
+    // the block arrives, not after a buffer fills with it.
+    const at_cap_len = constants.proxy_header_bytes_max - v2_prelude_bytes;
+    var at_cap: [constants.proxy_header_bytes_max]u8 = undefined;
+    @memcpy(at_cap[0..12], v2_signature);
+    at_cap[12] = 0x20; // LOCAL: the block is skipped, not read.
+    at_cap[13] = 0x00;
+    std.mem.writeInt(u16, at_cap[14..16], @intCast(at_cap_len), .big);
+    @memset(at_cap[16..], 0xaa);
+    try expectClient(&at_cap, null, constants.proxy_header_bytes_max);
+
+    var over_cap: [v2_prelude_bytes]u8 = undefined;
+    @memcpy(over_cap[0..12], v2_signature);
+    over_cap[12] = 0x20;
+    over_cap[13] = 0x00;
+    std.mem.writeInt(u16, over_cap[14..16], @intCast(at_cap_len + 1), .big);
+    try expectVerdict(&over_cap, .invalid);
+}
+
+const fuzz_corpus_v1 = "PROXY TCP4 198.51.100.1 203.0.113.9 56324 443\r\nGET /\r\n";
+const fuzz_corpus_v1_unknown = "PROXY UNKNOWN\r\n";
+const fuzz_corpus_v2_local = v2_local_min;
+const fuzz_corpus_v2_inet = v2_proxy_inet;
+
+test "fuzz: proxy protocol — parse or reject, no third outcome" {
+    try std.testing.fuzz({}, fuzzParseInputs, .{
+        .corpus = &.{
+            fuzz_corpus_v1,
+            fuzz_corpus_v1_unknown,
+            fuzz_corpus_v2_local,
+            fuzz_corpus_v2_inet,
+        },
+    });
+}
+
+fn fuzzParseInputs(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    // Twice the cap, so over-cap declarations and long garbage both get
+    // exercised alongside every legal size.
+    var input_buffer: [2 * constants.proxy_header_bytes_max]u8 = undefined;
+    const input_len = smith.slice(&input_buffer);
+    assert(input_len <= input_buffer.len);
+    checkParse(input_buffer[0..input_len]);
+}

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -167,9 +167,23 @@ pub fn Relay(comptime IoType: type) type {
         pub fn start(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .relaying);
             assert(conn.upstream_socket != null);
-            assert(conn.directions[0].phase == .idle);
+            const client_to_upstream =
+                &conn.directions[@intFromEnum(Direction.client_to_upstream)];
+            if (client_to_upstream.owed() >= 1) {
+                // Payload that arrived coalesced behind a PROXY header
+                // (#142): the receive phase staged it at the buffer's
+                // start and framed it as this direction's debt, so the
+                // relay enters the pump mid-cycle — received, owed, not
+                // yet sent — exactly where `onRecv` would stand after
+                // framing. The send drains the debt, then rejoins the
+                // recv loop; no byte is read ahead of it (§6).
+                assert(client_to_upstream.phase == .receiving);
+                PumpClientToUpstream.armSend(server, conn);
+            } else {
+                assert(client_to_upstream.phase == .idle);
+                PumpClientToUpstream.armRecv(server, conn);
+            }
             assert(conn.directions[1].phase == .idle);
-            PumpClientToUpstream.armRecv(server, conn);
             PumpUpstreamToClient.armRecv(server, conn);
         }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -51,6 +51,7 @@ test {
     _ = shed;
     _ = @import("mem/Pool.zig");
     _ = @import("net/Conn.zig");
+    _ = @import("net/proxy_protocol.zig");
     _ = @import("net/relay.zig");
     _ = @import("net/upstream.zig");
     _ = @import("testing/origin.zig");

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -88,6 +88,10 @@ pub const Client = struct {
     /// armed, so the accept "CQE" has already beaten the listener close:
     /// the §8 drain race, made deterministic.
     drain_on_connect: bool = false,
+    /// Bytes sent ahead of the token — a scripted PROXY protocol header
+    /// (#142) for `proxy_protocol` scenarios; empty for everyone else.
+    prefix: []const u8 = "",
+    prefix_sent: u32 = 0,
     sent_len: u32 = 0,
     received_len: u32 = 0,
     fin_sent: bool = false,
@@ -118,12 +122,19 @@ pub const Client = struct {
     }
 
     fn armSend(client: *Client) void {
-        assert(client.sent_len < echo_token.len);
         assert(!client.send_pending);
         client.send_pending = true;
+        // The scripted prefix goes first, then the token — two cursors,
+        // one send in flight at a time, resumed from whichever is short.
+        const bytes = if (client.prefix_sent < client.prefix.len)
+            client.prefix[client.prefix_sent..]
+        else blk: {
+            assert(client.sent_len < echo_token.len);
+            break :blk echo_token[client.sent_len..];
+        };
         client.scenario.io.send(
             client.socket,
-            echo_token[client.sent_len..],
+            bytes,
             &client.send_completion,
             Client,
             client,
@@ -140,11 +151,16 @@ pub const Client = struct {
             client.settleIfTerminal();
             return;
         };
-        client.sent_len += sent;
-        assert(client.sent_len <= echo_token.len);
+        if (client.prefix_sent < client.prefix.len) {
+            client.prefix_sent += sent;
+            assert(client.prefix_sent <= client.prefix.len);
+        } else {
+            client.sent_len += sent;
+            assert(client.sent_len <= echo_token.len);
+        }
         if (client.terminal_outcome != null) {
             client.settleIfTerminal();
-        } else if (client.sent_len < echo_token.len) {
+        } else if (client.prefix_sent < client.prefix.len or client.sent_len < echo_token.len) {
             client.armSend();
         }
     }
@@ -227,6 +243,9 @@ pub const TestBed = struct {
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 20,
+        /// The #142 receive gate on the one listener; null for everyone
+        /// but the PROXY protocol scenarios.
+        proxy_protocol: ?config_module.Config.Listener.ProxyProtocol = null,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -251,7 +270,12 @@ pub const TestBed = struct {
         bed.endpoints = .{originAddress()};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
-        bed.listeners = .{.{ .bind_address = bindAddress(), .routes = &bed.routes, .protocol = .l4 }};
+        bed.listeners = .{.{
+            .bind_address = bindAddress(),
+            .routes = &bed.routes,
+            .protocol = .l4,
+            .proxy_protocol = options.proxy_protocol,
+        }};
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
@@ -942,6 +966,140 @@ test "relay: a connection reaped by the idle deadline is logged as aborted" {
     try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_in\":0,") != null);
     try std.testing.expect(std.mem.indexOf(u8, line, "\"bytes_out\":0,") != null);
+}
+
+// The announced client deliberately differs from `SimIo`'s observed peer
+// (198.51.100.1:5xxxx) in *both* address and port, so the log oracle
+// below cannot pass by accident.
+const proxy_v1_line = "PROXY TCP4 203.0.113.7 10.0.0.1 4711 443\r\n";
+
+test "proxy protocol: the header is consumed, the payload relays, the client is believed" {
+    // The slice-3 promise end to end: a require-listener consumes the
+    // header (the origin sees the token alone, byte-exact), any payload
+    // coalesced behind it relays, and `client_address` becomes the
+    // announced client — witnessed through the access log, the same
+    // field the §7 hash pick reads. Partial-io seeds split the header
+    // across deliveries, so the accumulate-and-retry loop is exercised
+    // and not just the one-recv happy path.
+    var seed: u64 = 1;
+    while (seed <= 15) : (seed += 1) {
+        var bed: TestBed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .sim = .{
+                .seed = seed,
+                .adversary = .{ .partial_io = true, .connect_delay_ns_max = 2_000_000 },
+            },
+            .proxy_protocol = .require,
+            .access_log = true,
+        });
+        defer bed.tearDown();
+
+        bed.scenario.clients_count = 1;
+        const client = &bed.scenario.clients[0];
+        client.exchange = true;
+        client.prefix = proxy_v1_line;
+        client.start(&bed.scenario, TestBed.bindAddress());
+        try bed.sim_io.run();
+        try bed.expectDrained();
+
+        try std.testing.expectEqual(Client.Outcome.eof, client.outcome);
+        try std.testing.expectEqualStrings(
+            echo_token,
+            client.receive_buffer[0..client.received_len],
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_accepted"));
+        try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_invalid"));
+
+        const line = std.mem.trimEnd(u8, bed.sim_io.sinkBytes(), "\n");
+        try std.testing.expect(std.mem.indexOf(u8, line, "\"client\":\"203.0.113.7:4711\"") != null);
+        // `bytes_in` counts the payload alone: the header is metadata the
+        // origin never sees, whichever recv it arrived in.
+        var expected: [64]u8 = undefined;
+        try std.testing.expect(std.mem.indexOf(
+            u8,
+            line,
+            try std.fmt.bufPrint(&expected, "\"bytes_in\":{d},", .{echo_token.len}),
+        ) != null);
+    }
+}
+
+test "proxy protocol: an UNKNOWN header is accepted and keeps the observed peer" {
+    // The fronting proxy's health checks arrive exactly this way (§6):
+    // a valid header that announces nothing. The relay must proceed and
+    // the log must state the peer the kernel saw.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 11 },
+        .proxy_protocol = .require,
+        .access_log = true,
+    });
+    defer bed.tearDown();
+
+    bed.scenario.clients_count = 1;
+    const client = &bed.scenario.clients[0];
+    client.exchange = true;
+    client.prefix = "PROXY UNKNOWN\r\n";
+    client.start(&bed.scenario, TestBed.bindAddress());
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    try std.testing.expectEqual(Client.Outcome.eof, client.outcome);
+    try std.testing.expectEqualStrings(
+        echo_token,
+        client.receive_buffer[0..client.received_len],
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_accepted"));
+    const line = std.mem.trimEnd(u8, bed.sim_io.sinkBytes(), "\n");
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"client\":\"198.51.100.1:50000\"") != null);
+}
+
+test "proxy protocol: a peer that does not open with the header is refused" {
+    // `require`'s whole meaning: the raw token is a perfectly valid
+    // payload on any other listener, and this one closes on its first
+    // byte. Nothing reaches the origin; the counter names the verdict.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 7 },
+        .proxy_protocol = .require,
+    });
+    defer bed.tearDown();
+
+    bed.scenario.clients_count = 1;
+    const client = &bed.scenario.clients[0];
+    client.exchange = true; // Sends the raw token: no header anywhere.
+    client.start(&bed.scenario, TestBed.bindAddress());
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    try std.testing.expect(client.outcome == .eof or client.outcome == .reset);
+    try std.testing.expectEqual(@as(u32, 0), client.received_len);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_invalid"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_accepted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+}
+
+test "proxy protocol: a silent peer is reaped on the connect budget" {
+    // The phase runs under the connect clock, not the idle one: the
+    // fronting proxy speaks immediately after connecting, so a peer
+    // that says nothing is reaped on the dial-scale deadline.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 5 },
+        .connect_timeout_ms = 10,
+        .idle_timeout_ms = 20,
+        .proxy_protocol = .require,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, false); // Connects, then says nothing.
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    const client = &bed.scenario.clients[0];
+    try std.testing.expect(client.outcome == .eof or client.outcome == .reset);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_invalid"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_accepted"));
 }
 
 test "health: probes against a listening origin keep the endpoint healthy" {


### PR DESCRIPTION
Closes the **receive** half of #142: an `l4` listener can now require every
connection to open with a PROXY protocol header (v1 or v2) announcing the
real client, and that address is what zoxy then believes everywhere the
client address is consumed — the `pick: hash` endpoint choice (§7), the
access log's `client` field.

## Why

`client_address` comes from `accept()`. Put a load balancer in front and
every connection carries the LB's address, so `pick: hash` keys on one
value and the whole fleet lands on a single endpoint — stickiness
inverted, not degraded. The header is what makes `source_ip` mean the
client again.

## The trust model

`"proxy_protocol": { "mode": "require" }`, per listener, no default —
`forwarded`'s settled shape (#137), inverted to the receive side.
**There is no sniffing arm, deliberately**: a listener that accepted a
header only when one shows up would let any client choose its own sticky
backend and forge its own access-log lines; the spec forbids it of
receivers, and HAProxy gates the same feature behind an explicit
`accept-proxy`. `require` closes anything that does not open with a valid
header. Non-announcing headers (v1 `UNKNOWN`, v2 `LOCAL` — how an LB's
own health checks arrive) are accepted and keep the observed peer.
`http` listeners reject the block until the L7 receive phase exists.

## Five slices

1. **Parser** (`src/net/proxy_protocol.zig`) — pure, total, monotonic: a
   strict prefix of a header that parses is always `need_more`, never
   `invalid`, which is what makes accumulate-and-reparse sound. Fuzz
   oracle enforces both contracts; IPv4-mapped announcements unwrap to
   match the accept path's normalization (one client, one hash).
2. **Config gate** — mirrored on `forwarded` site for site; closed
   single-arm enum (`HashKey`'s shape) so a CIDR-gated variant is a new
   arm, not a new mechanism.
3. **The phase** — a new pre-dial state that reuses what was already
   there: stages in the relay buffer's client→upstream half (held since
   admission — zero new memory, §5 untouched), runs under the connect
   budget so the hand-over's fresh dial deadline only moves later (no
   timer rebase), hands over via `startProtocol(.l4)` — the second
   caller its doc anticipated — and enters the relay with coalesced
   payload pre-staged as the pump's first send. Ring budget: 2 of 4 ops.
   Counters deliberately outside the `shed_` gate identity (§9).
4. **Sim** — a third of seeds require the header; clients script both
   spec versions, both verdict families, and no-header refusals. The
   oracle with proven teeth: on clean seeds every announced address must
   appear as a log line's `client` field — reverting the one
   believe-the-header line fails seed 20 (`AccessLogAnnouncedClientMissing`).
   Header leakage to the origin is caught free by the echo-integrity
   oracle. Census exemptions added in slice 3 are retired in slice 4.
5. **Docs** — DESIGN.md §6 amends its own invariant honestly (no
   inspection *of the payload*; the opt-in header phase is the one
   stated exception), §7 gains the observed-client inversion, README
   gets the operator section beside its mirror.

## Testing

- `zig build ci` green at every slice and after the rebase onto
  `b29f3b5`: unit + directed tests, fuzz corpus, 4096-seed deterministic
  sim (census 48 counters fired / 12 exempt).
- Directed tests: byte-exact echo through a require listener under
  partial-io seeds (split headers), UNKNOWN keeps the observed peer,
  garbage refused on its first byte, silent peer reaped on the connect
  budget, announced address visible in the access log.
- `tiger-style-reviewer` ran on every slice; docs slice fact-checked
  claim-by-claim against the implementation.

Deliberately left out (tracked in #142): the **send** half (zoxy→origin,
#137's remaining piece) and `http`-listener receive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)