### PR TITLE
PROXY protocol send: origins learn the client, one identity across the chain (#142)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -651,6 +651,28 @@ accept → admit (slots? buffers?) → route by listener
   IPv6 announcements unwrap to the IPv4 address they are — the accept
   path's own normalization — so one client hashes one way however its
   address was conveyed.
+- **Sending PROXY protocol** (a cluster's
+  `"proxy_protocol": { "send": "v1"|"v2" }`, #142). The receive half's
+  mirror, and its machinery pays for the whole thing: the header —
+  composed by the same module's writers, pinned to the parser by
+  round-trip tests so a chained zoxy always accepts what another sends —
+  is prepended at the dial to the client→upstream direction's debt, and
+  the relay's pre-owed-debt entry sends it before any relayed byte. No
+  new state, no new op, no new memory beyond a stack buffer; the
+  destination field is the client socket's local address, asked through
+  the seam (`localAddress`) at the one moment it is needed. Per
+  *cluster* — HAProxy's `send-proxy` unit — because it states what the
+  origin reads, not who connects; and the identity it names is whatever
+  zoxy believes, so behind a `require` listener the announced-in client
+  is the announced-out client, one identity across the chain. The
+  restriction is *reachability*, enforced at load: an http listener may
+  not route to a sending cluster, because a pooled L7 upstream is shared
+  across clients (§3) and a per-connection header naming one client
+  would lie to every other. Two honest edges: a mixed-family pair
+  (an IPv4 client on an IPv6-local socket) promotes both addresses to
+  INET6 with the v4 side mapped, which receivers unwrap; and health
+  probes do not send the header — the dial-only tcp check is unaffected,
+  an http check against a sending cluster probes bare.
 
 ## 7. L7 data path — HTTP/1.1 reverse proxy
 
@@ -1297,7 +1319,7 @@ src/
     Pool.zig          // Pool(T): startup alloc, intrusive free list
   net/
     Conn.zig          // connection slot: state, completions, head-ring claim
-    proxy_protocol.zig // PROXY v1/v2 header parse: pure, total, monotonic (§6)
+    proxy_protocol.zig // PROXY v1/v2 parse + write: pure, round-trip-pinned (§6)
     relay.zig         // strict recv→send→recv relay (L4 + L7 bodies)
     upstream.zig      // shared upstream pool + endpoint idle lists + head pool
   http/

--- a/docs/README.md
+++ b/docs/README.md
@@ -367,6 +367,44 @@ configured proxy is reaching the listener — exactly what the mode
 exists to refuse. `http` listeners reject the block for now: the L7
 receive phase does not exist yet.
 
+### Telling an origin who the client is (PROXY protocol)
+
+The send direction: an origin behind an `l4` relay has no header to read
+an address from — the relay is the whole point — so the only way to tell
+it who connected is to open the upstream connection with a PROXY
+protocol header. A *cluster* opts in, because this states what its
+origins expect, not who connects (the same unit as HAProxy's
+`send-proxy`):
+
+```json
+"clusters": {
+    "postgres": {
+        "endpoints": ["10.0.0.1:5432"],
+        "proxy_protocol": { "send": "v2" }
+    }
+}
+```
+
+`send` is `v1` (text, readable in a tcpdump) or `v2` (binary, what cloud
+load balancers speak). The header names the client zoxy believes — which
+behind a `require` listener is the client the *fronting* proxy
+announced, so a chain of proxies carries one identity end to end.
+
+Two consequences of the header being per *connection*:
+
+- Only `l4` listeners may route to a sending cluster. A pooled HTTP
+  upstream is shared across clients, and a header naming one client
+  would lie to every other — the loader rejects the pairing outright.
+  For HTTP origins, use [`forwarded`](#telling-the-origin-who-the-client-is)
+  instead.
+- Health probes do not send the header. The dial-only `tcp` check is
+  unaffected (it proves the port accepts and sends nothing), but an
+  `http` check against a sending cluster probes bare — if the origin
+  strictly requires the header, prefer `tcp` checks there.
+
+`zoxy_l4_proxy_header_sent` counts headers staged, one per dialed
+connection to a sending cluster.
+
 ### Filters
 
 An `http` listener can carry a list of rules, evaluated top-down. Each has a

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -75,11 +75,19 @@ l7_clients: [clients_max]HttpClient,
 /// The #142 gate drawn for the l4 listener; `populateClients` reads it
 /// to decide whether its clients open with headers.
 proxy_protocol_l4: ?zoxy.config.Config.Listener.ProxyProtocol,
+/// The #142 send half drawn for the l4 cluster; the origin double then
+/// expects and strips a header on every connection, and `verify` holds
+/// what it heard against what the clients were (`verifyUpstreamIdentities`).
+proxy_protocol_send_l4: ?zoxy.config.Config.Cluster.ProxyProtocolSend,
 /// Per-L4-client address its header announced (len 0 = none): distinct
 /// per client, so `verifyAccessLog` can demand the log states each one
 /// on clean seeds — presence is attribution.
 l4_announced: [clients_max][announced_bytes_max]u8,
 l4_announced_len: [clients_max]u8,
+/// The same announcement as an address (valid where `l4_announced_len`
+/// is nonzero), for the #142 send-identity oracle — text serves the log
+/// needle, this serves `IpAddress.eql`.
+l4_announced_address: [clients_max]std.Io.net.IpAddress,
 l4_count: u8,
 l7_count: u8,
 clients_count: u8,
@@ -409,6 +417,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     const connect_timeout_ms: u32 = 20 + random.uintAtMost(u32, 40);
     const health = deriveHealthChecks(harness.clean, random, connect_timeout_ms);
     harness.http_origin_stop_at_ns = health.http_origin_stop_at_ns;
+    harness.proxy_protocol_send_l4 = deriveProxyProtocolSend(random);
     harness.clusters = .{
         .{
             .name = "origin-l4",
@@ -416,6 +425,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
             .pick = pick_l4,
             .check = health.check_l4,
             .max_inflight = deriveMaxInflight(harness.clean, random),
+            .proxy_protocol_send = harness.proxy_protocol_send_l4,
         },
         .{
             .name = "origin-http",
@@ -600,6 +610,22 @@ fn deriveProxyProtocol(random: std.Random) ?zoxy.config.Config.Listener.ProxyPro
     return null;
 }
 
+/// The #142 send half on the l4 cluster: half the announcing seeds speak
+/// v2 (what the writers' real receivers — cloud LBs, HAProxy — expect),
+/// the rest v1, and half send nothing at all. Drawn independently of the
+/// receive gate, so the sweep reaches all four quadrants — including the
+/// chain, where the identity announced in must be the identity announced
+/// out. The prober needs no carve-out: `check_l4` is always the
+/// dial-only tcp check, which gives a stripping origin no bytes to
+/// judge.
+fn deriveProxyProtocolSend(random: std.Random) ?zoxy.config.Config.Cluster.ProxyProtocolSend {
+    return switch (random.uintLessThan(u8, 6)) {
+        0 => .v1,
+        1, 2 => .v2,
+        else => null,
+    };
+}
+
 fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
     harness.filters_http = .{
         .{
@@ -693,6 +719,7 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
     harness.origin = .{
         .mode_selector = pickOriginMode,
         .context = harness,
+        .expect_proxy_header = harness.proxy_protocol_send_l4 != null,
     };
     try harness.origin.start(&harness.io, Harness.originAddress());
     harness.origin_http = .{
@@ -823,6 +850,8 @@ fn recordAnnounced(harness: *Harness, l4_index: u8, octet: u8, port: u16) void {
     assert(text.len >= 17);
     assert(text.len <= 19);
     harness.l4_announced_len[l4_index] = @intCast(text.len);
+    harness.l4_announced_address[l4_index] =
+        .{ .ip4 = .{ .bytes = .{ 203, 0, 113, octet }, .port = port } };
 }
 
 pub fn startClients(harness: *Harness) void {
@@ -880,12 +909,54 @@ pub fn verify(harness: *Harness) !void {
     if (!harness.io.sockets.isFullyReleased()) return error.SocketLeak;
     // §7: no malformed byte may ever reach an origin.
     if (harness.origin_http.violations != 0) return error.OriginSawMalformedBytes;
+    // #142 send: on any seed, garbage where a header belongs is zoxy's
+    // bug — the writers are pure and the adversary splits deliveries but
+    // never corrupts bytes, so a cut lands as EOF, not as a violation.
+    if (harness.origin.proxy_header_violations != 0) {
+        return error.OriginSawInvalidProxyHeader;
+    }
+    try harness.verifyUpstreamIdentities();
     try harness.verifyAccessLog();
     for (harness.clients[0..harness.l4_count]) |*client| {
         try client.verifyIntegrity();
     }
     for (harness.l7_clients[0..harness.l7_count]) |*client| {
         try client.verify();
+    }
+}
+
+/// #142 send, every seed: whatever identity the origin heard must be one
+/// some L4 client *was* — the announced-in address where the client
+/// carried one through the require listener, the observed peer
+/// otherwise. Inverted membership deliberately: origin conns whose drawn
+/// mode never parses (mute, frozen, reset) record nothing, and a cut
+/// header lands as EOF, so demanding every client be heard would fail
+/// legal schedules — but an identity heard that no client was is always
+/// a bug. Identities are per-client distinct (announced 203.0.113.N,
+/// synthetic ports climb), so a match is attribution, and a parsed
+/// header must always announce: zoxy's writers have no LOCAL/UNKNOWN
+/// arm. The completeness direction lives in the directed tests, where
+/// the origin's mode is pinned to echo.
+fn verifyUpstreamIdentities(harness: *const Harness) !void {
+    if (harness.proxy_protocol_send_l4 == null) {
+        assert(!harness.origin.expect_proxy_header);
+        return;
+    }
+    for (harness.origin.conns[0..harness.origin.conns_count]) |*conn| {
+        if (!conn.header_done) continue;
+        const announced = conn.announced orelse
+            return error.UpstreamHeaderAnnouncedNothing;
+        var matched = false;
+        var index: u8 = 0;
+        while (index < harness.l4_count) : (index += 1) {
+            const expected: std.Io.net.IpAddress =
+                if (harness.l4_announced_len[index] > 0)
+                    harness.l4_announced_address[index]
+                else
+                    harness.clients[index].observed_address orelse continue;
+            if (expected.eql(&announced)) matched = true;
+        }
+        if (!matched) return error.UpstreamHeardUnknownIdentity;
     }
 }
 

--- a/sim/l4.zig
+++ b/sim/l4.zig
@@ -60,6 +60,9 @@ pub fn Client(comptime IoType: type) type {
         socket: IoType.Socket = undefined,
         silent: bool = false,
         connected: bool = false,
+        /// This client's own address — the peer zoxy observes — captured
+        /// at connect for the harness's #142 send-identity oracle.
+        observed_address: ?std.Io.net.IpAddress = null,
         connect_settled: bool = false,
         cancel_requested: bool = false,
         fin_sent: bool = false,
@@ -110,6 +113,7 @@ pub fn Client(comptime IoType: type) type {
                 return;
             };
             client.connected = true;
+            client.observed_address = client.io.localAddress(client.socket);
             client.armRecv();
             if (!client.silent) {
                 client.armSend();

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -193,13 +193,6 @@ const uncovered = [_]Uncovered{
             "is a directed-test control; src/access_log_test.zig covers " ++
             "the keep-the-old-sink arm",
     },
-    .{
-        .name = "l4_proxy_header_sent",
-        .why = .unreached,
-        .reason = "no sweep cluster sends PROXY protocol yet — the #142 " ++
-            "send scripts land with the next slice; " ++
-            "src/server_test.zig drives the staged header meanwhile",
-    },
 };
 
 comptime {

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -193,6 +193,13 @@ const uncovered = [_]Uncovered{
             "is a directed-test control; src/access_log_test.zig covers " ++
             "the keep-the-old-sink arm",
     },
+    .{
+        .name = "l4_proxy_header_sent",
+        .why = .unreached,
+        .reason = "no sweep cluster sends PROXY protocol yet — the #142 " ++
+            "send scripts land with the next slice; " ++
+            "src/server_test.zig drives the staged header meanwhile",
+    },
 };
 
 comptime {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -997,6 +997,57 @@ pub fn Server(comptime IoType: type) type {
             server.startProtocol(conn, .l4);
         }
 
+        /// Stage the PROXY header a sending cluster's origin expects
+        /// (#142 send) as the client→upstream direction's front debt:
+        /// written ahead of whatever payload the receive phase already
+        /// framed, so `Relay.start`'s pre-owed-debt entry sends it before
+        /// any relayed byte with no new state and no new op. Runs at the
+        /// dial, the first moment the endpoint is settled and the last
+        /// where the client socket is guaranteed answerable for its
+        /// local address (the header's destination field).
+        fn stageProxySendHeader(
+            server: *Self,
+            conn: *ConnType,
+            version: config_module.Config.Cluster.ProxyProtocolSend,
+        ) void {
+            assert(conn.state == .connecting);
+            assert(conn.relay_buffer != null);
+            var header_buffer: [proxy_protocol.send_bytes_max]u8 = undefined;
+            const local_address = server.io.localAddress(conn.client_socket);
+            const header = switch (version) {
+                .v1 => proxy_protocol.writeV1(&header_buffer, &conn.client_address, &local_address),
+                .v2 => proxy_protocol.writeV2(&header_buffer, &conn.client_address, &local_address),
+            };
+            const direction = &conn.directions[
+                @intFromEnum(ConnType.Direction.client_to_upstream)
+            ];
+            const staging = &conn.relay_buffer.?.client_to_upstream;
+            const framed = direction.framed_len;
+            // Comptime-guaranteed in proxy_protocol: header + the largest
+            // receive leftover fit the buffer half together.
+            assert(header.len + framed <= staging.len);
+            if (framed >= 1) {
+                // Receive-phase payload sits at the front; move it over.
+                // Backwards copy: the regions overlap and the move is to
+                // the right.
+                assert(direction.phase == .receiving);
+                std.mem.copyBackwards(
+                    u8,
+                    staging[header.len..][0..framed],
+                    staging[0..framed],
+                );
+            } else {
+                assert(direction.phase == .idle);
+                direction.phase = .receiving;
+            }
+            @memcpy(staging[0..header.len], header);
+            direction.stageFront(@intCast(header.len));
+            // Counted at the stage: a dial that fails tears the whole
+            // connection down, so "staged" and "reached the wire" differ
+            // only by fates the dial counters already witness.
+            server.counters.increment("l4_proxy_header_sent");
+        }
+
         fn armConnect(server: *Self, conn: *ConnType, cluster_index: u16) void {
             assert(conn.state == .connecting);
             const pick = server.balancer.pick(
@@ -1025,6 +1076,9 @@ pub fn Server(comptime IoType: type) type {
             // origin this connection is being relayed to (§8).
             conn.log.endpoint_index = pick.endpoint_index;
             server.chargeL4(conn, cluster_index, pick.endpoint_index);
+            if (server.config.clusters[cluster_index].proxy_protocol_send) |version| {
+                server.stageProxySendHeader(conn, version);
+            }
             server.io.connect(
                 pick.address,
                 &conn.op_connect.completion,

--- a/src/config.zig
+++ b/src/config.zig
@@ -241,6 +241,15 @@ pub const Config = struct {
         /// beside any other policy rather than leaving it inert.
         hash_key: HashKey = .source_ip,
 
+        /// The PROXY protocol header this cluster's origins expect zoxy
+        /// to open every upstream connection with (#142 send), or null
+        /// for none. Per *cluster* — HAProxy's `send-proxy` unit — since
+        /// it states what the origin reads, not who connects. Only `l4`
+        /// listeners may route here: a pooled L7 upstream is shared
+        /// across clients (§3), and a per-connection header cannot name
+        /// one client — rejected at load, not silently ignored.
+        proxy_protocol_send: ?ProxyProtocolSend = null,
+
         pub const Pick = enum(u2) {
             rr,
             p2c,
@@ -261,6 +270,16 @@ pub const Config = struct {
             /// an L4 connection has nothing else, and an L7 request need
             /// not have been parsed yet.
             source_ip,
+        };
+
+        /// Which PROXY protocol version to write (#142): a closed
+        /// vocabulary rather than a bool because the wire formats differ
+        /// and the *origin's* parser — not zoxy — decides which it
+        /// reads. v2 is what cloud load balancers speak; v1 is
+        /// human-readable in a tcpdump.
+        pub const ProxyProtocolSend = enum(u1) {
+            v1,
+            v2,
         };
 
         /// One cluster's resolved check policy (§7). Every field is
@@ -345,6 +364,8 @@ pub const ValidationError = error{
     ListenerForwardedModeUnknown,
     ListenerHttpProxyProtocol,
     ListenerProxyProtocolModeUnknown,
+    ClusterProxyProtocolSendUnknown,
+    ClusterProxyProtocolOnHttpListener,
     FilterMethodEmpty,
     FilterMethodUnknown,
     FilterHeaderMatchKind,
@@ -1021,6 +1042,10 @@ pub const ClusterJson = struct {
     /// Optional §7 hash-policy detail; only valid beside `"pick": "hash"`,
     /// and absent there means the default key.
     hash: ?ClusterHashJson = null,
+    /// Optional PROXY protocol announcement on upstream connections
+    /// (#142); absent sends none. Only valid on clusters no http
+    /// listener routes to.
+    proxy_protocol: ?ClusterProxyProtocolJson = null,
 
     pub const schema_doc = "One upstream cluster: its endpoints, pick policy and health checks.";
     pub const schema_fields = .{
@@ -1044,6 +1069,28 @@ pub const ClusterJson = struct {
             .desc = "Cap on concurrent in-flight work per endpoint; absent leaves the cluster uncapped.",
             .minimum = 1,
             .maximum = constants.endpoint_inflight_max,
+        },
+        .proxy_protocol = .{
+            .desc = "Announce each client to this cluster's origins with a PROXY " ++
+                "protocol header on the upstream connection (l4-reachable " ++
+                "clusters only); absent sends none.",
+        },
+    };
+};
+
+pub const ClusterProxyProtocolJson = struct {
+    send: []const u8,
+
+    pub const schema_doc =
+        "What this cluster's origins expect ahead of the payload. The header " ++
+        "names the connection's client, so only l4 listeners may route to a " ++
+        "sending cluster — a pooled HTTP upstream is shared across clients " ++
+        "and cannot carry a per-client header.";
+    pub const schema_fields = .{
+        .send = .{
+            .desc = "PROXY protocol version to write: v1 (text) or v2 (binary — " ++
+                "what cloud load balancers speak).",
+            .enum_type = Config.Cluster.ProxyProtocolSend,
         },
     };
 };
@@ -1304,11 +1351,11 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// block below runs `assert_meta_matches` on each at comptime, so the
 /// metadata cannot drift from the fields whether or not the emitter builds.
 pub const dto_types = .{
-    ConfigJson,    ListenerJson,      RouteJson,    FilterJson,
-    MatchJson,     HeaderMatchJson,   ActionJson,   HeaderEditJson,
-    RewriteJson,   ClusterJson,       TimeoutsJson, LimitsJson,
-    AdminJson,     AccessLogJson,     CheckJson,    ClusterHashJson,
-    ForwardedJson, ProxyProtocolJson,
+    ConfigJson,    ListenerJson,      RouteJson,                FilterJson,
+    MatchJson,     HeaderMatchJson,   ActionJson,               HeaderEditJson,
+    RewriteJson,   ClusterJson,       TimeoutsJson,             LimitsJson,
+    AdminJson,     AccessLogJson,     CheckJson,                ClusterHashJson,
+    ForwardedJson, ProxyProtocolJson, ClusterProxyProtocolJson,
 };
 
 comptime {
@@ -1379,6 +1426,7 @@ fn resolveClusters(
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
             .hash_key = try hashKeyOf(pick, entry.cluster.hash),
             .max_inflight = try resolveMaxInflight(entry.cluster.max_inflight),
+            .proxy_protocol_send = try resolveClusterProxyProtocol(entry.cluster.proxy_protocol),
         };
     }
     assert(clusters.len == count);
@@ -1447,6 +1495,9 @@ fn resolveListeners(
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
             .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
         };
+        if (protocol == .http) {
+            try rejectHttpClusterSend(listeners[index].routes, clusters);
+        }
     }
 
     // Duplicate binds in O(n log n), for the reason `resolveClusters`
@@ -2015,6 +2066,39 @@ fn resolveProxyProtocol(
 fn pickOf(literal: []const u8) error{ClusterPickUnknown}!Config.Cluster.Pick {
     return std.meta.stringToEnum(Config.Cluster.Pick, literal) orelse
         error.ClusterPickUnknown;
+}
+
+/// A cluster that sends PROXY protocol (#142) may only be reached by l4
+/// listeners: a pooled L7 upstream is shared across clients (§3), and
+/// the header is per *connection*, naming one client — so an http route
+/// to a sending cluster describes a header that would lie, rejected
+/// rather than silently not sent. Reachability, not exclusivity: the
+/// same cluster stays valid for every l4 listener beside it.
+fn rejectHttpClusterSend(
+    routes: []const router.Route,
+    clusters: []const Config.Cluster,
+) ValidationError!void {
+    assert(routes.len >= 1);
+    for (routes) |route| {
+        assert(route.cluster_index < clusters.len);
+        if (clusters[route.cluster_index].proxy_protocol_send != null) {
+            return error.ClusterProxyProtocolOnHttpListener;
+        }
+    }
+}
+
+/// Resolve a cluster's PROXY protocol announcement (#142): absent is
+/// off, and the version vocabulary is closed. The l4-only restriction is
+/// enforced where listeners resolve — reachability is a property of the
+/// listener/cluster *pair*, and only that side sees both.
+fn resolveClusterProxyProtocol(
+    proxy_protocol_json: ?ClusterProxyProtocolJson,
+) ValidationError!?Config.Cluster.ProxyProtocolSend {
+    const proxy_protocol = proxy_protocol_json orelse return null;
+    return std.meta.stringToEnum(
+        Config.Cluster.ProxyProtocolSend,
+        proxy_protocol.send,
+    ) orelse error.ClusterProxyProtocolSendUnknown;
 }
 
 /// The §7 hash key for a cluster: its `hash` block's, or the default when
@@ -3606,6 +3690,58 @@ test "config: the proxy_protocol block resolves a mode, and is l4-only" {
     try expectParseError(
         error.MissingField,
         head ++ ",\"proxy_protocol\":{}" ++ tail,
+    );
+}
+
+test "config: the cluster proxy_protocol block resolves a version, l4-reachable only" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"";
+    const middle = "}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]";
+    const tail = "}},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // Absent: no header is sent — every config predating this.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ middle ++ tail);
+        try std.testing.expect(parsed.clusters[0].proxy_protocol_send == null);
+    }
+    // Both versions resolve on an l4-reachable cluster; neither is a default.
+    inline for (.{ "v1", "v2" }) |version| {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ middle ++ ",\"proxy_protocol\":{\"send\":\"" ++ version ++ "\"}" ++ tail,
+        );
+        try std.testing.expectEqual(
+            std.meta.stringToEnum(Config.Cluster.ProxyProtocolSend, version).?,
+            parsed.clusters[0].proxy_protocol_send.?,
+        );
+    }
+    // An http listener routing to a sending cluster is rejected: a pooled
+    // L7 upstream is shared across clients, so the per-connection header
+    // would name one client and serve many.
+    try expectParseError(
+        error.ClusterProxyProtocolOnHttpListener,
+        head ++ ",\"protocol\":\"http\"" ++ middle ++
+            ",\"proxy_protocol\":{\"send\":\"v2\"}" ++ tail,
+    );
+    // The same cluster reached by an http listener *beside* the l4 one is
+    // just as rejected — reachability poisons, not exclusivity.
+    try expectParseError(
+        error.ClusterProxyProtocolOnHttpListener,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}," ++
+            "{\"bind\":\"127.0.0.1:3\",\"protocol\":\"http\",\"cluster\":\"a\"" ++ middle ++
+            ",\"proxy_protocol\":{\"send\":\"v2\"}" ++ tail,
+    );
+    // The version vocabulary is closed and `send` is required.
+    try expectParseError(
+        error.ClusterProxyProtocolSendUnknown,
+        head ++ middle ++ ",\"proxy_protocol\":{\"send\":\"v3\"}" ++ tail,
+    );
+    try expectParseError(
+        error.MissingField,
+        head ++ middle ++ ",\"proxy_protocol\":{}" ++ tail,
     );
 }
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -268,6 +268,12 @@ pub const Counters = struct {
     /// not — `LOCAL` and `UNKNOWN` keep the observed peer, and a
     /// fronting proxy's health checks arrive exactly that way (§6).
     l4_proxy_header_accepted: Value = Value.init(0),
+    /// Headers staged for a sending cluster's origin (#142 send), one
+    /// per dialed L4 connection there. Counted at the stage, not the
+    /// wire: a dial that fails tears the connection down whole, so the
+    /// difference is exactly the fates `upstream_connect_failed` and the
+    /// teardown counters already witness. Pure observability.
+    l4_proxy_header_sent: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -329,6 +329,13 @@ const SocketEntry = struct {
     /// its peer may close first, and the log still has to name who
     /// connected.
     peer_address: std.Io.net.IpAddress,
+    /// What `localAddress` reports (§6 send: the header's destination
+    /// field): each end's local address is the other end's
+    /// `peer_address`, assigned at the same pair creation and held per
+    /// entry for the same reason — the peer may close first, and a
+    /// connection mid-dial still has to name the address its client
+    /// connected to.
+    local_address: std.Io.net.IpAddress,
     fin_received: bool,
     read_shutdown: bool,
     write_shutdown: bool,
@@ -749,6 +756,14 @@ pub fn logWrite(
 /// deterministically, so a seed's log lines are reproducible.
 pub fn peerAddress(io: *SimIo, socket: Socket) std.Io.net.IpAddress {
     return io.socketEntry(socket).peer_address;
+}
+
+/// This end of the pair. Held per entry like `peer_address` and for the
+/// same reason: the peer may already have closed — a client can hang up
+/// while the proxy is still dialing upstream — and deriving this through
+/// the peer index would turn that legal schedule into a panic.
+pub fn localAddress(io: *SimIo, socket: Socket) std.Io.net.IpAddress {
+    return io.socketEntry(socket).local_address;
 }
 
 /// The simulated wall clock (§8): the fixed epoch base plus however far
@@ -1306,6 +1321,10 @@ fn finishConnect(
         .bytes = client_ip_bytes,
         .port = io.next_client_port,
     } };
+    // Local addresses mirror the pair: each end's own address is what
+    // the other end names it (§6 send's destination field).
+    client_entry.local_address = server_entry.peer_address;
+    server_entry.local_address = address;
     io.next_client_port = if (io.next_client_port == std.math.maxInt(u16))
         client_port_base
     else
@@ -1607,6 +1626,7 @@ fn initSocketEntry(entry: *SocketEntry, inbox_capacity: u32) void {
     // the placeholder keeps a socket that somehow skipped that from
     // reporting another connection's peer out of a recycled slot.
     entry.peer_address = .{ .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 } };
+    entry.local_address = .{ .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 } };
 }
 
 fn closeEntry(io: *SimIo, socket: Socket) void {

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -897,6 +897,15 @@ pub fn peerAddress(io: *XevIo, socket: Socket) std.Io.net.IpAddress {
     return addressOf(@intFromEnum(socket), posix.system.getpeername);
 }
 
+/// This end of the pair: the address the peer connected *to*, which is
+/// the destination a §6 send header states. Same syscall trade as
+/// `peerAddress`, and asked at the one site that needs it rather than
+/// stored — the socket is live for the whole call by construction.
+pub fn localAddress(io: *XevIo, socket: Socket) std.Io.net.IpAddress {
+    _ = io;
+    return addressOf(@intFromEnum(socket), posix.system.getsockname);
+}
+
 pub fn close(
     io: *XevIo,
     socket: Socket,

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -39,6 +39,8 @@
 //!   shutdown(io, socket, how) void                      (sync control op)
 //!   closeNow(io, socket) void                           (sync; un-admitted sheds)
 //!   peerAddress(io, socket) IpAddress                   (sync; who connected)
+//!   localAddress(io, socket) IpAddress                  (sync; this end —
+//!       what the peer connected *to*, §6's send-header destination)
 //!   lastPressure(io) Pressure                           (classified cause
 //!       of the op just delivered, §8)
 //!   nowNs(io) u64                                       (per-tick clock, §4)
@@ -235,6 +237,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "shutdown",
             "closeNow",
             "peerAddress",
+            "localAddress",
             "lastPressure",
             "nowNs",
             "nowWallNs",

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -64,6 +64,19 @@ pub const DirectionState = struct {
         state.credited_len = 0;
     }
 
+    /// Grow the debt from the *front* (#142 send): `len` new bytes now
+    /// sit ahead of everything framed, nothing credited yet. Legal only
+    /// before the first credit — prepending to a partially-sent window
+    /// would resend bytes already gone — which in practice means at the
+    /// pre-relay staging sites, where the caller has just moved the
+    /// framed bytes over and written the new ones in front.
+    pub fn stageFront(state: *DirectionState, len: u32) void {
+        assert(len >= 1);
+        assert(state.credited_len == 0);
+        state.framed_len += len;
+        assert(state.owed() == state.framed_len);
+    }
+
     /// The target accepted `len` more of the debt.
     pub fn credit(state: *DirectionState, len: u32) void {
         assert(len >= 1);

--- a/src/net/proxy_protocol.zig
+++ b/src/net/proxy_protocol.zig
@@ -356,6 +356,140 @@ fn v2Address(family: u8, protocol: u8, block: []const u8) ?std.Io.net.IpAddress 
     }
 }
 
+// -- the send half (#142): composing the header this proxy announces ------
+//
+// The mirror of everything above: what zoxy writes on an upstream
+// connection so the *origin* learns the client, on a cluster whose config
+// says the origin expects it. Pure like the parser — bytes out, no I/O —
+// and pinned to it: every written header must parse back to the source it
+// announced (the round-trip tests below), so the two halves cannot drift.
+//
+// One shape decision lives here rather than in the caller: a v2 address
+// block (and a v1 line) is single-family, and a dual-stack listener can
+// observe an IPv4 client on a socket whose local address is IPv6. A
+// mixed pair promotes both addresses to INET6, the IPv4 one in its
+// mapped `::ffff:a.b.c.d` form — spec-legal, and receivers (this file's
+// own parser included) unwrap it back to the IPv4 address it is.
+
+/// The longest header either writer emits: the worst v1 TCP6 line —
+/// "PROXY TCP6 " + two uncompressed 39-char addresses + two 5-digit
+/// ports + separators + CRLF = 104 bytes (v2 tops out at 52). Bounded by
+/// the spec's own 107, and asserted under the receive cap so a chained
+/// zoxy always accepts what another zoxy sends.
+pub const send_bytes_max: u32 = 107;
+
+comptime {
+    assert(send_bytes_max <= constants.proxy_header_bytes_max);
+    // "PROXY TCP6 " + 39 + " " + 39 + " 65535 65535\r\n".
+    assert(11 + 39 + 1 + 39 + 14 == 104);
+    assert(104 <= send_bytes_max);
+    // The two v2 shapes land at fixed offsets; the writers' slices are
+    // these exact totals, both under the v1 worst case.
+    assert(v2_prelude_bytes + 12 == 28);
+    assert(v2_prelude_bytes + 36 == 52);
+    assert(v2_prelude_bytes + 36 <= send_bytes_max);
+}
+
+/// Compose a v1 line announcing `source` to a peer that reads text.
+pub fn writeV1(
+    buffer: *[send_bytes_max]u8,
+    source: *const std.Io.net.IpAddress,
+    destination: *const std.Io.net.IpAddress,
+) []const u8 {
+    const written = blk: {
+        if (source.* == .ip4 and destination.* == .ip4) {
+            const source_ip4 = source.ip4;
+            const destination_ip4 = destination.ip4;
+            break :blk std.fmt.bufPrint(
+                buffer,
+                "PROXY TCP4 {d}.{d}.{d}.{d} {d}.{d}.{d}.{d} {d} {d}\r\n",
+                .{
+                    source_ip4.bytes[0],      source_ip4.bytes[1],
+                    source_ip4.bytes[2],      source_ip4.bytes[3],
+                    destination_ip4.bytes[0], destination_ip4.bytes[1],
+                    destination_ip4.bytes[2], destination_ip4.bytes[3],
+                    source_ip4.port,          destination_ip4.port,
+                },
+            ) catch unreachable; // 56 bytes at most, under the 104 bound above.
+        }
+        var source_text: [39]u8 = undefined;
+        var destination_text: [39]u8 = undefined;
+        break :blk std.fmt.bufPrint(
+            buffer,
+            "PROXY TCP6 {s} {s} {d} {d}\r\n",
+            .{
+                v6Text(&source_text, &asV6Bytes(source)),
+                v6Text(&destination_text, &asV6Bytes(destination)),
+                source.getPort(),
+                destination.getPort(),
+            },
+        ) catch unreachable; // 104 bytes at most (comptime bound above).
+    };
+    assert(written.len >= header_bytes_min);
+    assert(written.len <= send_bytes_max);
+    return written;
+}
+
+/// Compose a v2 header announcing `source` to a peer that reads binary.
+pub fn writeV2(
+    buffer: *[send_bytes_max]u8,
+    source: *const std.Io.net.IpAddress,
+    destination: *const std.Io.net.IpAddress,
+) []const u8 {
+    @memcpy(buffer[0..v2_signature.len], v2_signature);
+    buffer[12] = 0x21; // Version 2, command PROXY.
+    if (source.* == .ip4 and destination.* == .ip4) {
+        buffer[13] = 0x11; // INET, STREAM.
+        std.mem.writeInt(u16, buffer[14..16], 12, .big);
+        buffer[16..20].* = source.ip4.bytes;
+        buffer[20..24].* = destination.ip4.bytes;
+        std.mem.writeInt(u16, buffer[24..26], source.ip4.port, .big);
+        std.mem.writeInt(u16, buffer[26..28], destination.ip4.port, .big);
+        assert(28 >= header_bytes_min);
+        assert(28 <= send_bytes_max);
+        return buffer[0..28];
+    }
+    buffer[13] = 0x21; // INET6, STREAM.
+    std.mem.writeInt(u16, buffer[14..16], 36, .big);
+    buffer[16..32].* = asV6Bytes(source);
+    buffer[32..48].* = asV6Bytes(destination);
+    std.mem.writeInt(u16, buffer[48..50], source.getPort(), .big);
+    std.mem.writeInt(u16, buffer[50..52], destination.getPort(), .big);
+    assert(52 >= header_bytes_min);
+    assert(52 <= send_bytes_max);
+    return buffer[0..52];
+}
+
+/// An address's 16 IPv6 bytes: its own, or the mapped form of an IPv4
+/// one — the promotion the module comment explains.
+fn asV6Bytes(address: *const std.Io.net.IpAddress) [16]u8 {
+    return switch (address.*) {
+        .ip4 => |v4| .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff } ++ v4.bytes,
+        .ip6 => |v6| v6.bytes,
+    };
+}
+
+/// Uncompressed lowercase-hex IPv6 text, eight groups: spec-legal
+/// (RFC 5952 compression is a *reader's* obligation, not a writer's
+/// here), fixed-shape, and exactly what `IpAddress.parse` round-trips.
+fn v6Text(buffer: *[39]u8, bytes: *const [16]u8) []const u8 {
+    var length: usize = 0;
+    var group: u8 = 0;
+    while (group < 8) : (group += 1) {
+        if (group >= 1) {
+            buffer[length] = ':';
+            length += 1;
+        }
+        const value = std.mem.readInt(u16, bytes[@as(usize, group) * 2 ..][0..2], .big);
+        const text = std.fmt.bufPrint(buffer[length..], "{x}", .{value}) catch
+            unreachable; // 4 hex digits at most into >= 4 remaining bytes.
+        length += text.len;
+    }
+    assert(length >= 15); // "0:0:0:0:0:0:0:0".
+    assert(length <= 39);
+    return buffer[0..length];
+}
+
 // -- tests ---------------------------------------------------------------
 
 const testing = std.testing;
@@ -562,6 +696,91 @@ test "proxy protocol v2: the declared length meets the cap at byte 16" {
     over_cap[13] = 0x00;
     std.mem.writeInt(u16, over_cap[14..16], @intCast(at_cap_len + 1), .big);
     try expectVerdict(&over_cap, .invalid);
+}
+
+/// The write-side property: whatever the writers emit, the parser must
+/// accept whole and hand back the announced source — the two halves of
+/// this file pinned to each other. The expected client is the source
+/// *normalized*: a mapped-IPv6 source unwraps, because the parser
+/// normalizes every mapped announcement (see `Header.client`).
+fn checkWrite(
+    source: std.Io.net.IpAddress,
+    destination: std.Io.net.IpAddress,
+) !void {
+    const expected: std.Io.net.IpAddress = switch (source) {
+        .ip4 => source,
+        .ip6 => |v6| std.Io.net.IpAddress.fromIp6(v6),
+    };
+    var buffer: [send_bytes_max]u8 = undefined;
+    inline for (.{ writeV1, writeV2 }) |write| {
+        const written = write(&buffer, &source, &destination);
+        checkParse(written);
+        const parsed = parse(written);
+        try testing.expect(parsed == .ok);
+        try testing.expectEqual(
+            @as(u32, @intCast(written.len)),
+            parsed.ok.bytes_len,
+        );
+        try testing.expect(clientEql(expected, parsed.ok.client));
+    }
+}
+
+const destination_v4: std.Io.net.IpAddress =
+    .{ .ip4 = .{ .bytes = .{ 203, 0, 113, 9 }, .port = 443 } };
+const client_v6: std.Io.net.IpAddress = .{ .ip6 = .{
+    .bytes = .{ 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+    .port = 56324,
+    .flow = 0,
+    .interface = .none,
+} };
+
+test "proxy protocol send: pinned bytes, both versions" {
+    var buffer: [send_bytes_max]u8 = undefined;
+    // The v1 line is the spec's own example shape, byte for byte.
+    try testing.expectEqualStrings(
+        "PROXY TCP4 198.51.100.1 203.0.113.9 56324 443\r\n",
+        writeV1(&buffer, &client_v4, &destination_v4),
+    );
+    // The v2 form is the parser tests' own INET vector — one constant,
+    // two directions, so reader and writer cannot drift apart.
+    try testing.expectEqualStrings(
+        v2_proxy_inet,
+        writeV2(&buffer, &client_v4, &destination_v4),
+    );
+}
+
+test "proxy protocol send: every written header parses back to its source" {
+    const mapped_source: std.Io.net.IpAddress = .{ .ip6 = .{
+        .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 198, 51, 100, 1 },
+        .port = 56324,
+        .flow = 0,
+        .interface = .none,
+    } };
+    try checkWrite(client_v4, destination_v4);
+    try checkWrite(client_v6, client_v6);
+    // Mixed families promote to INET6; the v4 side maps and unwraps.
+    try checkWrite(client_v4, client_v6);
+    try checkWrite(client_v6, destination_v4);
+    // A source that is itself a mapped address normalizes like any other.
+    try checkWrite(mapped_source, destination_v4);
+    // Port 0 is within range on both sides.
+    try checkWrite(
+        .{ .ip4 = .{ .bytes = .{ 198, 51, 100, 1 }, .port = 0 } },
+        .{ .ip4 = .{ .bytes = .{ 203, 0, 113, 9 }, .port = 0 } },
+    );
+}
+
+test "proxy protocol send: the worst case meets the bound exactly" {
+    const maximal: std.Io.net.IpAddress = .{ .ip6 = .{
+        .bytes = @splat(0xff),
+        .port = 65535,
+        .flow = 0,
+        .interface = .none,
+    } };
+    var buffer: [send_bytes_max]u8 = undefined;
+    try testing.expectEqual(@as(usize, 104), writeV1(&buffer, &maximal, &maximal).len);
+    try testing.expectEqual(@as(usize, 52), writeV2(&buffer, &maximal, &maximal).len);
+    try checkWrite(maximal, maximal);
 }
 
 const fuzz_corpus_v1 = "PROXY TCP4 198.51.100.1 203.0.113.9 56324 443\r\nGET /\r\n";

--- a/src/net/proxy_protocol.zig
+++ b/src/net/proxy_protocol.zig
@@ -380,6 +380,11 @@ pub const send_bytes_max: u32 = 107;
 
 comptime {
     assert(send_bytes_max <= constants.proxy_header_bytes_max);
+    // The stage site prepends a sent header to whatever payload the
+    // receive phase already framed; both must fit the relay buffer half
+    // they stage in, together, or the memmove there would clobber.
+    assert(send_bytes_max + constants.proxy_header_bytes_max <=
+        constants.relay_buffer_bytes);
     // "PROXY TCP6 " + 39 + " " + 39 + " 65535 65535\r\n".
     assert(11 + 39 + 1 + 39 + 14 == 104);
     assert(104 <= send_bytes_max);

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -246,6 +246,9 @@ pub const TestBed = struct {
         /// The #142 receive gate on the one listener; null for everyone
         /// but the PROXY protocol scenarios.
         proxy_protocol: ?config_module.Config.Listener.ProxyProtocol = null,
+        /// The #142 send gate on the one cluster; when set, the origin
+        /// double expects and strips the header before echoing.
+        proxy_protocol_send: ?config_module.Config.Cluster.ProxyProtocolSend = null,
     };
 
     fn bindAddress() std.Io.net.IpAddress {
@@ -268,7 +271,13 @@ pub const TestBed = struct {
         sim_options.buffer_group_count = options.server.head_buffers;
         try bed.sim_io.init(arena, sim_options);
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
+        bed.clusters = .{.{
+            .name = "origin",
+            .endpoints = &bed.endpoints,
+            .check = options.check,
+            .max_inflight = options.max_inflight,
+            .proxy_protocol_send = options.proxy_protocol_send,
+        }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -306,6 +315,7 @@ pub const TestBed = struct {
         };
         bed.scenario.origin.on_accept = Scenario.startPendingRacer;
         bed.scenario.origin.context = &bed.scenario;
+        bed.scenario.origin.expect_proxy_header = options.proxy_protocol_send != null;
         if (options.origin_listens) {
             try bed.scenario.origin.start(&bed.sim_io, originAddress());
         }
@@ -1100,6 +1110,87 @@ test "proxy protocol: a silent peer is reaped on the connect budget" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_invalid"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l4_proxy_header_accepted"));
+}
+
+test "proxy protocol send: the origin hears who connected, and only the payload echoes" {
+    // The send half end to end: a sending cluster's upstream connection
+    // opens with a header naming the observed client, the origin double
+    // strips and records it, and the echo stays byte-exact — so a header
+    // that leaked into the payload, or payload that leaked into the
+    // header, cannot hide. Partial-io seeds split the header across
+    // deliveries on the origin's side of the wire.
+    inline for (.{
+        config_module.Config.Cluster.ProxyProtocolSend.v1,
+        config_module.Config.Cluster.ProxyProtocolSend.v2,
+    }) |version| {
+        var seed: u64 = 1;
+        while (seed <= 8) : (seed += 1) {
+            var bed: TestBed = undefined;
+            try bed.setUp(std.testing.allocator, .{
+                .sim = .{
+                    .seed = seed,
+                    .adversary = .{ .partial_io = true, .connect_delay_ns_max = 2_000_000 },
+                },
+                .proxy_protocol_send = version,
+            });
+            defer bed.tearDown();
+
+            bed.startClients(1, true);
+            try bed.sim_io.run();
+            try bed.expectDrained();
+
+            const client = &bed.scenario.clients[0];
+            try std.testing.expectEqual(Client.Outcome.eof, client.outcome);
+            try std.testing.expectEqualStrings(
+                echo_token,
+                client.receive_buffer[0..client.received_len],
+            );
+            try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_sent"));
+            try std.testing.expectEqual(@as(u32, 1), bed.scenario.origin.proxy_header_conns);
+            try std.testing.expectEqual(@as(u32, 0), bed.scenario.origin.proxy_header_violations);
+            // The announced client is the peer zoxy observed: SimIo's
+            // synthetic dialer address.
+            const observed: std.Io.net.IpAddress =
+                .{ .ip4 = .{ .bytes = .{ 198, 51, 100, 1 }, .port = 50_000 } };
+            const announced = bed.scenario.origin.conns[0].announced.?;
+            try std.testing.expect(observed.eql(&announced));
+        }
+    }
+}
+
+test "proxy protocol: the received identity is the sent identity — the chain holds" {
+    // Both halves of #142 on one connection: the client announces
+    // 203.0.113.7:4711 through the require listener, and the sending
+    // cluster's origin must hear exactly that — zoxy in the middle of a
+    // PROXY protocol chain, believing inward and announcing outward.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 9, .adversary = .{ .partial_io = true } },
+        .proxy_protocol = .require,
+        .proxy_protocol_send = .v2,
+    });
+    defer bed.tearDown();
+
+    bed.scenario.clients_count = 1;
+    const client = &bed.scenario.clients[0];
+    client.exchange = true;
+    client.prefix = proxy_v1_line;
+    client.start(&bed.scenario, TestBed.bindAddress());
+    try bed.sim_io.run();
+    try bed.expectDrained();
+
+    try std.testing.expectEqual(Client.Outcome.eof, client.outcome);
+    try std.testing.expectEqualStrings(
+        echo_token,
+        client.receive_buffer[0..client.received_len],
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_accepted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l4_proxy_header_sent"));
+    try std.testing.expectEqual(@as(u32, 0), bed.scenario.origin.proxy_header_violations);
+    const announced_in: std.Io.net.IpAddress =
+        .{ .ip4 = .{ .bytes = .{ 203, 0, 113, 7 }, .port = 4711 } };
+    const announced_out = bed.scenario.origin.conns[0].announced.?;
+    try std.testing.expect(announced_in.eql(&announced_out));
 }
 
 test "health: probes against a listening origin keep the endpoint healthy" {

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -11,6 +11,7 @@
 const std = @import("std");
 
 const Io = @import("../io/io.zig");
+const proxy_protocol = @import("../net/proxy_protocol.zig");
 
 const assert = std.debug.assert;
 
@@ -38,6 +39,20 @@ pub fn Origin(comptime IoType: type) type {
         mode: Mode = .echo,
         /// Optional per-accept mode picker (the sim randomizes modes).
         mode_selector: ?*const fn (?*anyopaque) Mode = null,
+        /// The #142 send half's receiving end: expect every connection to
+        /// open with a PROXY protocol header, consume it before echoing,
+        /// and record what it announced. An origin double must fail
+        /// loudly — garbage where a header belongs is a violation the
+        /// harness asserts on, never a tolerated shape.
+        expect_proxy_header: bool = false,
+        /// Connections whose header parsed. Echo-mode only: the
+        /// misbehaving modes never parse — `reset_on_first_chunk` acts
+        /// on the first delivery, `mute` reads without judging (its
+        /// `header_len` never advances, so its recv window never
+        /// shrinks), and `frozen` never reads.
+        proxy_header_conns: u32 = 0,
+        /// Connections whose opening bytes were not a valid header.
+        proxy_header_violations: u32 = 0,
         /// Optional hook fired after each accept (the drain-race test
         /// starts a client from here).
         on_accept: ?*const fn (?*anyopaque) void = null,
@@ -61,11 +76,27 @@ pub fn Origin(comptime IoType: type) type {
             sent_len: u32 = 0,
             mode: Mode = .echo,
             done: bool = false,
+            /// The #142 header accumulates here until it parses; any
+            /// payload that rode the same delivery follows it and is
+            /// moved to `buffer` for the echo.
+            header_buffer: [proxy_protocol.send_bytes_max]u8 = undefined,
+            header_len: u32 = 0,
+            header_done: bool = false,
+            /// What the header announced (null: LOCAL/UNKNOWN), for the
+            /// harness's identity oracles.
+            announced: ?std.Io.net.IpAddress = null,
 
             fn armRecv(conn: *Conn) void {
+                // While a header is owed, bytes land in its accumulator —
+                // the payload behind it is extracted on completion.
+                const target: []u8 =
+                    if (conn.origin.expect_proxy_header and !conn.header_done)
+                        conn.header_buffer[conn.header_len..]
+                    else
+                        conn.buffer[0..];
                 conn.origin.io.recv(
                     conn.socket,
-                    &conn.buffer,
+                    target,
                     &conn.recv_completion,
                     Conn,
                     conn,
@@ -83,6 +114,10 @@ pub fn Origin(comptime IoType: type) type {
                 assert(received >= 1);
                 switch (conn.mode) {
                     .echo => {
+                        if (conn.origin.expect_proxy_header and !conn.header_done) {
+                            conn.feedProxyHeader(received);
+                            return;
+                        }
                         conn.transfer_len = received;
                         conn.sent_len = 0;
                         conn.armSend();
@@ -101,6 +136,55 @@ pub fn Origin(comptime IoType: type) type {
                     .mute => conn.armRecv(),
                     .frozen => unreachable,
                 }
+            }
+
+            /// Accumulate and judge the #142 header. Monotonic verdicts
+            /// make the re-parse sound; a buffer that fills without one
+            /// is a violation too, since zoxy's own writers top out at
+            /// 104 bytes and anything longer was never a sent header.
+            fn feedProxyHeader(conn: *Conn, received: u32) void {
+                const origin = conn.origin;
+                assert(origin.expect_proxy_header);
+                assert(!conn.header_done);
+                conn.header_len += received;
+                assert(conn.header_len <= conn.header_buffer.len);
+                switch (proxy_protocol.parse(conn.header_buffer[0..conn.header_len])) {
+                    .need_more => {
+                        if (conn.header_len == conn.header_buffer.len) {
+                            conn.witnessHeaderViolation();
+                            return;
+                        }
+                        conn.armRecv();
+                    },
+                    .invalid => conn.witnessHeaderViolation(),
+                    .ok => |header| {
+                        conn.header_done = true;
+                        conn.announced = header.client;
+                        origin.proxy_header_conns += 1;
+                        const leftover_len = conn.header_len - header.bytes_len;
+                        if (leftover_len >= 1) {
+                            // Payload rode the same delivery: echo it
+                            // like any chunk, from the echo buffer.
+                            assert(leftover_len <= buffer_bytes);
+                            std.mem.copyForwards(
+                                u8,
+                                conn.buffer[0..leftover_len],
+                                conn.header_buffer[header.bytes_len..conn.header_len],
+                            );
+                            conn.transfer_len = leftover_len;
+                            conn.sent_len = 0;
+                            conn.armSend();
+                            return;
+                        }
+                        conn.armRecv();
+                    },
+                }
+            }
+
+            fn witnessHeaderViolation(conn: *Conn) void {
+                conn.origin.proxy_header_violations += 1;
+                conn.origin.io.closeNow(conn.socket);
+                conn.done = true;
             }
 
             fn armSend(conn: *Conn) void {


### PR DESCRIPTION
Closes #142 — the **send** half, completing what #169 (receive) started:
a byte relay's origin has no header to read an address from, so a
sending cluster opens every upstream connection with a PROXY protocol
header naming the client zoxy believes. Behind a `require` listener that
is the client the fronting proxy announced — one identity end to end
through a chain of proxies, which the sim now asserts.

## The shape

```json
"clusters": { "db": { "endpoints": ["10.0.0.1:5432"],
                      "proxy_protocol": { "send": "v2" } } }
```

Per **cluster** — HAProxy's `send-proxy` unit — because it states what
the origin reads, not who connects. The restriction is *reachability*,
enforced at load: an `http` listener may not route to a sending cluster,
since a pooled L7 upstream is shared across clients and a per-connection
header naming one client would lie to every other (L4 dials fresh, so no
such conflict).

## The receive half's machinery pays for the whole feature

- **Writers pinned to the parser** in one module: every written header
  must parse back to its normalized source, and the v2 pinned-bytes test
  reuses the parser tests' own vector — the halves cannot drift, and a
  chained zoxy always accepts what another sends. Mixed-family pairs
  promote to INET6 with the v4 side mapped (receivers unwrap).
- **No new state, no new op**: the header is prepended at the dial to
  the client→upstream direction's debt (`DirectionState.stageFront`,
  receive-phase payload memmoves over), and the relay's existing
  pre-owed-debt entry sends it before any relayed byte.
- **One new seam method**, `localAddress`, for the header's destination
  field — getsockname in production, per-entry in the sim. The review
  caught the first sim draft deriving it through the peer index, which
  panics when a client hangs up mid-dial; it now mirrors
  `peer_address`'s stored-per-entry lesson exactly.

## Testing

- `zig build ci` green at every slice: 4096-seed sim, census 49
  counters fired / 12 exempt, fmt clean.
- The shared origin double becomes the receiving end: strips the header
  with the same monotonic parser, records what it announced, counts
  violations the oracles pin to zero on every seed.
- Sweep oracles, both teeth-tested at seed 6: configured-but-never-
  staged fails (`OriginSawInvalidProxyHeader`); announcing the listener
  instead of the client fails (`UpstreamHeardUnknownIdentity` — inverted
  membership, sound under randomized origin misbehavior).
- Directed tests: v1+v2 under partial-io seeds, and the chain test —
  announced-in `203.0.113.7:4711` must equal announced-out.

## Known limitation (documented)

Health probes do not send the header: the dial-only `tcp` check is
unaffected, but an `http` check against a sending cluster probes bare —
docs recommend `tcp` checks where the origin strictly requires the
header. (HAProxy's `check-send-proxy` is the follow-up shape if wanted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)