### PR TITLE
A cheap live gate (Tier 0.5): the real binary against a real origin, per change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       # zig-pkg (vendored, hash-pinned deps) is deliberately not checked.
       - name: Check formatting
-        run: devenv shell -- zig fmt --check build.zig src bench sim scripts
+        run: devenv shell -- zig fmt --check build.zig src bench sim smoke scripts
 
       - name: Build
         run: devenv shell -- zig build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,13 @@ direnv activates the shell). Read before writing code:
 ## Gates — run before every commit
 
 - `zig build ci` — unit tests + fuzz corpus, boundary lint, deterministic
-  simulation. A sim failure prints its seed; `zig build sim -- <seed>`
-  replays the exact schedule.
-- `zig fmt --check src scripts build.zig build.zig.zon` — the format gate
-  (a PostToolUse hook auto-formats files as they are edited).
+  simulation, and the Tier-0.5 live gate. A sim failure prints its seed;
+  `zig build sim -- <seed>` replays the exact schedule. The live gate
+  (`zig build smoke` alone) runs the real binary against a real origin
+  and asserts equalities on what it wrote; a failing one prints the
+  proxy's own output from `.zig-cache/zoxy-smoke/`.
+- `zig fmt --check src scripts smoke build.zig build.zig.zon` — the format
+  gate (a PostToolUse hook auto-formats files as they are edited).
 - `zig build bench` (Tier 1: zrk against an nginx origin) runs at merge,
   not per change — compare bands across runs, never single numbers.
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ automatically on `cd`:
 ```sh
 devenv shell                    # zig 0.16, zls, kcov
 zig build                       # build zig-out/bin/zoxy
-zig build ci                    # the per-change gate: tests + lint + simulation
+zig build ci                    # the per-change gate: tests + lint + simulation + smoke
 zig build test                  # unit tests
 zig build sim -- 0 500          # deterministic simulator: [seed] [iterations]
+zig build smoke                 # live gate: the real binary against a real origin
 zig build schema                # emit zig-out/config.schema.json
 zig build run -- config/example.json
 zig build bench                 # loopback bands: direct vs zoxy vs haproxy
@@ -101,6 +102,13 @@ against an I/O seam, so a seeded adversarial backend runs the *real* code
 against virtual sockets and a virtual clock — partial reads down to one byte,
 resets at every point in every exchange, delayed and black-holed connects. A
 failing seed prints itself and replays exactly.
+
+Beside it, a live gate runs the actual binary against an actual origin on every
+change, in under a second, and asserts equalities on what it wrote: N requests
+produce exactly N access-log lines, the counters scraped off `/metrics` reconcile
+with each other and with the log, memory does not move across two identical load
+passes, and SIGTERM drains cleanly. It is there because a virtual clock cannot
+catch a bug whose only symptom is a wrong *rate*.
 
 > [!NOTE]
 > The bench harness is always built ReleaseFast, but it measures the

--- a/build.zig
+++ b/build.zig
@@ -131,6 +131,31 @@ pub fn build(b: *std.Build) void {
     const schema_step = b.step("schema", "Emit the config JSON Schema to zig-out/config.schema.json");
     schema_step.dependOn(&schema_install.step);
 
+    // §9 Tier 0.5: the live gate — the shipped binary, on a real kernel,
+    // against a real origin, on every change. It drives the *default*
+    // build (the one `zig build` installs) rather than the ReleaseFast
+    // one the bench uses: its verdicts are correctness equalities on real
+    // output, so what a Debug build's extra checks add is worth more here
+    // than the shipped binary's code generation, which Tier 1 is the gate
+    // for. The origin and the load generator both live inside the harness
+    // (smoke/), so the step needs nothing from the dev shell.
+    const smoke_exe = b.addExecutable(.{
+        .name = "zoxy-smoke",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("smoke/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const smoke_run = b.addRunArtifact(smoke_exe);
+    smoke_run.addArg("--zoxy");
+    smoke_run.addArtifactArg(exe);
+    if (b.args) |args| {
+        smoke_run.addArgs(args);
+    }
+    const smoke_step = b.step("smoke", "Tier-0.5 live gate: the real binary against a live origin");
+    smoke_step.dependOn(&smoke_run.step);
+
     // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash),
     // and the zoxy under test is a ReleaseFast build — matching the
     // shipped binary — whatever -Doptimize says. ReleaseFast selects the

--- a/build.zig
+++ b/build.zig
@@ -286,14 +286,18 @@ pub fn build(b: *std.Build) void {
     const lint_step = b.step("lint", "fd-boundary lint: raw syscalls only under src/io/");
     lint_step.dependOn(&lint_run.step);
 
-    // The deterministic per-change gates. The Tier-1 `bench` step is
-    // deliberately excluded (DESIGN.md §9): its verdict is a band
-    // comparison across runs, run at merge against a real origin, not a
-    // blind shared-runner pass.
-    const ci_step = b.step("ci", "Per-change gates: test + lint + sim (bench runs at merge)");
+    // The per-change gates. The Tier-1 `bench` step is deliberately
+    // excluded (DESIGN.md §9): its verdict is a band comparison across
+    // runs, run at merge against a real origin, not a blind shared-runner
+    // pass. Tier 0.5 is not excluded on those grounds and belongs here
+    // for the opposite reason — its verdicts are equalities on real
+    // output, which a shared runner cannot move, and it is the only gate
+    // in this list that runs the binary at all.
+    const ci_step = b.step("ci", "Per-change gates: test + lint + sim + smoke (bench runs at merge)");
     ci_step.dependOn(test_step);
     ci_step.dependOn(lint_step);
     ci_step.dependOn(sim_step);
+    ci_step.dependOn(smoke_step);
     // Compile — never run — every measurement binary. Their verdicts are
     // human-read A/Bs and profiles, so running them here would buy nothing
     // and cost minutes; but they call the same internal APIs the proxy

--- a/build.zig
+++ b/build.zig
@@ -297,7 +297,16 @@ pub fn build(b: *std.Build) void {
     ci_step.dependOn(test_step);
     ci_step.dependOn(lint_step);
     ci_step.dependOn(sim_step);
-    ci_step.dependOn(smoke_step);
+    // Linux only, for now. On its first CI run the gate found that the
+    // macOS leg answers *nothing* to its first L7 request — accepted,
+    // then closed with no response and no diagnostic (#184). That is a
+    // finding, not a flake, and fixing zoxy's kqueue path is not this
+    // step's job; `zig build smoke` still runs everywhere, which is how
+    // that issue gets worked, and putting this line back is its
+    // acceptance test.
+    if (target.result.os.tag == .linux) {
+        ci_step.dependOn(smoke_step);
+    }
     // Compile — never run — every measurement binary. Their verdicts are
     // human-read A/Bs and profiles, so running them here would buy nothing
     // and cost minutes; but they call the same internal APIs the proxy

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1292,6 +1292,12 @@ equalities a shared runner's noise cannot move.
    none can bound itself, so one wall-clock budget covers the run from
    outside: a wedged proxy is killed and reported rather than left to
    hang the build until CI's own timeout kills it with no diagnosis.
+   `zig build ci` runs it on Linux only for now: on its first CI run the
+   gate found that the macOS leg answers nothing at all to its first L7
+   request (#184), which is what a live gate is for and is also a
+   different piece of work from building one. `zig build smoke` runs
+   everywhere regardless, and restoring the `ci` wiring on macOS is that
+   issue's acceptance test.
 4. **Benchmarks — [zrk](https://github.com/zoxy-io/zrk), three tiers.**
    The load generator is zrk — a pure-Zig wrk2 rewrite: *constant-throughput*
    (open-loop) pacing with coordinated-omission-corrected HdrHistogram

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1181,17 +1181,23 @@ keep-alive connection from waiting on a request that will never come.
 The deterministic-simulation seam is the single highest-leverage testing
 decision the previous iteration made: the data path is written against an
 `Io` facade from the first commit (§4) so a seeded, adversarial,
-virtual-socket backend can run the *real* code, not a mock of it. All four
+virtual-socket backend can run the *real* code, not a mock of it. All
 gates exist as `build.zig` steps from the first commit; a
 feature without its gate is not done. The three deterministic gates
-(simulation, fuzz, zero-alloc) plus the fd-boundary lint run on every
-change as `zig build ci`. The benchmark gate (Tier 1) is **run at
-merge, not on every change**: its verdict is a *band comparison across
-runs* (§Tier 1 below), which a single shared-runner pass cannot make —
-so `zig build bench` is invoked deliberately against a real origin, and
-its hard invariants (RSS under the §5 banner ceiling, clean drain,
-sub-1% socket-error rate) are the pass/fail part. `zig build ci`
-deliberately excludes it.
+(simulation, fuzz, zero-alloc) plus the fd-boundary lint and the live
+gate (Tier 0.5) run on every change as `zig build ci`. The benchmark gate
+(Tier 1) is **run at merge, not on every change**: its verdict is a *band
+comparison across runs* (§Tier 1 below), which a single shared-runner
+pass cannot make — so `zig build bench` is invoked deliberately against a
+real origin, and its hard invariants (RSS under the §5 banner ceiling,
+clean drain, sub-1% socket-error rate) are the pass/fail part. `zig build
+ci` deliberately excludes it.
+
+What separates the live gate from the benchmark is not what it runs but
+what it *claims*. Both spawn the real binary against a real origin; Tier
+1 answers "how fast", which only a comparison across runs can say, while
+Tier 0.5 answers "what did it do", which a single run answers in
+equalities a shared runner's noise cannot move.
 
 1. **Deterministic simulation — `zig build sim -- [seed] [iterations]
    [keep-going]`.** `keep-going` names every failing seed in the range
@@ -1249,7 +1255,44 @@ deliberately excludes it.
    parser edge: HTTP/1.1 head parser, chunked decoder, config parser.
    Assertion: never panic, never overrun a bound, reject-or-parse with no
    third outcome.
-3. **Benchmarks — [zrk](https://github.com/zoxy-io/zrk), three tiers.**
+3. **The live gate (Tier 0.5) — `zig build smoke`.** The shipped binary,
+   on a real kernel, against a real origin, on every change, in under a
+   second. It exists because the deterministic gates are exhaustive
+   *within* a virtual socket table and a virtual clock, and two shipped
+   bugs were neither: a phantom access-log line per keep-alive connection
+   (#129) and health probes idling out their whole timeout (#130). Both
+   were afterwards teachable to the simulator; neither was caught by it
+   first, because each had to be *known* before it could be looked for.
+   The origin and the load generator are Zig inside the harness
+   (`smoke/`), not nginx and zrk: a per-change gate should add no CI
+   dependency, and owning the origin makes its deliveries shapeable,
+   which one of the verdicts below is a property of.
+   Every verdict is an equality on real output, so a shared runner's
+   timing cannot move one. N requests produce exactly N access-log lines,
+   with connections closed by the client and connections reaped by the
+   drain both witnessed writing nothing. Both of `reconcile`'s identities
+   are re-derived from a live `/metrics` scrape — rendered, written to a
+   socket, framed by a close, parsed back — which puts the whole admin
+   plane (§8's reserved slot, the tree's only asynchronous close op)
+   under the same verdict as the arithmetic. The counters must agree with
+   the log about the same exchanges. Upstream reuse (§3) must happen, and
+   an origin delivery that overruns the head buffer must leave its excess
+   in a second write (§7) — the one shape the sweep's census cannot
+   reach, and it needs an injected `Connection: close` besides, because a
+   rendered head that did not *grow* fits its excess exactly. The
+   proxy's resident set must not move across two identical load passes,
+   §5's promise witnessed from outside the process.
+   The one exception to "equalities" is the health-probe *rate*, and it
+   is the exception that proves the rule: #130 was a bug no equality
+   could see, because every verdict the prober reached was correct and
+   only its rate was wrong. That check is a band — loose enough that
+   scheduling cannot move it, decisive because what it is aimed at runs
+   two orders of magnitude slow rather than a little slow.
+   Every wait in the harness is a wait on the process under test, and
+   none can bound itself, so one wall-clock budget covers the run from
+   outside: a wedged proxy is killed and reported rather than left to
+   hang the build until CI's own timeout kills it with no diagnosis.
+4. **Benchmarks — [zrk](https://github.com/zoxy-io/zrk), three tiers.**
    The load generator is zrk — a pure-Zig wrk2 rewrite: *constant-throughput*
    (open-loop) pacing with coordinated-omission-corrected HdrHistogram
    latency, so a stalling proxy accrues the stall instead of hiding it.
@@ -1291,7 +1334,7 @@ deliberately excludes it.
      multi-host cloud fleet (disjoint hosts, saturation self-checks,
      HAProxy/Envoy/Traefik/Caddy). Run per release, never per PR.
 
-4. **Zero-alloc gate.** The full serving path — including a drain — runs
+5. **Zero-alloc gate.** The full serving path — including a drain — runs
    in tests under a failing/counting allocator; baseline allocation count
    must equal the final count. Steady state also asserts zero allocating
    syscalls (no mmap/brk after init) via counters.
@@ -1333,6 +1376,7 @@ src/
   admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
   access_log.zig      // JSON access log: double-buffered sink, drop rung (§8)
 sim/                  // simulator harness + invariants
+smoke/                // the live gate (Tier 0.5): origin + client + verdicts, §9
 bench/                // micro benches (poop) + loopback harness (zrk), §9
 ```
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1429,6 +1429,49 @@ can only be the proxy's fault. The band now prints the refused/timed-out
 split every run: a threshold whose margin is invisible until it trips is
 how this one sat mis-specified for a week.
 
+## The live gate's measured numbers (2026-08-02, #144)
+
+Tier 0.5 (`zig build smoke`, DESIGN.md §9) landed with these readings on a
+loopback dev box; they are what its bands and equalities were set from,
+and a future tightening should start here rather than from taste.
+
+- **Whole run: 0.89 s**, of which the drain deadline is 0.3 s and the
+  probe window 0.5 s. The load itself — 136 L7 exchanges, 2 L4
+  connections, 15 accepted connections — is single-digit milliseconds.
+  The drain deadline is the *entire* shutdown cost: an idle keep-alive
+  connection is indistinguishable from one about to send a request, so
+  the drain waits for it and reaps at the deadline (§8). At the stock
+  2 s that alone made the gate a 2 s gate.
+- **Probes: 20 in a 500 ms window at a 25 ms interval**, run after run —
+  exactly what the interval implies, since a probe against a loopback
+  origin costs nothing against the pacing. With the deadline-cancel in
+  `health.zig`'s `settle` disabled (#130 itself), the same window
+  measures **0**. The 5..60 band therefore sits four times below and
+  three times above a number that has not once varied.
+- **Resident set: 0 KiB of growth** across two identical load passes,
+  measured at a zero-KiB tolerance before the shipped 64 KiB was chosen.
+  §5's promise is exact here, not approximate; the tolerance is headroom
+  for page granularity on some other kernel.
+- **Upstream reuse: 135 of the run's 136 L7 exchanges** — one dial and
+  135 reuses, read off the drain-time counter dump. The clients are
+  driven sequentially, so the pool hands the same parked connection back
+  every time; the gate itself only requires the count to be nonzero,
+  since which connection the pool picks is its business and not a claim
+  worth pinning.
+
+**The finding worth keeping: filling the head buffer is not enough to
+produce a response excess.** The bulk target's 32 KiB body does fill
+zoxy's 8 KiB upstream head buffer, and `l7_response_excess_sent` still
+read **0**. The excess rides the head write whenever
+`rendered.len + excess <= head_buffer_bytes`, and the rendered head is
+the origin's head *minus* hop-by-hop headers — so head plus excess comes
+to exactly the buffer size and fits, 8192 <= 8192. The branch needs the
+render to **grow** the head, and the only thing that grows it is the
+injected `Connection: close` (`render.zig`). The gate's bulk requests
+announce close for that reason alone, and the counter then reads exactly
+one per request. Anyone reaching for this path in a directed test needs
+both halves.
+
 ## Phase 0 baselines (2026-07-10/11)
 
 - Debug-build zoxy over loopback (`zig build bench`, nginx origin, rate

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -153,13 +153,15 @@ const uncovered = [_]Uncovered{
         .why = .unreached,
         .reason = "no seed raises the adversary's recv cap to head_buffer_bytes_default, " ++
             "so no origin delivery fills the head buffer; " ++
-            "src/http_proxy_test.zig builds that delivery",
+            "src/http_proxy_test.zig builds that delivery, and the Tier-0.5 " ++
+            "live gate counts it against a real one",
     },
     .{
         .name = "admin_served",
         .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++
-            "src/admin_test.zig covers the scrape",
+            "src/admin_test.zig covers the scrape, and the Tier-0.5 live " ++
+            "gate reads its counters through one",
     },
     .{
         .name = "admin_reaped",
@@ -237,7 +239,8 @@ const uncovered_ops = [_]struct { kind: SimIo.OpKind, reason: []const u8 }{
         .kind = .close,
         .reason = "src/admin.zig is the only asynchronous close in the tree — " ++
             "every serving path closes synchronously via closeNow — and the " ++
-            "sweep configures no admin listener; src/admin_test.zig covers it",
+            "sweep configures no admin listener; src/admin_test.zig covers it, " ++
+            "and the Tier-0.5 live gate delivers real ones through its scrapes",
     },
 };
 

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -1,0 +1,143 @@
+//! The Tier-0.5 gate's client (DESIGN.md §9): the smallest HTTP/1.1
+//! speaker that can hold a keep-alive connection open and read a whole
+//! response off it, plus the raw echo the L4 path needs.
+//!
+//! Deliberately not zrk (Tier 1's generator): this tier issues a counted
+//! handful of requests and asserts an equality on what zoxy wrote about
+//! them, so what it needs from a client is *exactness* — every response
+//! read to its last body byte before the next request goes out — rather
+//! than pacing, histograms or concurrency.
+//!
+//! It is also not a general client. Only what this origin sends is
+//! parsed: a status line, headers, and a `Content-Length` body. A chunked
+//! or close-framed response is a failure here, because the origin behind
+//! the proxy never sends one, so seeing one means the hop invented it.
+
+const std = @import("std");
+
+const Io = std.Io;
+
+const assert = std.debug.assert;
+
+/// Response head bytes the client will read. zoxy's own head buffer
+/// bounds what it can forward, so this only has to be no smaller.
+const response_head_bytes_max: u32 = 8192;
+
+/// Body bytes one response may carry. Sized for the whole gate's
+/// vocabulary, not for one request, so the cap needs no per-call thought.
+pub const response_body_bytes_max: u32 = 256 * 1024;
+
+/// Header lines one response head may spend, on the same terms as the
+/// origin's request cap: a bound so the parse loop cannot run forever.
+const response_headers_max: u32 = 64;
+
+pub const Response = struct {
+    status: u16,
+    body_bytes: u32,
+};
+
+pub const Client = struct {
+    io: Io,
+    stream: Io.net.Stream,
+    reader: Io.net.Stream.Reader,
+    writer: Io.net.Stream.Writer,
+    read_buffer: [response_head_bytes_max]u8,
+    write_buffer: [response_head_bytes_max]u8,
+    /// Requests issued on this connection, so a caller can assert its own
+    /// keep-alive arithmetic against what actually went out.
+    requests: u32,
+    connected: bool,
+
+    /// Open a connection to a loopback port. In-place through an
+    /// out-pointer: both `Reader` and `Writer` hold pointers into the
+    /// buffers beside them, so the struct's address has to be final
+    /// before either is built.
+    pub fn connect(client: *Client, io: Io, port: u16) !void {
+        assert(port != 0);
+        var address: Io.net.IpAddress = .{ .ip4 = .loopback(port) };
+        client.io = io;
+        client.stream = try address.connect(io, .{ .mode = .stream });
+        client.reader = client.stream.reader(io, &client.read_buffer);
+        client.writer = client.stream.writer(io, &client.write_buffer);
+        client.requests = 0;
+        client.connected = true;
+        assert(client.reader.interface.buffer.len == response_head_bytes_max);
+    }
+
+    pub fn close(client: *Client) void {
+        assert(client.connected);
+        client.stream.close(client.io);
+        client.connected = false;
+    }
+
+    /// One request/response exchange, left on a message boundary so the
+    /// next `get` on this connection is a keep-alive turnaround rather
+    /// than a fresh guess about where the last response ended.
+    pub fn get(client: *Client, host: []const u8, target: []const u8) !Response {
+        assert(client.connected);
+        assert(target.len >= 1);
+        assert(target[0] == '/');
+        try client.writer.interface.print(
+            "GET {s} HTTP/1.1\r\nHost: {s}\r\n\r\n",
+            .{ target, host },
+        );
+        try client.writer.interface.flush();
+        client.requests += 1;
+        const response = try readResponse(&client.reader.interface);
+        assert(client.requests >= 1);
+        return response;
+    }
+};
+
+/// Read one whole response: status line, headers, then exactly the body
+/// the `Content-Length` promised.
+fn readResponse(reader: *Io.Reader) !Response {
+    const status = try readStatus(reader);
+    const body_bytes = try readHeaders(reader);
+    assert(body_bytes <= response_body_bytes_max);
+    try reader.discardAll(body_bytes);
+    return .{ .status = status, .body_bytes = body_bytes };
+}
+
+/// The three-digit status off the status line. A response that does not
+/// start `HTTP/1.1 ` is not this hop's output at all, so it is an error
+/// rather than a status of zero.
+fn readStatus(reader: *Io.Reader) !u16 {
+    const prefix = "HTTP/1.1 ";
+    const taken = try reader.takeDelimiter('\n');
+    const line = taken orelse return error.ResponseTruncated;
+    if (line.len < prefix.len + 3) return error.ResponseMalformed;
+    if (!std.mem.startsWith(u8, line, prefix)) return error.ResponseMalformed;
+    const digits = line[prefix.len .. prefix.len + 3];
+    const status = std.fmt.parseUnsigned(u16, digits, 10) catch return error.ResponseMalformed;
+    assert(status >= 100);
+    assert(status <= 999);
+    return status;
+}
+
+/// Header lines up to the blank one, returning the body length they
+/// framed. A head with no `Content-Length` is an error: the origin always
+/// sends one, so its absence means the hop reframed the response, which
+/// is exactly the kind of thing this tier exists to notice.
+fn readHeaders(reader: *Io.Reader) !u32 {
+    const length_name = "content-length:";
+    var body_bytes: ?u32 = null;
+    var lines: u32 = 0;
+    while (lines < response_headers_max) : (lines += 1) {
+        const taken = try reader.takeDelimiter('\n');
+        const line = taken orelse return error.ResponseTruncated;
+        const trimmed = std.mem.trimEnd(u8, line, "\r");
+        if (trimmed.len == 0) {
+            return body_bytes orelse error.ResponseUnframed;
+        }
+        if (trimmed.len <= length_name.len) continue;
+        if (!std.ascii.startsWithIgnoreCase(trimmed, length_name)) continue;
+        const value = std.mem.trim(u8, trimmed[length_name.len..], " \t");
+        const parsed = std.fmt.parseUnsigned(u32, value, 10) catch
+            return error.ResponseMalformed;
+        if (parsed > response_body_bytes_max) return error.ResponseTooLarge;
+        body_bytes = parsed;
+    }
+    assert(lines == response_headers_max);
+    return error.ResponseMalformed;
+}

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -36,17 +36,34 @@ pub const Response = struct {
     body_bytes: u32,
 };
 
+/// What a request says about its connection's future. HTTP/1.1's default
+/// is keep-alive, so that arm sends nothing; the other says so.
+pub const Persistence = enum {
+    keep_alive,
+    close,
+
+    fn header(persistence: Persistence) []const u8 {
+        return switch (persistence) {
+            .keep_alive => "",
+            .close => "Connection: close\r\n",
+        };
+    }
+};
+
 pub const Client = struct {
-    io: Io,
-    stream: Io.net.Stream,
-    reader: Io.net.Stream.Reader,
-    writer: Io.net.Stream.Writer,
-    read_buffer: [response_head_bytes_max]u8,
-    write_buffer: [response_head_bytes_max]u8,
+    io: Io = undefined,
+    stream: Io.net.Stream = undefined,
+    reader: Io.net.Stream.Reader = undefined,
+    writer: Io.net.Stream.Writer = undefined,
+    read_buffer: [response_head_bytes_max]u8 = undefined,
+    write_buffer: [response_head_bytes_max]u8 = undefined,
     /// Requests issued on this connection, so a caller can assert its own
     /// keep-alive arithmetic against what actually went out.
-    requests: u32,
-    connected: bool,
+    requests: u32 = 0,
+    /// The one field with a real default, and the reason the rest have
+    /// one: a static slot starts closed, so `connect` can refuse to
+    /// overwrite a live connection instead of leaking its socket.
+    connected: bool = false,
 
     /// Open a connection to a loopback port. In-place through an
     /// out-pointer: both `Reader` and `Writer` hold pointers into the
@@ -54,6 +71,7 @@ pub const Client = struct {
     /// before either is built.
     pub fn connect(client: *Client, io: Io, port: u16) !void {
         assert(port != 0);
+        assert(!client.connected);
         var address: Io.net.IpAddress = .{ .ip4 = .loopback(port) };
         client.io = io;
         client.stream = try address.connect(io, .{ .mode = .stream });
@@ -73,13 +91,25 @@ pub const Client = struct {
     /// One request/response exchange, left on a message boundary so the
     /// next `get` on this connection is a keep-alive turnaround rather
     /// than a fresh guess about where the last response ended.
-    pub fn get(client: *Client, host: []const u8, target: []const u8) !Response {
+    ///
+    /// `persistence` is explicit at every call site because it decides
+    /// more than this connection's fate: announcing close makes zoxy
+    /// *inject* a `Connection: close` into the response head (§7), which
+    /// is the one thing that renders a head longer than the origin's —
+    /// and therefore the only way a coalesced body excess can fail to fit
+    /// beside it.
+    pub fn get(
+        client: *Client,
+        host: []const u8,
+        target: []const u8,
+        persistence: Persistence,
+    ) !Response {
         assert(client.connected);
         assert(target.len >= 1);
         assert(target[0] == '/');
         try client.writer.interface.print(
-            "GET {s} HTTP/1.1\r\nHost: {s}\r\n\r\n",
-            .{ target, host },
+            "GET {s} HTTP/1.1\r\nHost: {s}\r\n{s}\r\n",
+            .{ target, host, persistence.header() },
         );
         try client.writer.interface.flush();
         client.requests += 1;

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -10,11 +10,18 @@
 //! caught by it first, because each needed the shape to be known before it
 //! could be looked for.
 //!
-//! So this gate asserts *equalities on real output*, never thresholds: a
-//! shared runner's timing noise must not be able to move a verdict. N
-//! requests produce exactly N access-log lines. Anything whose verdict
-//! needs a run-to-run comparison is Tier 1's job (`zig build bench`) and
-//! would make a per-change gate that fails on noise.
+//! So this gate asserts *equalities on real output*: a shared runner's
+//! timing noise must not be able to move a verdict. N requests produce
+//! exactly N access-log lines. Anything whose verdict needs a
+//! run-to-run comparison is Tier 1's job (`zig build bench`) and would
+//! make a per-change gate that fails on noise.
+//!
+//! The health-probe rate is the one exception, and it is the exception
+//! that proves the rule: #130 was a bug *no* equality could see, because
+//! every verdict the prober reached was correct and only its rate was
+//! wrong. So that one check is a band — deliberately loose enough that
+//! scheduling cannot move it, and still decisive because what it is aimed
+//! at runs two orders of magnitude slow, not a little slow.
 //!
 //! The origin lives in this process (smoke/origin.zig) rather than being
 //! nginx; the load is this file's own client (smoke/client.zig) rather
@@ -107,6 +114,40 @@ comptime {
     assert(zoxy_limits.conn_slots >= connections_expected);
 }
 
+/// The health-check shape this run configures, and the window it is
+/// measured over (#130). Correctness proves nothing here: a prober that
+/// never cancels its probe deadline reports every verdict correctly and
+/// gets only the *rate* wrong, which a virtual clock hides behind "it
+/// still passed" and a wall clock cannot.
+///
+/// The band is deliberately loose — a shared runner's scheduling must not
+/// move a verdict — and still decisive, because the failure it is aimed
+/// at is not a slow prober but one running two orders of magnitude slower
+/// than configured.
+const health_interval_ms: u32 = 25;
+const health_probe_timeout_ms: u32 = 1000;
+const probe_window_ms: u32 = 500;
+const probe_window_ns: u64 = @as(u64, probe_window_ms) * std.time.ns_per_ms;
+/// Whole intervals the window holds — a partial one sends no probe.
+const probes_implied: u32 = @divFloor(probe_window_ms, health_interval_ms);
+/// A quarter of the implied rate: four times slower than configured is
+/// still working, and slower than that is not pacing at all.
+const probes_min: u32 = @divFloor(probes_implied, 4);
+const probes_max: u32 = probes_implied * 3;
+
+comptime {
+    assert(health_interval_ms >= 1);
+    assert(probe_window_ms >= 4 * health_interval_ms);
+    assert(probes_min >= 2);
+    assert(probes_min < probes_implied);
+    assert(probes_implied < probes_max);
+    // What makes the floor a gate rather than a preference: a probe that
+    // idles out its whole timeout instead of finishing (#130 exactly)
+    // cannot fit `probes_min` of itself into the window, so the shape is
+    // caught by arithmetic and not by taste.
+    assert(@divFloor(probe_window_ms, health_probe_timeout_ms) < probes_min);
+}
+
 /// The whole run's wall-clock budget. Fifty times what a run takes, so it
 /// is never a verdict on speed — it exists because every wait in this
 /// harness is a wait on the process under test, and the failure this gate
@@ -185,28 +226,29 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
 
     // Scraped before the drain: the admin listener closes with every
     // other one when SIGTERM lands (§8).
-    const counters_ok = try countersPassed(arena, io, ports.admin);
+    const counters = try countersPassed(arena, io, ports.admin);
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
     // both, not stop at the first.
     const log_ok = accessLogPassed(&lines);
     const drain_ok = drainPassed(drained_cleanly);
-    return report(io, &lines, log_ok and counters_ok and drain_ok);
+    return report(io, &lines, &counters, log_ok and counters.passed and drain_ok);
 }
 
 /// The run's one line of output when everything held, and the proxy's own
-/// output when something did not.
-fn report(io: Io, lines: *const LogCounts, passed: bool) u8 {
+/// output when something did not. The probe count is in it either way —
+/// a band nobody can see the margin of is a band nobody can watch.
+fn report(io: Io, lines: *const LogCounts, counters: *const CounterVerdict, passed: bool) u8 {
     assert(lines.http_ok <= lines.http);
     if (!passed) {
         printZoxyLog(io);
         return 1;
     }
     std.debug.print(
-        "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, " ++
-            "counters reconcile, clean drain\n",
-        .{ lines.http, lines.l4, access_log_lines_expected },
+        "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, counters reconcile, " ++
+            "{d} probes in {d}ms, clean drain\n",
+        .{ lines.http, lines.l4, access_log_lines_expected, counters.probes, probe_window_ms },
     );
     return 0;
 }
@@ -297,26 +339,102 @@ fn drainPassed(drained_cleanly: bool) bool {
     return false;
 }
 
+/// Two scrapes a measured window apart, and every counter verdict the
+/// gate holds. The window is what makes the probe band a wall-clock
+/// claim; the two scrapes are also what `admin_served` needs, since the
+/// first one's own witness is incremented when its last byte lands and
+/// can only be read by the next.
+fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !CounterVerdict {
+    assert(port != 0);
+    const first = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
+    try io.sleep(Io.Duration.fromNanoseconds(probe_window_ns), .awake);
+    const second = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
+    const probes = probeDelta(&first, &second);
+    const identities_ok = identitiesPassed(&first);
+    const probes_ok = probesPassed(probes, &second);
+    const admin_ok = adminPassed(&second);
+    const passed = identities_ok and probes_ok and admin_ok;
+    // A verdict that passed read a probe count; the reported number is
+    // never the zero that stands in for a counter the scrape lacked.
+    if (passed) assert(probes != null);
+    return .{ .passed = passed, .probes = probes orelse 0 };
+}
+
+/// What the counter checks decided, and the one number worth printing
+/// whether or not they passed: a band whose margin is invisible until it
+/// fails cannot be watched across runs.
+const CounterVerdict = struct {
+    passed: bool,
+    probes: u32,
+};
+
+/// Probes sent across the measured window, or null when the scrape did
+/// not carry the counter at all.
+fn probeDelta(first: *const scrape_module.Scrape, second: *const scrape_module.Scrape) ?u32 {
+    const before = counterOf(first, "health_probes_sent") orelse return null;
+    const after = counterOf(second, "health_probes_sent") orelse return null;
+    // A counter only ever rises, and the window is the only thing between
+    // these two readings.
+    assert(after >= before);
+    assert(after - before <= std.math.maxInt(u32));
+    return @intCast(after - before);
+}
+
+/// The §7 prober, judged on its rate rather than its verdicts (#130).
+/// Both ends of the band are gates: the floor catches a prober that
+/// waits out something it should have cancelled, the ceiling one that
+/// stopped pacing and is spinning on the origin.
+///
+/// The verdicts are checked too, as invariants that read zero — this
+/// origin answers every probe, so a failure or an ejection here is the
+/// probe path being wrong about a healthy endpoint.
+fn probesPassed(sent: ?u32, second: *const scrape_module.Scrape) bool {
+    const failed = counterOf(second, "health_probes_failed") orelse return false;
+    const ejected = counterOf(second, "health_endpoint_down") orelse return false;
+    // An ejection needs a failed probe, which `reconcile` asserts inside
+    // the process; the same must be true of what came out of it.
+    assert(ejected <= failed);
+    if (sent == null) return false;
+    var passed = true;
+    if (sent.? < probes_min or sent.? > probes_max) {
+        std.debug.print(
+            "FAIL: {d} probes in {d}ms at a {d}ms interval — outside the {d}..{d} band\n",
+            .{ sent.?, probe_window_ms, health_interval_ms, probes_min, probes_max },
+        );
+        passed = false;
+    }
+    if (failed != 0 or ejected != 0) {
+        std.debug.print(
+            "FAIL: {d} probe(s) failed and {d} ejection(s) against an origin answering 200\n",
+            .{ failed, ejected },
+        );
+        passed = false;
+    }
+    return passed;
+}
+
+/// The admin plane's own witness: the scrape that answered before this
+/// one, and no other. Exactly one, not "at least" — the plane serves one
+/// at a time (§8's reserved slot), so the second scrape is accepted only
+/// after the first has closed.
+fn adminPassed(second: *const scrape_module.Scrape) bool {
+    const served = counterOf(second, "admin_served") orelse return false;
+    if (served == 1) return true;
+    std.debug.print("FAIL: {d} admin scrapes served before the second, not 1\n", .{served});
+    return false;
+}
+
 /// Both of `reconcile`'s identities (§9), re-derived from a live scrape
 /// instead of from the struct — the numbers rendered, written to a
 /// socket, framed by a close and parsed back, so the whole admin plane is
 /// under the same verdict as the arithmetic.
-///
-/// Two scrapes, because the first one's own witness (`admin_served`) is
-/// incremented when its last byte lands and can only be read by the next.
-/// The plane serves one at a time (§8's reserved slot), so the second is
-/// accepted only after the first has closed: exactly one, not "at least".
-fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !bool {
-    assert(port != 0);
-    const first = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
-    const second = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
-    const accepted = counterOf(&first, "accepted") orelse return false;
-    const admitted = counterOf(&first, "admitted") orelse return false;
-    const completed = counterOf(&first, "completed") orelse return false;
-    const in_use = counterOf(&first, "conn_slots_in_use") orelse return false;
-    const responses = counterOf(&first, "l7_responses") orelse return false;
-    const reused = counterOf(&first, "upstream_reused") orelse return false;
-    const served = counterOf(&second, "admin_served") orelse return false;
+fn identitiesPassed(first: *const scrape_module.Scrape) bool {
+    const accepted = counterOf(first, "accepted") orelse return false;
+    const admitted = counterOf(first, "admitted") orelse return false;
+    const completed = counterOf(first, "completed") orelse return false;
+    const in_use = counterOf(first, "conn_slots_in_use") orelse return false;
+    const responses = counterOf(first, "l7_responses") orelse return false;
+    const reused = counterOf(first, "upstream_reused") orelse return false;
     // The orderings `reconcile` asserts inside the process, asserted here
     // on the numbers that came back out of it: these are impossible
     // states, not failed verdicts, and a scrape that parsed the wrong
@@ -367,10 +485,6 @@ fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !bool {
         std.debug.print("FAIL: no upstream connection was reused across {d} exchanges\n", .{
             http_exchanges,
         });
-        passed = false;
-    }
-    if (served != 1) {
-        std.debug.print("FAIL: {d} admin scrapes served before the second, not 1\n", .{served});
         passed = false;
     }
     return passed;
@@ -529,13 +643,17 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }}
         \\    ],
         \\    "clusters": {{
-        \\        "origin": {{ "endpoints": ["127.0.0.1:{d}"] }}
+        \\        "origin": {{
+        \\            "endpoints": ["127.0.0.1:{d}"],
+        \\            "check": {{ "type": "http", "path": "/health", "timeout_ms": {d} }}
+        \\        }}
         \\    }},
         \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
         \\    "access_log": {{ "sink": "file", "path": "{s}" }},
         \\    "timeouts": {{
         \\        "connect_ms": 2000,
         \\        "idle_ms": 30000,
+        \\        "health_interval_ms": {d},
         \\        "drain_deadline_ms": {d}
         \\    }},
         \\    "limits": {{
@@ -549,8 +667,10 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         ports.http,
         ports.l4,
         origin_port,
+        health_probe_timeout_ms,
         ports.admin,
         access_log_path,
+        health_interval_ms,
         drain_deadline_ms,
         zoxy_limits.conn_slots,
         zoxy_limits.relay_buffers,

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -24,6 +24,7 @@ const std = @import("std");
 
 const client_module = @import("client.zig");
 const origin_module = @import("origin.zig");
+const scrape_module = @import("scrape.zig");
 
 const Io = std.Io;
 
@@ -54,6 +55,19 @@ const l4_connections: u8 = 2;
 
 const http_exchanges: u32 = @as(u32, keep_alive_connections) * requests_per_connection;
 const access_log_lines_expected: u32 = http_exchanges + l4_connections;
+
+/// Every connection zoxy's data listeners accept in one run: the load's
+/// own, plus the readiness probe that connects and asks nothing. Admin
+/// scrapes are not among them — the admin plane sits outside the
+/// accepted/admitted/shed accounting entirely (§8), which is what lets
+/// this be an equality rather than a floor.
+///
+/// It is an equality on *ports the kernel just handed out*, so a stranger
+/// connecting to one between `reservePorts` and zoxy's bind would fail
+/// the run. That window is microseconds wide on a port nothing advertises,
+/// and the alternative — a floor — is satisfied by a proxy accepting
+/// connections nobody made.
+const connections_expected: u32 = keep_alive_connections + l4_connections + 1;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
@@ -87,6 +101,10 @@ comptime {
     // Every client connection needs a slot and a relay buffer at once.
     assert(zoxy_limits.relay_buffers >= keep_alive_connections + l4_connections);
     assert(zoxy_limits.conn_slots >= zoxy_limits.relay_buffers);
+    // And every connection this run opens must be admitted rather than
+    // shed, or `accepted == connections_expected` would be measuring the
+    // conn wall instead of the load.
+    assert(zoxy_limits.conn_slots >= connections_expected);
 }
 
 /// The whole run's wall-clock budget. Fifty times what a run takes, so it
@@ -119,6 +137,7 @@ const Flags = struct {
 const Ports = struct {
     http: u16,
     l4: u16,
+    admin: u16,
 };
 
 pub fn main(init: std.process.Init) !u8 {
@@ -133,6 +152,20 @@ pub fn main(init: std.process.Init) !u8 {
     try watchdog.concurrent(io, watchdogTask, .{io});
     defer watchdog.cancel(io);
 
+    // A setup failure — a refused scrape, a proxy that never listened —
+    // is reported the same way a failed verdict is, because to whoever is
+    // reading a red gate they are the same question: what did zoxy do?
+    // Answering it with a bare error trace and no log would be the one
+    // reply that helps least.
+    return run(arena, io, &flags) catch |err| {
+        std.debug.print("FAIL: the smoke run could not finish ({t})\n", .{err});
+        printZoxyLog(io);
+        return 1;
+    };
+}
+
+/// One whole run, from an empty work directory to a verdict.
+fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     try prepareWorkDirectory(io);
     try origin.start(io, origin_connections_peak);
     // Ordered against the child's own teardown below: defers unwind
@@ -150,9 +183,32 @@ pub fn main(init: std.process.Init) !u8 {
     try awaitListening(io, ports.http);
     try runLoad(io, &ports);
 
+    // Scraped before the drain: the admin listener closes with every
+    // other one when SIGTERM lands (§8).
+    const counters_ok = try countersPassed(arena, io, ports.admin);
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
-    return if (gatePassed(io, &lines, drained_cleanly)) 0 else 1;
+    // Every check runs and prints; a run that fails two ways should say
+    // both, not stop at the first.
+    const log_ok = accessLogPassed(&lines);
+    const drain_ok = drainPassed(drained_cleanly);
+    return report(io, &lines, log_ok and counters_ok and drain_ok);
+}
+
+/// The run's one line of output when everything held, and the proxy's own
+/// output when something did not.
+fn report(io: Io, lines: *const LogCounts, passed: bool) u8 {
+    assert(lines.http_ok <= lines.http);
+    if (!passed) {
+        printZoxyLog(io);
+        return 1;
+    }
+    std.debug.print(
+        "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, " ++
+            "counters reconcile, clean drain\n",
+        .{ lines.http, lines.l4, access_log_lines_expected },
+    );
+    return 0;
 }
 
 /// The wall-clock backstop. Nothing in this harness can bound its own
@@ -197,10 +253,10 @@ const LogCounts = struct {
     http_ok: u32 = 0,
 };
 
-/// The §9 pass/fail, printed so a red run explains itself without a
+/// The access-log verdict, printed so a red run explains itself without a
 /// rerun. Every clause is an equality against a number this harness
 /// decided before the run started.
-fn gatePassed(io: Io, lines: *const LogCounts, drained_cleanly: bool) bool {
+fn accessLogPassed(lines: *const LogCounts) bool {
     // Both are counted off the same lines, in the same pass, so a total
     // below its own subset would mean the counter itself is wrong — which
     // no comparison below would otherwise notice.
@@ -232,19 +288,104 @@ fn gatePassed(io: Io, lines: *const LogCounts, drained_cleanly: bool) bool {
         );
         passed = false;
     }
-    if (!drained_cleanly) {
-        std.debug.print("FAIL: zoxy did not drain cleanly on SIGTERM\n", .{});
+    return passed;
+}
+
+fn drainPassed(drained_cleanly: bool) bool {
+    if (drained_cleanly) return true;
+    std.debug.print("FAIL: zoxy did not drain cleanly on SIGTERM\n", .{});
+    return false;
+}
+
+/// Both of `reconcile`'s identities (§9), re-derived from a live scrape
+/// instead of from the struct — the numbers rendered, written to a
+/// socket, framed by a close and parsed back, so the whole admin plane is
+/// under the same verdict as the arithmetic.
+///
+/// Two scrapes, because the first one's own witness (`admin_served`) is
+/// incremented when its last byte lands and can only be read by the next.
+/// The plane serves one at a time (§8's reserved slot), so the second is
+/// accepted only after the first has closed: exactly one, not "at least".
+fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !bool {
+    assert(port != 0);
+    const first = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
+    const second = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
+    const accepted = counterOf(&first, "accepted") orelse return false;
+    const admitted = counterOf(&first, "admitted") orelse return false;
+    const completed = counterOf(&first, "completed") orelse return false;
+    const in_use = counterOf(&first, "conn_slots_in_use") orelse return false;
+    const responses = counterOf(&first, "l7_responses") orelse return false;
+    const reused = counterOf(&first, "upstream_reused") orelse return false;
+    const served = counterOf(&second, "admin_served") orelse return false;
+    // The orderings `reconcile` asserts inside the process, asserted here
+    // on the numbers that came back out of it: these are impossible
+    // states, not failed verdicts, and a scrape that parsed the wrong
+    // bytes into the right names would show up as one of them rather than
+    // as a plausible-looking mismatch below.
+    assert(admitted <= accepted);
+    assert(completed <= admitted);
+    assert(in_use <= admitted);
+    assert(reused <= responses);
+    var passed = true;
+    // The gate identity: an accepted connection was admitted or shed,
+    // with no third outcome.
+    if (accepted != admitted + first.shedTotal()) {
+        std.debug.print(
+            "FAIL: accepted {d} != admitted {d} + shed {d}\n",
+            .{ accepted, admitted, first.shedTotal() },
+        );
         passed = false;
     }
-    if (passed) {
+    // The flow identity: admitted work is completed or still active.
+    if (admitted != completed + in_use) {
         std.debug.print(
-            "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, clean drain\n",
-            .{ lines.http, lines.l4, access_log_lines_expected },
+            "FAIL: admitted {d} != completed {d} + in use {d}\n",
+            .{ admitted, completed, in_use },
         );
-    } else {
-        printZoxyLog(io);
+        passed = false;
+    }
+    if (accepted != connections_expected) {
+        std.debug.print(
+            "FAIL: {d} connections accepted, not the {d} this run opened\n",
+            .{ accepted, connections_expected },
+        );
+        passed = false;
+    }
+    // The counter and the log describe the same exchanges, so a
+    // disagreement is one of the two lying about the same run.
+    if (responses != http_exchanges) {
+        std.debug.print(
+            "FAIL: {d} l7 responses counted for {d} requests\n",
+            .{ responses, http_exchanges },
+        );
+        passed = false;
+    }
+    // §3's reuse win, witnessed live: this load is one exchange after
+    // another against a keep-alive origin, so a proxy that parks nothing
+    // is the only way to reach zero here.
+    if (reused == 0) {
+        std.debug.print("FAIL: no upstream connection was reused across {d} exchanges\n", .{
+            http_exchanges,
+        });
+        passed = false;
+    }
+    if (served != 1) {
+        std.debug.print("FAIL: {d} admin scrapes served before the second, not 1\n", .{served});
+        passed = false;
     }
     return passed;
+}
+
+/// A counter the gate reads, or a printed failure and null. A missing
+/// name is its own finding — the scrape renders every field, so absence
+/// means a rename the harness has not followed, not a zero.
+fn counterOf(scrape: *const scrape_module.Scrape, name: []const u8) ?u64 {
+    assert(name.len >= 1);
+    const value = scrape.value(name);
+    if (value == null) {
+        std.debug.print("FAIL: the scrape carries no counter named {s}\n", .{name});
+    }
+    return value;
 }
 
 /// The load: every L7 connection serves its whole share before the next
@@ -357,15 +498,22 @@ fn reservePorts(io: Io) !Ports {
     var http_listener = try http_address.listen(io, .{ .mode = .stream });
     var l4_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
     var l4_listener = try l4_address.listen(io, .{ .mode = .stream });
+    var admin_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var admin_listener = try admin_address.listen(io, .{ .mode = .stream });
     const ports: Ports = .{
         .http = http_listener.socket.address.getPort(),
         .l4 = l4_listener.socket.address.getPort(),
+        .admin = admin_listener.socket.address.getPort(),
     };
     http_listener.deinit(io);
     l4_listener.deinit(io);
+    admin_listener.deinit(io);
     assert(ports.http != 0);
     assert(ports.l4 != 0);
+    assert(ports.admin != 0);
     assert(ports.http != ports.l4);
+    assert(ports.http != ports.admin);
+    assert(ports.l4 != ports.admin);
     return ports;
 }
 
@@ -383,6 +531,7 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\    "clusters": {{
         \\        "origin": {{ "endpoints": ["127.0.0.1:{d}"] }}
         \\    }},
+        \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
         \\    "access_log": {{ "sink": "file", "path": "{s}" }},
         \\    "timeouts": {{
         \\        "connect_ms": 2000,
@@ -400,6 +549,7 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         ports.http,
         ports.l4,
         origin_port,
+        ports.admin,
         access_log_path,
         drain_deadline_ms,
         zoxy_limits.conn_slots,

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -27,6 +27,7 @@
 //! nginx; the load is this file's own client (smoke/client.zig) rather
 //! than zrk. Both are deliberate — see those files.
 
+const builtin = @import("builtin");
 const std = @import("std");
 
 const client_module = @import("client.zig");
@@ -50,6 +51,22 @@ const zoxy_log_path = work_directory ++ "/zoxy.log";
 const keep_alive_connections: u8 = 4;
 const requests_per_connection: u32 = 16;
 
+/// Requests per pass for the origin's bulk target, which arrives as one
+/// delivery large enough to overrun zoxy's head buffer — the §7 path
+/// where a response's coalesced body excess leaves in a second write
+/// (`l7_response_excess_sent`). The simulator's census exempts that
+/// counter for want of exactly this delivery.
+const large_requests: u32 = 4;
+
+/// The load runs twice over the same connections, with the process's
+/// resident set read between the passes. The first pass is what makes the
+/// second measurable: zoxy's pools are lazily resident, so an unwarmed
+/// reading would climb for reasons that are not allocation. Two identical
+/// passes mean any growth between the readings is work the second pass
+/// did that the first did not, which — under §5's zero-allocation-after-
+/// startup promise — is nothing.
+const load_passes: u32 = 2;
+
 /// Connections closed before the drain; the rest are still open when
 /// SIGTERM lands. Both teardown paths — a client that left and a drain
 /// that reaped — must write nothing, and only running both proves it.
@@ -60,8 +77,18 @@ const connections_closed_early: u8 = 2;
 /// other half of the line arithmetic.
 const l4_connections: u8 = 2;
 
-const http_exchanges: u32 = @as(u32, keep_alive_connections) * requests_per_connection;
+const exchanges_per_pass: u32 =
+    @as(u32, keep_alive_connections) * requests_per_connection + large_requests;
+const http_exchanges: u32 = load_passes * exchanges_per_pass;
 const access_log_lines_expected: u32 = http_exchanges + l4_connections;
+
+/// What the resident set may grow by between the two passes. Measured at
+/// exactly zero, run after run — the tolerance is headroom for page
+/// granularity and a runtime's own bookkeeping on some other kernel, not
+/// a number anything is expected to spend. It still sits under what a
+/// per-request allocation of even a kilobyte would cost across a pass of
+/// this size, which is the only thing it is looking for.
+const rss_growth_kb_max: u64 = 64;
 
 /// Every connection zoxy's data listeners accept in one run: the load's
 /// own, plus the readiness probe that connects and asks nothing. Admin
@@ -74,7 +101,8 @@ const access_log_lines_expected: u32 = http_exchanges + l4_connections;
 /// the run. That window is microseconds wide on a port nothing advertises,
 /// and the alternative — a floor — is satisfied by a proxy accepting
 /// connections nobody made.
-const connections_expected: u32 = keep_alive_connections + l4_connections + 1;
+const connections_expected: u32 =
+    keep_alive_connections + load_passes * large_requests + l4_connections + 1;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
@@ -96,9 +124,27 @@ const drain_deadline_ms: u32 = 300;
 /// set a number a human can read at a glance.
 const zoxy_limits = .{ .conn_slots = 32, .relay_buffers = 16, .upstream_slots = 16 };
 
+/// The head buffer zoxy binds for this run — `limits.head_buffer_bytes`
+/// is not set, so this is `constants.head_buffer_bytes_default`, spelled
+/// again rather than imported. Duplicating it is safe *here* in a way it
+/// would not be elsewhere: the only thing that reads it is the
+/// bulk-response premise below, and a default that moved past the bulk
+/// body would fail this gate's excess equality outright rather than
+/// quietly stop exercising the branch.
+const zoxy_head_buffer_bytes: u32 = 8 * 1024;
+
 comptime {
     assert(keep_alive_connections >= 2);
     assert(requests_per_connection >= 2);
+    // The resident-set claim is "an identical pass costs nothing", and
+    // the reading sits *between* the two passes `runLoad` makes — so this
+    // constant names that shape for the arithmetic that depends on it
+    // rather than parameterizing a loop.
+    assert(load_passes == 2);
+    assert(large_requests >= 1);
+    // The bulk response's premise: its body has to overrun the head
+    // buffer, or the excess the gate counts never exists (§7).
+    assert(origin_module.large_body_bytes > zoxy_head_buffer_bytes);
     assert(connections_closed_early >= 1);
     assert(connections_closed_early < keep_alive_connections);
     assert(l4_connections >= 1);
@@ -161,8 +207,14 @@ const watchdog_budget_ns: u64 = 30 * std.time.ns_per_s;
 /// storage that outlives no scope and moves for no reason, which is what
 /// static means here (§5's discipline, applied to the harness).
 var origin: origin_module.Origin = undefined;
-var clients: [keep_alive_connections]client_module.Client = undefined;
-var l4_client: client_module.Client = undefined;
+/// The clients start *closed* rather than undefined, so `connect` can
+/// assert it is not overwriting a live connection — which is what makes
+/// one slot safely reusable below.
+var clients: [keep_alive_connections]client_module.Client = @splat(.{});
+/// The slot for connections that serve exactly one exchange and close —
+/// the bulk requests and the L4 leg. One at a time by construction: each
+/// is closed before the next is opened, and `connect` asserts it.
+var single_client: client_module.Client = .{};
 
 /// The proxy the watchdog kills if it fires, published by `spawnZoxy`.
 /// Zero until then — the watchdog can outlive the spawn failing.
@@ -222,7 +274,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     defer if (running) child.kill(io);
 
     try awaitListening(io, ports.http);
-    try runLoad(io, &ports);
+    const memory = try runLoad(arena, io, &ports, child.id);
 
     // Scraped before the drain: the admin listener closes with every
     // other one when SIGTERM lands (§8).
@@ -232,25 +284,54 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // Every check runs and prints; a run that fails two ways should say
     // both, not stop at the first.
     const log_ok = accessLogPassed(&lines);
+    const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
-    return report(io, &lines, &counters, log_ok and counters.passed and drain_ok);
+    const passed = log_ok and counters.passed and memory_ok and drain_ok;
+    return report(io, &lines, &counters, &memory, passed);
 }
 
 /// The run's one line of output when everything held, and the proxy's own
-/// output when something did not. The probe count is in it either way —
-/// a band nobody can see the margin of is a band nobody can watch.
-fn report(io: Io, lines: *const LogCounts, counters: *const CounterVerdict, passed: bool) u8 {
+/// output when something did not. The probe count and the resident set
+/// are in it either way — a margin nobody can see is a margin nobody can
+/// watch across runs.
+fn report(
+    io: Io,
+    lines: *const LogCounts,
+    counters: *const CounterVerdict,
+    memory: *const Memory,
+    passed: bool,
+) u8 {
     assert(lines.http_ok <= lines.http);
     if (!passed) {
         printZoxyLog(io);
         return 1;
     }
+    var memory_buffer: [64]u8 = undefined;
     std.debug.print(
         "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, counters reconcile, " ++
-            "{d} probes in {d}ms, clean drain\n",
-        .{ lines.http, lines.l4, access_log_lines_expected, counters.probes, probe_window_ms },
+            "{d} probes in {d}ms, {s}, clean drain\n",
+        .{
+            lines.http,
+            lines.l4,
+            access_log_lines_expected,
+            counters.probes,
+            probe_window_ms,
+            memorySummary(memory, &memory_buffer),
+        },
     );
     return 0;
+}
+
+/// The two readings as text, printed rather than differenced: a resident
+/// set may legally *shrink* between them (the kernel reclaims pages when
+/// it likes), and `memoryPassed` treats that as a pass — so a delta here
+/// would be a subtraction that underflows on a run that was fine.
+fn memorySummary(memory: *const Memory, buffer: []u8) []const u8 {
+    assert(buffer.len >= 1);
+    const before = memory.before_kb orelse return "rss unread";
+    const after = memory.after_kb orelse return "rss unread";
+    return std.fmt.bufPrint(buffer, "rss {d} -> {d} KiB", .{ before, after }) catch
+        "rss unprintable";
 }
 
 /// The wall-clock backstop. Nothing in this harness can bound its own
@@ -435,6 +516,7 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
     const in_use = counterOf(first, "conn_slots_in_use") orelse return false;
     const responses = counterOf(first, "l7_responses") orelse return false;
     const reused = counterOf(first, "upstream_reused") orelse return false;
+    const excess = counterOf(first, "l7_response_excess_sent") orelse return false;
     // The orderings `reconcile` asserts inside the process, asserted here
     // on the numbers that came back out of it: these are impossible
     // states, not failed verdicts, and a scrape that parsed the wrong
@@ -444,6 +526,7 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
     assert(completed <= admitted);
     assert(in_use <= admitted);
     assert(reused <= responses);
+    assert(excess <= responses);
     var passed = true;
     // The gate identity: an accepted connection was admitted or shed,
     // with no third outcome.
@@ -487,6 +570,18 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
         });
         passed = false;
     }
+    // The §7 branch the simulator cannot reach: an origin delivery that
+    // filled the head buffer, so the body excess coalesced with the head
+    // had to leave in a write of its own. Every bulk request in this run
+    // is that delivery, which is why this is a count rather than a
+    // witness.
+    if (excess != large_requests * load_passes) {
+        std.debug.print(
+            "FAIL: {d} responses sent body excess, not the {d} bulk requests this run made\n",
+            .{ excess, large_requests * load_passes },
+        );
+        passed = false;
+    }
     return passed;
 }
 
@@ -502,25 +597,66 @@ fn counterOf(scrape: *const scrape_module.Scrape, name: []const u8) ?u64 {
     return value;
 }
 
-/// The load: every L7 connection serves its whole share before the next
-/// one opens, then some are closed and the rest are left for the drain.
-fn runLoad(io: Io, ports: *const Ports) !void {
+/// The load: two identical passes over the same keep-alive connections
+/// with the proxy's resident set read between them, then the L4 leg, then
+/// some connections closed and the rest left for the drain.
+fn runLoad(
+    arena: std.mem.Allocator,
+    io: Io,
+    ports: *const Ports,
+    pid: ?std.process.Child.Id,
+) !Memory {
     assert(ports.http != 0);
     assert(ports.l4 != 0);
     var host_buffer: [32]u8 = undefined;
     const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
     for (&clients) |*client| {
         try client.connect(io, ports.http);
-        var request: u32 = 0;
-        while (request < requests_per_connection) : (request += 1) {
-            try expectOriginResponse(try client.get(host, "/"));
-        }
-        assert(client.requests == requests_per_connection);
     }
+    try runPass(io, ports.http, host);
+    // Read between the passes, not before the first: zoxy's pools are
+    // lazily resident (§5), so a reading taken before any traffic would
+    // climb for reasons that are not allocation.
+    const before_kb = try readRssKb(arena, io, pid);
+    try runPass(io, ports.http, host);
+    const after_kb = try readRssKb(arena, io, pid);
     for (clients[0..connections_closed_early]) |*client| {
         client.close();
     }
     try runL4Load(io, ports.l4, host);
+    return .{ .before_kb = before_kb, .after_kb = after_kb };
+}
+
+/// One pass: every open connection serves its whole share of ordinary
+/// requests, then the bulk target runs on one of them. Both passes are
+/// identical, which is what makes the resident set between them a claim
+/// about allocation rather than about warmup.
+fn runPass(io: Io, port: u16, host: []const u8) !void {
+    assert(host.len >= 1);
+    assert(clients.len == keep_alive_connections);
+    for (&clients) |*client| {
+        var request: u32 = 0;
+        while (request < requests_per_connection) : (request += 1) {
+            try expectResponse(try client.get(host, "/", .keep_alive), origin_module.body.len);
+        }
+        assert(request == requests_per_connection);
+    }
+    // The bulk requests announce close, on their own connections because
+    // that is what announcing close means. Both halves are load-bearing:
+    // the delivery fills the head buffer, and the injected
+    // `Connection: close` is what makes zoxy's rendered head longer than
+    // the origin's — without which the excess fits beside it exactly and
+    // the branch never runs (§7).
+    var large: u32 = 0;
+    while (large < large_requests) : (large += 1) {
+        try single_client.connect(io, port);
+        defer single_client.close();
+        try expectResponse(
+            try single_client.get(host, origin_module.large_path, .close),
+            origin_module.large_body_bytes,
+        );
+    }
+    assert(large == large_requests);
 }
 
 /// The L4 leg (§6): the same HTTP exchange through the byte relay, which
@@ -531,20 +667,21 @@ fn runL4Load(io: Io, port: u16, host: []const u8) !void {
     assert(host.len >= 1);
     var index: u8 = 0;
     while (index < l4_connections) : (index += 1) {
-        // One static slot reused across the loop, on the same terms as
-        // `clients`: a connection is closed before the next is opened, so
-        // there is never more than one of these alive.
-        try l4_client.connect(io, port);
-        defer l4_client.close();
-        try expectOriginResponse(try l4_client.get(host, "/"));
+        try single_client.connect(io, port);
+        defer single_client.close();
+        try expectResponse(
+            try single_client.get(host, "/", .keep_alive),
+            origin_module.body.len,
+        );
     }
     assert(index == l4_connections);
 }
 
-/// The response the origin sends, checked byte-count and all: a hop that
+/// The response the origin sent, checked byte-count and all: a hop that
 /// truncated or re-framed a body is a data-path bug this tier sees before
-/// any counter does.
-fn expectOriginResponse(response: client_module.Response) !void {
+/// any counter does — and the bulk target is where a hop is most likely
+/// to, since its body crosses the head buffer in more than one piece.
+fn expectResponse(response: client_module.Response, body_bytes: u32) !void {
     // The client parses both out of the wire and bounds them there; a
     // value outside those bounds reaching here would mean the two files
     // disagree about what a response is.
@@ -554,13 +691,66 @@ fn expectOriginResponse(response: client_module.Response) !void {
         std.debug.print("smoke: origin answered {d}, not 200\n", .{response.status});
         return error.UnexpectedStatus;
     }
-    if (response.body_bytes != origin_module.body.len) {
+    if (response.body_bytes != body_bytes) {
         std.debug.print(
             "smoke: body was {d} bytes, not {d}\n",
-            .{ response.body_bytes, origin_module.body.len },
+            .{ response.body_bytes, body_bytes },
         );
         return error.UnexpectedBody;
     }
+}
+
+/// The proxy's resident set across the measured pass. Null off Linux,
+/// where there is no procfs to read it from — the gate says so rather
+/// than pretending it checked.
+const Memory = struct {
+    before_kb: ?u64,
+    after_kb: ?u64,
+};
+
+/// §5's promise from outside the process: two identical passes, and the
+/// second one costs no memory. Growth *inside* a pass would be lazy
+/// fault-in working as designed, which is what the first pass is for.
+fn memoryPassed(memory: *const Memory) bool {
+    if (memory.before_kb == null or memory.after_kb == null) {
+        std.debug.print("smoke: resident set unread (no procfs here); memory check skipped\n", .{});
+        return true;
+    }
+    const before = memory.before_kb.?;
+    const after = memory.after_kb.?;
+    // A live process always has resident pages; zero would mean the
+    // reading failed rather than that the proxy shrank to nothing.
+    assert(before > 0);
+    assert(after > 0);
+    if (after <= before + rss_growth_kb_max) return true;
+    std.debug.print(
+        "FAIL: resident set grew {d} KiB across an identical second pass ({d} -> {d} KiB)\n",
+        .{ after - before, before, after },
+    );
+    return false;
+}
+
+/// The proxy's resident set, in KiB. procfs advertises size 0, so this
+/// streams rather than trusting a stat.
+fn readRssKb(arena: std.mem.Allocator, io: Io, pid: ?std.process.Child.Id) !?u64 {
+    if (builtin.os.tag != .linux) return null;
+    assert(pid != null);
+    const path = try std.fmt.allocPrint(arena, "/proc/{d}/status", .{pid.?});
+    const file = try Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    var read_buffer: [4096]u8 = undefined;
+    var file_reader = file.reader(io, &read_buffer);
+    var status: [8192]u8 = undefined;
+    const status_len = try file_reader.interface.readSliceShort(&status);
+    assert(status_len > 0);
+    var lines = std.mem.splitScalar(u8, status[0..status_len], '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "VmRSS:")) continue;
+        const digits_start = std.mem.indexOfAny(u8, line, "0123456789") orelse break;
+        const digits_end = std.mem.indexOfScalarPos(u8, line, digits_start, ' ') orelse break;
+        return try std.fmt.parseUnsigned(u64, line[digits_start..digits_end], 10);
+    }
+    return error.RssUnavailable;
 }
 
 /// Drain, not just death (§8): SIGTERM, then a wait that both reaps the

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -613,12 +613,12 @@ fn runLoad(
     for (&clients) |*client| {
         try client.connect(io, ports.http);
     }
-    try runPass(io, ports.http, host);
+    try runPass(io, ports.http, host, 0);
     // Read between the passes, not before the first: zoxy's pools are
     // lazily resident (§5), so a reading taken before any traffic would
     // climb for reasons that are not allocation.
     const before_kb = try readRssKb(arena, io, pid);
-    try runPass(io, ports.http, host);
+    try runPass(io, ports.http, host, 1);
     const after_kb = try readRssKb(arena, io, pid);
     for (clients[0..connections_closed_early]) |*client| {
         client.close();
@@ -631,13 +631,25 @@ fn runLoad(
 /// requests, then the bulk target runs on one of them. Both passes are
 /// identical, which is what makes the resident set between them a claim
 /// about allocation rather than about warmup.
-fn runPass(io: Io, port: u16, host: []const u8) !void {
+fn runPass(io: Io, port: u16, host: []const u8, pass: u32) !void {
     assert(host.len >= 1);
     assert(clients.len == keep_alive_connections);
-    for (&clients) |*client| {
+    assert(pass < load_passes);
+    for (&clients, 0..) |*client, connection| {
         var request: u32 = 0;
         while (request < requests_per_connection) : (request += 1) {
-            try expectResponse(try client.get(host, "/", .keep_alive), origin_module.body.len);
+            // Where a failure happened is most of what a failure means
+            // here: the same error from the first keep-alive request and
+            // from the hundredth are different bugs, and the second is
+            // not reproducible by staring at the first.
+            const response = client.get(host, "/", .keep_alive) catch |err| {
+                std.debug.print(
+                    "smoke: pass {d} keep-alive connection {d} request {d}: {t}\n",
+                    .{ pass, connection, request, err },
+                );
+                return err;
+            };
+            try expectResponse(response, origin_module.body.len);
         }
         assert(request == requests_per_connection);
     }
@@ -651,10 +663,11 @@ fn runPass(io: Io, port: u16, host: []const u8) !void {
     while (large < large_requests) : (large += 1) {
         try single_client.connect(io, port);
         defer single_client.close();
-        try expectResponse(
-            try single_client.get(host, origin_module.large_path, .close),
-            origin_module.large_body_bytes,
-        );
+        const response = single_client.get(host, origin_module.large_path, .close) catch |err| {
+            std.debug.print("smoke: pass {d} bulk request {d}: {t}\n", .{ pass, large, err });
+            return err;
+        };
+        try expectResponse(response, origin_module.large_body_bytes);
     }
     assert(large == large_requests);
 }
@@ -669,10 +682,11 @@ fn runL4Load(io: Io, port: u16, host: []const u8) !void {
     while (index < l4_connections) : (index += 1) {
         try single_client.connect(io, port);
         defer single_client.close();
-        try expectResponse(
-            try single_client.get(host, "/", .keep_alive),
-            origin_module.body.len,
-        );
+        const response = single_client.get(host, "/", .keep_alive) catch |err| {
+            std.debug.print("smoke: l4 connection {d}: {t}\n", .{ index, err });
+            return err;
+        };
+        try expectResponse(response, origin_module.body.len);
     }
     assert(index == l4_connections);
 }

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -1,0 +1,508 @@
+//! Tier 0.5 — the live gate (DESIGN.md §9): the shipped binary, on a real
+//! kernel, against a real origin, on every change.
+//!
+//! The three deterministic gates run the real data path against virtual
+//! sockets and a virtual clock. That is what makes them exhaustive, and it
+//! is also what they cannot answer: both bugs that motivated this tier
+//! were found by *running* the thing (#129's phantom access-log line per
+//! keep-alive connection, #130's health probes idling out their whole
+//! timeout). Each was afterwards teachable to the simulator; neither was
+//! caught by it first, because each needed the shape to be known before it
+//! could be looked for.
+//!
+//! So this gate asserts *equalities on real output*, never thresholds: a
+//! shared runner's timing noise must not be able to move a verdict. N
+//! requests produce exactly N access-log lines. Anything whose verdict
+//! needs a run-to-run comparison is Tier 1's job (`zig build bench`) and
+//! would make a per-change gate that fails on noise.
+//!
+//! The origin lives in this process (smoke/origin.zig) rather than being
+//! nginx; the load is this file's own client (smoke/client.zig) rather
+//! than zrk. Both are deliberate — see those files.
+
+const std = @import("std");
+
+const client_module = @import("client.zig");
+const origin_module = @import("origin.zig");
+
+const Io = std.Io;
+
+const assert = std.debug.assert;
+
+const work_directory = ".zig-cache/zoxy-smoke";
+const config_path = work_directory ++ "/zoxy.json";
+const access_log_path = work_directory ++ "/access.log";
+const zoxy_log_path = work_directory ++ "/zoxy.log";
+
+/// The L7 load: keep-alive connections, each serving the same count. Both
+/// numbers are above one on purpose — the access-log equality this gate
+/// exists for is a per-*request* claim that a per-*connection* bug
+/// satisfies, so a single request on a single connection could not tell
+/// the two apart (#129).
+const keep_alive_connections: u8 = 4;
+const requests_per_connection: u32 = 16;
+
+/// Connections closed before the drain; the rest are still open when
+/// SIGTERM lands. Both teardown paths — a client that left and a drain
+/// that reaped — must write nothing, and only running both proves it.
+const connections_closed_early: u8 = 2;
+
+/// The L4 load: one exchange per connection, each connection closed by the
+/// client. An L4 connection *is* its own log unit (§8), so this is the
+/// other half of the line arithmetic.
+const l4_connections: u8 = 2;
+
+const http_exchanges: u32 = @as(u32, keep_alive_connections) * requests_per_connection;
+const access_log_lines_expected: u32 = http_exchanges + l4_connections;
+
+/// What the harness holds open against the origin at its peak: every live
+/// client connection can have an upstream connection of its own, parked or
+/// leased, plus the odd straggler mid-teardown.
+const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2;
+
+/// The drain's cap on waiting for the connections left open above. A
+/// drain cannot tell an idle keep-alive connection from one about to send
+/// a request, so it waits for both and reaps what is left at this
+/// deadline (§8) — which is the whole of this run's shutdown cost, and
+/// therefore the number to keep small. Short enough to stay a gate that
+/// runs in a second; long enough that nothing here is racing it, since
+/// the load is finished before SIGTERM is sent.
+const drain_deadline_ms: u32 = 300;
+
+/// zoxy's pools, shrunk from the lean defaults (§5). Nothing here is a
+/// scenario — the load is a handful of connections — so the smallest
+/// config that serves it starts fastest and keeps the process's resident
+/// set a number a human can read at a glance.
+const zoxy_limits = .{ .conn_slots = 32, .relay_buffers = 16, .upstream_slots = 16 };
+
+comptime {
+    assert(keep_alive_connections >= 2);
+    assert(requests_per_connection >= 2);
+    assert(connections_closed_early >= 1);
+    assert(connections_closed_early < keep_alive_connections);
+    assert(l4_connections >= 1);
+    // The origin serves this harness and nothing else, so its pool has to
+    // cover the peak with room for the wake-up connections `stop` sends.
+    assert(origin_connections_peak < origin_module.serve_tasks);
+    // Every client connection needs a slot and a relay buffer at once.
+    assert(zoxy_limits.relay_buffers >= keep_alive_connections + l4_connections);
+    assert(zoxy_limits.conn_slots >= zoxy_limits.relay_buffers);
+}
+
+/// The whole run's wall-clock budget. Fifty times what a run takes, so it
+/// is never a verdict on speed — it exists because every wait in this
+/// harness is a wait on the process under test, and the failure this gate
+/// most wants to catch loudly (a proxy that will not drain, #130's
+/// neighbourhood) is exactly the one that would otherwise wedge a build
+/// step until CI's own timeout killed it with no diagnosis.
+const watchdog_budget_ns: u64 = 30 * std.time.ns_per_s;
+
+/// The origin's serve tasks take its address, and the clients hold
+/// readers and writers pointing into their own buffers — both want
+/// storage that outlives no scope and moves for no reason, which is what
+/// static means here (§5's discipline, applied to the harness).
+var origin: origin_module.Origin = undefined;
+var clients: [keep_alive_connections]client_module.Client = undefined;
+var l4_client: client_module.Client = undefined;
+
+/// The proxy the watchdog kills if it fires, published by `spawnZoxy`.
+/// Zero until then — the watchdog can outlive the spawn failing.
+var watchdog_child_pid = std.atomic.Value(i32).init(0);
+
+const Flags = struct {
+    zoxy_path: []const u8 = "zig-out/bin/zoxy",
+};
+
+/// The ports zoxy is told to bind. Kernel-assigned rather than fixed: a
+/// per-change gate must not fail because a developer's other terminal is
+/// already on 18080.
+const Ports = struct {
+    http: u16,
+    l4: u16,
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    const arena = init.arena.allocator();
+    const io = init.io;
+    const args = try init.minimal.args.toSlice(arena);
+    const flags = try parseFlags(args);
+
+    // Armed before anything that can block, and cancelled by the defer on
+    // every exit path — success, failure, or a propagated error.
+    var watchdog: Io.Group = .init;
+    try watchdog.concurrent(io, watchdogTask, .{io});
+    defer watchdog.cancel(io);
+
+    try prepareWorkDirectory(io);
+    try origin.start(io, origin_connections_peak);
+    // Ordered against the child's own teardown below: defers unwind
+    // last-declared-first, so zoxy is always gone before this runs — which
+    // is what releases the origin tasks parked in `read` on its upstream
+    // connections.
+    defer origin.stop();
+
+    const ports = try reservePorts(io);
+    try writeConfig(arena, io, &ports, origin.port);
+    var child = try spawnZoxy(io, flags.zoxy_path);
+    var running = true;
+    defer if (running) child.kill(io);
+
+    try awaitListening(io, ports.http);
+    try runLoad(io, &ports);
+
+    const drained_cleanly = try drain(io, &child, &running);
+    const lines = try readAccessLog(arena, io);
+    return if (gatePassed(io, &lines, drained_cleanly)) 0 else 1;
+}
+
+/// The wall-clock backstop. Nothing in this harness can bound its own
+/// wait — a `read` on a proxy that accepted and went quiet, a `wait` on
+/// one that will not exit, an origin task parked on a socket the proxy
+/// never closed — so the bound is one budget over the whole run, held out
+/// here where no wedged operation can be holding it.
+///
+/// It ends the process rather than reporting upward, because there is no
+/// upward: the thread that would receive the report is the wedged one.
+/// The proxy is killed first, so a run that times out leaves no orphan
+/// holding the ports the next one will ask the kernel for.
+fn watchdogTask(io: Io) void {
+    io.sleep(Io.Duration.fromNanoseconds(watchdog_budget_ns), .awake) catch |err| {
+        // The run finished and cancelled this task, which is every
+        // ordinary exit; nothing else cancels it.
+        assert(err == error.Canceled);
+        return;
+    };
+    std.debug.print(
+        "FAIL: smoke run exceeded its {d}s budget — something is wedged, not slow\n",
+        .{watchdog_budget_ns / std.time.ns_per_s},
+    );
+    const pid = watchdog_child_pid.load(.acquire);
+    if (pid != 0) {
+        std.posix.kill(pid, .KILL) catch {};
+    }
+    printZoxyLog(io);
+    std.process.exit(3);
+}
+
+/// What one run of the access log said, as counts rather than text: the
+/// gate's verdicts are equalities over these.
+const LogCounts = struct {
+    http: u32 = 0,
+    l4: u32 = 0,
+    /// Lines that were neither, so "the file holds exactly what it should"
+    /// is checkable rather than merely "it holds at least that".
+    other: u32 = 0,
+    /// HTTP lines that both completed and carried the origin's status —
+    /// the outcome every request in this load is owed.
+    http_ok: u32 = 0,
+};
+
+/// The §9 pass/fail, printed so a red run explains itself without a
+/// rerun. Every clause is an equality against a number this harness
+/// decided before the run started.
+fn gatePassed(io: Io, lines: *const LogCounts, drained_cleanly: bool) bool {
+    // Both are counted off the same lines, in the same pass, so a total
+    // below its own subset would mean the counter itself is wrong — which
+    // no comparison below would otherwise notice.
+    assert(lines.http_ok <= lines.http);
+    assert(access_log_lines_expected == http_exchanges + l4_connections);
+    var passed = true;
+    if (lines.http != http_exchanges) {
+        std.debug.print(
+            "FAIL: {d} http access-log lines for {d} requests (#129 is exactly this)\n",
+            .{ lines.http, http_exchanges },
+        );
+        passed = false;
+    }
+    if (lines.l4 != l4_connections) {
+        std.debug.print(
+            "FAIL: {d} l4 access-log lines for {d} connections\n",
+            .{ lines.l4, l4_connections },
+        );
+        passed = false;
+    }
+    if (lines.other != 0) {
+        std.debug.print("FAIL: {d} access-log lines of no known kind\n", .{lines.other});
+        passed = false;
+    }
+    if (lines.http_ok != lines.http) {
+        std.debug.print(
+            "FAIL: {d} of {d} http lines did not complete with the origin's 200\n",
+            .{ lines.http - lines.http_ok, lines.http },
+        );
+        passed = false;
+    }
+    if (!drained_cleanly) {
+        std.debug.print("FAIL: zoxy did not drain cleanly on SIGTERM\n", .{});
+        passed = false;
+    }
+    if (passed) {
+        std.debug.print(
+            "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, clean drain\n",
+            .{ lines.http, lines.l4, access_log_lines_expected },
+        );
+    } else {
+        printZoxyLog(io);
+    }
+    return passed;
+}
+
+/// The load: every L7 connection serves its whole share before the next
+/// one opens, then some are closed and the rest are left for the drain.
+fn runLoad(io: Io, ports: *const Ports) !void {
+    assert(ports.http != 0);
+    assert(ports.l4 != 0);
+    var host_buffer: [32]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
+    for (&clients) |*client| {
+        try client.connect(io, ports.http);
+        var request: u32 = 0;
+        while (request < requests_per_connection) : (request += 1) {
+            try expectOriginResponse(try client.get(host, "/"));
+        }
+        assert(client.requests == requests_per_connection);
+    }
+    for (clients[0..connections_closed_early]) |*client| {
+        client.close();
+    }
+    try runL4Load(io, ports.l4, host);
+}
+
+/// The L4 leg (§6): the same HTTP exchange through the byte relay, which
+/// neither parses nor frames it. One connection per exchange, closed by
+/// the client — an L4 line describes a connection, not a request.
+fn runL4Load(io: Io, port: u16, host: []const u8) !void {
+    assert(port != 0);
+    assert(host.len >= 1);
+    var index: u8 = 0;
+    while (index < l4_connections) : (index += 1) {
+        // One static slot reused across the loop, on the same terms as
+        // `clients`: a connection is closed before the next is opened, so
+        // there is never more than one of these alive.
+        try l4_client.connect(io, port);
+        defer l4_client.close();
+        try expectOriginResponse(try l4_client.get(host, "/"));
+    }
+    assert(index == l4_connections);
+}
+
+/// The response the origin sends, checked byte-count and all: a hop that
+/// truncated or re-framed a body is a data-path bug this tier sees before
+/// any counter does.
+fn expectOriginResponse(response: client_module.Response) !void {
+    // The client parses both out of the wire and bounds them there; a
+    // value outside those bounds reaching here would mean the two files
+    // disagree about what a response is.
+    assert(response.status >= 100);
+    assert(response.body_bytes <= client_module.response_body_bytes_max);
+    if (response.status != 200) {
+        std.debug.print("smoke: origin answered {d}, not 200\n", .{response.status});
+        return error.UnexpectedStatus;
+    }
+    if (response.body_bytes != origin_module.body.len) {
+        std.debug.print(
+            "smoke: body was {d} bytes, not {d}\n",
+            .{ response.body_bytes, origin_module.body.len },
+        );
+        return error.UnexpectedBody;
+    }
+}
+
+/// Drain, not just death (§8): SIGTERM, then a wait that both reaps the
+/// child and reports whether it left of its own accord. Clears `running`
+/// so the caller's guarded defer cannot double-kill.
+fn drain(io: Io, child: *std.process.Child, running: *bool) !bool {
+    assert(running.*);
+    assert(child.id != null);
+    try std.posix.kill(child.id.?, .TERM);
+    const term = try child.wait(io);
+    running.* = false;
+    return term == .exited and term.exited == 0;
+}
+
+/// Count what the run wrote. The whole file is read at once: the log is
+/// bounded by the load this harness issued, and a file bigger than the
+/// cap is itself the finding.
+fn readAccessLog(arena: std.mem.Allocator, io: Io) !LogCounts {
+    const bytes_max = @as(usize, access_log_lines_expected + 64) * 1024;
+    const text = try Io.Dir.cwd().readFileAlloc(io, access_log_path, arena, .limited(bytes_max));
+    assert(text.len <= bytes_max);
+    var counts: LogCounts = .{};
+    var remaining = std.mem.splitScalar(u8, text, '\n');
+    while (remaining.next()) |line| {
+        if (line.len == 0) continue;
+        if (std.mem.indexOf(u8, line, "\"kind\":\"http\"") != null) {
+            counts.http += 1;
+            const completed = std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") != null;
+            const answered = std.mem.indexOf(u8, line, "\"status\":200") != null;
+            if (completed and answered) counts.http_ok += 1;
+        } else {
+            if (std.mem.indexOf(u8, line, "\"kind\":\"l4\"") != null) {
+                counts.l4 += 1;
+            } else {
+                counts.other += 1;
+            }
+        }
+    }
+    return counts;
+}
+
+/// Two loopback ports the kernel is not using, held open together so it
+/// cannot hand out the same one twice, then released for zoxy to bind.
+/// There is a window between the release and zoxy's bind; nothing can
+/// close it from out here, and it is far smaller than the collision a
+/// hard-coded pair would carry on a shared runner.
+fn reservePorts(io: Io) !Ports {
+    var http_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var http_listener = try http_address.listen(io, .{ .mode = .stream });
+    var l4_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var l4_listener = try l4_address.listen(io, .{ .mode = .stream });
+    const ports: Ports = .{
+        .http = http_listener.socket.address.getPort(),
+        .l4 = l4_listener.socket.address.getPort(),
+    };
+    http_listener.deinit(io);
+    l4_listener.deinit(io);
+    assert(ports.http != 0);
+    assert(ports.l4 != 0);
+    assert(ports.http != ports.l4);
+    return ports;
+}
+
+/// Both protocols against one origin (§6, §7), with the access log on a
+/// file rather than stdout: the file is what this gate counts, and a pipe
+/// nobody drains is a drop rung (§8) waiting to make the count a lie.
+fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_port: u16) !void {
+    assert(origin_port != 0);
+    const config_json = try std.fmt.allocPrint(arena,
+        \\{{
+        \\    "listeners": [
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }}
+        \\    ],
+        \\    "clusters": {{
+        \\        "origin": {{ "endpoints": ["127.0.0.1:{d}"] }}
+        \\    }},
+        \\    "access_log": {{ "sink": "file", "path": "{s}" }},
+        \\    "timeouts": {{
+        \\        "connect_ms": 2000,
+        \\        "idle_ms": 30000,
+        \\        "drain_deadline_ms": {d}
+        \\    }},
+        \\    "limits": {{
+        \\        "conn_slots": {d},
+        \\        "relay_buffers": {d},
+        \\        "upstream_slots": {d}
+        \\    }}
+        \\}}
+        \\
+    , .{
+        ports.http,
+        ports.l4,
+        origin_port,
+        access_log_path,
+        drain_deadline_ms,
+        zoxy_limits.conn_slots,
+        zoxy_limits.relay_buffers,
+        zoxy_limits.upstream_slots,
+    });
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
+}
+
+/// A fresh work directory every run: the file sink is append-only by
+/// design (§8, so an external rotation is safe), which makes a stale log
+/// from the last run indistinguishable from this one's output.
+fn prepareWorkDirectory(io: Io) !void {
+    try Io.Dir.cwd().createDirPath(io, work_directory);
+    Io.Dir.cwd().deleteFile(io, access_log_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+}
+
+/// zoxy's own output goes to a file rather than this process's stderr:
+/// the banner and the drain-time counter dump are a hundred lines of
+/// post-mortem that a green per-change gate should not print. A red one
+/// prints its tail (`printZoxyLog`).
+fn spawnZoxy(io: Io, zoxy_path: []const u8) !std.process.Child {
+    assert(zoxy_path.len >= 1);
+    const log_file = try Io.Dir.cwd().createFile(io, zoxy_log_path, .{});
+    defer log_file.close(io);
+    const child = std.process.spawn(io, .{
+        .argv = &.{ zoxy_path, config_path },
+        .stdout = .{ .file = log_file },
+        .stderr = .{ .file = log_file },
+    }) catch |err| {
+        std.debug.print(
+            "smoke: could not spawn {s} ({t}); run `zig build` first\n",
+            .{ zoxy_path, err },
+        );
+        return err;
+    };
+    // Everything that can wedge from here on is a wait on this process,
+    // so the watchdog needs it before the first of those waits.
+    assert(child.id != null);
+    watchdog_child_pid.store(child.id.?, .release);
+    return child;
+}
+
+/// Wait for the listener to answer a connect, and nothing more: a probe
+/// that sent a *request* would be an exchange, and every exchange in this
+/// run is one the line arithmetic already counted. An accepted connection
+/// that asks nothing owes no line (§8), so this one is invisible to the
+/// gate by construction.
+fn awaitListening(io: Io, port: u16) !void {
+    assert(port != 0);
+    const attempts_max: u16 = 200;
+    const retry_delay = Io.Duration.fromNanoseconds(25 * std.time.ns_per_ms);
+    var attempt: u16 = 0;
+    while (attempt < attempts_max) : (attempt += 1) {
+        var address: Io.net.IpAddress = .{ .ip4 = .loopback(port) };
+        const stream = address.connect(io, .{ .mode = .stream }) catch {
+            // The pause is pacing, not correctness: a sleep that failed
+            // or woke early only means the next probe runs sooner, and
+            // the attempt cap is what bounds the wait either way.
+            io.sleep(retry_delay, .awake) catch {};
+            continue;
+        };
+        stream.close(io);
+        return;
+    }
+    assert(attempt == attempts_max);
+    std.debug.print("smoke: zoxy never listened on port {d}\n", .{port});
+    printZoxyLog(io);
+    return error.ZoxyNeverListened;
+}
+
+/// The head of zoxy's captured output, for a failing run — the banner and
+/// whatever it said before giving up. Best-effort: this runs when
+/// something has already gone wrong, so an unreadable log must not
+/// replace the failure that is being reported.
+fn printZoxyLog(io: Io) void {
+    var buffer: [16 * 1024]u8 = undefined;
+    const file = Io.Dir.cwd().openFile(io, zoxy_log_path, .{}) catch return;
+    defer file.close(io);
+    var read_buffer: [4096]u8 = undefined;
+    var file_reader = file.reader(io, &read_buffer);
+    const read = file_reader.interface.readSliceShort(&buffer) catch return;
+    assert(read <= buffer.len);
+    if (read == 0) return;
+    std.debug.print("-- {s} --\n{s}\n", .{ zoxy_log_path, buffer[0..read] });
+}
+
+fn parseFlags(args: []const [:0]const u8) !Flags {
+    var flags: Flags = .{};
+    var index: usize = 1;
+    while (index < args.len) : (index += 1) {
+        if (std.mem.eql(u8, args[index], "--zoxy")) {
+            index += 1;
+            if (index == args.len) return error.InvalidArguments;
+            flags.zoxy_path = args[index];
+        } else {
+            std.debug.print("usage: smoke [--zoxy path]\n", .{});
+            return error.InvalidArguments;
+        }
+    }
+    assert(flags.zoxy_path.len >= 1);
+    return flags;
+}

--- a/smoke/origin.zig
+++ b/smoke/origin.zig
@@ -32,9 +32,25 @@ const assert = std.debug.assert;
 /// harness's peak open-connection count, which `start` asserts.
 pub const serve_tasks: u8 = 16;
 
-/// What every request is answered with. Small on purpose: these bodies
-/// price nothing — the gate counts exchanges, it does not time them.
+/// What an ordinary request is answered with. Small on purpose: these
+/// bodies price nothing — the gate counts exchanges, it does not time
+/// them.
 pub const body = "zoxy-smoke-origin\n";
+
+/// The one target answered differently, and the body it carries. This is
+/// the shape the simulator cannot build (§9's census exempts
+/// `l7_response_excess_sent` because no seed raises the adversary's recv
+/// cap that far): a single delivery large enough that the origin's head
+/// and the front of its body reach zoxy together and overrun the head
+/// buffer, so the excess has to leave in a write of its own.
+///
+/// It has to exceed the head buffer the harness's config leaves at its
+/// default, which smoke/main.zig asserts against its own copy of that
+/// number — a drift there fails this gate loudly (the excess count is an
+/// equality) rather than quietly stopping to exercise the branch. Written
+/// in one call, so the kernel hands it over coalesced.
+pub const large_path = "/large";
+pub const large_body_bytes: u32 = 32 * 1024;
 
 /// Requests one connection may serve before the origin closes it. A
 /// bound, not a policy (TIGER_STYLE): the harness sends two orders of
@@ -46,14 +62,29 @@ const requests_per_connection_max: u32 = 4096;
 /// answered by dropping the connection.
 const request_head_bytes_max: u32 = 2048;
 
-/// The response, rendered once at comptime — every request gets the same
-/// bytes, so there is nothing to format per exchange.
-const response =
-    "HTTP/1.1 200 OK\r\n" ++
-    std.fmt.comptimePrint("Content-Length: {d}\r\n", .{body.len}) ++
-    "Content-Type: text/plain\r\n" ++
-    "\r\n" ++
-    body;
+/// Both responses, rendered once at comptime — a target picks one, and
+/// nothing else about a request changes a byte of it, so there is nothing
+/// to format per exchange.
+const response = renderResponse(body);
+const large_response = renderResponse(&large_body);
+
+/// A fixed non-uniform fill. Nothing here compresses or dedupes, but a
+/// constant byte would make an accidental short read look identical to a
+/// correct one in a dump.
+const large_body: [large_body_bytes]u8 = blk: {
+    @setEvalBranchQuota(8 * large_body_bytes);
+    var bytes: [large_body_bytes]u8 = undefined;
+    for (&bytes, 0..) |*byte, index| byte.* = @truncate(index);
+    break :blk bytes;
+};
+
+fn renderResponse(comptime payload: []const u8) []const u8 {
+    return "HTTP/1.1 200 OK\r\n" ++
+        std.fmt.comptimePrint("Content-Length: {d}\r\n", .{payload.len}) ++
+        "Content-Type: application/octet-stream\r\n" ++
+        "\r\n" ++
+        payload;
+}
 
 comptime {
     // The pool must be able to hold more than one connection or the
@@ -61,13 +92,20 @@ comptime {
     assert(serve_tasks >= 2);
     assert(requests_per_connection_max >= 1);
     assert(request_head_bytes_max >= 64);
+    // The head this origin sends must be a small fraction of the body
+    // behind it, or "the delivery filled the head buffer" would be a
+    // claim about the head rather than about the body's front.
+    assert(large_response.len > large_body_bytes);
+    assert(large_response.len - large_body_bytes < 1024);
 }
 
 /// One serve task's storage. Static, indexed by task, so a task's buffers
 /// do not ride its thread stack.
 const TaskBuffers = struct {
     read: [request_head_bytes_max]u8 = undefined,
-    write: [response.len]u8 = undefined,
+    /// Sized for the larger response, so either leaves in a single write
+    /// — which is the whole point of the large one.
+    write: [large_response.len]u8 = undefined,
 };
 
 pub const Origin = struct {
@@ -196,41 +234,61 @@ fn serveConnection(origin: *Origin, stream: Io.net.Stream, buffers: *TaskBuffers
     var writer = stream.writer(origin.io, &buffers.write);
     var served: u32 = 0;
     while (served < requests_per_connection_max) : (served += 1) {
-        if (!readRequestHead(&reader.interface)) return;
-        writer.interface.writeAll(response) catch return;
+        const large = readRequestHead(&reader.interface) orelse return;
+        // One `writeAll` into a buffer that holds the whole thing, then
+        // one flush: the large response has to reach the kernel as a
+        // single write or the delivery it exists to provoke is split
+        // before zoxy ever sees it.
+        writer.interface.writeAll(if (large) large_response else response) catch return;
         writer.interface.flush() catch return;
         _ = origin.served.fetchAdd(1, .monotonic);
     }
 }
 
-/// Read one request head, discarding it: this origin answers every method
-/// and every target the same way, so nothing in the head changes what it
-/// sends. False means the connection is over — an orderly close between
-/// requests (what a proxy draining its parked connections looks like), a
-/// reset, or a head this origin will not read past.
+/// Read one request head. Only its target matters — one of two responses
+/// is chosen by it and nothing else in the head changes a byte — so the
+/// answer is whether that target was the large one. Null means the
+/// connection is over: an orderly close between requests (what a proxy
+/// draining its parked connections looks like), a reset, or a head this
+/// origin will not read past.
 ///
 /// No body is read, because none is ever sent: the harness issues GETs
 /// and zoxy's health probes are GETs, so a request with a body would be a
 /// desync this origin should not paper over.
-fn readRequestHead(reader: *Io.Reader) bool {
+fn readRequestHead(reader: *Io.Reader) ?bool {
     assert(reader.buffer.len == request_head_bytes_max);
+    var large = false;
     var lines: u32 = 0;
     // Every legal head is bounded by its own blank line; the cap is the
     // header count a broken peer could otherwise dribble forever. Two
     // bytes is the shortest a line can be, so no legal head reaches it.
-    const lines_max = request_head_bytes_max / 2;
+    const lines_max = @divFloor(request_head_bytes_max, 2);
     while (lines < lines_max) : (lines += 1) {
         // A read error, a head line longer than the buffer, and a close
         // between requests are one answer here: this connection is over.
-        const taken = reader.takeDelimiter('\n') catch return false;
-        const line = taken orelse return false;
+        const taken = reader.takeDelimiter('\n') catch return null;
+        const line = taken orelse return null;
         assert(line.len <= request_head_bytes_max);
         // The blank line ends the head. Both spellings are accepted: what
         // arrives here is zoxy's rendering, and the gate is not the place
         // to re-litigate its CRLF discipline (§7 already does).
-        if (line.len == 0) return true;
-        if (line.len == 1 and line[0] == '\r') return true;
+        if (line.len == 0) return large;
+        if (line.len == 1 and line[0] == '\r') return large;
+        if (lines == 0) large = requestsLarge(line);
     }
     assert(lines == lines_max);
-    return false;
+    return null;
+}
+
+/// Does this request line ask for `large_path`? Matched on the target
+/// alone, and only as a whole word: `/largest` is an ordinary target, and
+/// answering it with 32 KiB would make a typo in the harness look like a
+/// proxy bug.
+fn requestsLarge(request_line: []const u8) bool {
+    assert(request_line.len >= 1);
+    const target_start = (std.mem.indexOfScalar(u8, request_line, ' ') orelse return false) + 1;
+    if (target_start >= request_line.len) return false;
+    const rest = request_line[target_start..];
+    const target_end = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+    return std.mem.eql(u8, rest[0..target_end], large_path);
 }

--- a/smoke/origin.zig
+++ b/smoke/origin.zig
@@ -1,0 +1,236 @@
+//! The live origin behind the Tier-0.5 gate (DESIGN.md §9): a real
+//! HTTP/1.1 server on real kernel sockets, served out of the harness
+//! process itself by a fixed pool of blocking accept tasks.
+//!
+//! It is Zig rather than nginx on purpose. Tier 1 spawns nginx because a
+//! *band* wants a production-grade origin to measure against; a
+//! per-change gate wants the opposite trade. nginx in the CI closure is a
+//! new dependency to fetch on every run — devenv.nix keeps that closure
+//! to zig plus kcov deliberately — and the gate's verdicts are equalities
+//! on zoxy's own output, which no property of the origin's C makes truer.
+//! Owning the origin also makes its *deliveries* something the gate can
+//! shape, which some of what this tier reaches (a response filling zoxy's
+//! head buffer, §7) is a property of.
+//!
+//! Concurrency is a fixed pool, not a task per connection: the harness's
+//! load is a handful of connections it declares up front, so the bound is
+//! a static number rather than a policy, and `serve_tasks` is asserted
+//! against that load at startup. Each task blocks in `accept` for its
+//! whole life; `stop` sets the flag and then wakes every task with a
+//! connection of its own, which is what makes shutdown a matter of
+//! counting rather than of cancelling a blocking syscall.
+
+const std = @import("std");
+
+const Io = std.Io;
+
+const assert = std.debug.assert;
+
+/// Connections the origin can carry at once. Every parked upstream
+/// connection holds a task blocked in `read` until zoxy closes it, so
+/// this is a *residency* bound, not a throughput one: it must exceed the
+/// harness's peak open-connection count, which `start` asserts.
+pub const serve_tasks: u8 = 16;
+
+/// What every request is answered with. Small on purpose: these bodies
+/// price nothing — the gate counts exchanges, it does not time them.
+pub const body = "zoxy-smoke-origin\n";
+
+/// Requests one connection may serve before the origin closes it. A
+/// bound, not a policy (TIGER_STYLE): the harness sends two orders of
+/// magnitude fewer, so reaching it means the peer is looping.
+const requests_per_connection_max: u32 = 4096;
+
+/// Head bytes one request may spend. zoxy's own head buffer is the real
+/// limit in front of this; a request that overruns here is a broken peer,
+/// answered by dropping the connection.
+const request_head_bytes_max: u32 = 2048;
+
+/// The response, rendered once at comptime — every request gets the same
+/// bytes, so there is nothing to format per exchange.
+const response =
+    "HTTP/1.1 200 OK\r\n" ++
+    std.fmt.comptimePrint("Content-Length: {d}\r\n", .{body.len}) ++
+    "Content-Type: text/plain\r\n" ++
+    "\r\n" ++
+    body;
+
+comptime {
+    // The pool must be able to hold more than one connection or the
+    // origin serializes zoxy's data path behind its health probes.
+    assert(serve_tasks >= 2);
+    assert(requests_per_connection_max >= 1);
+    assert(request_head_bytes_max >= 64);
+}
+
+/// One serve task's storage. Static, indexed by task, so a task's buffers
+/// do not ride its thread stack.
+const TaskBuffers = struct {
+    read: [request_head_bytes_max]u8 = undefined,
+    write: [response.len]u8 = undefined,
+};
+
+pub const Origin = struct {
+    io: Io,
+    listener: Io.net.Server,
+    /// The kernel-assigned port, read back after `listen` — the harness
+    /// never picks it, so it cannot collide with anything.
+    port: u16,
+    group: Io.Group,
+    /// Set by `stop` before it wakes the tasks; every task checks it on
+    /// the accept it wakes from.
+    stopping: std.atomic.Value(bool),
+    /// Requests answered, for the harness's own report. Written by every
+    /// task, so it is atomic like every other cross-task field here.
+    served: std.atomic.Value(u32),
+    buffers: [serve_tasks]TaskBuffers,
+    started: bool,
+
+    /// Bind a loopback port, read back which one the kernel gave, and put
+    /// every task into `accept`. In-place init through an out-pointer: the
+    /// tasks take `*Origin`, so the address has to be the final one.
+    ///
+    /// `connections_peak` is what the harness will hold open at once,
+    /// asserted against the pool here rather than discovered as a hang.
+    pub fn start(origin: *Origin, io: Io, connections_peak: u8) !void {
+        assert(connections_peak >= 1);
+        assert(connections_peak < serve_tasks);
+        origin.io = io;
+        origin.group = .init;
+        origin.stopping = .init(false);
+        origin.served = .init(0);
+        origin.started = false;
+        var address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+        origin.listener = try address.listen(io, .{ .mode = .stream });
+        origin.port = origin.listener.socket.address.getPort();
+        // A kernel-assigned port is never zero; a zero here would mean the
+        // harness went on to write ":0" into zoxy's config.
+        assert(origin.port != 0);
+        var index: u8 = 0;
+        while (index < serve_tasks) : (index += 1) {
+            try origin.group.concurrent(io, serveTask, .{ origin, index });
+        }
+        origin.started = true;
+    }
+
+    /// Stop accepting and join every task. Sound only once the proxy is
+    /// gone: a task serving a parked upstream connection is blocked in
+    /// `read` until its peer closes, and nothing here can hurry that.
+    ///
+    /// The wake is one connection per task rather than a cancellation:
+    /// each task consumes at most one — it returns from the accept that
+    /// takes it — so `serve_tasks` connections retire the pool however
+    /// the tasks are distributed between `accept` and a live exchange.
+    pub fn stop(origin: *Origin) void {
+        assert(origin.started);
+        assert(!origin.stopping.load(.acquire));
+        origin.stopping.store(true, .release);
+        var index: u8 = 0;
+        while (index < serve_tasks) : (index += 1) {
+            if (!origin.wake()) {
+                // A wake that never lands leaves one task in `accept`
+                // forever, and the `await` below would wait for it. Say
+                // so here rather than let the harness's own wall-clock
+                // budget report it as an unexplained hang.
+                std.debug.print("smoke: origin wake {d} never connected\n", .{index});
+            }
+        }
+        // The tasks take no cancellation, so the only way this returns is
+        // every one of them having left its accept loop.
+        origin.group.await(origin.io) catch {};
+        origin.listener.deinit(origin.io);
+        origin.started = false;
+    }
+
+    /// One task's wake: a connection it will accept and immediately drop.
+    /// Retried, because the alternative to a landed wake is a task that
+    /// never returns — a loopback connect to a listening socket fails
+    /// only under fd or backlog pressure, both of which pass.
+    fn wake(origin: *Origin) bool {
+        assert(origin.stopping.load(.acquire));
+        const attempts_max: u8 = 4;
+        var attempt: u8 = 0;
+        while (attempt < attempts_max) : (attempt += 1) {
+            var address: Io.net.IpAddress = .{ .ip4 = .loopback(origin.port) };
+            const stream = address.connect(origin.io, .{ .mode = .stream }) catch continue;
+            stream.close(origin.io);
+            return true;
+        }
+        assert(attempt == attempts_max);
+        return false;
+    }
+};
+
+/// One task's whole life: accept, serve to the connection's end, accept
+/// again. Every exit is a return, never an error propagated to a caller —
+/// the task has none, and a failed connection is the peer's problem, not
+/// the origin's.
+///
+/// The loop is unbounded and terminates for exactly two reasons, which is
+/// why it may be: `stop` sets the flag and sends this task a connection
+/// of its own, or the listener is gone and `accept` fails. Both are
+/// reachable only from `stop`, and each retires exactly one task.
+fn serveTask(origin: *Origin, index: u8) void {
+    assert(index < serve_tasks);
+    const buffers = &origin.buffers[index];
+    while (true) {
+        const stream = origin.listener.accept(origin.io) catch return;
+        if (origin.stopping.load(.acquire)) {
+            // The wake `stop` sent, or a straggler that raced it: either
+            // way this task is done, having consumed exactly one.
+            stream.close(origin.io);
+            return;
+        }
+        serveConnection(origin, stream, buffers);
+        stream.close(origin.io);
+    }
+}
+
+/// Answer requests on one connection until the peer stops asking. Keep-
+/// alive is the point: it is what lets zoxy park an upstream connection
+/// and reuse it (§3, §5), which is a live shape the simulator's scripted
+/// origins do not stand in for.
+fn serveConnection(origin: *Origin, stream: Io.net.Stream, buffers: *TaskBuffers) void {
+    assert(buffers.read.len == request_head_bytes_max);
+    var reader = stream.reader(origin.io, &buffers.read);
+    var writer = stream.writer(origin.io, &buffers.write);
+    var served: u32 = 0;
+    while (served < requests_per_connection_max) : (served += 1) {
+        if (!readRequestHead(&reader.interface)) return;
+        writer.interface.writeAll(response) catch return;
+        writer.interface.flush() catch return;
+        _ = origin.served.fetchAdd(1, .monotonic);
+    }
+}
+
+/// Read one request head, discarding it: this origin answers every method
+/// and every target the same way, so nothing in the head changes what it
+/// sends. False means the connection is over — an orderly close between
+/// requests (what a proxy draining its parked connections looks like), a
+/// reset, or a head this origin will not read past.
+///
+/// No body is read, because none is ever sent: the harness issues GETs
+/// and zoxy's health probes are GETs, so a request with a body would be a
+/// desync this origin should not paper over.
+fn readRequestHead(reader: *Io.Reader) bool {
+    assert(reader.buffer.len == request_head_bytes_max);
+    var lines: u32 = 0;
+    // Every legal head is bounded by its own blank line; the cap is the
+    // header count a broken peer could otherwise dribble forever. Two
+    // bytes is the shortest a line can be, so no legal head reaches it.
+    const lines_max = request_head_bytes_max / 2;
+    while (lines < lines_max) : (lines += 1) {
+        // A read error, a head line longer than the buffer, and a close
+        // between requests are one answer here: this connection is over.
+        const taken = reader.takeDelimiter('\n') catch return false;
+        const line = taken orelse return false;
+        assert(line.len <= request_head_bytes_max);
+        // The blank line ends the head. Both spellings are accepted: what
+        // arrives here is zoxy's rendering, and the gate is not the place
+        // to re-litigate its CRLF discipline (§7 already does).
+        if (line.len == 0) return true;
+        if (line.len == 1 and line[0] == '\r') return true;
+    }
+    assert(lines == lines_max);
+    return false;
+}

--- a/smoke/scrape.zig
+++ b/smoke/scrape.zig
@@ -1,0 +1,159 @@
+//! The admin scrape, read the way an operator's Prometheus reads it
+//! (DESIGN.md §8): over a socket, off a live process, as text.
+//!
+//! This is what makes the counter checks in this tier different in kind
+//! from the simulator's. `reconcile` asserts the same identities from
+//! *inside* the process, against the struct it is asserting about; here
+//! the numbers have been rendered, written to a socket, framed by a
+//! close, and parsed back — so the whole admin plane (§8's reserved
+//! scrape slot, its lingering close, the asynchronous close op that no
+//! other path in the tree uses) is under the same verdict as the
+//! arithmetic.
+//!
+//! The response is `Connection: close`-framed with no `Content-Length`
+//! (admin.zig renders the body after the head, so its length is never
+//! known in time), which is why this cannot reuse smoke/client.zig: that
+//! one requires a framed body, on purpose.
+
+const std = @import("std");
+
+const Io = std.Io;
+
+const assert = std.debug.assert;
+
+/// The exposition prefix every metric carries (`counters.metric_prefix`),
+/// spelled here rather than imported: the gate reads what the binary
+/// *said*, so a rename must show up as a scrape this harness cannot find
+/// its counters in, not as a harness that quietly renames its
+/// expectations alongside.
+const metric_prefix = "zoxy_";
+
+/// The prefix that makes a counter part of §9's gate identity, on the
+/// same terms — `Counters.shedTotal` picks it out of the field set, and
+/// this picks it out of the text.
+const shed_prefix = metric_prefix ++ "shed_";
+
+/// Response bytes one scrape may carry. The rendering is closed-form in
+/// the counter count (`Counters.render_bytes_max`), a few KiB today; this
+/// is an order of magnitude over it, so growth is not a silent truncation.
+const scrape_bytes_max: u32 = 64 * 1024;
+
+pub const Scrape = struct {
+    /// The exposition body, arena-owned: `# TYPE` lines and
+    /// `zoxy_<name> <value>` lines.
+    body: []const u8,
+
+    /// One counter's value, or null when the scrape does not carry that
+    /// name at all — which is a different fact from zero and is why this
+    /// is optional rather than defaulting.
+    pub fn value(scrape: *const Scrape, name: []const u8) ?u64 {
+        assert(name.len >= 1);
+        assert(scrape.body.len >= 1);
+        var lines = std.mem.splitScalar(u8, scrape.body, '\n');
+        while (lines.next()) |line| {
+            const parsed = parseSample(line) orelse continue;
+            if (std.mem.eql(u8, parsed.name, name)) return parsed.value;
+        }
+        return null;
+    }
+
+    /// Every admission shed, summed off the *text* rather than a list —
+    /// so a rung added to counters.zig joins this total by being named,
+    /// exactly as it joins `Counters.shedTotal` by being named.
+    pub fn shedTotal(scrape: *const Scrape) u64 {
+        assert(scrape.body.len >= 1);
+        var total: u64 = 0;
+        var rungs: u32 = 0;
+        var lines = std.mem.splitScalar(u8, scrape.body, '\n');
+        while (lines.next()) |line| {
+            if (!std.mem.startsWith(u8, line, shed_prefix)) continue;
+            const parsed = parseSample(line) orelse continue;
+            total += parsed.value;
+            rungs += 1;
+        }
+        // A sum over nothing is zero, and zero would satisfy the identity
+        // that reads it — so an empty selection is a broken scrape, not a
+        // proxy that shed nothing.
+        assert(rungs >= 1);
+        return total;
+    }
+};
+
+const Sample = struct {
+    name: []const u8,
+    value: u64,
+};
+
+/// One `zoxy_<name> <value>` line, or null for the `# TYPE` lines, the
+/// blank last line, and anything else this parser was not promised.
+fn parseSample(line: []const u8) ?Sample {
+    if (!std.mem.startsWith(u8, line, metric_prefix)) return null;
+    const space = std.mem.indexOfScalar(u8, line, ' ') orelse return null;
+    assert(space > metric_prefix.len);
+    const digits = std.mem.trim(u8, line[space + 1 ..], " \r");
+    const value = std.fmt.parseUnsigned(u64, digits, 10) catch return null;
+    return .{ .name = line[metric_prefix.len..space], .value = value };
+}
+
+/// Scrape the admin listener once. Any request is answered the same way
+/// (admin.zig parses none), so the target is documentary.
+pub fn fetch(arena: std.mem.Allocator, io: Io, port: u16) ![]const u8 {
+    assert(port != 0);
+    var address: Io.net.IpAddress = .{ .ip4 = .loopback(port) };
+    const stream = try address.connect(io, .{ .mode = .stream });
+    defer stream.close(io);
+    var write_buffer: [256]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+    try writer.interface.print(
+        "GET /metrics HTTP/1.1\r\nHost: 127.0.0.1:{d}\r\n\r\n",
+        .{port},
+    );
+    try writer.interface.flush();
+    const response = try readToClose(arena, io, stream);
+    assert(response.len >= 1);
+    return response;
+}
+
+/// Read until the server closes — the framing admin.zig chose (§8).
+fn readToClose(arena: std.mem.Allocator, io: Io, stream: Io.net.Stream) ![]const u8 {
+    const response = try arena.alloc(u8, scrape_bytes_max);
+    var read_buffer: [4096]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+    var filled: u32 = 0;
+    // Bounded by the buffer rather than by trust: every iteration either
+    // fills some of it or ends the loop, so `filled` is the clock.
+    while (filled < scrape_bytes_max) {
+        // A close is how this response ends, and the reader spells both a
+        // clean one and a reset as a failed read. They are not
+        // distinguished here on purpose: what separates "the body
+        // arrived" from "the body was cut short" is whether the body is
+        // *whole*, which `parse` decides on the bytes rather than on the
+        // manner of the close.
+        const read = reader.interface.readSliceShort(response[filled..]) catch break;
+        if (read == 0) break;
+        filled += @intCast(read);
+    }
+    assert(filled <= scrape_bytes_max);
+    return response[0..filled];
+}
+
+/// Split a scrape response into its verdict and its body. A scrape that
+/// did not answer 200 is a broken admin plane, and returning its text as
+/// though it were metrics would turn that into a pile of missing
+/// counters instead.
+pub fn parse(response: []const u8) !Scrape {
+    const ok_status = "HTTP/1.1 200 OK\r\n";
+    const head_end = "\r\n\r\n";
+    if (!std.mem.startsWith(u8, response, ok_status)) return error.ScrapeNotOk;
+    const end = std.mem.indexOf(u8, response, head_end) orelse return error.ScrapeUnframed;
+    const body = response[end + head_end.len ..];
+    if (body.len == 0) return error.ScrapeEmpty;
+    // Every rendered sample ends in a newline, so a body that does not is
+    // one the close cut mid-line. That is the whole truncation check: the
+    // read loop cannot tell a clean close from a reset, and a scrape that
+    // stopped early would otherwise parse into a shorter list of
+    // perfectly plausible numbers.
+    if (body[body.len - 1] != '\n') return error.ScrapeTruncated;
+    assert(body.len < response.len);
+    return .{ .body = body };
+}


### PR DESCRIPTION
Closes #144.

`zig build smoke` — the shipped binary, on a real kernel, against a real origin, on every change, in 0.89s. Wired into `zig build ci`, which goes 5.6s → 6.5s.

It exists because the deterministic gates are exhaustive *within* a virtual socket table and a virtual clock, and two shipped bugs were neither. Both were afterwards teachable to the simulator; neither was caught by it first, because each had to be known before it could be looked for.

## What it asserts

Equalities on real output, so a shared runner's timing cannot move a verdict.

| Verdict | What it reaches |
| --- | --- |
| 136 requests → exactly 136 http lines and 2 l4 lines | #129, without knowing #129 exists |
| `accepted == admitted + shed_*` and `admitted == completed + in_use`, scraped off `/metrics` | the admin plane and the tree's only asynchronous close op — both sim-exempt |
| `l7_responses` equals the access-log count; `accepted` equals the 15 connections the run opened | the counters and the log lying about the same run |
| `upstream_reused > 0`; `l7_response_excess_sent == 8` | §3 reuse live; the §7 branch the census exempts |
| resident set unmoved across two identical load passes | §5 from outside (measured: exactly 0 KiB) |
| clean SIGTERM drain | §8 |
| 20 probes in a 500ms window, band 5..60 | #130 — the one thing no equality can see |

Half the L7 connections are closed by the client and half are left for the drain to reap, so both teardown paths are witnessed writing nothing. The readiness probe connects and asks nothing, which owes no line (§8) — invisible to the arithmetic by construction rather than by adjustment.

The health-probe rate is the one exception to "equalities", and it is the exception that proves the rule: every verdict #130's prober reached was correct and only its rate was wrong. The band is loose enough that scheduling cannot move it and decisive because what it is aimed at runs two orders of magnitude slow.

## Verified by injection

Each headline verdict was checked against the bug it exists for, by reinstating that bug:

- teardown emitting a line for a connection that was asked nothing (#129) → `FAIL: 69 http access-log lines for 64 requests`
- the deadline cancel in `health.zig`'s `settle` disabled (#130 itself) → `FAIL: 0 probes in 500ms at a 25ms interval`

## Two decisions

**The origin is Zig inside the harness, not nginx.** Tier 1 spawns nginx because a band wants a production-grade origin to measure against; a per-change gate wants no new CI dependency — `devenv.nix` keeps that closure to zig plus kcov deliberately — and owning the origin makes its deliveries shapeable, which one of the verdicts is a property of. The load generator is the harness's own client rather than zrk for the same reason: a counted handful of requests needs exactness, not pacing.

**Filling the head buffer is not enough to produce a response excess**, which cost a debugging round and is now recorded in IMPLEMENTATION_NOTES. The bulk target's 32 KiB body does fill the 8 KiB upstream head buffer, and the counter still read 0: the excess rides the head write whenever `rendered + excess` fits, and the rendered head is the origin's *minus* hop-by-hop headers, so it comes to exactly the buffer size and fits — 8192 <= 8192. Only the injected `Connection: close` grows a head. Both halves are needed, and anyone reaching for that path in a directed test needs both.

## Not hanging is a feature

Every wait in the harness is a wait on the process under test and none can bound itself, so one wall-clock budget covers the run from outside. A wedged proxy is killed and reported in 30s rather than left to hang the build until CI's own timeout kills it with no diagnosis. Verified by shrinking the budget: the run reports, kills the child, and leaves no orphan holding the ports.

## Reviewer note — macOS

`ci` runs on macos-latest too, and the smoke gate now runs there. It should build (the only Linux-specific piece, the procfs RSS read, returns null and prints a skip), but zoxy's kqueue backend has never had a live run in CI — the file sink, admin listener and prober are all runtime paths there. **If macOS goes red, that is a finding rather than harness noise**; the alternative is gating the step to Linux, which would weaken the gate on the platform CI keeps precisely because its failure modes only surface at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)