### PR TITLE
fix: read the wall clock through posix.system, not the Linux ABI (#184)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -297,16 +297,15 @@ pub fn build(b: *std.Build) void {
     ci_step.dependOn(test_step);
     ci_step.dependOn(lint_step);
     ci_step.dependOn(sim_step);
-    // Linux only, for now. On its first CI run the gate found that the
-    // macOS leg answers *nothing* to its first L7 request — accepted,
-    // then closed with no response and no diagnostic (#184). That is a
-    // finding, not a flake, and fixing zoxy's kqueue path is not this
-    // step's job; `zig build smoke` still runs everywhere, which is how
-    // that issue gets worked, and putting this line back is its
-    // acceptance test.
-    if (target.result.os.tag == .linux) {
-        ci_step.dependOn(smoke_step);
-    }
+    // Every platform. On its first CI run the gate found that the macOS
+    // leg answered *nothing* to its first L7 request — accepted, then
+    // closed with no response and no diagnostic (#184). The cause was
+    // `nowWallNs` reading CLOCK_REALTIME through the Linux-kernel ABI on a
+    // libc-linked build, so a garbage timespec tripped an assert on the
+    // first logged request; the read now goes through `posix.system` like
+    // every other syscall here. This unconditional line is that fix's
+    // acceptance test — kqueue's failure modes only surface at runtime.
+    ci_step.dependOn(smoke_step);
     // Compile — never run — every measurement binary. Their verdicts are
     // human-read A/Bs and profiles, so running them here would buy nothing
     // and cost minutes; but they call the same internal APIs the proxy

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1167,15 +1167,21 @@ pub fn nowNs(io: *XevIo) u64 {
 /// call site keeps that a wrong number rather than a wrapped one.
 pub fn nowWallNs(io: *XevIo) u64 {
     _ = io;
-    var ts: linux.timespec = undefined;
+    var ts: posix.timespec = undefined;
     // The read stands on its own line, never inside the assert: an
     // assertion argument is not the place for the syscall the function
     // exists to make. CLOCK_REALTIME with a valid pointer has no failure
     // mode on a running kernel — EFAULT and EINVAL are both unreachable
     // from here — so the result is an invariant, asserted rather than
     // absorbed into a zero stamp that would date every line to 1970 and
-    // report a fifty-year duration. Same shape as `shutdown` and `closeFd`.
-    const rc = linux.clock_gettime(linux.CLOCK.REALTIME, &ts);
+    // report a fifty-year duration. Same shape as `shutdown` and `closeFd`:
+    // the read goes through `posix.system`, so its return convention matches
+    // the `posix.errno` that checks it — on kqueue that is libc's -1 sentinel,
+    // on io_uring the raw kernel value. A bare `linux.clock_gettime` here
+    // would pair a kernel-ABI return (a positive errno, never -1) with a
+    // libc-ABI `posix.errno`, which reads .SUCCESS and lets a garbage
+    // timespec through — the macOS live-gate panic of #184.
+    const rc = posix.system.clock_gettime(posix.CLOCK.REALTIME, &ts);
     assert(posix.errno(rc) == .SUCCESS);
     assert(ts.sec >= 0);
     return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s +


### PR DESCRIPTION
## The bug

`zig build smoke` fails on the **very first L7 request** on macOS but is green on Linux (#184). Reproduced locally on Darwin — and it isn't a silent close, it's a **panic** in zoxy:

```
thread panic: reached unreachable code
  src/io/XevIo.zig:1180  assert(ts.sec >= 0)              in nowWallNs
  src/Server.zig:1224    started_wall_ns = io.nowWallNs()  in beginLogRequest
  src/http/proxy.zig:260 server.beginLogRequest(conn)      in onHeadGroupRecv
```

The panic tears down the process mid-request, so the socket closes with zero bytes written → the harness client's `ResponseTruncated`. (The "no panic in the log" from the issue was because the panic goes to stderr, not the captured `zoxy.log`.) It only fires when the **access log is on**, which is why it took the live gate to surface it.

## Root cause — a clock-ABI mismatch, not the kqueue path

`nowWallNs` read `CLOCK_REALTIME` with the **Linux kernel ABI** (`std.os.linux.clock_gettime`) but checked the result with `posix.errno`. On macOS Zig auto-links libSystem (`link_libc=true`), so `posix.errno` follows the **libc convention** — an error only when `rc == -1`. The Linux call returns `rc=22` (a positive errno) with an **uninitialized** timespec (`ts.sec = 0xAAAA…`). `22 ≠ -1`, so the errno assert reads `.SUCCESS`, and the garbage `ts.sec` trips `assert(ts.sec >= 0)`. On Linux the same call is a real kernel syscall and works — hence green there.

This was the **only** syscall in `XevIo.zig` using `linux.*` directly on a runtime path; every sibling (`shutdown`, `closeFd`, `getsockname`, …) already routes through `posix.system.*`. Its own comment even claimed to be the "same shape as `shutdown` and `closeFd`" — but it wasn't.

## The fix

Route the read through the portable `posix.system.clock_gettime` / `posix.CLOCK.REALTIME` / `posix.timespec`, matching the rest of the file.

- **Linux:** `use_libc=false` ⇒ `posix.system == std.os.linux`, so the compiled code is **byte-identical** — zero regression on the green platform.
- **macOS:** routes through libSystem, correctly paired with the libc-convention `posix.errno`.

Access-log timestamps are now real (`2026-08-02T…Z`, `duration_us: 210`) instead of 1970-dated 50-year durations.

## Acceptance test

`build.zig` — removed the `if (target.result.os.tag == .linux)` guard so the live gate runs in `ci` on every platform. That was the fix's acceptance test per the issue.

## Verification

- `zig build ci` green on macOS (smoke + sim over 4096 seeds + lint + fmt).
- `zig build smoke` green on macOS: `136 http + 2 l4 exchanges, 138 access-log lines, counters reconcile, clean drain`.
- `zig fmt --check` clean; `tiger-style-reviewer` clean.

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)