### PR TITLE
feat: per-endpoint weights and the labeled exposition (#174, #179)

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -4,7 +4,7 @@
     ],
     "clusters": {
         "origin": {
-            "endpoints": ["127.0.0.1:9000"],
+            "endpoints": ["127.0.0.1:9000", { "address": "127.0.0.1:9001", "weight": 3 }],
             "check": { "type": "tcp", "fall": 3, "rise": 2 }
         }
     },

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -481,6 +481,18 @@ in the head buffer, which the response head renders over (§7) and the
 turnaround returns to the ring, so they have to be copied out while they
 are still there.
 
+The labeled metrics (§8, #179) add one more reservation on the same
+promise: the per-endpoint counter tables with their prebuilt label
+strings, and the two render staging buffers — the admin scrape response
+and the SIGUSR1 dump. The buffers stopped being comptime constants when
+the exposition gained labels: the rendered text's length depends on
+endpoint count, cluster-name length and address literals, none known
+before config load. The term stays closed-form — `Server.metricsBytes`
+prices the same labels `init` builds, through the same renderer, so the
+banner's prediction is met exactly — and it is deliberately its own
+line: the cost of labelling your metrics sits next to everything else
+you pay for.
+
 The config arena is in that total for the same reason — it is never
 freed — but it is the one term that is **measured rather than derived**,
 and the banner labels it so. There is no constant bounding a config
@@ -856,13 +868,15 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   the FIN-before-checkout race is overwhelmingly the real cause. The
   replay is spent before its try begins (no loop) and always dials
   fresh — the endpoint's whole idle list may be stale the same way. The
-  endpoint pick is per-cluster config: `p2c` (two uniform candidates
-  from a fixed-seed PRNG, the lower **in-flight total** wins — L7 leases
-  and live L4 connections summed, since both are work the origin is
-  carrying) by default, `rr`
-  for strict rotation, `hash` for stickiness. Cluster endpoints are
+  endpoint pick is per-cluster config: `p2c` (two weight-biased
+  candidates from a fixed-seed PRNG — uniform at the default weights —
+  the lower **in-flight total** wins: L7 leases and live L4 connections
+  summed, since both are work the origin is carrying) by default, `rr`
+  for smooth weighted rotation (strict rotation at equal weights),
+  `hash` for stickiness. Cluster endpoints are
   static socket addresses resolved once at config load, never on the
-  loop (dynamic DNS is a non-goal, §1).
+  loop (dynamic DNS is a non-goal, §1), each optionally weighted — two
+  bullets below.
 - **A pick chooses among the endpoints that are both healthy and under
   capacity**, in that order, and the two filters differ in what an empty
   result means. Health fails **open**: a cluster with every endpoint
@@ -875,6 +889,29 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   respects its caps. The in-flight total both this and `p2c` read counts
   L7 leases and live L4 connections alike, which is what lets an L4-only
   deployment be protected and load-balanced at all.
+- **Endpoints carry weights, and every policy honors them** (#174,
+  settled 2026-08-02). An endpoint is the bare `"IP:port"` string —
+  weight 1, the homogeneous common case — or `{ "address": …,
+  "weight": 3 }`, bounded by `endpoint_weight_max` (256, HAProxy's own
+  ceiling). Each policy absorbs the weight without changing character,
+  and each unit-weight path is bit-identical to the unweighted algorithm
+  it grew from, so existing clusters keep their draws, rotations and
+  client mappings. `rr` runs nginx's smooth weighted rotation — weight 3
+  beside weight 1 serves a,a,b,a, never three in a burst, and at unit
+  weights it is exactly the strict rotation it replaced. `p2c` draws its
+  two candidates in proportion to weight and leaves the in-flight
+  comparison untouched: a heavier endpoint is likelier to be
+  *considered*, and load still outranks share. `hash` scores one replica
+  hash per weight point and keeps the best — proportional by
+  construction, integer-only (no float log whose libm could re-home the
+  fleet across builds) — and re-weighting an endpoint disrupts only the
+  clients it gains or loses, so the 1/n property survives weighting.
+  A weight of `0` **drains** its endpoint: never picked, not even
+  through fail-open — a drain is an operator's statement where an
+  ejection is only a probe's verdict — while the prober keeps probing
+  it, so recovery is still observed. A cluster whose weights are all
+  zero is rejected at load (`EndpointWeightsAllZero`) rather than
+  accepted as one that can never answer.
 - **`hash` is rendezvous hashing, and it is stateless because it has to
   be.** Client-to-backend stickiness is normally a *table* — the proxy
   records which server a client went to. That mechanism cannot work
@@ -905,7 +942,10 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   endpoint count is a cost the operator chooses: 71 ns per pick at 64
   endpoints, against a request served in ~100 µs, and linear in the
   count from there. Nothing caps it — the pick simply gets slower, and
-  that trade is visible where it is made. Jump consistent
+  that trade is visible where it is made. Weights turn the same dial:
+  a weighted pick scores one hash per weight point, so the scan is
+  O(sum of weights), bounded per endpoint by `endpoint_weight_max` and,
+  like the count, priced by the operator's own config. Jump consistent
   hash is excluded outright — it can only add or remove the *last*
   bucket, and an ejection removes an arbitrary one.
   Two honest costs. Stickiness holds only while processes agree on the
@@ -1063,6 +1103,26 @@ origin, not one this proxy can pick for them.
   the admin/metrics listener's Prometheus rendering (`admin.zig`, one
   reserved scrape slot off the shared pools) plus a SIGUSR1 dump through
   the seam's `signal` primitive (§4).
+- **The exposition says which backend, not only how many** (#179,
+  settled 2026-08-02). Beside the process totals, labeled families:
+  per-endpoint counters for dial failures, responses served and health
+  transitions
+  (`zoxy_endpoint_connect_failed{cluster="api",endpoint="10.0.0.1:8080"}`),
+  per-*cluster* counters for the two inflight sheds — those fire
+  precisely because no endpoint could be picked, so an endpoint label
+  would be an invention — and two gauges read off the owners' live
+  state at render time: the per-endpoint in-flight level the balancer
+  compares, and the prober's healthy verdict for checked clusters
+  (unprobed endpoints render nothing rather than a constant 1 dressed
+  as a verdict). Each labeled family **partitions** the bare total it
+  breaks down — the contract the kernel-pressure counters already keep,
+  where the per-op and per-cause splits are two views of one total
+  (`counters.zig`) — and `reconcile` holds the views equal under every
+  simulator seed, so neither can drift. Label cardinality is bounded by config: there is
+  no user-controlled dimension — no per-path, no per-status — and
+  there must never be one. That bound is also what let the render
+  buffer move from a comptime constant to a config-derived arena term
+  with its own banner line (§5).
 - **The access log is a shed rung of its own.** Counters say how much and
   how often; an access log says *which request*, and that is what an
   operator needs when one client is being served badly and the aggregates

--- a/docs/README.md
+++ b/docs/README.md
@@ -193,12 +193,29 @@ by a compiled ceiling — the startup banner prints what the endpoint tables cos
 
 | `pick` | behavior |
 |---|---|
-| `p2c` *(default)* | two uniform candidates; the one carrying less in-flight work wins — HTTP requests and L4 connections both count |
-| `rr` | strict rotation — predictable spread, useful for cache warming |
-| `hash` | the same client always reaches the same endpoint |
+| `p2c` *(default)* | two weight-biased candidates; the one carrying less in-flight work wins — HTTP requests and L4 connections both count |
+| `rr` | smooth weighted rotation — exact rotation at equal weights, predictable spread, useful for cache warming |
+| `hash` | the same client always reaches the same endpoint, with traffic split by weight |
 
 Upstream connections are pooled process-wide and reusable by any request,
 which is the single largest throughput lever in this design.
+
+#### Weights
+
+An endpoint is a bare `"IP:port"` string — weight 1 — or an object adding
+a relative share, up to 256:
+
+```json
+"endpoints": ["10.0.0.1:8080", { "address": "10.0.0.2:8080", "weight": 3 }]
+```
+
+Every policy honors it: a 16-core box can take four times a 4-core box's
+share, a canary can start at 1-in-20 and move by editing one number, and
+a pool can be drained gradually by shifting weight instead of ejecting
+hosts. A weight of `0` **drains** the endpoint — still health-checked,
+never picked, not even when everything else is ejected — so taking a
+backend out of rotation no longer needs a restart. At least one endpoint
+must hold weight, or the config is rejected.
 
 ### Sticky sessions
 
@@ -537,6 +554,27 @@ the same rendering to stderr, which needs no listener at all.
 The gauges matter as much as the counters: a `shed_*` counter only moves once
 a wall is *hit*, while `zoxy_conn_slots_in_use` against
 `zoxy_conn_slots_capacity` shows the approach.
+
+The scrape also says **which backend**, per cluster and endpoint:
+
+```
+zoxy_endpoint_responses{cluster="api",endpoint="10.0.0.1:8080"} 4182
+zoxy_endpoint_connect_failed{cluster="api",endpoint="10.0.0.2:8080"} 17
+zoxy_endpoint_health_down{cluster="api",endpoint="10.0.0.2:8080"} 2
+zoxy_endpoint_healthy{cluster="api",endpoint="10.0.0.2:8080"} 0
+```
+
+Dial failures, responses served and the health transitions
+(`endpoint_health_down`/`_up`) carry both labels; the "every endpoint
+was full" sheds carry only `cluster` (no single endpoint was full — all
+of them were). Two gauges read live state: `zoxy_endpoint_inflight` is
+the level the balancer compares, and `zoxy_endpoint_healthy` is the
+prober's current verdict, rendered for health-checked clusters only.
+Each labeled family sums to the bare process total it breaks down — an
+identity the simulator asserts on every seed and the smoke gate
+re-derives from a live scrape. Label cardinality is bounded by your
+config — endpoints and cluster names, never request data — and the
+startup banner prices what the labels and their render buffers cost.
 
 ### Access log
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -62,6 +62,10 @@ io: SimIo,
 server: ServerSim,
 endpoints_l4: [1]std.Io.net.IpAddress,
 endpoints_http: [1]std.Io.net.IpAddress,
+/// The #174 weight tables the clusters may reference; single-entry like
+/// the endpoint lists they parallel.
+weights_l4: [1]u16,
+weights_http: [1]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
@@ -418,10 +422,21 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     const health = deriveHealthChecks(harness.clean, random, connect_timeout_ms);
     harness.http_origin_stop_at_ns = health.http_origin_stop_at_ns;
     harness.proxy_protocol_send_l4 = deriveProxyProtocolSend(random);
+    // #174 weights on a single-endpoint topology: the share itself is
+    // moot (there is nobody to share against, and one endpoint at any
+    // nonzero weight routes identically), but drawing a table at all
+    // flows the weights contract — parallel lengths, the nonzero-sum
+    // init assertion, the eligibility filter's weight read — through
+    // every schedule the adversary can produce. The proportional
+    // properties are pinned by balancer.zig's own tests, exactly like
+    // `hash`'s stickiness above.
+    harness.weights_l4 = .{1 + random.uintAtMost(u16, 255)};
+    harness.weights_http = .{1 + random.uintAtMost(u16, 255)};
     harness.clusters = .{
         .{
             .name = "origin-l4",
             .endpoints = &harness.endpoints_l4,
+            .weights = if (random.boolean()) &harness.weights_l4 else null,
             .pick = pick_l4,
             .check = health.check_l4,
             .max_inflight = deriveMaxInflight(harness.clean, random),
@@ -430,6 +445,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         .{
             .name = "origin-http",
             .endpoints = &harness.endpoints_http,
+            .weights = if (random.boolean()) &harness.weights_http else null,
             .pick = pick_http,
             .check = health.check_http,
             .max_inflight = deriveMaxInflight(harness.clean, random),

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -278,7 +278,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
 
     // Scraped before the drain: the admin listener closes with every
     // other one when SIGTERM lands (§8).
-    const counters = try countersPassed(arena, io, ports.admin);
+    const counters = try countersPassed(arena, io, ports.admin, origin.port);
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
@@ -425,8 +425,14 @@ fn drainPassed(drained_cleanly: bool) bool {
 /// claim; the two scrapes are also what `admin_served` needs, since the
 /// first one's own witness is incremented when its last byte lands and
 /// can only be read by the next.
-fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !CounterVerdict {
+fn countersPassed(
+    arena: std.mem.Allocator,
+    io: Io,
+    port: u16,
+    origin_port: u16,
+) !CounterVerdict {
     assert(port != 0);
+    assert(origin_port != 0);
     const first = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
     try io.sleep(Io.Duration.fromNanoseconds(probe_window_ns), .awake);
     const second = try scrape_module.parse(try scrape_module.fetch(arena, io, port));
@@ -434,11 +440,68 @@ fn countersPassed(arena: std.mem.Allocator, io: Io, port: u16) !CounterVerdict {
     const identities_ok = identitiesPassed(&first);
     const probes_ok = probesPassed(probes, &second);
     const admin_ok = adminPassed(&second);
-    const passed = identities_ok and probes_ok and admin_ok;
+    const labeled_ok = try labeledPassed(arena, &first, origin_port);
+    const passed = identities_ok and probes_ok and admin_ok and labeled_ok;
     // A verdict that passed read a probe count; the reported number is
     // never the zero that stands in for a counter the scrape lacked.
     if (passed) assert(probes != null);
     return .{ .passed = passed, .probes = probes orelse 0 };
+}
+
+/// The #179 labeled families, judged on the wire like the identities
+/// above. This config has one cluster with one endpoint, so every
+/// labeled series must carry its whole process total — the partition
+/// identities `reconcile` asserts inside the process, re-derived from
+/// the rendered text — and the two gauges must be present, with the
+/// prober's verdict reading healthy against an origin answering 200.
+fn labeledPassed(
+    arena: std.mem.Allocator,
+    first: *const scrape_module.Scrape,
+    origin_port: u16,
+) !bool {
+    assert(origin_port != 0);
+    const endpoint_label = try std.fmt.allocPrint(
+        arena,
+        "{{cluster=\"origin\",endpoint=\"127.0.0.1:{d}\"}}",
+        .{origin_port},
+    );
+    var passed = true;
+    const partitions = [_]struct { family: []const u8, total: []const u8, labeled: bool }{
+        .{ .family = "endpoint_responses", .total = "l7_responses", .labeled = true },
+        .{ .family = "endpoint_connect_failed", .total = "upstream_connect_failed", .labeled = true },
+        .{ .family = "endpoint_health_down", .total = "health_endpoint_down", .labeled = true },
+        .{ .family = "endpoint_health_up", .total = "health_endpoint_up", .labeled = true },
+        .{ .family = "cluster_l7_shed_inflight", .total = "l7_shed_endpoint_inflight", .labeled = false },
+        .{ .family = "cluster_l4_shed_inflight", .total = "l4_shed_endpoint_inflight", .labeled = false },
+    };
+    for (partitions) |partition| {
+        const label = if (partition.labeled) endpoint_label else "{cluster=\"origin\"}";
+        const series = try std.fmt.allocPrint(arena, "{s}{s}", .{ partition.family, label });
+        const series_value = counterOf(first, series) orelse {
+            passed = false;
+            continue;
+        };
+        const total = counterOf(first, partition.total) orelse {
+            passed = false;
+            continue;
+        };
+        if (series_value != total) {
+            std.debug.print(
+                "FAIL: {s} reads {d} but {s} reads {d} — the one endpoint must hold its whole partition\n",
+                .{ series, series_value, partition.total, total },
+            );
+            passed = false;
+        }
+    }
+    const healthy_series = try std.fmt.allocPrint(arena, "endpoint_healthy{s}", .{endpoint_label});
+    const healthy = counterOf(first, healthy_series) orelse return false;
+    if (healthy != 1) {
+        std.debug.print("FAIL: {s} reads {d} against an origin answering 200\n", .{ healthy_series, healthy });
+        passed = false;
+    }
+    const inflight_series = try std.fmt.allocPrint(arena, "endpoint_inflight{s}", .{endpoint_label});
+    if (counterOf(first, inflight_series) == null) passed = false;
+    return passed;
 }
 
 /// What the counter checks decided, and the one number worth printing

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -643,8 +643,12 @@ pub fn Server(comptime IoType: type) type {
 
         /// Counter reconciliation (§8/§9) supplying the in-flight term
         /// from the pool the server owns, so no caller has to guess it —
-        /// holds mid-scenario, not only when idle.
+        /// holds mid-scenario, not only when idle. The labeled partition
+        /// identities (#179) ride along: every labeled family must sum
+        /// to the process total it breaks down, under every seed the
+        /// simulator runs this on.
         pub fn reconcile(server: *const Self) bool {
+            server.labeled.reconciles(&server.counters);
             return server.counters.reconcile(server.activeCount());
         }
 
@@ -1161,8 +1165,11 @@ pub fn Server(comptime IoType: type) type {
                 // protocol to answer in — so the ladder's L4 answer
                 // applies: close. Counted outside the gate identity,
                 // because this connection was admitted before an endpoint
-                // was ever picked (§8).
+                // was ever picked (§8) — which is also why the labeled
+                // twin carries only the cluster: no endpoint was full,
+                // all of them were.
                 server.counters.increment("l4_shed_endpoint_inflight");
+                server.labeled.incrementCluster(.l4_shed_inflight, cluster_index);
                 // Nothing was armed for this dial yet — the arm below is
                 // the first — so teardown here cancels only the deadline
                 // admission left running (§5).
@@ -1204,6 +1211,15 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.state == .connecting);
             const socket = result catch |err| {
                 server.counters.increment("upstream_connect_failed");
+                // The labeled twin (#179): the pick did not survive the
+                // await, but the L4 charge did — `chargeL4` recorded the
+                // endpoint this dial was for, and the charge is released
+                // only at teardown, after this line.
+                assert(conn.charged_endpoint != conn_module.LogState.endpoint_none);
+                server.labeled.incrementEndpoint(
+                    .connect_failed,
+                    server.upstreams.keys.key(conn.charged_cluster, conn.charged_endpoint),
+                );
                 // Refused/timed-out/unreachable arrive typed and are the
                 // origin's verdict; anything else is resource pressure on
                 // our side — ephemeral ports and socket memory both land

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -224,13 +224,13 @@ pub fn Server(comptime IoType: type) type {
                 @sizeOf(u32) + // UpstreamPool.idle_heads
                 @sizeOf(u16) + // UpstreamPool.leased_counts
                 @sizeOf(u64) + // Balancer.endpoint_hashes
+                @sizeOf(i64) + // Balancer.rr_current
                 @sizeOf(u16) + // Server.l4_inflight
                 @sizeOf(bool) + // Checker.healthy
                 @sizeOf(u8) + // Checker.fail_streaks
                 @sizeOf(u8); // Checker.ok_streaks
-            const cursors = @as(u64, config.clusters.len) * @sizeOf(u64);
             const scratch = @as(u64, keys.stride) * @sizeOf(u16);
-            const total = count * per_key + cursors + scratch;
+            const total = count * per_key + scratch;
             assert(total > 0);
             return total;
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -67,6 +67,17 @@ pub fn Server(comptime IoType: type) type {
         /// hardcodes how an endpoint is chosen (§7).
         balancer: Balancer,
         counters: counters_module.Counters,
+        /// The #179 labeled breakdown beside the process totals: which
+        /// backend, per cluster and endpoint. Tables sized by the loaded
+        /// config's endpoint index space; every labeled witness site
+        /// also moves the matching bare counter, and `reconcile` holds
+        /// the partitions equal.
+        labeled: counters_module.Labeled,
+        /// Staging for the SIGUSR1/post-drain metrics dump (§8): the
+        /// full exposition — counters then labeled — no longer fits a
+        /// fixed stack buffer once its length is the config's, so it is
+        /// arena memory priced in the banner (`metricsBytes`).
+        dump_buffer: []u8,
         draining: bool,
         /// §8 watermark state, one flag per pool: set once a pool crosses
         /// its high watermark, cleared once it drains back below the low
@@ -235,6 +246,28 @@ pub fn Server(comptime IoType: type) type {
             return total;
         }
 
+        /// What the #179 labeled metrics take from the startup arena for
+        /// this config (§5): the tables and prebuilt label strings, plus
+        /// the two staging buffers sized to the full exposition — the
+        /// admin response (head + counters + labeled) and the dump. Its
+        /// own banner term rather than a fold into the endpoint tables,
+        /// because the issue's whole point is that the cost of labelling
+        /// your metrics should be visible next to everything else you
+        /// pay for. `init` allocates exactly this.
+        pub fn metricsBytes(config: *const config_module.Config) u64 {
+            assert(config.clusters.len >= 1);
+            const keys = endpointKeysFor(config);
+            const tables = counters_module.Labeled.tableBytes(config, keys);
+            const labeled_render = counters_module.Labeled.renderBytesMaxFor(config);
+            const admin_response = admin_module.response_head.len +
+                counters_module.Counters.render_bytes_max + labeled_render;
+            const dump_staging =
+                counters_module.Counters.render_bytes_max + labeled_render;
+            const total = tables + admin_response + dump_staging;
+            assert(total > 0);
+            return total;
+        }
+
         pub fn init(
             server: *Self,
             arena: std.mem.Allocator,
@@ -282,6 +315,29 @@ pub fn Server(comptime IoType: type) type {
             try server.upstreams.init(arena, options.upstream_slots, keys);
             assert(options.upstream_head_buffers <= options.upstream_slots);
             try server.upstream_head_buffers.init(arena, options.upstream_head_buffers);
+            try server.initHeadBuffers(arena, &options);
+            server.l4_inflight = try arena.alloc(u16, keys.count);
+            @memset(server.l4_inflight, 0);
+            server.listeners = try arena.alloc(ListenerState, config.listeners.len);
+            server.listeners_count = @intCast(config.listeners.len);
+            try server.balancer.init(arena, config, keys);
+            try server.initMetrics(arena, config, keys);
+            server.resetRuntimeState(&options);
+            try server.admin.init(server, config.admin_bind, arena);
+            server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
+            try server.access_log.reserve(arena);
+            try server.health.init(arena, server, keys, options.head_buffer_bytes);
+        }
+
+        /// The §5 upstream head slab wiring and the serving path's two
+        /// canonicalization scratches — split from `init` for the length
+        /// limit, called once right after the upstream head pool exists.
+        fn initHeadBuffers(
+            server: *Self,
+            arena: std.mem.Allocator,
+            options: *const InitOptions,
+        ) error{OutOfMemory}!void {
+            assert(server.upstream_head_buffers.slots.len == options.upstream_head_buffers);
             // The pool's slab, wired once: `Pool` never touches `data`,
             // so the wiring survives every acquire/release cycle.
             const upstream_head_slab = try arena.alloc(
@@ -307,13 +363,33 @@ pub fn Server(comptime IoType: type) type {
             server.target_scratch = try arena.alloc(u8, scratch_bytes);
             server.rewrite_scratch = try arena.alloc(u8, scratch_bytes);
             assert(server.target_scratch.len + server.rewrite_scratch.len +
-                options.head_buffer_bytes == headScratchBytes(options));
-            server.l4_inflight = try arena.alloc(u16, keys.count);
-            @memset(server.l4_inflight, 0);
-            server.listeners = try arena.alloc(ListenerState, config.listeners.len);
-            server.listeners_count = @intCast(config.listeners.len);
-            try server.balancer.init(arena, config, keys);
+                options.head_buffer_bytes == headScratchBytes(options.*));
+        }
+
+        /// The metrics state (§8, #179): the process totals, the labeled
+        /// tables, and the dump staging sized to the full exposition.
+        /// Split from `init` for the length limit; `admin.init` depends
+        /// on the labeled render bound this establishes.
+        fn initMetrics(
+            server: *Self,
+            arena: std.mem.Allocator,
+            config: *const config_module.Config,
+            keys: upstream_module.EndpointKeys,
+        ) error{OutOfMemory}!void {
+            assert(keys.count >= 1);
             server.counters = .{};
+            try server.labeled.init(arena, config, keys);
+            server.dump_buffer = try arena.alloc(
+                u8,
+                counters_module.Counters.render_bytes_max + server.labeled.render_bytes_max,
+            );
+            assert(server.dump_buffer.len > counters_module.Counters.render_bytes_max);
+        }
+
+        /// Every runtime scalar `init` owes a first value — the flags,
+        /// levels, peaks and embedded completions. Split from `init` for
+        /// the length limit; allocation-free by construction.
+        fn resetRuntimeState(server: *Self, options: *const InitOptions) void {
             server.draining = false;
             server.relay_pressure = false;
             server.conn_pressure = false;
@@ -330,10 +406,8 @@ pub fn Server(comptime IoType: type) type {
             server.drain_deadline_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
-            server.admin.init(server, config.admin_bind);
-            server.access_log.init(server, config.access_log_sink, options.access_log_buffer_bytes);
-            try server.access_log.reserve(arena);
-            try server.health.init(arena, server, keys, options.head_buffer_bytes);
+            assert(!server.draining);
+            assert(server.head_buffers_in_use == 0);
         }
 
         /// Override the admin/metrics bind before `start` — the simulator
@@ -430,12 +504,38 @@ pub fn Server(comptime IoType: type) type {
         fn onSignal(server: *Self, signal: Io.Signal) void {
             switch (signal) {
                 .terminate => server.beginDrain(),
-                .dump_counters => {
-                    const snapshot = server.gauges();
-                    server.counters.dump(&snapshot);
-                },
+                .dump_counters => server.dumpMetrics(),
                 .reopen_log => server.access_log.requestReopen(),
             }
+        }
+
+        /// The SIGUSR1 / post-drain §8 dump: the exact exposition the
+        /// scrape serves — counters then the labeled breakdown — through
+        /// the same two renderers, so the dump and the endpoint can never
+        /// disagree on the wire format. Staged in the arena buffer sized
+        /// for both at init; one print, so the two halves cannot
+        /// interleave with other stderr writers.
+        pub fn dumpMetrics(server: *const Self) void {
+            assert(server.dump_buffer.len >= counters_module.Counters.render_bytes_max);
+            const snapshot = server.gauges();
+            const text = server.counters.render(&snapshot, server.dump_buffer);
+            const views = server.labeledViews();
+            const labeled_text =
+                server.labeled.render(&views, server.dump_buffer[text.len..]);
+            assert(text.len + labeled_text.len <= server.dump_buffer.len);
+            std.debug.print("{s}{s}", .{ text, labeled_text });
+        }
+
+        /// The live views the labeled gauges read at render time (§8,
+        /// #179): the same load view the balancer picks through and the
+        /// same mask the prober owns — borrowed at the moment of the
+        /// scrape, so a labeled level can never drift from the truth its
+        /// owner holds.
+        pub fn labeledViews(server: *const Self) counters_module.Labeled.LiveViews {
+            return .{
+                .load = server.endpointLoad(),
+                .healthy = server.health.healthy,
+            };
         }
 
         pub fn maybeStopAfterDrain(server: *Self) void {

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -35,9 +35,11 @@ pub const response_head =
     "Content-Type: text/plain; version=0.0.4\r\n" ++
     "Connection: close\r\n\r\n";
 
-/// A full response is the fixed head plus one rendering of every counter.
-pub const response_bytes_max = response_head.len + counters_module.Counters.render_bytes_max;
-
+/// A full response is the fixed head, one rendering of every counter,
+/// then the #179 labeled breakdown — whose length is the config's, so
+/// the buffer bound went from a comptime constant to a value `init`
+/// derives per server (`response.len`) and the memory banner prices
+/// (`Server.metricsBytes`).
 pub fn Admin(comptime IoType: type) type {
     const ServerType = @import("Server.zig").Server(IoType);
 
@@ -56,8 +58,13 @@ pub fn Admin(comptime IoType: type) type {
         /// it is due, then reaps (the §4 single-timer discipline).
         deadline_ns: u64,
         /// The rendered response and the send cursor over it (short sends
-        /// resume from `sent`).
-        response: [response_bytes_max]u8,
+        /// resume from `sent`). Arena-allocated at `init` — head plus
+        /// both renderings — because the labeled half's length is only
+        /// known once the config is (#179). Allocated whether or not a
+        /// bind is configured: the sim and tests set the bind after
+        /// `init` (`setBind`), and the admin plane's budgets are
+        /// reserved unconditionally everywhere else too (§8).
+        response: []u8,
         response_len: u32,
         sent: u32,
         drain_scratch: [constants.admin_drain_scratch_bytes]u8,
@@ -109,7 +116,15 @@ pub fn Admin(comptime IoType: type) type {
             admin: *Self,
             server: *ServerType,
             bind_address: ?std.Io.net.IpAddress,
-        ) void {
+            arena: std.mem.Allocator,
+        ) error{OutOfMemory}!void {
+            // The server's labeled tables are initialized first
+            // (`Server.init` orders it so): their render bound is a term
+            // of this buffer.
+            admin.response = try arena.alloc(u8, response_head.len +
+                counters_module.Counters.render_bytes_max +
+                server.labeled.render_bytes_max);
+            assert(admin.response.len <= std.math.maxInt(u32));
             admin.server = server;
             admin.bind_address = bind_address;
             admin.listening = false;
@@ -235,14 +250,21 @@ pub fn Admin(comptime IoType: type) type {
         }
 
         /// Build the full response once, into the fixed buffer: the static
-        /// head then the counters-and-gauges rendering (zero-alloc, §5).
-        /// The gauges are sampled here, at render time, so a scrape reports
-        /// the pool levels as of the response it is answering.
+        /// head, the counters-and-gauges rendering, then the #179 labeled
+        /// breakdown (zero-alloc, §5). The gauges and the labeled live
+        /// views are sampled here, at render time, so a scrape reports
+        /// the pool levels and per-endpoint state as of the response it
+        /// is answering.
         fn renderResponse(admin: *Self) void {
             @memcpy(admin.response[0..response_head.len], response_head);
             const gauges = admin.server.gauges();
             const body = admin.server.counters.render(&gauges, admin.response[response_head.len..]);
-            admin.response_len = @intCast(response_head.len + body.len);
+            const views = admin.server.labeledViews();
+            const labeled = admin.server.labeled.render(
+                &views,
+                admin.response[response_head.len + body.len ..],
+            );
+            admin.response_len = @intCast(response_head.len + body.len + labeled.len);
             admin.sent = 0;
             assert(admin.response_len >= response_head.len);
             assert(admin.response_len <= admin.response.len);

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -109,13 +109,30 @@ const Harness = struct {
 /// snapshot keeps this expectation honest — a scrape that rendered stale or
 /// invented levels would fail here rather than quietly matching a
 /// hand-written constant.
-fn expectedResponse(gauges: *const counters_module.Counters.Gauges, buffer: []u8) []const u8 {
-    assert(buffer.len >= admin.response_bytes_max);
+fn expectedResponse(
+    server: *const ServerSim,
+    gauges: *const counters_module.Counters.Gauges,
+    buffer: []u8,
+) []const u8 {
+    assert(buffer.len >= server.admin.response.len);
     var zero: counters_module.Counters = .{};
     @memcpy(buffer[0..admin.response_head.len], admin.response_head);
     const body = zero.render(gauges, buffer[admin.response_head.len..]);
-    return buffer[0 .. admin.response_head.len + body.len];
+    // The labeled tail (#179): these scenarios move no labeled counter,
+    // so the server's own tables render the all-zero series — and the
+    // live views are as idle at compare time as they were at accept.
+    const views = server.labeledViews();
+    const labeled = server.labeled.render(
+        &views,
+        buffer[admin.response_head.len + body.len ..],
+    );
+    return buffer[0 .. admin.response_head.len + body.len + labeled.len];
 }
+
+/// Generous fixed size for the test-side response staging: the bed's
+/// one-cluster config renders far below this, and `expectedResponse`
+/// asserts it covers the server's real buffer.
+const response_scratch_bytes = 64 * 1024;
 
 /// A scripted scrape client. `.normal` sends the request and reads the
 /// response to EOF; `.drain_mid_scrape` begins the server drain the instant
@@ -132,7 +149,7 @@ const Scrape = struct {
     recv_completion: SimIo.Completion = .{},
     timer_completion: SimIo.Completion = .{},
     socket: SimIo.Socket = undefined,
-    recv_buffer: [admin.response_bytes_max]u8 = undefined,
+    recv_buffer: [response_scratch_bytes]u8 = undefined,
     received_len: u32 = 0,
     sent_len: u32 = 0,
     send_pending: bool = false,
@@ -313,11 +330,11 @@ test "admin: a scrape returns the counters as byte-exact Prometheus text" {
         try harness.sim_io.run();
 
         try testing.expectEqual(Scrape.Outcome.eof, harness.scrape.outcome);
-        var expected_buffer: [admin.response_bytes_max]u8 = undefined;
+        var expected_buffer: [response_scratch_bytes]u8 = undefined;
         // The data path is idle at scrape time, so the levels the scrape
         // rendered are the ones still live here.
         const gauges = harness.server.gauges();
-        const expected = expectedResponse(&gauges, &expected_buffer);
+        const expected = expectedResponse(&harness.server, &gauges, &expected_buffer);
         try testing.expectEqualStrings(
             expected,
             harness.scrape.recv_buffer[0..harness.scrape.received_len],
@@ -349,9 +366,9 @@ test "admin: a scrape stays intact and drains under resets" {
         harness.scrape.start();
         try harness.sim_io.run();
 
-        var expected_buffer: [admin.response_bytes_max]u8 = undefined;
+        var expected_buffer: [response_scratch_bytes]u8 = undefined;
         const gauges = harness.server.gauges();
-        const expected = expectedResponse(&gauges, &expected_buffer);
+        const expected = expectedResponse(&harness.server, &gauges, &expected_buffer);
         const got = harness.scrape.recv_buffer[0..harness.scrape.received_len];
         try testing.expect(std.mem.startsWith(u8, expected, got));
         try harness.expectDrained();

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -2,13 +2,24 @@
 //! kept behind a seam so the serving path never hardcodes *how* an
 //! endpoint is chosen — it only asks "which endpoint for this cluster?".
 //! Three policies, selected per cluster in the config (§5 parse-once):
-//! `rr` rotates a per-cluster cursor, `p2c` draws two distinct candidates
-//! uniformly and leases the calmer one, `hash` sends a given client to a
-//! given endpoint every time. P2C's load is the per-endpoint in-flight
-//! total across both protocols — the pool's L7 leases plus the server's
-//! live L4 connections — passed in by the caller as a view: the balancer
-//! owns the draw, the pool and the server own the truth. A single-endpoint
-//! cluster short-circuits every policy without touching its state.
+//! `rr` runs a smooth weighted rotation, `p2c` draws two distinct
+//! weight-biased candidates and leases the calmer one, `hash` sends a
+//! given client to a given endpoint every time. P2C's load is the
+//! per-endpoint in-flight total across both protocols — the pool's L7
+//! leases plus the server's live L4 connections — passed in by the caller
+//! as a view: the balancer owns the draw, the pool and the server own the
+//! truth. A single-endpoint cluster short-circuits every policy without
+//! touching its state.
+//!
+//! **Weights (#174).** Every policy honors `Config.Cluster.weights` —
+//! null means every endpoint at 1, and each unit-weight path below is
+//! *bit-identical* to the unweighted algorithm it grew from, so existing
+//! clusters keep their draws, their rotations and their client-to-endpoint
+//! mappings. A weight of 0 drains its endpoint: it never enters the
+//! eligible set, not even through fail-open — a drain is an operator's
+//! statement, where an ejection is only a probe's verdict — while the
+//! prober keeps probing it, so a drained endpoint's recovery is still
+//! observed (§7).
 //!
 //! **Why `hash` is stateless, and why that is not merely a simplification.**
 //! Stickiness is usually a *table*: HAProxy records client → server as
@@ -34,13 +45,18 @@
 //! it scans the eligible set the health mask already produced. It costs
 //! O(n) instead of O(log n), which is why a cluster's endpoint count is a
 //! cost the operator chooses: measured at 71 ns per pick at 64 endpoints,
-//! against a request this proxy serves in ~100 µs. Jump consistent hash is
-//! excluded outright: it can only add or remove the *last* bucket, and an
-//! ejection removes an arbitrary one.
+//! against a request this proxy serves in ~100 µs. Weights scale that
+//! same dial — a weighted pick scores one hash per weight point (§7,
+//! `score`), so the scan is O(sum of weights), bounded per endpoint by
+//! `endpoint_weight_max` and, like the endpoint count, priced by the
+//! operator's own config. Jump consistent hash is excluded outright: it
+//! can only add or remove the *last* bucket, and an ejection removes an
+//! arbitrary one.
 
 const std = @import("std");
 
 const config_module = @import("config.zig");
+const constants = @import("constants.zig");
 const upstream = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
@@ -107,13 +123,44 @@ fn endpointId(address: *const std.Io.net.IpAddress) u64 {
     };
 }
 
+/// One endpoint's §7 pick weight: the configured table's entry, or 1 —
+/// the `Config.Cluster.weights` contract, read through one helper so
+/// "null means unit weights" is spelled exactly once.
+fn weightOf(cluster: *const config_module.Config.Cluster, endpoint_index: u16) u16 {
+    assert(endpoint_index < cluster.endpoints.len);
+    const weights = cluster.weights orelse return 1;
+    assert(weights.len == cluster.endpoints.len);
+    return weights[endpoint_index];
+}
+
+/// The weight sum over the eligible set — one weighted draw's modulus.
+/// u32 room to spare: 65535 endpoints at weight 256 stays under 2²⁵.
+fn totalWeight(cluster: *const config_module.Config.Cluster, eligible: []const u16) u32 {
+    assert(eligible.len >= 1);
+    var total: u32 = 0;
+    for (eligible) |endpoint_index| {
+        total += weightOf(cluster, endpoint_index);
+    }
+    // Every eligible endpoint weighs at least 1 — weight 0 never enters
+    // the set — so the total covers the set.
+    assert(total >= eligible.len);
+    return total;
+}
+
 pub const Balancer = struct {
     config: *const config_module.Config,
-    /// Per-cluster round-robin cursors, used by `.rr` clusters only.
-    /// u64 so a cursor never wraps in any realistic process lifetime — a
-    /// u16 wrap reset the rotation phase and double-picked one endpoint
-    /// for non-power-of-two cluster sizes. One per configured cluster.
-    cursors: []u64,
+    /// Per-endpoint smooth-WRR running totals, used by `.rr` clusters
+    /// only (§7, #174). Replaced the per-cluster cursor when weights
+    /// arrived, because a weighted rotation is a property of each
+    /// endpoint's credit rather than of one shared position: a pick
+    /// raises every eligible endpoint's entry by its weight, takes the
+    /// largest, and the winner repays the round's whole sum — nginx's
+    /// smooth algorithm, so weight 3 is `a,a,b,a` and never three
+    /// consecutive hits. At unit weights the schedule it produces is
+    /// exactly the strict rotation the cursor produced. i64 because
+    /// totals dip negative by design (the winner pays the round), with
+    /// magnitude bounded by one cluster's weight sum.
+    rr_current: []i64,
     /// xorshift64* draw state, used by `.p2c` clusters only. Seeded from
     /// a fixed named constant, never the clock: the simulator replays
     /// every seed twice and demands byte-identical traces (§9), and load
@@ -159,10 +206,10 @@ pub const Balancer = struct {
         assert(keys.count == @as(u32, @intCast(config.clusters.len)) * keys.stride);
         balancer.config = config;
         balancer.keys = keys;
-        balancer.cursors = try arena.alloc(u64, config.clusters.len);
+        balancer.rr_current = try arena.alloc(i64, keys.count);
         balancer.endpoint_hashes = try arena.alloc(u64, keys.count);
         balancer.eligible_scratch = try arena.alloc(u16, keys.stride);
-        @memset(balancer.cursors, 0);
+        @memset(balancer.rr_current, 0);
         balancer.pick_state = pick_seed;
         assert(balancer.pick_state != 0); // xorshift64* cycles on nonzero state.
         // Every key, not only the configured ones: a ragged config leaves
@@ -170,18 +217,30 @@ pub const Balancer = struct {
         // the whole table keeps "what did init leave here" a question with
         // one answer.
         @memset(balancer.endpoint_hashes, 0);
-        for (config.clusters, 0..) |cluster, cluster_index| {
+        for (config.clusters, 0..) |*cluster, cluster_index| {
             // Re-checked here rather than trusted from the loader, the
             // same defense `pick` and `eligibleEndpoints` keep: this loop
             // indexes a table sized by that stride.
             assert(cluster.endpoints.len >= 1);
             assert(cluster.endpoints.len <= keys.stride);
+            // The #174 weights contract: parallel to the endpoints, and
+            // at least one endpoint routable. The loader rejects both
+            // breaches (`EndpointWeightsAllZero`); a config built by
+            // hand — tests, the simulator — re-proves them here, since
+            // an all-drained cluster would fail `eligibleEndpoints`'s
+            // count assertion on its first pick instead of at startup.
+            var weight_sum: u32 = 0;
             for (cluster.endpoints, 0..) |*address, endpoint_index| {
                 const key = keys.key(@intCast(cluster_index), @intCast(endpoint_index));
                 balancer.endpoint_hashes[key] = endpointId(address);
+                weight_sum += weightOf(cluster, @intCast(endpoint_index));
+            }
+            assert(weight_sum >= 1);
+            if (cluster.weights) |weights| {
+                assert(weights.len == cluster.endpoints.len);
             }
         }
-        assert(balancer.cursors.len == config.clusters.len);
+        assert(balancer.rr_current.len == keys.count);
         assert(balancer.endpoint_hashes.len == keys.count);
     }
 
@@ -240,13 +299,20 @@ pub const Balancer = struct {
         };
     }
 
-    /// The endpoints a pick may choose between, in two passes.
+    /// The endpoints a pick may choose between, in three passes.
     ///
-    /// First §7 health: the healthy ones — or, the fail-open rule, every
-    /// endpoint when the whole cluster is ejected. Dialing a maybe-dead
-    /// endpoint reports the outage the way it always did; routing
-    /// nowhere would turn a probe verdict into an outage of its own, and
-    /// a same-port TCP probe cannot know better than the dial.
+    /// First the #174 drain: a weight-0 endpoint never enters the set.
+    /// Unlike the health mask this is not a verdict to fail open past —
+    /// it is the operator saying *stop sending here*, and the whole
+    /// point of the spelling is that it holds while everything else
+    /// flaps.
+    ///
+    /// Then §7 health over the routable set: the healthy ones — or, the
+    /// fail-open rule, every routable endpoint when all of them are
+    /// ejected. Dialing a maybe-dead endpoint reports the outage the way
+    /// it always did; routing nowhere would turn a probe verdict into an
+    /// outage of its own, and a same-port TCP probe cannot know better
+    /// than the dial.
     ///
     /// Then §8 capacity, over whatever survived: an endpoint already
     /// carrying its `max_inflight` is dropped. This pass **may return
@@ -267,6 +333,7 @@ pub const Balancer = struct {
         var count: u16 = 0;
         for (0..cluster.endpoints.len) |endpoint_index| {
             const index: u16 = @intCast(endpoint_index);
+            if (weightOf(cluster, index) == 0) continue;
             if (healthy[keys.key(cluster_index, index)]) {
                 eligible[count] = index;
                 count += 1;
@@ -274,10 +341,15 @@ pub const Balancer = struct {
         }
         if (count == 0) {
             for (0..cluster.endpoints.len) |endpoint_index| {
-                eligible[endpoint_index] = @intCast(endpoint_index);
+                const index: u16 = @intCast(endpoint_index);
+                if (weightOf(cluster, index) == 0) continue;
+                eligible[count] = index;
+                count += 1;
             }
-            count = @intCast(cluster.endpoints.len);
         }
+        // At least one endpoint holds weight — the loader rejects an
+        // all-zero cluster and `init` re-proves it — so the drain filter
+        // alone can never empty the set.
         assert(count >= 1);
         if (cluster.max_inflight) |cap| {
             assert(cap >= 1);
@@ -294,45 +366,79 @@ pub const Balancer = struct {
         return count;
     }
 
-    /// Strict rotation over the eligible set: the cursor modulo its
-    /// size, then incremented — every eligible endpoint sees its share,
-    /// in order. Ejections shift the rotation phase; the share stays
-    /// exact for whatever set is eligible at each pick.
+    /// Smooth weighted rotation over the eligible set (nginx's SWRR):
+    /// every eligible endpoint's running total rises by its weight, the
+    /// largest total wins — a tie keeps the lowest index — and the
+    /// winner repays the round's whole weight sum. "Smooth" is the
+    /// property the issue asks for by name: weight 3 beside weight 1
+    /// serves a,a,b,a, never three consecutive hits, because the winner
+    /// goes to the back of the queue by exactly what the round was
+    /// worth. At unit weights the schedule is strict rotation, in order.
+    /// State survives eligibility changes: an ejected endpoint's total
+    /// freezes, so a flap neither owes it rounds nor forgives them.
     fn pickRoundRobin(
         balancer: *Balancer,
         cluster_index: u16,
         eligible: []const u16,
     ) u16 {
-        assert(balancer.config.clusters[cluster_index].pick == .rr);
+        const cluster = &balancer.config.clusters[cluster_index];
+        assert(cluster.pick == .rr);
         assert(eligible.len >= 1);
-        const slot: u16 = @intCast(balancer.cursors[cluster_index] % eligible.len);
-        balancer.cursors[cluster_index] += 1;
-        assert(slot < eligible.len);
-        return eligible[slot];
+        var round_total: i64 = 0;
+        var best_slot: usize = 0;
+        var best_current: i64 = std.math.minInt(i64);
+        for (eligible, 0..) |endpoint_index, slot| {
+            const key = balancer.keys.key(cluster_index, endpoint_index);
+            const weight: i64 = weightOf(cluster, endpoint_index);
+            assert(weight >= 1); // weight 0 never enters the eligible set
+            balancer.rr_current[key] += weight;
+            round_total += weight;
+            if (balancer.rr_current[key] > best_current) {
+                best_current = balancer.rr_current[key];
+                best_slot = slot;
+            }
+        }
+        assert(round_total >= @as(i64, @intCast(eligible.len)));
+        const chosen = eligible[best_slot];
+        balancer.rr_current[balancer.keys.key(cluster_index, chosen)] -= round_total;
+        return chosen;
     }
 
-    /// P2C over the eligible set: two distinct uniform candidates, the
-    /// lower in-flight total wins, a tie goes to the first. A mask narrowed
-    /// to one endpoint skips the draw the way a one-endpoint cluster
-    /// does — no candidates to compare, no PRNG state spent.
+    /// P2C over the eligible set: two distinct candidates drawn with
+    /// probability proportional to weight (#174) — a heavier endpoint is
+    /// likelier to be *considered*; the in-flight comparison that decides
+    /// the winner is untouched, so load still outranks share. A tie goes
+    /// to the first. At unit weights both draws are bit-identical to the
+    /// uniform ones this grew from — the same PRNG values land on the
+    /// same slots — so an unweighted cluster's §9 traces are unchanged.
+    /// A mask narrowed to one endpoint skips the draw the way a
+    /// one-endpoint cluster does — no candidates to compare, no PRNG
+    /// state spent.
     fn pickPowerOfTwo(
         balancer: *Balancer,
         cluster_index: u16,
         eligible: []const u16,
         load: *const upstream.Load,
     ) u16 {
-        assert(balancer.config.clusters[cluster_index].pick == .p2c);
+        const cluster = &balancer.config.clusters[cluster_index];
+        assert(cluster.pick == .p2c);
         assert(eligible.len >= 1);
         if (eligible.len == 1) {
             return eligible[0];
         }
-        const first_slot: u16 = @intCast(balancer.next() % eligible.len);
-        var second_slot: u16 = @intCast(balancer.next() % (eligible.len - 1));
-        // Skip past `first_slot`, mapping the (n-1)-range draw onto the
-        // other n-1 eligible slots uniformly.
-        if (second_slot >= first_slot) {
-            second_slot += 1;
-        }
+        const total = totalWeight(cluster, eligible);
+        const first_slot = weightedSlot(cluster, eligible, balancer.next() % total, null);
+        // The second draw runs over the weight that remains once the
+        // first candidate steps out, mapping onto the other n-1 slots —
+        // still proportional, and never a duplicate.
+        const remaining = total - weightOf(cluster, eligible[first_slot]);
+        assert(remaining >= 1); // n >= 2 eligible, each weighing >= 1
+        const second_slot = weightedSlot(
+            cluster,
+            eligible,
+            balancer.next() % remaining,
+            first_slot,
+        );
         assert(first_slot != second_slot);
         assert(second_slot < eligible.len);
         const first = eligible[first_slot];
@@ -344,6 +450,36 @@ pub const Balancer = struct {
         const first_load = load.inFlight(balancer.keys.key(cluster_index, first));
         const second_load = load.inFlight(balancer.keys.key(cluster_index, second));
         return if (second_load < first_load) second else first;
+    }
+
+    /// The eligible slot a cumulative-weight draw lands on, skipping
+    /// `exclude` — one weighted candidacy (#174). `draw` must sit below
+    /// the participating weight total, and every participant weighs at
+    /// least 1, so the walk always lands; at unit weights slot k is
+    /// exactly draw k (with the post-exclude slots shifted by one), which
+    /// is the uniform mapping the unweighted draw used.
+    fn weightedSlot(
+        cluster: *const config_module.Config.Cluster,
+        eligible: []const u16,
+        draw: u64,
+        exclude: ?u16,
+    ) u16 {
+        assert(eligible.len >= 1);
+        var remaining = draw;
+        for (eligible, 0..) |endpoint_index, slot| {
+            if (exclude) |excluded| {
+                if (excluded == slot) continue;
+            }
+            const weight = weightOf(cluster, endpoint_index);
+            assert(weight >= 1);
+            if (remaining < weight) {
+                return @intCast(slot);
+            }
+            remaining -= weight;
+        }
+        // The caller drew modulo the participating total, so the walk
+        // cannot run off the end.
+        unreachable;
     }
 
     /// Rendezvous hashing (§7): score every eligible endpoint against the
@@ -405,12 +541,34 @@ pub const Balancer = struct {
         // zeroed slot — a real endpoint losing to one that does not exist.
         assert(cluster_index < balancer.config.clusters.len);
         assert(endpoint_index < balancer.config.clusters[cluster_index].endpoints.len);
+        const cluster = &balancer.config.clusters[cluster_index];
         const endpoint_hash =
             balancer.endpoint_hashes[balancer.keys.key(cluster_index, endpoint_index)];
-        // Both operands are already avalanched, so the xor combines them
-        // without structure and the final mix restores it to a uniform
-        // 64-bit score.
-        return mix64(key ^ endpoint_hash);
+        // Weighted rendezvous by replication (#174): the endpoint's score
+        // is the best of `weight` independent scores, one per replica, so
+        // it holds the argmax for exactly weight/total of the key space —
+        // proportional by construction, integer-only, and pinned like the
+        // rest of the mapping (no float log whose libm could re-home the
+        // fleet across builds). Replica 0 mixes in `mix64(0) == 0`, so a
+        // weight-1 endpoint's score is byte-identical to the unweighted
+        // form and existing clusters keep their client mappings. The scan
+        // is bounded by `endpoint_weight_max` per endpoint; like the O(n)
+        // eligible walk, its cost is chosen by the operator's own config.
+        //
+        // Both xor operands are already avalanched, so each combine is
+        // structureless and the final mix restores uniformity.
+        const weight = weightOf(cluster, endpoint_index);
+        assert(weight >= 1); // weight 0 never enters the eligible set
+        assert(weight <= constants.endpoint_weight_max);
+        var best: u64 = 0;
+        var replica: u32 = 0;
+        while (replica < weight) : (replica += 1) {
+            const candidate = mix64(key ^ endpoint_hash ^ mix64(replica));
+            if (candidate > best) {
+                best = candidate;
+            }
+        }
+        return best;
     }
 
     /// xorshift64* (Vigna): the full-period 64-bit shift generator with a
@@ -644,6 +802,139 @@ test "balancer: rr rotates over the healthy endpoints only" {
         const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
+}
+
+test "balancer: rr honors weights, and the schedule is smooth" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const weights = [_]u16{ 2, 1 };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "canary", .endpoints = &pair, .pick = .rr, .weights = &weights },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Two shares for endpoint 0, one for endpoint 1 — and the heavier
+    // endpoint's hits are spread through the cycle (0,1,0), not bunched
+    // (0,0,1): the "smooth" in smooth WRR, which is what keeps a weight-3
+    // backend from taking three consecutive requests as one burst.
+    const counts = [_]u16{0} ** test_counts_len;
+    const expected = [_]u16{ 0, 1, 0, 0, 1, 0 };
+    for (expected) |want_index| {
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        try std.testing.expectEqual(want_index, picked.endpoint_index);
+    }
+}
+
+test "balancer: rr weight zero drains an endpoint, past fail-open" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const weights = [_]u16{ 1, 0, 1 };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "draining", .endpoints = &trio, .pick = .rr, .weights = &weights },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // The drained endpoint never rotates in: the survivors alternate as
+    // if the cluster had two endpoints.
+    const counts = [_]u16{0} ** test_counts_len;
+    const expected = [_]u16{ 0, 2, 0, 2 };
+    for (expected) |want_index| {
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        try std.testing.expectEqual(want_index, picked.endpoint_index);
+    }
+    // Fail-open re-admits the ejected, never the drained: a weight of 0
+    // is the operator's statement, not a probe's verdict, so even a
+    // fully-ejected cluster keeps routing around it.
+    const none_healthy = [_]bool{false} ** test_keys.count;
+    var round: u32 = 0;
+    while (round < 20) : (round += 1) {
+        const picked = balancer.pick(0, &testLoad(&counts), &none_healthy, &test_client).?;
+        try std.testing.expect(picked.endpoint_index != 1);
+    }
+}
+
+test "balancer: p2c candidacy follows weight" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const weights = [_]u16{ 8, 1, 1 };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "weighted", .endpoints = &trio, .pick = .p2c, .weights = &weights },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Under equal load the tie rule keeps the first candidate, so the
+    // pick distribution is the candidacy distribution — and candidacy is
+    // the weighted draw. The 8-weight endpoint must dominate, and the
+    // 1-weight endpoints must still appear: bias, not exclusion.
+    const counts = [_]u16{0} ** test_counts_len;
+    var hits = [_]u32{0} ** 3;
+    var round: u32 = 0;
+    while (round < 400) : (round += 1) {
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        hits[picked.endpoint_index] += 1;
+    }
+    try std.testing.expect(hits[0] > hits[1] + hits[2]);
+    try std.testing.expect(hits[1] >= 1);
+    try std.testing.expect(hits[2] >= 1);
+}
+
+test "balancer: p2c at unit weights draws exactly as the unweighted form" {
+    // An explicit all-ones table and no table at all must be the same
+    // policy, draw for draw: the weighted path's unit case is the
+    // uniform draw this grew from, which is what keeps unweighted §9
+    // traces byte-stable across the change.
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const unit_weights = [_]u16{ 1, 1, 1 };
+    const bare_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "bare", .endpoints = &trio, .pick = .p2c },
+    };
+    const spelled_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "spelled", .endpoints = &trio, .pick = .p2c, .weights = &unit_weights },
+    };
+    const bare_config = testConfig(&bare_clusters);
+    const spelled_config = testConfig(&spelled_clusters);
+
+    var bare_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer bare_arena.deinit();
+    var bare: Balancer = undefined;
+    try bare.init(bare_arena.allocator(), &bare_config, testKeysFor(&bare_config));
+    var spelled_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer spelled_arena.deinit();
+    var spelled: Balancer = undefined;
+    try spelled.init(spelled_arena.allocator(), &spelled_config, testKeysFor(&spelled_config));
+
+    const counts = [_]u16{0} ** test_counts_len;
+    var round: u32 = 0;
+    while (round < 100) : (round += 1) {
+        try std.testing.expectEqual(
+            bare.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
+            spelled.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
+        );
+    }
+    try std.testing.expectEqual(bare.pick_state, spelled.pick_state);
 }
 
 test "balancer: p2c never picks an ejected endpoint" {
@@ -921,6 +1212,126 @@ fn countOf(picks: []const u16, wanted: u16) u32 {
         if (pick_index == wanted) total += 1;
     }
     return total;
+}
+
+test "balancer: hash spreads clients in proportion to weight" {
+    const endpoints = testHashEndpoints(2);
+    const weights = [_]u16{ 3, 1 };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash, .weights = &weights },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Replica-max scoring holds the argmax for weight/total of the key
+    // space, so a 3:1 pair splits clients ~3:1 — not the ~3.4:1 that
+    // naive score *scaling* gives, which is why the replicas exist.
+    const counts = [_]u16{0} ** test_counts_len;
+    const clients: u16 = 4000;
+    var hits = [_]u32{0} ** 2;
+    var index: u16 = 0;
+    while (index < clients) : (index += 1) {
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index] += 1;
+    }
+    const expected_heavy = clients * 3 / 4;
+    try std.testing.expect(hits[0] > expected_heavy - 400);
+    try std.testing.expect(hits[0] < expected_heavy + 400);
+    try std.testing.expectEqual(clients, hits[0] + hits[1]);
+}
+
+test "balancer: re-weighting an endpoint disrupts only the clients it gains" {
+    // The #174 issue's open question, answered: the disruption property
+    // survives weighting. Raising one endpoint's weight adds replicas to
+    // its score and touches nobody else's, so the only clients who move
+    // are the ones the new replicas now win — every move lands on the
+    // re-weighted endpoint, and every other assignment is untouched.
+    const endpoints = testHashEndpoints(8);
+    const flat_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
+    };
+    var weights = [_]u16{1} ** 8;
+    weights[3] = 2;
+    const weighted_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash, .weights = &weights },
+    };
+    const flat_config = testConfig(&flat_clusters);
+    const weighted_config = testConfig(&weighted_clusters);
+
+    var flat_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer flat_arena.deinit();
+    var flat: Balancer = undefined;
+    try flat.init(flat_arena.allocator(), &flat_config, testKeysFor(&flat_config));
+    var weighted_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer weighted_arena.deinit();
+    var weighted: Balancer = undefined;
+    try weighted.init(weighted_arena.allocator(), &weighted_config, testKeysFor(&weighted_config));
+
+    const counts = [_]u16{0} ** test_counts_len;
+    const clients: u16 = 4000;
+    var moved: u32 = 0;
+    var index: u16 = 0;
+    while (index < clients) : (index += 1) {
+        const client = testClientAt(index);
+        const before = flat.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+        const after = weighted.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+        if (after != before) {
+            try std.testing.expectEqual(@as(u16, 3), after);
+            moved += 1;
+        }
+    }
+    // The gained share is 2/9 - 1/8 ≈ 9.7% of clients: real movement,
+    // nowhere near a reshuffle.
+    try std.testing.expect(moved > 0);
+    try std.testing.expect(moved < clients / 4);
+}
+
+test "balancer: hash weight zero drains an endpoint, past fail-open" {
+    const endpoints = testHashEndpoints(8);
+    const flat_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
+    };
+    var weights = [_]u16{1} ** 8;
+    weights[3] = 0;
+    const drained_clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash, .weights = &weights },
+    };
+    const flat_config = testConfig(&flat_clusters);
+    const drained_config = testConfig(&drained_clusters);
+
+    var flat_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer flat_arena.deinit();
+    var flat: Balancer = undefined;
+    try flat.init(flat_arena.allocator(), &flat_config, testKeysFor(&flat_config));
+    var drained_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer drained_arena.deinit();
+    var drained: Balancer = undefined;
+    try drained.init(drained_arena.allocator(), &drained_config, testKeysFor(&drained_config));
+
+    // Draining by weight is the ejection disruption, chosen: only the
+    // drained endpoint's clients move, and the mapping is what the
+    // healthy-mask ejection of the same endpoint produces — the next
+    // replica down the same preference order.
+    const counts = [_]u16{0} ** test_counts_len;
+    const none_healthy = [_]bool{false} ** test_keys.count;
+    var ejected_mask = test_healthy_all;
+    ejected_mask[test_keys.key(0, 3)] = false;
+    var index: u16 = 0;
+    while (index < 500) : (index += 1) {
+        const client = testClientAt(index);
+        const after = drained.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+        try std.testing.expect(after != 3);
+        try std.testing.expectEqual(
+            flat.pick(0, &testLoad(&counts), &ejected_mask, &client).?.endpoint_index,
+            after,
+        );
+        // Fail-open re-admits the ejected, never the drained.
+        try std.testing.expect(
+            drained.pick(0, &testLoad(&counts), &none_healthy, &client).?.endpoint_index != 3,
+        );
+    }
 }
 
 test "balancer: two processes agree, and so do a config's reorderings" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -2351,6 +2351,10 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
     try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].getPort());
+    // The example carries both endpoint spellings (#174): a bare literal
+    // at weight 1 beside a weighted object.
+    try std.testing.expectEqual(@as(u16, 9001), parsed.clusters[0].endpoints[1].getPort());
+    try std.testing.expectEqualSlices(u16, &.{ 1, 3 }, parsed.clusters[0].weights.?);
     // The example's tcp check resolves with its thresholds, and its
     // omitted budget inherits the connect timeout.
     const example_check = parsed.clusters[0].check.?;

--- a/src/config.zig
+++ b/src/config.zig
@@ -216,6 +216,14 @@ pub const Config = struct {
     pub const Cluster = struct {
         name: []const u8,
         endpoints: []const std.Io.net.IpAddress,
+        /// Per-endpoint §7 pick weights, parallel to `endpoints` — or
+        /// null when every endpoint carries the default weight of 1,
+        /// which is what the bare-string config form says and what most
+        /// clusters are, so the loader only materializes the table when
+        /// some weight differs. A weight of `0` drains its endpoint:
+        /// still probed (§7), never picked — the balancer treats it as
+        /// administratively out, so not even fail-open reaches it.
+        weights: ?[]const u16 = null,
         /// The §7 endpoint-pick policy the balancer runs for this
         /// cluster. The JSON field is optional and defaults to `p2c`
         /// (the §7 default), with `rr` kept for strict rotation
@@ -381,6 +389,8 @@ pub const ValidationError = error{
     EndpointsOverLimit,
     EndpointInvalid,
     EndpointPortZero,
+    EndpointWeightOverLimit,
+    EndpointWeightsAllZero,
     TimeoutZero,
     TimeoutOverLimit,
     TimeoutOrderInvalid,
@@ -1030,7 +1040,7 @@ pub const RouteJson = struct {
 };
 
 pub const ClusterJson = struct {
-    endpoints: []const []const u8,
+    endpoints: []const EndpointJson,
     /// Optional §7 pick policy; absent means `p2c` (the design's
     /// trajectory), `rr` opts back into strict rotation.
     pick: []const u8 = "p2c",
@@ -1050,7 +1060,8 @@ pub const ClusterJson = struct {
     pub const schema_doc = "One upstream cluster: its endpoints, pick policy and health checks.";
     pub const schema_fields = .{
         .endpoints = .{
-            .desc = "IP:port endpoint literals (port must be non-zero).",
+            .desc = "Endpoints: IP:port literals (port must be non-zero), each " ++
+                "optionally an object adding a pick weight (#174).",
             .min_items = 1,
         },
         .pick = .{
@@ -1076,6 +1087,80 @@ pub const ClusterJson = struct {
                 "clusters only); absent sends none.",
         },
     };
+};
+
+/// One cluster endpoint (#174): the bare `"IP:port"` string every config
+/// has always written, or an object naming the same literal plus a pick
+/// weight. Both spellings parse to this one shape — a bare string is
+/// weight 1 — so the homogeneous cluster, which is most clusters, keeps
+/// the cheap form and a canary is one endpoint's worth of ceremony.
+pub const EndpointJson = struct {
+    address: []const u8,
+    weight: u32 = 1,
+
+    pub const schema_doc =
+        "One endpoint: an IP:port literal, or an object carrying the " ++
+        "literal and a relative pick weight.";
+    pub const schema_fields = .{
+        .address = .{
+            .desc = "IP:port endpoint literal (port must be non-zero).",
+            .min_length = 1,
+        },
+        .weight = .{
+            .desc = "Relative share of the cluster's traffic under every pick " ++
+                "policy; endpoints default to equal (1). 0 drains the endpoint: " ++
+                "still health-checked, never picked.",
+            .minimum = 0,
+            .maximum = constants.endpoint_weight_max,
+        },
+    };
+
+    /// The object form as a plain struct, so `innerParse` reads it with
+    /// the loader's own strictness (unknown fields rejected) without
+    /// recursing back into `jsonParse` below.
+    const ObjectForm = struct {
+        address: []const u8,
+        weight: u32 = 1,
+    };
+
+    comptime {
+        // The two shapes are one contract: a field added to either and
+        // forgotten on the other would let the schema advertise a key
+        // the parser rejects, or the parser accept one the schema hides.
+        const outer = @typeInfo(EndpointJson).@"struct".fields;
+        const inner = @typeInfo(ObjectForm).@"struct".fields;
+        assert(outer.len == inner.len);
+        for (outer, inner) |a, b| {
+            assert(std.mem.eql(u8, a.name, b.name));
+            assert(a.type == b.type);
+        }
+    }
+
+    pub fn jsonParse(
+        allocator: std.mem.Allocator,
+        source: anytype,
+        options: std.json.ParseOptions,
+    ) !EndpointJson {
+        switch (try source.peekNextTokenType()) {
+            .string => {
+                const token = try source.nextAlloc(allocator, .alloc_if_needed);
+                const literal: []const u8 = switch (token) {
+                    .string, .allocated_string => |slice| slice,
+                    // The peek promised a string; anything else is the
+                    // scanner disagreeing with itself.
+                    else => unreachable,
+                };
+                return .{ .address = literal, .weight = 1 };
+            },
+            .object_begin => {
+                const object = try std.json.innerParse(ObjectForm, allocator, source, options);
+                return .{ .address = object.address, .weight = object.weight };
+            },
+            // A number, bool, null, or nested array can never name an
+            // endpoint; reject the token rather than coercing it.
+            else => return error.UnexpectedToken,
+        }
+    }
 };
 
 pub const ClusterProxyProtocolJson = struct {
@@ -1355,7 +1440,7 @@ pub const dto_types = .{
     MatchJson,     HeaderMatchJson,   ActionJson,               HeaderEditJson,
     RewriteJson,   ClusterJson,       TimeoutsJson,             LimitsJson,
     AdminJson,     AccessLogJson,     CheckJson,                ClusterHashJson,
-    ForwardedJson, ProxyProtocolJson, ClusterProxyProtocolJson,
+    ForwardedJson, ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
 };
 
 comptime {
@@ -1381,32 +1466,7 @@ fn resolveClusters(
 
     const count: u16 = @intCast(clusters_json.entries.len);
     const clusters = try arena.alloc(Config.Cluster, count);
-
-    // Duplicate names in O(n log n), by sorting an index permutation and
-    // comparing neighbours. It was a nested scan over the entries, which
-    // the 16-cluster ceiling kept to ~120 compares; with the ceiling gone
-    // that same scan would cost ~2.1e9 string compares on a config at the
-    // index type's edge — minutes of startup for a config whose memory
-    // fits easily. Which name is reported first changes, and nothing
-    // reads it: the error carries no payload.
-    const order = try arena.alloc(u16, count);
-    for (order, 0..) |*slot, index| slot.* = @intCast(index);
-    const ByName = struct {
-        entries: []const ClustersJson.Entry,
-        fn lessThan(ctx: @This(), a: u16, b: u16) bool {
-            return std.mem.lessThan(u8, ctx.entries[a].name, ctx.entries[b].name);
-        }
-    };
-    std.mem.sort(u16, order, ByName{ .entries = clusters_json.entries }, ByName.lessThan);
-    for (order[1..], order[0 .. order.len - 1]) |current, previous| {
-        if (std.mem.eql(
-            u8,
-            clusters_json.entries[current].name,
-            clusters_json.entries[previous].name,
-        )) {
-            return error.ClusterNameDuplicate;
-        }
-    }
+    try rejectDuplicateClusterNames(arena, clusters_json.entries);
 
     for (clusters_json.entries, 0..) |entry, index| {
         // A name is an identifier an operator writes and the access log
@@ -1419,9 +1479,11 @@ fn resolveClusters(
             return error.ClusterNameTooLong;
         }
         const pick = try pickOf(entry.cluster.pick);
+        const endpoints = try resolveEndpoints(arena, entry.cluster.endpoints);
         clusters[index] = .{
             .name = entry.name,
-            .endpoints = try resolveEndpoints(arena, entry.cluster.endpoints),
+            .endpoints = endpoints.addresses,
+            .weights = endpoints.weights,
             .pick = pick,
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
             .hash_key = try hashKeyOf(pick, entry.cluster.hash),
@@ -1433,11 +1495,49 @@ fn resolveClusters(
     return clusters;
 }
 
+/// Duplicate names in O(n log n), by sorting an index permutation and
+/// comparing neighbours. It was a nested scan over the entries, which
+/// the 16-cluster ceiling kept to ~120 compares; with the ceiling gone
+/// that same scan would cost ~2.1e9 string compares on a config at the
+/// index type's edge — minutes of startup for a config whose memory
+/// fits easily. Which name is reported first changes, and nothing
+/// reads it: the error carries no payload.
+fn rejectDuplicateClusterNames(
+    arena: std.mem.Allocator,
+    entries: []const ClustersJson.Entry,
+) ParseError!void {
+    assert(entries.len >= 1);
+    assert(entries.len <= std.math.maxInt(u16));
+    const order = try arena.alloc(u16, entries.len);
+    for (order, 0..) |*slot, index| slot.* = @intCast(index);
+    const ByName = struct {
+        entries: []const ClustersJson.Entry,
+        fn lessThan(ctx: @This(), a: u16, b: u16) bool {
+            return std.mem.lessThan(u8, ctx.entries[a].name, ctx.entries[b].name);
+        }
+    };
+    std.mem.sort(u16, order, ByName{ .entries = entries }, ByName.lessThan);
+    for (order[1..], order[0 .. order.len - 1]) |current, previous| {
+        if (std.mem.eql(u8, entries[current].name, entries[previous].name)) {
+            return error.ClusterNameDuplicate;
+        }
+    }
+}
+
+/// A cluster's resolved endpoint list, in the two parallel halves
+/// `Config.Cluster` stores: the addresses, and the weights — null when
+/// every endpoint carries weight 1, so the unweighted common case
+/// allocates nothing beyond the addresses it always did.
+const ResolvedEndpoints = struct {
+    addresses: []const std.Io.net.IpAddress,
+    weights: ?[]const u16,
+};
+
 fn resolveEndpoints(
     arena: std.mem.Allocator,
-    endpoint_literals: []const []const u8,
-) ParseError![]const std.Io.net.IpAddress {
-    if (endpoint_literals.len == 0) {
+    endpoints_json: []const EndpointJson,
+) ParseError!ResolvedEndpoints {
+    if (endpoints_json.len == 0) {
         return error.EndpointsEmpty;
     }
     // No policy bound: endpoints cost an arena address each and a column
@@ -1446,21 +1546,45 @@ fn resolveEndpoints(
     // `0..n-1`, and the largest of those must stay inside
     // `endpoint_index_max`, which `Conn` asserts sits below its
     // no-endpoint sentinel.
-    if (endpoint_literals.len > @as(usize, constants.endpoint_index_max) + 1) {
+    if (endpoints_json.len > @as(usize, constants.endpoint_index_max) + 1) {
         return error.EndpointsOverLimit;
     }
 
-    const endpoints = try arena.alloc(std.Io.net.IpAddress, endpoint_literals.len);
-    for (endpoint_literals, endpoints) |literal, *endpoint| {
-        endpoint.* = std.Io.net.IpAddress.parseLiteral(literal) catch {
+    const addresses = try arena.alloc(std.Io.net.IpAddress, endpoints_json.len);
+    var weighted = false;
+    var weight_sum: u64 = 0;
+    for (endpoints_json, addresses) |entry, *address| {
+        address.* = std.Io.net.IpAddress.parseLiteral(entry.address) catch {
             return error.EndpointInvalid;
         };
-        if (endpoint.getPort() == 0) {
+        if (address.getPort() == 0) {
             return error.EndpointPortZero;
         }
+        if (entry.weight > constants.endpoint_weight_max) {
+            return error.EndpointWeightOverLimit;
+        }
+        weighted = weighted or entry.weight != 1;
+        weight_sum += entry.weight;
     }
-    assert(endpoints.len == endpoint_literals.len);
-    return endpoints;
+    if (weight_sum == 0) {
+        // Every endpoint at weight 0 is a cluster drained to nowhere.
+        // Unlike an all-ejected cluster this does not fail open — a
+        // drain is a statement, not a verdict — so the config is
+        // rejected like an empty endpoint list rather than accepted as
+        // one that can never answer.
+        return error.EndpointWeightsAllZero;
+    }
+    assert(addresses.len == endpoints_json.len);
+    if (!weighted) {
+        return .{ .addresses = addresses, .weights = null };
+    }
+    const weights = try arena.alloc(u16, endpoints_json.len);
+    for (endpoints_json, weights) |entry, *weight| {
+        assert(entry.weight <= constants.endpoint_weight_max);
+        weight.* = @intCast(entry.weight);
+    }
+    assert(weights.len == addresses.len);
+    return .{ .addresses = addresses, .weights = weights };
 }
 
 fn resolveListeners(
@@ -3206,6 +3330,97 @@ test "config: references and addresses are validated" {
     );
 }
 
+test "config: endpoint weights parse in both spellings" {
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["10.0.0.1:8080",
+        \\   {"address":"10.0.0.2:8080","weight":3},
+        \\   {"address":"10.0.0.3:8080"},
+        \\   {"address":"10.0.0.4:8080","weight":0}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const cluster = parsed.clusters[0];
+    // The two spellings resolve to one shape: a bare string and an
+    // object with no weight are both weight 1, and zero — the drain
+    // spelling — is carried, not rejected, while a sibling holds weight.
+    try std.testing.expectEqual(@as(usize, 4), cluster.endpoints.len);
+    try std.testing.expectEqualSlices(u16, &.{ 1, 3, 1, 0 }, cluster.weights.?);
+    try std.testing.expectEqual(@as(u16, 8080), cluster.endpoints[1].getPort());
+}
+
+test "config: unweighted endpoints leave the weights table null" {
+    // The bare form and an object spelling the default out loud say the
+    // same thing, so neither materializes a table: null is the loader's
+    // statement that every endpoint shares alike, and the balancer's
+    // license to skip weighted arithmetic for the common case.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2",
+        \\   {"address":"127.0.0.1:3","weight":1}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    try std.testing.expect(parsed.clusters[0].weights == null);
+}
+
+test "config: the weight ceiling itself is a legal share" {
+    // The bound is inclusive — `endpoint_weight_max` parses, one past it
+    // is the error — matching the at-limit convention the name-length
+    // bound establishes below.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"127.0.0.1:2","weight":256}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    try std.testing.expectEqual(constants.endpoint_weight_max, parsed.clusters[0].weights.?[0]);
+}
+
+test "config: endpoint weight validation has its own errors" {
+    try expectParseError(error.EndpointWeightOverLimit,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"127.0.0.1:2","weight":257}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    // Every weight zero is a cluster drained to nowhere — rejected like
+    // an empty endpoint list, not accepted as one that can never answer.
+    try expectParseError(error.EndpointWeightsAllZero,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"127.0.0.1:2","weight":0},
+        \\   {"address":"127.0.0.1:3","weight":0}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    // The object form validates its address exactly like the bare one.
+    try expectParseError(error.EndpointInvalid,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"origin.internal:80","weight":2}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    try expectParseError(error.EndpointPortZero,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"127.0.0.1:0","weight":2}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    // Strictness reaches inside the object form: a typo'd key is an
+    // unknown field, not a silently-dropped weight.
+    try expectParseError(error.UnknownField,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[{"address":"127.0.0.1:2","weigth":2}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    // An endpoint is a string or an object; any other token is refused
+    // rather than coerced.
+    try expectParseError(error.UnexpectedToken,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":[42]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+}
+
 test "config: every emptiness and limit has its own error" {
     try expectParseError(error.ListenersEmpty,
         \\{"listeners":[],
@@ -3295,7 +3510,8 @@ var fuzz_arena_buffer: [1 << 20]u8 = undefined;
 const fuzz_seed_json =
     \\{"listeners":[{"bind":"127.0.0.1:8080","routes":[{"prefix":"/","cluster":"o"}],
     \\ "protocol":"http"}],
-    \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000"],"pick":"p2c","max_inflight":8,
+    \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000",
+    \\ {"address":"127.0.0.1:9001","weight":3}],"pick":"p2c","max_inflight":8,
     \\ "check":{"type":"http","path":"/health","expect_status":200,"timeout_ms":250}}},
     \\ "timeouts":{"connect_ms":5000,"idle_ms":60000,"drain_deadline_ms":10000,
     \\ "max_lifetime_ms":300000,"request_ms":30000,"health_interval_ms":2000},
@@ -3305,7 +3521,9 @@ const fuzz_seed_json =
 ;
 // The `file` arm here, `stdout` in `example_json` beside it: between the
 // two corpus entries the mutator sees every sink spelling, including the
-// `path` key only one of them may carry.
+// `path` key only one of them may carry — and both endpoint spellings
+// (#174), so the `{address, weight}` grammar is a starting point rather
+// than a shape the mutator must blindly discover.
 
 test "config: the fuzz seed carrying every block parses" {
     // It is a corpus entry, so it has to be a *valid* config — an
@@ -3316,6 +3534,7 @@ test "config: the fuzz seed carrying every block parses" {
     const parsed = try expectParseOk(&arena_state, fuzz_seed_json);
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
     try std.testing.expectEqual(@as(u32, 30000), parsed.request_timeout_ms);
+    try std.testing.expectEqualSlices(u16, &.{ 1, 3 }, parsed.clusters[0].weights.?);
 }
 
 test "fuzz: parse never panics — parse or reject, no third outcome" {

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -221,7 +221,10 @@ fn writeArrayShape(out: *Stringify, comptime Child: type, comptime meta: anytype
 /// metadata marks it, or a plain string otherwise.
 fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Writer.Error!void {
     switch (@typeInfo(Child)) {
-        .@"struct" => try writeObjectBody(out, Child, true),
+        .@"struct" => if (Child == config.EndpointJson)
+            try writeEndpointItems(out)
+        else
+            try writeObjectBody(out, Child, true),
         .pointer => |ptr| {
             comptime assert(ptr.child == u8);
             if (comptime @hasField(@TypeOf(meta), "items")) {
@@ -234,6 +237,27 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
         },
         else => comptime unreachable,
     }
+}
+
+/// A cluster endpoint accepts two spellings (#174) — the bare `IP:port`
+/// string every existing config writes, or the `{address, weight}` object
+/// — so its items schema is the document's one `anyOf`. Emitted here
+/// rather than reflected because reflection sees only the resolved DTO
+/// (`EndpointJson`), whose custom `jsonParse` is where the string form
+/// lives; the two arms below mirror that parser exactly.
+fn writeEndpointItems(out: *Stringify) Writer.Error!void {
+    try out.objectField("anyOf");
+    try out.beginArray();
+    try out.beginObject();
+    try out.objectField("type");
+    try out.write("string");
+    try out.objectField("description");
+    try out.write("IP:port endpoint literal (port must be non-zero) — weight 1.");
+    try out.endObject();
+    try out.beginObject();
+    try writeObjectBody(out, config.EndpointJson, true);
+    try out.endObject();
+    try out.endArray();
 }
 
 /// An `"enum"` array of an enum type's field names — the same closed
@@ -376,6 +400,36 @@ test "config_schema: the shipped example's top-level keys are all declared" {
     while (it.next()) |entry| {
         try std.testing.expect(properties.get(entry.key_ptr.*) != null);
     }
+}
+
+test "config_schema: endpoint items accept both spellings" {
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer parsed.deinit();
+
+    const clusters = parsed.value.object.get("properties").?.object.get("clusters").?.object;
+    const cluster_schema = clusters.get("additionalProperties").?.object;
+    const endpoints = cluster_schema.get("properties").?.object.get("endpoints").?.object;
+    const arms = endpoints.get("items").?.object.get("anyOf").?.array;
+
+    // Exactly the loader's two spellings: a bare literal, or the object.
+    try std.testing.expectEqual(@as(usize, 2), arms.items.len);
+    try std.testing.expectEqualStrings("string", arms.items[0].object.get("type").?.string);
+    const object_arm = arms.items[1].object;
+    try std.testing.expectEqualStrings("object", object_arm.get("type").?.string);
+    // `address` is the one required key — `weight` defaults — and the
+    // emitted weight ceiling is the loader's own constant, so the schema
+    // cannot promise a weight the loader would then reject.
+    const required = object_arm.get("required").?.array;
+    try std.testing.expectEqual(@as(usize, 1), required.items.len);
+    try std.testing.expectEqualStrings("address", required.items[0].string);
+    const weight = object_arm.get("properties").?.object.get("weight").?.object;
+    try std.testing.expectEqual(
+        @as(i64, constants.endpoint_weight_max),
+        weight.get("maximum").?.integer,
+    );
+    try std.testing.expectEqual(@as(i64, 0), weight.get("minimum").?.integer);
 }
 
 test "config_schema: the method enum matches what the parser accepts" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -273,6 +273,17 @@ pub const endpoint_index_max: u16 = std.math.maxInt(u16) - 1;
 /// log line's width closed-form rather than a function of the config file.
 pub const cluster_name_bytes_max: u16 = 64;
 
+/// Upper bound on one endpoint's configured pick weight (#174) —
+/// HAProxy's own `weight` ceiling. 256 steps is a 1-in-257 canary
+/// granularity, finer than any signal an operator could act on, and the
+/// bound is load-bearing for the `hash` policy: a weighted rendezvous
+/// pick scores one hash per weight point, so this constant is what
+/// keeps that scan's cost a number an operator can read off their own
+/// config rather than an open-ended loop. Zero stays *below* the bound
+/// deliberately — it is the drain spelling (never picked, still probed),
+/// not a share.
+pub const endpoint_weight_max: u16 = 256;
+
 /// Lower bound on configured clusters: a config with no cluster can route
 /// nowhere, so the loader rejects an empty map and the config JSON Schema
 /// emits it as `minProperties`.
@@ -836,6 +847,9 @@ comptime {
     assert(access_log_path_bytes_max >= 16);
     assert(access_log_method_bytes_max >= 7); // "OPTIONS", the longest standard method.
     assert(cluster_name_bytes_max >= 1);
+    // A weight ceiling of zero would make every cluster all-drained and
+    // unloadable; one weight step is the degenerate-but-legal minimum.
+    assert(endpoint_weight_max >= 1);
     // The health prober's reservations and thresholds (§7): the op budget
     // covers dial + deadline + one cancel, a threshold of zero would eject
     // or restore on no evidence, and the default probe interval is a legal

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -904,10 +904,10 @@ pub const PoolSizes = struct {
     /// covers all of that. `accessLogBytes` is the closed form.
     access_log_bytes: u64,
     /// The endpoint-keyed tables (§7) — the pool's idle heads and lease
-    /// counts, the balancer's endpoint hashes, cursors and pick scratch,
-    /// the server's L4 charges, and the health checker's mask and two
-    /// streak counters. Startup arena memory held for the process's life,
-    /// so §5's promise covers it.
+    /// counts, the balancer's endpoint hashes, rotation state and pick
+    /// scratch, the server's L4 charges, and the health checker's mask
+    /// and two streak counters. Startup arena memory held for the
+    /// process's life, so §5's promise covers it.
     ///
     /// Passed in rather than derived here because the per-entry widths
     /// belong to those modules' element types, not to this file: computing

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -914,6 +914,14 @@ pub const PoolSizes = struct {
     /// it from hardcoded widths would silently drift the moment one of
     /// them changed. `Server.endpointTableBytes` is the closed form.
     endpoint_table_bytes: u64,
+    /// The #179 labeled metrics (§8): the per-endpoint/per-cluster
+    /// counter tables and their prebuilt label strings, plus the two
+    /// render staging buffers — the admin response and the SIGUSR1 dump
+    /// — whose length became the config's when the exposition gained
+    /// labels. Its own term on the issue's own argument: the cost of
+    /// labelling your metrics should be visible next to everything else
+    /// you pay for. `Server.metricsBytes` is the closed form.
+    metrics_bytes: u64,
     /// The §5 head-buffer ring: how many buffers the deployment registered
     /// (`limits.head_buffers`; zero on an L4-only config) and the unit
     /// size of each. The total term is `count × (unit + 1)` — the slab
@@ -975,10 +983,14 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
         sizes.upstream_head_buffer_bytes >= head_buffer_bytes_min);
     // At least the prober's one buffer, at least the smallest legal size.
     assert(sizes.head_scratch_bytes >= head_buffer_bytes_min);
+    // A config has at least one cluster with one endpoint, so the
+    // labeled tables and their buffers can never price at zero.
+    assert(sizes.metrics_bytes > 0);
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
         sizes.access_log_bytes + sizes.endpoint_table_bytes +
+        sizes.metrics_bytes +
         @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
         bufferGroupDescriptorBytes(sizes.head_buffers) +
         @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes +
@@ -1035,10 +1047,15 @@ test "budgets: memory total matches the closed form" {
     try std.testing.expectEqual(@as(u64, 0), bufferGroupDescriptorBytes(0));
     // The side buffers: two serving scratches plus the prober's one.
     const head_scratch: u64 = 3 * @as(u64, head_buffer_bytes_default);
+    // A stand-in for the labeled-metrics term: any nonzero figure works,
+    // since this test pins the *sum*, not the term's own closed form
+    // (`Server.metricsBytes` owns that).
+    const metrics: u64 = 4096;
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
         accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables +
+        metrics +
         head_ring +
         @as(u64, upstream_slots_max) * upstream_head_bytes +
         head_scratch;
@@ -1051,15 +1068,17 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(access_log_buffer_bytes_default),
         .endpoint_table_bytes = endpoint_tables,
+        .metrics_bytes = metrics,
         .head_buffers = conn_slots_max,
         .head_buffer_bytes = head_buffer_bytes_default,
         .upstream_head_buffers = upstream_slots_max,
         .upstream_head_buffer_bytes = upstream_head_bytes,
         .head_scratch_bytes = head_scratch,
     }));
-    // The L4-only shape still carries the prober's one response buffer.
+    // The L4-only shape still carries the prober's one response buffer —
+    // and the labeled metrics, which exist for every config (§8).
     const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes +
-        head_buffer_bytes_default;
+        metrics + head_buffer_bytes_default;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
@@ -1069,6 +1088,7 @@ test "budgets: memory total matches the closed form" {
         .upstream_bytes = upstream_bytes,
         .access_log_bytes = accessLogBytes(0),
         .endpoint_table_bytes = 0,
+        .metrics_bytes = metrics,
         // The L4-only shape: no ring, no upstream head pool, no scratch
         // terms — but the prober's buffer is unconditional.
         .head_buffers = 0,

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -455,16 +455,6 @@ pub const Counters = struct {
         return buffer[0..cursor];
     }
 
-    /// Phase 0 exposure (§8): SIGUSR1 dumps the Prometheus rendering to
-    /// stderr through the signal seam. Shares `render` so the dump and the
-    /// scrape endpoint never disagree on the wire format.
-    pub fn dump(counters: *const Counters, gauges: *const Gauges) void {
-        var buffer: [render_bytes_max]u8 = undefined;
-        const text = counters.render(gauges, &buffer);
-        assert(text.len <= buffer.len);
-        std.debug.print("{s}", .{text});
-    }
-
     /// The §9 invariant: admitted work is completed or still active, and
     /// every accepted connection was admitted or shed — no third outcome.
     /// The prefix that makes a counter part of the gate identity below.
@@ -732,7 +722,7 @@ pub const Labeled = struct {
                     try endpointLabel(arena, cluster.name, address);
             }
         }
-        labeled.render_bytes_max = labeled.renderBytesBound();
+        labeled.render_bytes_max = renderBytesMaxFor(config);
         assert(labeled.render_bytes_max >= 1);
     }
 
@@ -757,16 +747,8 @@ pub const Labeled = struct {
         "\",endpoint=\"".len + endpoint_literal_bytes_max + "\"}".len;
 
     fn clusterLabel(arena: std.mem.Allocator, name: []const u8) error{OutOfMemory}![]const u8 {
-        assert(name.len >= 1);
-        assert(name.len <= constants.cluster_name_bytes_max);
         var scratch: [label_scratch_bytes]u8 = undefined;
-        var writer = std.Io.Writer.fixed(&scratch);
-        // The scratch is sized to the loader's own bounds just above, so
-        // the fixed writer cannot fill.
-        writer.writeAll("{cluster=\"") catch unreachable;
-        writeEscaped(&writer, name) catch unreachable;
-        writer.writeAll("\"}") catch unreachable;
-        return try arena.dupe(u8, writer.buffered());
+        return try arena.dupe(u8, renderClusterLabel(&scratch, name));
     }
 
     fn endpointLabel(
@@ -774,16 +756,73 @@ pub const Labeled = struct {
         name: []const u8,
         address: *const std.Io.net.IpAddress,
     ) error{OutOfMemory}![]const u8 {
+        var scratch: [label_scratch_bytes]u8 = undefined;
+        return try arena.dupe(u8, renderEndpointLabel(&scratch, name, address));
+    }
+
+    /// The label built in caller scratch — shared by `init`, which dupes
+    /// it into the arena, and the config-walking budget forms
+    /// (`tableBytes`, `renderBytesMaxFor`), which only measure it: one
+    /// renderer, so the banner cannot price a label init did not build.
+    fn renderClusterLabel(scratch: []u8, name: []const u8) []const u8 {
         assert(name.len >= 1);
         assert(name.len <= constants.cluster_name_bytes_max);
-        var scratch: [label_scratch_bytes]u8 = undefined;
-        var writer = std.Io.Writer.fixed(&scratch);
-        // Same cannot-fill argument as `clusterLabel`; the address half
-        // is bounded by the bracketed-IPv6 term of the scratch.
+        assert(scratch.len >= label_scratch_bytes);
+        var writer = std.Io.Writer.fixed(scratch);
+        // The scratch is sized to the loader's own bounds just above, so
+        // the fixed writer cannot fill.
+        writer.writeAll("{cluster=\"") catch unreachable;
+        writeEscaped(&writer, name) catch unreachable;
+        writer.writeAll("\"}") catch unreachable;
+        return writer.buffered();
+    }
+
+    fn renderEndpointLabel(
+        scratch: []u8,
+        name: []const u8,
+        address: *const std.Io.net.IpAddress,
+    ) []const u8 {
+        assert(name.len >= 1);
+        assert(name.len <= constants.cluster_name_bytes_max);
+        assert(scratch.len >= label_scratch_bytes);
+        var writer = std.Io.Writer.fixed(scratch);
+        // Same cannot-fill argument as `renderClusterLabel`; the address
+        // half is bounded by the bracketed-IPv6 term of the scratch.
         writer.writeAll("{cluster=\"") catch unreachable;
         writeEscaped(&writer, name) catch unreachable;
         writer.print("\",endpoint=\"{f}\"}}", .{address.*}) catch unreachable;
-        return try arena.dupe(u8, writer.buffered());
+        return writer.buffered();
+    }
+
+    /// What `init` takes from the startup arena for this config (§5):
+    /// the six value tables, the label slice headers and the label bytes
+    /// themselves, and the two per-cluster scalars. Closed-form in the
+    /// config — it renders the same labels init dupes, through the same
+    /// renderer — so the banner's term is a prediction `init` then meets
+    /// exactly.
+    pub fn tableBytes(
+        config: *const config_module.Config,
+        keys: upstream_module.EndpointKeys,
+    ) u64 {
+        assert(config.clusters.len >= 1);
+        assert(keys.count >= 1);
+        const cluster_count: u64 = config.clusters.len;
+        var total: u64 = 0;
+        total += @as(u64, keys.count) * @sizeOf([]const u8); // endpoint_labels
+        total += cluster_count * @sizeOf([]const u8); // cluster_labels
+        total += cluster_count * @sizeOf(u16); // endpoint_counts
+        total += cluster_count * @sizeOf(bool); // cluster_checked
+        total += 4 * @as(u64, keys.count) * @sizeOf(Value); // endpoint families
+        total += 2 * cluster_count * @sizeOf(Value); // cluster families
+        var scratch: [label_scratch_bytes]u8 = undefined;
+        for (config.clusters) |*cluster| {
+            total += renderClusterLabel(&scratch, cluster.name).len;
+            for (cluster.endpoints) |*address| {
+                total += renderEndpointLabel(&scratch, cluster.name, address).len;
+            }
+        }
+        assert(total >= 1);
+        return total;
     }
 
     /// Prometheus label-value escaping: backslash, quote, newline. The
@@ -968,25 +1007,45 @@ pub const Labeled = struct {
         return count;
     }
 
-    /// The exact bound `render` is held to, walked over the same rows
-    /// render walks. Runtime because the label lengths are the config's;
-    /// exact because every term is — which is what lets the tightness
-    /// test prove it by filling the buffer to the last byte.
-    fn renderBytesBound(labeled: *const Labeled) usize {
+    /// The exact bound `render` is held to, priced over the same rows
+    /// render walks. A function of the *config* rather than of a built
+    /// `Labeled`, so the memory banner can state it before `Server.init`
+    /// runs — `init` stores the same number on the instance. Exact
+    /// because every term is, which is what lets the tightness test
+    /// prove it by filling the buffer to the last byte.
+    pub fn renderBytesMaxFor(config: *const config_module.Config) usize {
+        assert(config.clusters.len >= 1);
         var total: usize = 0;
         inline for (comptime std.enums.values(EndpointFamily)) |family| {
             total += typeLineLen(family.name(), "counter");
-            total += labeled.endpointRowsLen(family.name(), u64_digits_max, false);
         }
         inline for (comptime std.enums.values(ClusterFamily)) |family| {
             total += typeLineLen(family.name(), "counter");
-            total += labeled.clusterRowsLen(family.name(), u64_digits_max);
         }
         total += typeLineLen("endpoint_inflight", "gauge");
-        total += labeled.endpointRowsLen("endpoint_inflight", inflight_digits_max, false);
-        if (labeled.checkedClusterCount() >= 1) {
+        var checked_clusters: usize = 0;
+        var scratch: [label_scratch_bytes]u8 = undefined;
+        for (config.clusters) |*cluster| {
+            const cluster_label_len = renderClusterLabel(&scratch, cluster.name).len;
+            const cluster_checked = cluster.check != null;
+            inline for (comptime std.enums.values(ClusterFamily)) |family| {
+                total += rowLen(family.name(), cluster_label_len, u64_digits_max);
+            }
+            if (cluster_checked) checked_clusters += 1;
+            for (cluster.endpoints) |*address| {
+                const label_len =
+                    renderEndpointLabel(&scratch, cluster.name, address).len;
+                inline for (comptime std.enums.values(EndpointFamily)) |family| {
+                    total += rowLen(family.name(), label_len, u64_digits_max);
+                }
+                total += rowLen("endpoint_inflight", label_len, inflight_digits_max);
+                if (cluster_checked) {
+                    total += rowLen("endpoint_healthy", label_len, healthy_digits_max);
+                }
+            }
+        }
+        if (checked_clusters >= 1) {
             total += typeLineLen("endpoint_healthy", "gauge");
-            total += labeled.endpointRowsLen("endpoint_healthy", healthy_digits_max, true);
         }
         assert(total >= 1);
         return total;
@@ -998,36 +1057,11 @@ pub const Labeled = struct {
         return "# TYPE ".len + metric_prefix.len + name.len + " ".len + kind.len + "\n".len;
     }
 
-    fn endpointRowsLen(
-        labeled: *const Labeled,
-        name: []const u8,
-        digits: usize,
-        checked_only: bool,
-    ) usize {
+    fn rowLen(name: []const u8, label_len: usize, digits: usize) usize {
+        assert(name.len >= 1);
+        assert(label_len >= "{cluster=\"\"}".len);
         assert(digits >= 1);
-        var total: usize = 0;
-        for (0..labeled.endpoint_counts.len) |cluster_index| {
-            if (checked_only) {
-                if (!labeled.cluster_checked[cluster_index]) continue;
-            }
-            for (0..labeled.endpoint_counts[cluster_index]) |endpoint_index| {
-                const key = labeled.keys.key(@intCast(cluster_index), @intCast(endpoint_index));
-                assert(labeled.endpoint_labels[key].len >= 1);
-                total += metric_prefix.len + name.len +
-                    labeled.endpoint_labels[key].len + " ".len + digits + "\n".len;
-            }
-        }
-        return total;
-    }
-
-    fn clusterRowsLen(labeled: *const Labeled, name: []const u8, digits: usize) usize {
-        assert(digits >= 1);
-        var total: usize = 0;
-        for (labeled.cluster_labels) |label| {
-            assert(label.len >= 1);
-            total += metric_prefix.len + name.len + label.len + " ".len + digits + "\n".len;
-        }
-        return total;
+        return metric_prefix.len + name.len + label_len + " ".len + digits + "\n".len;
     }
 
     fn tableTotal(values: []const Value) u64 {

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -6,7 +6,10 @@
 
 const std = @import("std");
 
+const config_module = @import("config.zig");
+const constants = @import("constants.zig");
 const io_module = @import("io/io.zig");
+const upstream_module = @import("net/upstream.zig");
 
 const assert = std.debug.assert;
 
@@ -585,6 +588,475 @@ pub const Counters = struct {
     }
 };
 
+/// The per-cluster and per-endpoint breakdown of the exposition (§8,
+/// #179): which backend, not only how many. Same single-writer
+/// relaxed-atomic discipline as `Counters`, in tables sized by the loaded
+/// config's endpoint index space (`EndpointKeys`) rather than by a field
+/// list — the first counter tables among the §7 endpoint-keyed state.
+///
+/// Each labeled family **partitions** one process total above, the
+/// kernel-pressure op/cause precedent: the bare counter stays the total a
+/// dashboard already reads, the labeled series say *where*, and
+/// `reconciles` holds the two views equal so neither can drift — a
+/// witness that moves one side without the other is a bug the simulator
+/// trips on every seed, not a state.
+///
+/// Label cardinality is bounded by config, and that property is what
+/// makes labelling safe at all: there is no user-controlled dimension —
+/// no per-path, no per-status — and there must never be one. The label
+/// strings are prebuilt here at init, so a scrape renders them with the
+/// same zero-allocation discipline as everything else (§5).
+pub const Labeled = struct {
+    keys: upstream_module.EndpointKeys,
+    /// Rendered `{cluster="…",endpoint="…"}` per key — empty at the
+    /// ragged holes between clusters, which no render row ever reads.
+    /// Cluster names are escaped (an operator identifier may hold any
+    /// byte); the endpoint half is an address literal and cannot need it.
+    endpoint_labels: [][]const u8,
+    /// Rendered `{cluster="…"}` per cluster, for the families whose
+    /// witness site cannot know an endpoint.
+    cluster_labels: [][]const u8,
+    /// Endpoints per cluster — the row bound every walk below shares, so
+    /// a ragged config's holes are skipped by construction.
+    endpoint_counts: []u16,
+    /// Which clusters run §7 checks: the healthy gauge renders only
+    /// where a prober actually writes a verdict.
+    cluster_checked: []bool,
+    /// Per-endpoint counters (`EndpointKeys`-keyed). Each partitions the
+    /// like-named process total — see `reconciles`.
+    connect_failed: []Value,
+    responses: []Value,
+    health_down: []Value,
+    health_up: []Value,
+    /// Per-cluster counters: the inflight sheds fire precisely because
+    /// *no* endpoint could be picked, so a per-endpoint label would be an
+    /// invention — the cluster is everything the witness knows.
+    l7_shed_inflight: []Value,
+    l4_shed_inflight: []Value,
+    /// Exact byte bound on one `render` of this config — the runtime
+    /// sibling of `Counters.render_bytes_max`, tight the same way, and
+    /// the term the caller sizes its buffer (and the memory banner its
+    /// budget) from.
+    render_bytes_max: usize,
+
+    const Value = Counters.Value;
+    const metric_prefix = Counters.metric_prefix;
+
+    const u64_digits_max = 20; // len("18446744073709551615")
+    /// The inflight gauge sums two u16 tables, so its reachable maximum
+    /// is 131070 — six digits, and the tightness test fills the buffer
+    /// exactly because this is the true ceiling rather than a u32's.
+    const inflight_digits_max = 6;
+    const inflight_max: u32 = 2 * @as(u32, std.math.maxInt(u16));
+    comptime {
+        assert(inflight_max >= 100_000);
+        assert(inflight_max < 1_000_000);
+    }
+    /// Healthy is a 0/1 gauge: one digit is its widest rendering.
+    const healthy_digits_max = 1;
+
+    /// The per-endpoint families, tag names matching the field they
+    /// count into — `incrementEndpoint` resolves the table by tag, so a
+    /// rename that split the two would not compile.
+    pub const EndpointFamily = enum {
+        connect_failed,
+        responses,
+        health_down,
+        health_up,
+
+        /// The exposition name (behind `zoxy_`). A switch, not
+        /// concatenation, so the rendered vocabulary reads in one place.
+        fn name(family: EndpointFamily) []const u8 {
+            return switch (family) {
+                .connect_failed => "endpoint_connect_failed",
+                .responses => "endpoint_responses",
+                .health_down => "endpoint_health_down",
+                .health_up => "endpoint_health_up",
+            };
+        }
+    };
+
+    pub const ClusterFamily = enum {
+        l7_shed_inflight,
+        l4_shed_inflight,
+
+        fn name(family: ClusterFamily) []const u8 {
+            return switch (family) {
+                .l7_shed_inflight => "cluster_l7_shed_inflight",
+                .l4_shed_inflight => "cluster_l4_shed_inflight",
+            };
+        }
+    };
+
+    /// What the gauges read at render time, borrowed from their owners
+    /// exactly as the balancer borrows them (§7): the pool and the
+    /// server own the load, the prober owns the mask, and reading live
+    /// beats mirroring — a mirror is one missed release from lying.
+    pub const LiveViews = struct {
+        load: upstream_module.Load,
+        healthy: []const bool,
+    };
+
+    pub fn init(
+        labeled: *Labeled,
+        arena: std.mem.Allocator,
+        config: *const config_module.Config,
+        keys: upstream_module.EndpointKeys,
+    ) error{OutOfMemory}!void {
+        assert(config.clusters.len >= 1);
+        assert(keys.count == @as(u32, @intCast(config.clusters.len)) * keys.stride);
+        labeled.keys = keys;
+        const cluster_count = config.clusters.len;
+        labeled.endpoint_labels = try arena.alloc([]const u8, keys.count);
+        labeled.cluster_labels = try arena.alloc([]const u8, cluster_count);
+        labeled.endpoint_counts = try arena.alloc(u16, cluster_count);
+        labeled.cluster_checked = try arena.alloc(bool, cluster_count);
+        labeled.connect_failed = try allocValues(arena, keys.count);
+        labeled.responses = try allocValues(arena, keys.count);
+        labeled.health_down = try allocValues(arena, keys.count);
+        labeled.health_up = try allocValues(arena, keys.count);
+        labeled.l7_shed_inflight = try allocValues(arena, cluster_count);
+        labeled.l4_shed_inflight = try allocValues(arena, cluster_count);
+        // Holes stay empty — the one answer to "what did init leave
+        // here", and the tripwire `incrementEndpoint` asserts against.
+        @memset(labeled.endpoint_labels, "");
+        for (config.clusters, 0..) |*cluster, cluster_index| {
+            assert(cluster.endpoints.len >= 1);
+            assert(cluster.endpoints.len <= keys.stride);
+            labeled.endpoint_counts[cluster_index] = @intCast(cluster.endpoints.len);
+            labeled.cluster_checked[cluster_index] = cluster.check != null;
+            labeled.cluster_labels[cluster_index] = try clusterLabel(arena, cluster.name);
+            for (cluster.endpoints, 0..) |*address, endpoint_index| {
+                const key = keys.key(@intCast(cluster_index), @intCast(endpoint_index));
+                labeled.endpoint_labels[key] =
+                    try endpointLabel(arena, cluster.name, address);
+            }
+        }
+        labeled.render_bytes_max = labeled.renderBytesBound();
+        assert(labeled.render_bytes_max >= 1);
+    }
+
+    fn allocValues(arena: std.mem.Allocator, count: usize) error{OutOfMemory}![]Value {
+        assert(count >= 1);
+        const values = try arena.alloc(Value, count);
+        for (values) |*value| value.* = Value.init(0);
+        return values;
+    }
+
+    /// Widest rendered endpoint literal: a bracketed IPv6 address with
+    /// its port — 47 bytes, and truly the widest, since `parseLiteral`
+    /// cannot carry a scope id and the `{f}` render omits scopes anyway.
+    /// 64 is round headroom over that, not a scope allowance.
+    const endpoint_literal_bytes_max = 64;
+
+    /// Scratch wide enough for any label this config could produce: the
+    /// grammar, a fully-escaped cluster name (every byte doubling), and
+    /// the widest endpoint literal.
+    const label_scratch_bytes = "{cluster=\"".len +
+        2 * @as(usize, constants.cluster_name_bytes_max) +
+        "\",endpoint=\"".len + endpoint_literal_bytes_max + "\"}".len;
+
+    fn clusterLabel(arena: std.mem.Allocator, name: []const u8) error{OutOfMemory}![]const u8 {
+        assert(name.len >= 1);
+        assert(name.len <= constants.cluster_name_bytes_max);
+        var scratch: [label_scratch_bytes]u8 = undefined;
+        var writer = std.Io.Writer.fixed(&scratch);
+        // The scratch is sized to the loader's own bounds just above, so
+        // the fixed writer cannot fill.
+        writer.writeAll("{cluster=\"") catch unreachable;
+        writeEscaped(&writer, name) catch unreachable;
+        writer.writeAll("\"}") catch unreachable;
+        return try arena.dupe(u8, writer.buffered());
+    }
+
+    fn endpointLabel(
+        arena: std.mem.Allocator,
+        name: []const u8,
+        address: *const std.Io.net.IpAddress,
+    ) error{OutOfMemory}![]const u8 {
+        assert(name.len >= 1);
+        assert(name.len <= constants.cluster_name_bytes_max);
+        var scratch: [label_scratch_bytes]u8 = undefined;
+        var writer = std.Io.Writer.fixed(&scratch);
+        // Same cannot-fill argument as `clusterLabel`; the address half
+        // is bounded by the bracketed-IPv6 term of the scratch.
+        writer.writeAll("{cluster=\"") catch unreachable;
+        writeEscaped(&writer, name) catch unreachable;
+        writer.print("\",endpoint=\"{f}\"}}", .{address.*}) catch unreachable;
+        return try arena.dupe(u8, writer.buffered());
+    }
+
+    /// Prometheus label-value escaping: backslash, quote, newline. The
+    /// loader bounds a cluster name's *length*, not its bytes, and a
+    /// label that broke the exposition grammar would corrupt the whole
+    /// scrape, not one line.
+    fn writeEscaped(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
+        for (value) |byte| {
+            switch (byte) {
+                '\\' => try writer.writeAll("\\\\"),
+                '"' => try writer.writeAll("\\\""),
+                '\n' => try writer.writeAll("\\n"),
+                else => try writer.writeByte(byte),
+            }
+        }
+    }
+
+    /// Loop thread only — the single writer (§8), like `Counters`.
+    /// `key` must name a configured endpoint: the empty-label assert is
+    /// what turns "charged a hole" from a silent lost count into a bug.
+    pub fn incrementEndpoint(
+        labeled: *Labeled,
+        comptime family: EndpointFamily,
+        key: u32,
+    ) void {
+        assert(key < labeled.keys.count);
+        assert(labeled.endpoint_labels[key].len >= 1);
+        const table = @field(labeled, @tagName(family));
+        const previous = table[key].fetchAdd(1, .monotonic);
+        assert(previous < std.math.maxInt(u64));
+    }
+
+    pub fn incrementCluster(
+        labeled: *Labeled,
+        comptime family: ClusterFamily,
+        cluster_index: u16,
+    ) void {
+        assert(cluster_index < labeled.cluster_labels.len);
+        const table = @field(labeled, @tagName(family));
+        const previous = table[cluster_index].fetchAdd(1, .monotonic);
+        assert(previous < std.math.maxInt(u64));
+    }
+
+    /// Render every labeled family as Prometheus exposition text —
+    /// `Counters.render`'s dialect, appended after it by the callers
+    /// that serve both. Zero-alloc into a caller-owned buffer of at
+    /// least `render_bytes_max`, a bound that is exact for the same
+    /// reason the comptime one is: every row is priced at its type's
+    /// widest rendering.
+    pub fn render(labeled: *const Labeled, views: *const LiveViews, buffer: []u8) []const u8 {
+        assert(buffer.len >= labeled.render_bytes_max);
+        assert(views.load.l7.len == labeled.keys.count);
+        assert(views.load.l4.len == labeled.keys.count);
+        assert(views.healthy.len == labeled.keys.count);
+        var writer = std.Io.Writer.fixed(buffer);
+        inline for (comptime std.enums.values(EndpointFamily)) |family| {
+            labeled.renderEndpointFamily(&writer, family);
+        }
+        inline for (comptime std.enums.values(ClusterFamily)) |family| {
+            labeled.renderClusterFamily(&writer, family);
+        }
+        labeled.renderInflight(&writer, views);
+        labeled.renderHealthy(&writer, views);
+        const text = writer.buffered();
+        assert(text.len >= 1);
+        assert(text.len <= labeled.render_bytes_max);
+        return text;
+    }
+
+    fn renderEndpointFamily(
+        labeled: *const Labeled,
+        writer: *std.Io.Writer,
+        comptime family: EndpointFamily,
+    ) void {
+        const table = @field(labeled, @tagName(family));
+        assert(table.len == labeled.keys.count);
+        // Every write below is inside `render_bytes_max`, which `init`
+        // computed over exactly these rows — the cannot-fail argument
+        // `Counters.render` makes against its comptime bound.
+        writer.print(
+            "# TYPE {s}{s} counter\n",
+            .{ metric_prefix, comptime family.name() },
+        ) catch unreachable;
+        for (0..labeled.endpoint_counts.len) |cluster_index| {
+            for (0..labeled.endpoint_counts[cluster_index]) |endpoint_index| {
+                const key = labeled.keys.key(@intCast(cluster_index), @intCast(endpoint_index));
+                writer.print("{s}{s}{s} {d}\n", .{
+                    metric_prefix,
+                    comptime family.name(),
+                    labeled.endpoint_labels[key],
+                    table[key].load(.monotonic),
+                }) catch unreachable;
+            }
+        }
+    }
+
+    fn renderClusterFamily(
+        labeled: *const Labeled,
+        writer: *std.Io.Writer,
+        comptime family: ClusterFamily,
+    ) void {
+        const table = @field(labeled, @tagName(family));
+        assert(table.len == labeled.cluster_labels.len);
+        writer.print(
+            "# TYPE {s}{s} counter\n",
+            .{ metric_prefix, comptime family.name() },
+        ) catch unreachable;
+        for (labeled.cluster_labels, table) |label, *value| {
+            writer.print("{s}{s}{s} {d}\n", .{
+                metric_prefix,
+                comptime family.name(),
+                label,
+                value.load(.monotonic),
+            }) catch unreachable;
+        }
+    }
+
+    /// The per-endpoint in-flight level — the §7 total the balancer
+    /// compares and `max_inflight` caps, seen from the scrape. Read off
+    /// the owners' live tables at render time, never mirrored.
+    fn renderInflight(
+        labeled: *const Labeled,
+        writer: *std.Io.Writer,
+        views: *const LiveViews,
+    ) void {
+        assert(views.load.l7.len == labeled.keys.count);
+        writer.print(
+            "# TYPE {s}endpoint_inflight gauge\n",
+            .{metric_prefix},
+        ) catch unreachable;
+        for (0..labeled.endpoint_counts.len) |cluster_index| {
+            for (0..labeled.endpoint_counts[cluster_index]) |endpoint_index| {
+                const key = labeled.keys.key(@intCast(cluster_index), @intCast(endpoint_index));
+                const level = views.load.inFlight(key);
+                assert(level <= inflight_max);
+                writer.print("{s}endpoint_inflight{s} {d}\n", .{
+                    metric_prefix,
+                    labeled.endpoint_labels[key],
+                    level,
+                }) catch unreachable;
+            }
+        }
+    }
+
+    /// The §7 verdict per checked endpoint, 1 healthy / 0 ejected. Only
+    /// for clusters with a `check` block: an unprobed endpoint has no
+    /// verdict, and rendering a constant 1 for it would dress "unknown"
+    /// as "known good".
+    fn renderHealthy(
+        labeled: *const Labeled,
+        writer: *std.Io.Writer,
+        views: *const LiveViews,
+    ) void {
+        assert(views.healthy.len == labeled.keys.count);
+        if (labeled.checkedClusterCount() == 0) {
+            return;
+        }
+        assert(labeled.checkedClusterCount() >= 1);
+        writer.print(
+            "# TYPE {s}endpoint_healthy gauge\n",
+            .{metric_prefix},
+        ) catch unreachable;
+        for (0..labeled.endpoint_counts.len) |cluster_index| {
+            if (!labeled.cluster_checked[cluster_index]) continue;
+            for (0..labeled.endpoint_counts[cluster_index]) |endpoint_index| {
+                const key = labeled.keys.key(@intCast(cluster_index), @intCast(endpoint_index));
+                writer.print("{s}endpoint_healthy{s} {d}\n", .{
+                    metric_prefix,
+                    labeled.endpoint_labels[key],
+                    @intFromBool(views.healthy[key]),
+                }) catch unreachable;
+            }
+        }
+    }
+
+    fn checkedClusterCount(labeled: *const Labeled) u16 {
+        var count: u16 = 0;
+        for (labeled.cluster_checked) |checked| {
+            if (checked) count += 1;
+        }
+        assert(count <= labeled.cluster_checked.len);
+        return count;
+    }
+
+    /// The exact bound `render` is held to, walked over the same rows
+    /// render walks. Runtime because the label lengths are the config's;
+    /// exact because every term is — which is what lets the tightness
+    /// test prove it by filling the buffer to the last byte.
+    fn renderBytesBound(labeled: *const Labeled) usize {
+        var total: usize = 0;
+        inline for (comptime std.enums.values(EndpointFamily)) |family| {
+            total += typeLineLen(family.name(), "counter");
+            total += labeled.endpointRowsLen(family.name(), u64_digits_max, false);
+        }
+        inline for (comptime std.enums.values(ClusterFamily)) |family| {
+            total += typeLineLen(family.name(), "counter");
+            total += labeled.clusterRowsLen(family.name(), u64_digits_max);
+        }
+        total += typeLineLen("endpoint_inflight", "gauge");
+        total += labeled.endpointRowsLen("endpoint_inflight", inflight_digits_max, false);
+        if (labeled.checkedClusterCount() >= 1) {
+            total += typeLineLen("endpoint_healthy", "gauge");
+            total += labeled.endpointRowsLen("endpoint_healthy", healthy_digits_max, true);
+        }
+        assert(total >= 1);
+        return total;
+    }
+
+    fn typeLineLen(name: []const u8, kind: []const u8) usize {
+        assert(name.len >= 1);
+        assert(kind.len >= 1);
+        return "# TYPE ".len + metric_prefix.len + name.len + " ".len + kind.len + "\n".len;
+    }
+
+    fn endpointRowsLen(
+        labeled: *const Labeled,
+        name: []const u8,
+        digits: usize,
+        checked_only: bool,
+    ) usize {
+        assert(digits >= 1);
+        var total: usize = 0;
+        for (0..labeled.endpoint_counts.len) |cluster_index| {
+            if (checked_only) {
+                if (!labeled.cluster_checked[cluster_index]) continue;
+            }
+            for (0..labeled.endpoint_counts[cluster_index]) |endpoint_index| {
+                const key = labeled.keys.key(@intCast(cluster_index), @intCast(endpoint_index));
+                assert(labeled.endpoint_labels[key].len >= 1);
+                total += metric_prefix.len + name.len +
+                    labeled.endpoint_labels[key].len + " ".len + digits + "\n".len;
+            }
+        }
+        return total;
+    }
+
+    fn clusterRowsLen(labeled: *const Labeled, name: []const u8, digits: usize) usize {
+        assert(digits >= 1);
+        var total: usize = 0;
+        for (labeled.cluster_labels) |label| {
+            assert(label.len >= 1);
+            total += metric_prefix.len + name.len + label.len + " ".len + digits + "\n".len;
+        }
+        return total;
+    }
+
+    fn tableTotal(values: []const Value) u64 {
+        assert(values.len >= 1);
+        var total: u64 = 0;
+        for (values) |*value| {
+            total += value.load(.monotonic);
+        }
+        return total;
+    }
+
+    /// The #179 partition identities: each labeled family sums to the
+    /// process total it breaks down — two views of one number, the
+    /// kernel-pressure op/cause contract. Asserted rather than returned,
+    /// exactly like `reconcile`'s inequalities: a witness that moved one
+    /// side without the other is a bug for the simulator to trip on, not
+    /// a state to report — which is why there is no `false` to return.
+    pub fn reconciles(labeled: *const Labeled, counters: *const Counters) void {
+        assert(tableTotal(labeled.connect_failed) == counters.get("upstream_connect_failed"));
+        assert(tableTotal(labeled.responses) == counters.get("l7_responses"));
+        assert(tableTotal(labeled.health_down) == counters.get("health_endpoint_down"));
+        assert(tableTotal(labeled.health_up) == counters.get("health_endpoint_up"));
+        assert(tableTotal(labeled.l7_shed_inflight) ==
+            counters.get("l7_shed_endpoint_inflight"));
+        assert(tableTotal(labeled.l4_shed_inflight) ==
+            counters.get("l4_shed_endpoint_inflight"));
+    }
+};
+
 test "counters: reconcile holds across a lifecycle" {
     var counters: Counters = .{};
     try std.testing.expect(counters.reconcile(0));
@@ -797,4 +1269,244 @@ test "counters: an admission shed and an L7 reject land on opposite sides" {
     try std.testing.expect(!counters.reconcile(0));
     counters.increment("completed");
     try std.testing.expect(counters.reconcile(0));
+}
+
+/// A two-cluster, deliberately ragged shape for the `Labeled` tests:
+/// "api" (checked, two endpoints) beside "solo" (unchecked, one), under
+/// a stride of 2 — so key (1,1) is a hole, and a walk that forgot the
+/// per-cluster row bound would read it.
+fn labeledTestConfig(clusters: []const config_module.Config.Cluster) config_module.Config {
+    return .{
+        .listeners = &.{},
+        .clusters = clusters,
+        .connect_timeout_ms = 1,
+        .idle_timeout_ms = 1,
+        .drain_deadline_ms = 1,
+        .max_lifetime_ms = 0,
+        .request_timeout_ms = 0,
+    };
+}
+
+fn labeledTestAddress(comptime literal: []const u8) std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral(literal) catch unreachable;
+}
+
+const labeled_test_keys: upstream_module.EndpointKeys = .init(2, 2);
+
+fn labeledTestClusters() [2]config_module.Config.Cluster {
+    const api_endpoints = struct {
+        const list = [_]std.Io.net.IpAddress{
+            labeledTestAddress("10.0.0.1:8080"),
+            labeledTestAddress("10.0.0.2:8080"),
+        };
+    };
+    const solo_endpoints = struct {
+        const list = [_]std.Io.net.IpAddress{
+            labeledTestAddress("[2001:db8::1]:9000"),
+        };
+    };
+    return .{
+        .{
+            .name = "api",
+            .endpoints = &api_endpoints.list,
+            .check = .{ .timeout_ms = 50 },
+        },
+        .{
+            .name = "solo",
+            .endpoints = &solo_endpoints.list,
+        },
+    };
+}
+
+test "counters: labeled init builds one label per configured endpoint" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const clusters = labeledTestClusters();
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, labeled_test_keys);
+
+    try std.testing.expectEqualStrings(
+        "{cluster=\"api\",endpoint=\"10.0.0.1:8080\"}",
+        labeled.endpoint_labels[labeled_test_keys.key(0, 0)],
+    );
+    try std.testing.expectEqualStrings(
+        "{cluster=\"api\",endpoint=\"10.0.0.2:8080\"}",
+        labeled.endpoint_labels[labeled_test_keys.key(0, 1)],
+    );
+    try std.testing.expectEqualStrings("{cluster=\"solo\"}", labeled.cluster_labels[1]);
+    // The IPv6 literal renders bracketed, port attached — the exact text
+    // an operator grep for their own config's endpoint will match.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        labeled.endpoint_labels[labeled_test_keys.key(1, 0)],
+        "[2001:db8::1]:9000",
+    ) != null);
+    // The ragged hole carries no label — and `incrementEndpoint` asserts
+    // on that emptiness, so charging a hole is a crash, not a lost count.
+    try std.testing.expectEqual(@as(usize, 0), labeled.endpoint_labels[labeled_test_keys.key(1, 1)].len);
+    try std.testing.expectEqual(true, labeled.cluster_checked[0]);
+    try std.testing.expectEqual(false, labeled.cluster_checked[1]);
+}
+
+test "counters: labeled labels escape what the exposition grammar reserves" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const endpoints = struct {
+        const list = [_]std.Io.net.IpAddress{labeledTestAddress("127.0.0.1:1")};
+    };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "we\"ird\\name", .endpoints = &endpoints.list },
+    };
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, .init(1, 1));
+
+    // A quote or backslash in a cluster name must not break the label
+    // grammar: the loader bounds a name's length, never its bytes.
+    try std.testing.expectEqualStrings(
+        "{cluster=\"we\\\"ird\\\\name\"}",
+        labeled.cluster_labels[0],
+    );
+}
+
+test "counters: labeled render speaks the exposition dialect" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const clusters = labeledTestClusters();
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, labeled_test_keys);
+
+    labeled.incrementEndpoint(.responses, labeled_test_keys.key(0, 1));
+    labeled.incrementEndpoint(.responses, labeled_test_keys.key(0, 1));
+    labeled.incrementCluster(.l7_shed_inflight, 1);
+
+    var l7 = [_]u16{0} ** labeled_test_keys.count;
+    var l4 = [_]u16{0} ** labeled_test_keys.count;
+    l7[labeled_test_keys.key(0, 0)] = 3;
+    l4[labeled_test_keys.key(0, 0)] = 2;
+    var healthy = [_]bool{true} ** labeled_test_keys.count;
+    healthy[labeled_test_keys.key(0, 1)] = false;
+    const views: Labeled.LiveViews = .{
+        .load = .{ .l7 = &l7, .l4 = &l4 },
+        .healthy = &healthy,
+    };
+
+    const buffer = try arena_state.allocator().alloc(u8, labeled.render_bytes_max);
+    const text = labeled.render(&views, buffer);
+
+    // Counters carry their values, and untouched series render at zero —
+    // a scrape sees the whole configured set, exactly like `Counters`.
+    try std.testing.expect(std.mem.indexOf(u8, text, "# TYPE zoxy_endpoint_responses counter\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_responses{cluster=\"api\",endpoint=\"10.0.0.2:8080\"} 2\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_connect_failed{cluster=\"api\",endpoint=\"10.0.0.1:8080\"} 0\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_cluster_l7_shed_inflight{cluster=\"solo\"} 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_cluster_l4_shed_inflight{cluster=\"api\"} 0\n") != null);
+    // The inflight gauge reads the live view: both protocols summed.
+    try std.testing.expect(std.mem.indexOf(u8, text, "# TYPE zoxy_endpoint_inflight gauge\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_inflight{cluster=\"api\",endpoint=\"10.0.0.1:8080\"} 5\n") != null);
+    // Healthy renders the prober's verdict for checked endpoints only:
+    // an unprobed endpoint has no verdict to dress up as a 1.
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_healthy{cluster=\"api\",endpoint=\"10.0.0.2:8080\"} 0\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_healthy{cluster=\"api\",endpoint=\"10.0.0.1:8080\"} 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_healthy{cluster=\"solo\"") == null);
+
+    // One TYPE line per family: four endpoint counters, two cluster
+    // counters, the inflight gauge, and healthy (a checked cluster exists).
+    var type_lines: usize = 0;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, text, search, "# TYPE ")) |at| {
+        type_lines += 1;
+        search = at + "# TYPE ".len;
+    }
+    try std.testing.expectEqual(@as(usize, 8), type_lines);
+}
+
+test "counters: labeled render bound is exact at the maximum values" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const clusters = labeledTestClusters();
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, labeled_test_keys);
+
+    for ([_][]Counters.Value{
+        labeled.connect_failed,   labeled.responses,
+        labeled.health_down,      labeled.health_up,
+        labeled.l7_shed_inflight, labeled.l4_shed_inflight,
+    }) |table| {
+        for (table) |*value| value.store(std.math.maxInt(u64), .monotonic);
+    }
+    // The widest live view either owner can produce: both u16 tables
+    // saturated (the inflight bound is their sum, not a u32's), and a
+    // healthy verdict — "1" — on every checked endpoint.
+    var l7 = [_]u16{std.math.maxInt(u16)} ** labeled_test_keys.count;
+    var l4 = [_]u16{std.math.maxInt(u16)} ** labeled_test_keys.count;
+    const healthy = [_]bool{true} ** labeled_test_keys.count;
+    const views: Labeled.LiveViews = .{
+        .load = .{ .l7 = &l7, .l4 = &l4 },
+        .healthy = &healthy,
+    };
+
+    const buffer = try arena_state.allocator().alloc(u8, labeled.render_bytes_max);
+    const text = labeled.render(&views, buffer);
+    // Every value at its type's reachable maximum fills the buffer
+    // exactly: the bound is tight, not merely sufficient — the same
+    // claim `Counters.render_bytes_max` proves at comptime.
+    try std.testing.expectEqual(labeled.render_bytes_max, text.len);
+    try std.testing.expect(std.mem.indexOf(u8, text, "18446744073709551615\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, " 131070\n") != null);
+}
+
+test "counters: labeled render drops the healthy family with nothing checked" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const endpoints = struct {
+        const list = [_]std.Io.net.IpAddress{labeledTestAddress("127.0.0.1:1")};
+    };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "quiet", .endpoints = &endpoints.list },
+    };
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, .init(1, 1));
+
+    var l7 = [_]u16{0};
+    var l4 = [_]u16{0};
+    const healthy = [_]bool{true};
+    const views: Labeled.LiveViews = .{
+        .load = .{ .l7 = &l7, .l4 = &l4 },
+        .healthy = &healthy,
+    };
+    const buffer = try arena_state.allocator().alloc(u8, labeled.render_bytes_max);
+    const text = labeled.render(&views, buffer);
+    // No prober, no verdicts: the whole family is absent, TYPE line and
+    // all, rather than a page of constant 1s meaning "unknown".
+    try std.testing.expect(std.mem.indexOf(u8, text, "endpoint_healthy") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_inflight{cluster=\"quiet\"") != null);
+}
+
+test "counters: the labeled families partition their process totals" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const clusters = labeledTestClusters();
+    const config = labeledTestConfig(&clusters);
+    var labeled: Labeled = undefined;
+    try labeled.init(arena_state.allocator(), &config, labeled_test_keys);
+    var counters: Counters = .{};
+
+    // Every witness moves both views of its total: the bare counter and
+    // one labeled cell. The sums then agree, whatever the distribution.
+    counters.increment("upstream_connect_failed");
+    labeled.incrementEndpoint(.connect_failed, labeled_test_keys.key(0, 0));
+    counters.increment("l7_responses");
+    counters.increment("l7_responses");
+    labeled.incrementEndpoint(.responses, labeled_test_keys.key(0, 1));
+    labeled.incrementEndpoint(.responses, labeled_test_keys.key(1, 0));
+    counters.increment("health_endpoint_down");
+    labeled.incrementEndpoint(.health_down, labeled_test_keys.key(0, 0));
+    counters.increment("l4_shed_endpoint_inflight");
+    labeled.incrementCluster(.l4_shed_inflight, 0);
+    labeled.reconciles(&counters);
 }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -607,6 +607,11 @@ pub fn Proxy(comptime IoType: type) type {
                 server.health.healthy,
                 &conn.client_address,
             ) orelse {
+                // The labeled twin (#179) carries only the cluster: this
+                // fires precisely because no endpoint could be picked —
+                // all of them were full, so an endpoint label would be
+                // an invention.
+                server.labeled.incrementCluster(.l7_shed_inflight, conn.cluster_index);
                 respond(server, conn, 503, "l7_shed_endpoint_inflight");
                 return null;
             };
@@ -749,6 +754,15 @@ pub fn Proxy(comptime IoType: type) type {
             }
             const socket = result catch |err| {
                 server.counters.increment("upstream_connect_failed");
+                // The labeled twin (#179): the pick did not survive the
+                // await, but the leased slot did — it still names the
+                // endpoint this dial was for, and `respond`'s disposal
+                // releases it only after this line.
+                assert(conn.upstream != null);
+                server.labeled.incrementEndpoint(.connect_failed, server.upstreams.keys.key(
+                    conn.upstream.?.cluster_index,
+                    conn.upstream.?.endpoint_index,
+                ));
                 // Same split as the L4 dial: the origin's verdict arrives
                 // typed, our own resource exhaustion does not (§8).
                 server.witnessKernelPressure(.connect, err);
@@ -1610,6 +1624,14 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_started);
             conn.l7.response_leg = .done;
             server.counters.increment("l7_responses");
+            // The labeled twin (#179): the slot is still attached here —
+            // park and detach run below — and it names the endpoint that
+            // actually served, which is what "requests per backend" means.
+            assert(conn.upstream != null);
+            server.labeled.incrementEndpoint(.responses, server.upstreams.keys.key(
+                conn.upstream.?.cluster_index,
+                conn.upstream.?.endpoint_index,
+            ));
             // The whole response reached the client: the line goes out
             // now, before the turnaround below clears what it reports.
             // This is also the only place `ok` is earned — nothing between

--- a/src/main.zig
+++ b/src/main.zig
@@ -117,8 +117,7 @@ pub fn main(init: std.process.Init) !void {
 
     // The loop only stops after a completed drain (§8).
     assert(server.isIdle());
-    const gauges = server.gauges();
-    server.counters.dump(&gauges);
+    server.dumpMetrics();
 }
 
 /// The §5/§8 startup budget gauntlet: fds and the ring are sized to the
@@ -350,6 +349,7 @@ fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
         .upstream_bytes = @sizeOf(UpstreamType),
         .access_log_bytes = zoxy.constants.accessLogBytes(limits.access_log_buffer_bytes),
         .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
+        .metrics_bytes = ServerXev.metricsBytes(config),
         .head_buffers = limits.head_buffers,
         .head_buffer_bytes = limits.head_buffer_bytes,
         .upstream_head_buffers = limits.upstream_head_buffers,
@@ -438,6 +438,7 @@ fn printMemoryBanner(
         \\          + upstream head buffers {d} x {d} B + head scratch {d} B
         \\          + access log {d} KiB
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
+        \\          + labeled metrics {d} B (tables, labels and render buffers)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\
     , .{
@@ -462,6 +463,7 @@ fn printMemoryBanner(
         ServerXev.endpointTableBytes(config),
         config.clusters.len,
         ServerXev.endpointKeysFor(config).stride,
+        ServerXev.metricsBytes(config),
         config_arena_bytes / 1024,
     });
 }

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -660,6 +660,9 @@ pub fn Checker(comptime IoType: type) type {
             assert(checker.unhealthy_count >= 1);
             checker.unhealthy_count -= 1;
             checker.server.counters.increment("health_endpoint_up");
+            // The labeled twin (#179): a transition always knows its
+            // endpoint — the probe was addressed to it.
+            checker.server.labeled.incrementEndpoint(.health_up, key);
         }
 
         fn witnessFail(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
@@ -679,6 +682,8 @@ pub fn Checker(comptime IoType: type) type {
             checker.unhealthy_count += 1;
             assert(checker.unhealthy_count <= checker.checked_count);
             checker.server.counters.increment("health_endpoint_down");
+            // The labeled twin (#179), same key the mask just flipped.
+            checker.server.labeled.incrementEndpoint(.health_down, key);
             checker.closeParked(cluster_index, endpoint_index);
         }
 

--- a/src/net/upstream.zig
+++ b/src/net/upstream.zig
@@ -22,10 +22,10 @@ const idle_none: u32 = std.math.maxInt(u32);
 
 /// The flattened endpoint index space for one loaded config (§7).
 ///
-/// Seven tables are keyed by it — the pool's idle heads and lease
-/// counts, the balancer's cursors-adjacent endpoint hashes, the server's
-/// L4 in-flight charges, and the health checker's mask and two streak
-/// counters. All were fixed 16 × 64 = 1024-entry
+/// Eight tables are keyed by it — the pool's idle heads and lease
+/// counts, the balancer's endpoint hashes and rotation state, the
+/// server's L4 in-flight charges, and the health checker's mask and two
+/// streak counters. All were fixed 16 × 64 = 1024-entry
 /// arrays sized for the worst config any build could accept; they are
 /// now sized for the config this process actually loaded, so a
 /// two-endpoint deployment stops carrying a 1024-entry table.


### PR DESCRIPTION
Two features in one batch, six slices, each gated by the full `zig build ci` (unit + fuzz corpus, 4096-seed sim, Tier-0.5 live smoke) and a tiger-style review.

Closes #174. Closes #179.

## #174 — Per-endpoint weights

- An endpoint is the bare `"IP:port"` string it always was — weight 1 — or `{ "address": …, "weight": 3 }`, bounded by `endpoint_weight_max` (256, HAProxy's ceiling). Every existing config stays byte-valid; the generated schema gains its one `anyOf`, reflected from the same DTO the loader parses.
- Every policy honors the weight without changing character:
  - **`rr`** is nginx's smooth weighted rotation — weight 3 beside weight 1 serves a,a,b,a, never a burst. The per-cluster cursor became a per-endpoint credit table.
  - **`p2c`** draws its two candidates in proportion to weight; the in-flight comparison is untouched, so load still outranks share.
  - **`hash`** scores one replica hash per weight point and keeps the best — exactly proportional (weight/total of the key space), integer-only (no float log to drift across builds), and re-weighting an endpoint moves only the clients it gains or loses. The disruption property the issue asked to confirm is pinned by a test.
- **Weight 0 drains**: never picked, not even through fail-open — a drain is an operator's statement, an ejection only a probe's verdict — while the prober keeps probing, so recovery is still observed. All-zero clusters are rejected at load (`EndpointWeightsAllZero`).
- The load-bearing property: every unit-weight path is **bit-identical** to the unweighted algorithm it grew from — same PRNG consumption, same slots, same hash mapping — so existing clusters keep their client mappings and unweighted §9 traces are unchanged. All pre-existing balancer tests passed without edits.

## #179 — The exposition says which backend

- New labeled families beside the bare process totals: per-endpoint `zoxy_endpoint_{connect_failed,responses,health_down,health_up}`, per-cluster `zoxy_cluster_{l7,l4}_shed_inflight` (those sheds fire precisely because *no* endpoint could be picked — an endpoint label would be an invention), plus two render-time gauges reading the owners' live state: `zoxy_endpoint_inflight` and `zoxy_endpoint_healthy` (checked clusters only).
- Each labeled family **partitions** the total it breaks down — the kernel-pressure op/cause precedent — and `reconcile` asserts the sums equal, so every one of the 4096 sim seeds proves a witness cannot move one view without the other. The smoke gate re-derives the same identities from the rendered text of a live scrape.
- The render buffer moves from a comptime constant to an exact config-derived arena term, as the issue sketched: label strings are prebuilt at init (scrapes stay zero-alloc), the bound stays tight (the test fills the buffer to the last byte), and the banner gains the term the issue argued for — `+ labeled metrics N B (tables, labels and render buffers)`.
- Label cardinality is bounded by config: endpoints and cluster names, never request data.

Along the way `Server.init`, over the 70-line limit since before this batch, was split and landed at 60 lines. DESIGN.md §5/§7/§8, the operator docs, and the shipped example record both features as settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)