### PR TITLE
feat: response filters — header edits on the way out (#175)

### DIFF
--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -58,7 +58,7 @@ pub fn main() void {
         // suppression test is pure overhead.
         const upstream = render.renderRequestHead(&request, target, no_edits, false, null, &upstream_head) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
-        const downstream = render.renderResponseHead(&response, true, &downstream_head) catch unreachable;
+        const downstream = render.renderResponseHead(&response, true, no_edits, &downstream_head) catch unreachable;
 
         // Consume the outputs so nothing is dead-code-eliminated.
         checksum +%= upstream[upstream.len - 1];

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -852,6 +852,38 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   with unbounded fuel or an embedded allocator cannot satisfy the gate);
   anything beyond the closed action enum is a Zig function added to the
   owning phase module at compile time.
+- **Response filters are a second table, not a scope marker** (#175,
+  settled 2026-08-03). `request_filters` (né `filters`, hard-renamed
+  while no deployed config existed to break) runs before routing;
+  `response_filters` runs after the origin's head parses — and its
+  deciding predicate, the response's own status (`header_set` on 5xx
+  only), is temporally impossible in a table evaluated before any
+  response exists. That is what settled the shape: a shared table with
+  a scope field would carry match fields that cannot be evaluated at
+  their own application point, the exact conditionally-dead-fields
+  hole this loader refuses everywhere else. A response match is a
+  conjunction over exact statuses, a status class (`"1xx"`..`"5xx"`)
+  and response-header predicates — the request side's own header
+  vocabulary, evaluated by the same code — and the actions are exactly
+  the three header verbs: reject and rewrite have no meaning on the
+  way out, and the loader refuses those arms by name rather than
+  ignoring them. Edits apply during the downstream re-render through
+  the same suppress-and-append machinery, under the same
+  `header_edits_max` bound on the table's total; the proxy-managed
+  names (framing, hop-by-hop, `X-Forwarded-For`) stay barred by the
+  same validator, since a hand-written `Content-Length` would
+  desynchronise the relay. A head that no longer fits after edits is
+  the response side's oversize verdict: **502, not 431** — an origin
+  response the proxy cannot re-render is not the client's fault, and
+  it takes the exact path the close-injection overflow already took.
+  Response edits carry no counter of their own, deliberately: they
+  reject nothing and shed nothing, and the render they ride is already
+  witnessed by `l7_responses`. Static responses (§8's sheds and
+  rejects) bypass the response render and therefore the edits — the
+  simulator's client oracle holds that boundary from outside, and the
+  live gate holds both directions per listener: the http leg must
+  carry a configured stamp, the l4 leg must not, because byte
+  transparency is that leg's whole claim.
 - **Resilience is minimal by design:** per-request and per-try deadlines
   (head-read gets its own deadline, so a slowloris meets the clock or
   `limits.head_buffer_bytes`, whichever comes first; each dial — the

--- a/docs/README.md
+++ b/docs/README.md
@@ -424,12 +424,13 @@ connection to a sending cluster.
 
 ### Filters
 
-An `http` listener can carry a list of rules, evaluated top-down. Each has a
-match predicate — absent fields match anything — and actions applied in order.
-As with routes, nothing caps the list but the file you write.
+An `http` listener can carry `request_filters` — a list of rules evaluated
+top-down against each request. Each has a match predicate — absent fields
+match anything — and actions applied in order. As with routes, nothing caps
+the list but the file you write.
 
 ```json
-"filters": [
+"request_filters": [
     {
         "match": {
             "path_prefix": "/admin",

--- a/docs/README.md
+++ b/docs/README.md
@@ -458,6 +458,38 @@ bounded loops — no plugins, no scripting, nothing that can allocate or run
 unbounded. A rewrite changes only what is *forwarded*: routing already chose
 the cluster from the original path, so a rewrite never re-routes.
 
+#### Response filters
+
+`response_filters` edits the origin's response on the way out — the
+routine edge work an origin you do not control cannot do for you: add
+`Strict-Transport-Security`, strip `Server`, advertise a retry on 5xx.
+
+```json
+"response_filters": [
+    { "actions": [
+        { "header_remove": "Server" },
+        { "header_set": { "name": "Strict-Transport-Security",
+                          "value": "max-age=63072000" } }
+    ] },
+    { "match": { "status_class": "5xx" },
+      "actions": [{ "header_set": { "name": "Retry-After", "value": "1" } }] }
+]
+```
+
+A response rule matches on `status` (exact codes), `status_class`
+(`"1xx"` through `"5xx"`), and response-header predicates — the same
+`present` / `equals` / `contains` vocabulary. Its actions are the three
+header verbs only: `reject` and `rewrite_prefix` are request-side ideas,
+and the loader says so by name if you reach for them here.
+
+The same guardrails hold in both directions: filters may not touch the
+headers zoxy owns (`Content-Length`, `Transfer-Encoding`, `Connection`
+and the hop-by-hop set, `X-Forwarded-For`), and a response head that no
+longer fits after edits is answered `502` — an origin response the proxy
+cannot re-render is not the client's fault. Responses zoxy generates
+itself (`404`, `503`, filter rejects) are not origin responses and carry
+no edits.
+
 ### Timeouts
 
 ```json

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -69,7 +69,7 @@ weights_http: [1]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
-filters_http: [3]zoxy.http.filter.Rule,
+request_filters_http: [3]zoxy.http.filter.Rule,
 listener_configs: [2]zoxy.config.Config.Listener,
 config: zoxy.config.Config,
 origin: Origin,
@@ -643,7 +643,7 @@ fn deriveProxyProtocolSend(random: std.Random) ?zoxy.config.Config.Cluster.Proxy
 }
 
 fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
-    harness.filters_http = .{
+    harness.request_filters_http = .{
         .{
             .match = .{ .path_prefix = "/reject" },
             .actions = &.{.{ .reject = 403 }},
@@ -667,7 +667,7 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
         .{
             .bind_address = httpBindAddress(),
             .routes = &harness.routes_http,
-            .filters = &harness.filters_http,
+            .request_filters = &harness.request_filters_http,
             .protocol = .http,
             .forwarded = forwarded,
         },

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -70,6 +70,10 @@ clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
 request_filters_http: [3]zoxy.http.filter.Rule,
+/// The #175 response rules beside them: the always-on stamp the client
+/// oracle requires on every proxied 200, and the 5xx rule whose edit
+/// must never appear (the scripted origin answers no 5xx).
+response_filters_http: [2]zoxy.http.filter.ResponseRule,
 listener_configs: [2]zoxy.config.Config.Listener,
 config: zoxy.config.Config,
 origin: Origin,
@@ -657,6 +661,26 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .actions = &.{.{ .rewrite_prefix = .{ .from = "/rewrite", .to = "/sim" } }},
         },
     };
+    // #175 response rules, always on: every response the render forwards
+    // gains the stamp — so the client can require it on every 200 and
+    // refuse it on every static, which is what separates the two render
+    // paths from outside — and the 5xx rule matches a class the scripted
+    // origin never answers, so its edit appearing anywhere is the class
+    // predicate misfiring under some schedule.
+    harness.response_filters_http = .{
+        .{
+            .match = .{},
+            .edits = &.{.{
+                .kind = .set,
+                .name = l7.canon.response_edit_name,
+                .value = l7.canon.response_edit_value,
+            }},
+        },
+        .{
+            .match = .{ .status_class = 5 },
+            .edits = &.{.{ .kind = .set, .name = l7.canon.response_never_name, .value = "1" }},
+        },
+    };
     harness.listener_configs = .{
         .{
             .bind_address = bindAddress(),
@@ -668,6 +692,7 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .bind_address = httpBindAddress(),
             .routes = &harness.routes_http,
             .request_filters = &harness.request_filters_http,
+            .response_filters = &harness.response_filters_http,
             .protocol = .http,
             .forwarded = forwarded,
         },

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -19,6 +19,14 @@ pub const until_close_head = "HTTP/1.1 200 OK\r\n\r\n";
 pub const until_close_response = until_close_head ++ until_close_body;
 pub const truncated_response = sized_head ++ sized_body[0..16];
 
+/// The #175 response-filter edit every proxied response must carry, and
+/// the one no response may (its rule matches a class the origin never
+/// answers). One definition shared by the harness's rule table and the
+/// client's oracle, so the two cannot drift on a spelling.
+pub const response_edit_name = "X-Sim-Response";
+pub const response_edit_value = "on";
+pub const response_never_name = "X-Sim-Never";
+
 /// A parseable head that cannot survive the render: 8190 bytes fits the
 /// proxy's 8 KiB response buffer, but no Content-Length and no
 /// Transfer-Encoding makes it until-close framing, which forces a

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -40,6 +40,14 @@ pub const ClientError = error{
     ResponseOverrun,
     /// A clean seed did not produce the script's exact golden outcome.
     GoldenOutcomeMissed,
+    /// A proxied 200 arrived without the #175 response-filter stamp the
+    /// harness configures unconditionally: the edit path did not run.
+    ResponseEditMissing,
+    /// A response carried an edit it must not: the stamp on a static
+    /// (which bypasses the response render), or the 5xx rule's edit
+    /// anywhere (the scripted origin answers no 5xx) — either way a
+    /// predicate fired where it could not have.
+    ResponseEditForged,
 };
 
 pub fn Client(comptime IoType: type) type {
@@ -382,6 +390,10 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = ClientError.ResponseStatusUnexpected;
                     return walk;
                 }
+                if (responseEditViolation(&response)) |violation| {
+                    walk.violation = violation;
+                    return walk;
+                }
                 const body = bytes[walk.offset + response.head_len ..];
                 const verdict = walkBody(response, body) orelse return walk;
                 if (verdict.violation) |violation| {
@@ -401,6 +413,56 @@ pub fn Client(comptime IoType: type) type {
                 }
             }
             return walk;
+        }
+
+        /// The #175 oracle over one parsed response head: every 200 is
+        /// proxied through the response render, so it must carry the
+        /// harness's unconditional stamp; every legal non-200 here is a
+        /// static that bypasses that render, so the stamp on one means a
+        /// static grew filter edits; and the 5xx rule's edit anywhere
+        /// means the class predicate fired on a class the origin never
+        /// answers. Distinguishes the two render paths from outside the
+        /// process, under every schedule the adversary produces.
+        fn responseEditViolation(response: *const parser.ResponseHead) ?ClientError {
+            assert(response.status >= 100);
+            assert(response.headers.len <= zoxy.constants.headers_max);
+            const stamped = headerEquals(
+                response.headers,
+                canon.response_edit_name,
+                canon.response_edit_value,
+            );
+            if (response.status == 200) {
+                if (!stamped) {
+                    return ClientError.ResponseEditMissing;
+                }
+            } else {
+                if (stamped) {
+                    return ClientError.ResponseEditForged;
+                }
+            }
+            if (headerPresent(response.headers, canon.response_never_name)) {
+                return ClientError.ResponseEditForged;
+            }
+            return null;
+        }
+
+        fn headerEquals(headers: []const parser.Header, name: []const u8, value: []const u8) bool {
+            assert(name.len >= 1);
+            assert(headers.len <= zoxy.constants.headers_max);
+            for (headers) |header| {
+                if (!std.ascii.eqlIgnoreCase(header.name, name)) continue;
+                if (std.mem.eql(u8, header.value, value)) return true;
+            }
+            return false;
+        }
+
+        fn headerPresent(headers: []const parser.Header, name: []const u8) bool {
+            assert(name.len >= 1);
+            assert(headers.len <= zoxy.constants.headers_max);
+            for (headers) |header| {
+                if (std.ascii.eqlIgnoreCase(header.name, name)) return true;
+            }
+            return false;
         }
 
         /// Every legal response starts "HTTP/1."; a partial tail that

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -34,6 +34,10 @@ const response_headers_max: u32 = 64;
 pub const Response = struct {
     status: u16,
     body_bytes: u32,
+    /// Whether the head carried the #175 response-filter stamp the smoke
+    /// config sets unconditionally (`X-Zoxy-Smoke: 1`) — the live gate's
+    /// witness that the response edit path ran on this very hop.
+    edited: bool,
 };
 
 /// What a request says about its connection's future. HTTP/1.1's default
@@ -123,10 +127,10 @@ pub const Client = struct {
 /// the `Content-Length` promised.
 fn readResponse(reader: *Io.Reader) !Response {
     const status = try readStatus(reader);
-    const body_bytes = try readHeaders(reader);
-    assert(body_bytes <= response_body_bytes_max);
-    try reader.discardAll(body_bytes);
-    return .{ .status = status, .body_bytes = body_bytes };
+    const head = try readHeaders(reader);
+    assert(head.body_bytes <= response_body_bytes_max);
+    try reader.discardAll(head.body_bytes);
+    return .{ .status = status, .body_bytes = head.body_bytes, .edited = head.edited };
 }
 
 /// The three-digit status off the status line. A response that does not
@@ -145,20 +149,37 @@ fn readStatus(reader: *Io.Reader) !u16 {
     return status;
 }
 
+/// What the header walk found: the framing, and whether the #175 stamp
+/// was among the lines.
+const Head = struct {
+    body_bytes: u32,
+    edited: bool,
+};
+
 /// Header lines up to the blank one, returning the body length they
 /// framed. A head with no `Content-Length` is an error: the origin always
 /// sends one, so its absence means the hop reframed the response, which
-/// is exactly the kind of thing this tier exists to notice.
-fn readHeaders(reader: *Io.Reader) !u32 {
+/// is exactly the kind of thing this tier exists to notice. The #175
+/// stamp is scanned for on the same walk — spelled here rather than
+/// imported, like the counter names: the gate reads what the binary
+/// *wrote*, so a drift must fail loudly.
+fn readHeaders(reader: *Io.Reader) !Head {
     const length_name = "content-length:";
+    const stamp = "x-zoxy-smoke: 1";
     var body_bytes: ?u32 = null;
+    var edited = false;
     var lines: u32 = 0;
     while (lines < response_headers_max) : (lines += 1) {
         const taken = try reader.takeDelimiter('\n');
         const line = taken orelse return error.ResponseTruncated;
         const trimmed = std.mem.trimEnd(u8, line, "\r");
         if (trimmed.len == 0) {
-            return body_bytes orelse error.ResponseUnframed;
+            const framed = body_bytes orelse return error.ResponseUnframed;
+            return .{ .body_bytes = framed, .edited = edited };
+        }
+        if (std.ascii.eqlIgnoreCase(trimmed, stamp)) {
+            edited = true;
+            continue;
         }
         if (trimmed.len <= length_name.len) continue;
         if (!std.ascii.startsWithIgnoreCase(trimmed, length_name)) continue;

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -712,7 +712,7 @@ fn runPass(io: Io, port: u16, host: []const u8, pass: u32) !void {
                 );
                 return err;
             };
-            try expectResponse(response, origin_module.body.len);
+            try expectResponse(response, origin_module.body.len, .http);
         }
         assert(request == requests_per_connection);
     }
@@ -730,7 +730,7 @@ fn runPass(io: Io, port: u16, host: []const u8, pass: u32) !void {
             std.debug.print("smoke: pass {d} bulk request {d}: {t}\n", .{ pass, large, err });
             return err;
         };
-        try expectResponse(response, origin_module.large_body_bytes);
+        try expectResponse(response, origin_module.large_body_bytes, .http);
     }
     assert(large == large_requests);
 }
@@ -749,16 +749,22 @@ fn runL4Load(io: Io, port: u16, host: []const u8) !void {
             std.debug.print("smoke: l4 connection {d}: {t}\n", .{ index, err });
             return err;
         };
-        try expectResponse(response, origin_module.body.len);
+        try expectResponse(response, origin_module.body.len, .l4);
     }
     assert(index == l4_connections);
 }
+
+/// Which listener the exchange crossed, because the #175 stamp cuts both
+/// ways: the http leg re-renders the response head and must carry it,
+/// while the l4 leg's whole claim is byte transparency — the stamp there
+/// would mean L7 machinery leaked into the raw relay.
+const Leg = enum { http, l4 };
 
 /// The response the origin sent, checked byte-count and all: a hop that
 /// truncated or re-framed a body is a data-path bug this tier sees before
 /// any counter does — and the bulk target is where a hop is most likely
 /// to, since its body crosses the head buffer in more than one piece.
-fn expectResponse(response: client_module.Response, body_bytes: u32) !void {
+fn expectResponse(response: client_module.Response, body_bytes: u32, leg: Leg) !void {
     // The client parses both out of the wire and bounds them there; a
     // value outside those bounds reaching here would mean the two files
     // disagree about what a response is.
@@ -774,6 +780,19 @@ fn expectResponse(response: client_module.Response, body_bytes: u32) !void {
             .{ response.body_bytes, body_bytes },
         );
         return error.UnexpectedBody;
+    }
+    // The #175 stamp, judged per leg: on http its absence means the
+    // response edit path did not run on the real wire; on l4 its
+    // presence means the relay stopped being a relay.
+    switch (leg) {
+        .http => if (!response.edited) {
+            std.debug.print("smoke: http response carried no X-Zoxy-Smoke stamp\n", .{});
+            return error.ResponseEditMissing;
+        },
+        .l4 => if (response.edited) {
+            std.debug.print("smoke: l4-relayed response gained the X-Zoxy-Smoke stamp\n", .{});
+            return error.ResponseEditForged;
+        },
     }
 }
 
@@ -906,7 +925,10 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
     const config_json = try std.fmt.allocPrint(arena,
         \\{{
         \\    "listeners": [
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http",
+        \\          "response_filters": [
+        \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
+        \\          ] }},
         \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }}
         \\    ],
         \\    "clusters": {{

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -184,9 +184,13 @@ pub fn Server(comptime IoType: type) type {
             /// The listener's §7 route table, handed to each admitted L7
             /// connection so `routeRequest` can pick a cluster by path.
             routes: []const router.Route,
-            /// The listener's §7 filter rules, handed to each admitted L7
-            /// connection so `routeRequest` can evaluate policy.
+            /// The listener's §7 request filter rules, handed to each
+            /// admitted L7 connection so `routeRequest` can evaluate
+            /// policy.
             request_filters: []const filter.Rule,
+            /// The listener's #175 response filter rules, handed over the
+            /// same way so the response re-render can apply its edits.
+            response_filters: []const filter.ResponseRule,
             /// The listener's §7 client-address forwarding mode (null = off),
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
@@ -433,6 +437,7 @@ pub fn Server(comptime IoType: type) type {
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
                     .request_filters = listener_config.request_filters,
+                    .response_filters = listener_config.response_filters,
                     .forwarded = listener_config.forwarded,
                     .proxy_protocol = listener_config.proxy_protocol,
                     .protocol = listener_config.protocol,
@@ -911,6 +916,7 @@ pub fn Server(comptime IoType: type) type {
             // rule rather than a third fork.
             conn.routes = listener.routes;
             conn.request_filters = listener.request_filters;
+            conn.response_filters = listener.response_filters;
             conn.forwarded = listener.forwarded;
             assert(conn.routes.len >= 1);
             server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -186,7 +186,7 @@ pub fn Server(comptime IoType: type) type {
             routes: []const router.Route,
             /// The listener's §7 filter rules, handed to each admitted L7
             /// connection so `routeRequest` can evaluate policy.
-            filters: []const filter.Rule,
+            request_filters: []const filter.Rule,
             /// The listener's §7 client-address forwarding mode (null = off),
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
@@ -432,7 +432,7 @@ pub fn Server(comptime IoType: type) type {
                     // path's route once the head parses (§7).
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
-                    .filters = listener_config.filters,
+                    .request_filters = listener_config.request_filters,
                     .forwarded = listener_config.forwarded,
                     .proxy_protocol = listener_config.proxy_protocol,
                     .protocol = listener_config.protocol,
@@ -910,7 +910,7 @@ pub fn Server(comptime IoType: type) type {
             // exactly one catch-all route and no filters, so this is one
             // rule rather than a third fork.
             conn.routes = listener.routes;
-            conn.filters = listener.filters;
+            conn.request_filters = listener.request_filters;
             conn.forwarded = listener.forwarded;
             assert(conn.routes.len >= 1);
             server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));

--- a/src/config.zig
+++ b/src/config.zig
@@ -152,6 +152,13 @@ pub const Config = struct {
         /// Empty on the L4 path and whenever no `"request_filters"` were given.
         /// Compiled and interpreted by `http/filter.zig`.
         request_filters: []const filter.Rule = &.{},
+        /// The #175 response filter rules, same discipline on the way
+        /// out: empty on the L4 path and whenever no `"response_filters"`
+        /// were given. Compiled by this loader, matched by
+        /// `http/filter.zig`; the response re-render's application is
+        /// #175's next slice — until it lands, a compiled table is
+        /// carried but consulted by nothing.
+        response_filters: []const filter.ResponseRule = &.{},
         protocol: Protocol,
         /// How this listener tells the origin who the client is (§7), or
         /// null to leave `X-Forwarded-For` exactly as it arrived — the
@@ -368,6 +375,7 @@ pub const ValidationError = error{
     RouteHostNotCanonical,
     RouteDuplicate,
     ListenerL4RequestFilters,
+    ListenerL4ResponseFilters,
     ListenerL4Forwarded,
     ListenerForwardedModeUnknown,
     ListenerHttpProxyProtocol,
@@ -385,6 +393,12 @@ pub const ValidationError = error{
     FilterActionKind,
     FilterRejectStatus,
     FilterHeaderEditsOverLimit,
+    ResponseFilterReject,
+    ResponseFilterRewrite,
+    ResponseFilterStatusInvalid,
+    ResponseFilterStatusClassUnknown,
+    ResponseFilterStatusEmpty,
+    ResponseFilterHeaderEditsOverLimit,
     EndpointsEmpty,
     EndpointsOverLimit,
     EndpointInvalid,
@@ -841,6 +855,9 @@ pub const ListenerJson = struct {
     routes: ?[]const RouteJson = null,
     /// Optional §7 request filter rules; absent means none. HTTP-only.
     request_filters: ?[]const FilterJson = null,
+    /// Optional #175 response filter rules; absent means none. HTTP-only,
+    /// like everything with a head to match on.
+    response_filters: ?[]const ResponseFilterJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
     /// Optional §7 client-address forwarding; absent leaves the header
@@ -862,6 +879,10 @@ pub const ListenerJson = struct {
         },
         .request_filters = .{
             .desc = "Request filter rules, evaluated top-down (http listeners only).",
+        },
+        .response_filters = .{
+            .desc = "Response filter rules — header edits on the origin's response, " ++
+                "evaluated top-down (http listeners only).",
         },
         .protocol = .{
             .desc = "What the listener speaks: l4 relays bytes blindly, http runs the reverse-proxy state machine.",
@@ -1000,6 +1021,52 @@ pub const ActionJson = struct {
         .header_add = .{ .desc = "Append a request header." },
         .header_remove = .{ .desc = "Remove a request header by name." },
         .rewrite_prefix = .{ .desc = "Rewrite the request path prefix before proxying." },
+    };
+};
+
+/// One response filter rule (#175): a match over the origin's response —
+/// status and response headers; the request's facts are gone by the time
+/// a response exists, which is the reason this is its own table rather
+/// than a scope marker on `FilterJson` — and the header edits applied
+/// when it matches. Reject and rewrite are request-side ideas, rejected
+/// here by their own names.
+pub const ResponseFilterJson = struct {
+    match: ResponseMatchJson = .{},
+    actions: []const ActionJson,
+
+    pub const schema_doc =
+        "One response filter rule: a match over the origin's response and " ++
+        "the header edits applied when it matches.";
+    pub const schema_fields = .{
+        .match = .{ .desc = "Response-match predicate; absent fields match anything." },
+        .actions = .{
+            .desc = "Header edits (header_set / header_add / header_remove) applied " ++
+                "in order when the rule matches; reject and rewrite_prefix are " ++
+                "request-side only.",
+            .min_items = 1,
+        },
+    };
+};
+
+pub const ResponseMatchJson = struct {
+    status: ?[]const u16 = null,
+    status_class: ?[]const u8 = null,
+    headers: ?[]const HeaderMatchJson = null,
+
+    pub const schema_doc = "Response-match predicate; every absent field matches anything.";
+    pub const schema_fields = .{
+        .status = .{
+            .desc = "Exact response status codes to match; absent matches any status.",
+            .min_items = 1,
+            .minimum = 100,
+            .maximum = 599,
+        },
+        .status_class = .{
+            .desc = "Response status class to match (\"1xx\" through \"5xx\"); " ++
+                "absent matches any class.",
+            .enum_type = filter.StatusClass,
+        },
+        .headers = .{ .desc = "Response-header predicates; all must match." },
     };
 };
 
@@ -1436,11 +1503,12 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// block below runs `assert_meta_matches` on each at comptime, so the
 /// metadata cannot drift from the fields whether or not the emitter builds.
 pub const dto_types = .{
-    ConfigJson,    ListenerJson,      RouteJson,                FilterJson,
-    MatchJson,     HeaderMatchJson,   ActionJson,               HeaderEditJson,
-    RewriteJson,   ClusterJson,       TimeoutsJson,             LimitsJson,
-    AdminJson,     AccessLogJson,     CheckJson,                ClusterHashJson,
-    ForwardedJson, ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
+    ConfigJson,         ListenerJson,      RouteJson,                FilterJson,
+    MatchJson,          HeaderMatchJson,   ActionJson,               HeaderEditJson,
+    RewriteJson,        ClusterJson,       TimeoutsJson,             LimitsJson,
+    AdminJson,          AccessLogJson,     CheckJson,                ClusterHashJson,
+    ForwardedJson,      ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
+    ResponseFilterJson, ResponseMatchJson,
 };
 
 comptime {
@@ -1615,6 +1683,7 @@ fn resolveListeners(
             .bind_address = bind_address,
             .routes = try resolveRoutes(arena, &listener_json, clusters, protocol, head_buffer_bytes),
             .request_filters = try resolveRequestFilters(arena, &listener_json, protocol, head_buffer_bytes),
+            .response_filters = try resolveResponseFilters(arena, &listener_json, protocol),
             .protocol = protocol,
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
             .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
@@ -1727,6 +1796,129 @@ fn countHeaderEdits(actions: []const filter.Action) u32 {
     return count;
 }
 
+/// Compile a listener's `response_filters` (#175): matches over the
+/// origin's response, actions restricted to the three header verbs.
+/// The edits compile straight to the renderer's flattened
+/// `AppliedHeaderEdit` contract — there is no reject to interleave, so
+/// the `Action` union has nothing to carry — and the whole table's edit
+/// count is capped like the request side's, since one response applies
+/// every matched rule's edits from a single fixed buffer.
+fn resolveResponseFilters(
+    arena: std.mem.Allocator,
+    listener_json: *const ListenerJson,
+    protocol: Config.Listener.Protocol,
+) ParseError![]const filter.ResponseRule {
+    const rules_json = listener_json.response_filters orelse return &.{};
+    // The same rejection as `request_filters`: an l4 relay has no
+    // response head to edit, so the key — populated or vacuously empty —
+    // describes a proxy that is not running.
+    if (protocol == .l4) {
+        return error.ListenerL4ResponseFilters;
+    }
+    if (rules_json.len == 0) {
+        return &.{};
+    }
+    const rules = try arena.alloc(filter.ResponseRule, rules_json.len);
+    var header_edits: u32 = 0;
+    for (rules_json, rules) |rule_json, *rule| {
+        rule.* = .{
+            .match = try resolveResponseMatch(arena, &rule_json.match),
+            .edits = try resolveResponseEdits(arena, rule_json.actions),
+        };
+        header_edits += @intCast(rule.edits.len);
+    }
+    if (header_edits > constants.header_edits_max) {
+        return error.ResponseFilterHeaderEditsOverLimit;
+    }
+    assert(header_edits <= constants.header_edits_max);
+    assert(rules.len == rules_json.len);
+    return rules;
+}
+
+fn resolveResponseMatch(
+    arena: std.mem.Allocator,
+    match_json: *const ResponseMatchJson,
+) ParseError!filter.ResponseMatch {
+    var match: filter.ResponseMatch = .{};
+    if (match_json.status) |statuses_json| {
+        // An explicitly empty list is a mistake, not "any" — absence
+        // already says that, unambiguously (the `FilterMethodEmpty`
+        // rule).
+        if (statuses_json.len == 0) {
+            return error.ResponseFilterStatusEmpty;
+        }
+        const statuses = try arena.alloc(u16, statuses_json.len);
+        for (statuses_json, statuses) |status, *slot| {
+            // The parser only ever produces 100..599 (§7), so a value
+            // outside it is a rule that can never fire — a typo, told at
+            // load rather than left silently inert.
+            if (status < 100 or status > 599) {
+                return error.ResponseFilterStatusInvalid;
+            }
+            slot.* = status;
+        }
+        match.statuses = statuses;
+    }
+    if (match_json.status_class) |literal| {
+        const class = std.meta.stringToEnum(filter.StatusClass, literal) orelse
+            return error.ResponseFilterStatusClassUnknown;
+        match.status_class = @intFromEnum(class);
+        // The digit contract `responseMatches` asserts on its side of
+        // the seam, proven where it is produced.
+        assert(match.status_class.? >= 1);
+        assert(match.status_class.? <= 5);
+    }
+    if (match_json.headers) |headers_json| {
+        match.headers = try resolveHeaderMatches(arena, headers_json);
+    }
+    return match;
+}
+
+/// Resolve a response rule's actions: the same `ActionJson` vocabulary
+/// the request side reads — one muscle memory — with the two arms that
+/// have no meaning on the way out rejected by their own names, so an
+/// operator reaching for `reject` on a response is told which idea does
+/// not transfer rather than handed a generic kind error.
+fn resolveResponseEdits(
+    arena: std.mem.Allocator,
+    actions_json: []const ActionJson,
+) ParseError![]const filter.AppliedHeaderEdit {
+    if (actions_json.len == 0) {
+        return error.FilterActionsEmpty;
+    }
+    assert(actions_json.len >= 1); // Past the empty guard.
+    const edits = try arena.alloc(filter.AppliedHeaderEdit, actions_json.len);
+    for (actions_json, edits) |action_json, *edit| {
+        edit.* = try resolveResponseEdit(&action_json);
+    }
+    assert(edits.len == actions_json.len);
+    return edits;
+}
+
+fn resolveResponseEdit(action_json: *const ActionJson) ParseError!filter.AppliedHeaderEdit {
+    // The shared kind fork runs before the arm rejections, so a
+    // two-kind object is a kind error here too, never a misleading
+    // arm one.
+    try requireOneActionKind(action_json);
+    if (action_json.reject != null) {
+        return error.ResponseFilterReject;
+    }
+    if (action_json.rewrite_prefix != null) {
+        return error.ResponseFilterRewrite;
+    }
+    if (action_json.header_set) |edit| {
+        const resolved = try resolveHeaderEdit(&edit);
+        return .{ .kind = .set, .name = resolved.name, .value = resolved.value };
+    }
+    if (action_json.header_add) |edit| {
+        const resolved = try resolveHeaderEdit(&edit);
+        return .{ .kind = .add, .name = resolved.name, .value = resolved.value };
+    }
+    const name = action_json.header_remove.?;
+    try validateEditableHeaderName(name);
+    return .{ .kind = .remove, .name = name, .value = "" };
+}
+
 fn resolveMatch(
     arena: std.mem.Allocator,
     match_json: *const MatchJson,
@@ -1815,8 +2007,10 @@ fn resolveActions(
     return actions;
 }
 
-fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseError!filter.Action {
-    // Exactly one action field carries the kind.
+/// Exactly one action field may carry the kind — the "exactly one of"
+/// fork both action resolvers share, so a sixth kind cannot be counted
+/// in one table and forgotten in the other.
+fn requireOneActionKind(action_json: *const ActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
         @intFromBool(action_json.header_set != null) +
         @intFromBool(action_json.header_add != null) +
@@ -1826,6 +2020,11 @@ fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseEr
     if (set != 1) {
         return error.FilterActionKind;
     }
+    assert(set == 1);
+}
+
+fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseError!filter.Action {
+    try requireOneActionKind(action_json);
     if (action_json.reject) |status| {
         if (!filter.isRejectStatus(status)) {
             return error.FilterRejectStatus;
@@ -2793,6 +2992,97 @@ test "config: a filter set over the header-edit budget is rejected" {
     const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"cluster\":\"a\",\"request_filters\":[" ++ rules ++ "]}]," ++ tail;
     try expectParseError(error.FilterHeaderEditsOverLimit, json);
+}
+
+test "config: response filters compile into rules with matches and edits" {
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","response_filters":[
+        \\   {"actions":[{"header_remove":"Server"},
+        \\               {"header_set":{"name":"Strict-Transport-Security","value":"max-age=63072000"}}]},
+        \\   {"match":{"status_class":"5xx"},
+        \\    "actions":[{"header_set":{"name":"Retry-After","value":"1"}}]},
+        \\   {"match":{"status":[301,302],"headers":[{"name":"Location","contains":"http:"}]},
+        \\    "actions":[{"header_add":{"name":"X-Insecure-Redirect","value":"1"}}]}
+        \\ ]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const rules = parsed.listeners[0].response_filters;
+    try std.testing.expectEqual(@as(usize, 3), rules.len);
+    // The unconditional rule: an all-empty match, edits flattened to the
+    // renderer's contract in action order — no `Action` union on the way
+    // out, because there is no reject to interleave.
+    try std.testing.expectEqual(@as(usize, 0), rules[0].match.statuses.len);
+    try std.testing.expectEqual(@as(?u8, null), rules[0].match.status_class);
+    try std.testing.expectEqual(@as(usize, 2), rules[0].edits.len);
+    try std.testing.expectEqual(filter.AppliedHeaderEdit.Kind.remove, rules[0].edits[0].kind);
+    try std.testing.expectEqualStrings("Server", rules[0].edits[0].name);
+    try std.testing.expectEqual(filter.AppliedHeaderEdit.Kind.set, rules[0].edits[1].kind);
+    // The class spelling compiles to its digit.
+    try std.testing.expectEqual(@as(?u8, 5), rules[1].match.status_class);
+    // Exact statuses and response-header predicates ride the request
+    // side's own vocabularies.
+    try std.testing.expectEqualSlices(u16, &.{ 301, 302 }, rules[2].match.statuses);
+    try std.testing.expectEqual(filter.HeaderMatch.Kind.contains, rules[2].match.headers[0].kind);
+    try std.testing.expectEqual(filter.AppliedHeaderEdit.Kind.add, rules[2].edits[0].kind);
+    // The request-side table stays independent: none was configured.
+    try std.testing.expectEqual(@as(usize, 0), parsed.listeners[0].request_filters.len);
+}
+
+test "config: response filter schema rejects what has no meaning on the way out" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"response_filters\":[";
+    // The two request-side arms are rejected by their own names, so an
+    // operator is told which idea does not transfer.
+    try expectParseError(error.ResponseFilterReject, head ++ "{\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.ResponseFilterRewrite, head ++ "{\"actions\":[{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b\"}}]}]}]," ++ tail);
+    // A two-kind action is still a kind error, never a misleading arm one.
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"reject\":403,\"header_remove\":\"X\"}]}]}]," ++ tail);
+    try expectParseError(error.FilterActionsEmpty, head ++ "{\"actions\":[]}]}]," ++ tail);
+    // A status the parser can never produce is a rule that can never
+    // fire — a typo, told at load.
+    try expectParseError(error.ResponseFilterStatusInvalid, head ++ "{\"match\":{\"status\":[99]},\"actions\":[{\"header_remove\":\"X\"}]}]}]," ++ tail);
+    try expectParseError(error.ResponseFilterStatusInvalid, head ++ "{\"match\":{\"status\":[600]},\"actions\":[{\"header_remove\":\"X\"}]}]}]," ++ tail);
+    // An explicitly empty status list is a mistake — absence already
+    // says "any", unambiguously.
+    try expectParseError(error.ResponseFilterStatusEmpty, head ++ "{\"match\":{\"status\":[]},\"actions\":[{\"header_remove\":\"X\"}]}]}]," ++ tail);
+    try expectParseError(error.ResponseFilterStatusClassUnknown, head ++ "{\"match\":{\"status_class\":\"6xx\"},\"actions\":[{\"header_remove\":\"X\"}]}]}]," ++ tail);
+    // The proxy-managed names hold on the way out too: hand-written
+    // framing would desynchronise the relay.
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"Content-Length\",\"value\":\"0\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_remove\":\"connection\"}]}]}]," ++ tail);
+    // L4 listeners may not carry the key, populated or vacuously empty.
+    try expectParseError(error.ListenerL4ResponseFilters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"response_filters\":[{\"actions\":[{\"header_remove\":\"Server\"}]}]}]," ++ tail);
+    try expectParseError(error.ListenerL4ResponseFilters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"response_filters\":[]}]," ++ tail);
+}
+
+test "config: a response filter set over the header-edit budget is rejected" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    // Same whole-table cap as the request side, on its own error name:
+    // one response applies every matched rule's edits from one fixed
+    // buffer, so the total is what must fit.
+    const rules = comptime blk: {
+        var s: []const u8 = "";
+        var edit: u16 = 0;
+        while (edit < constants.header_edits_max + 1) : (edit += 1) {
+            if (edit != 0) s = s ++ ",";
+            s = s ++ "{\"actions\":[{\"header_remove\":\"X-Drop\"}]}";
+        }
+        break :blk s;
+    };
+    const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
+        "\"cluster\":\"a\",\"response_filters\":[" ++ rules ++ "]}]," ++ tail;
+    try expectParseError(error.ResponseFilterHeaderEditsOverLimit, json);
 }
 
 test "config: cluster pick policy parses, defaults to p2c, rejects typos" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -148,10 +148,10 @@ pub const Config = struct {
         /// listeners always have exactly that one route (no path to
         /// match). Matched by `http/router.zig`.
         routes: []const router.Route,
-        /// The §7 filter rules, in config order (evaluated top-down).
-        /// Empty on the L4 path and whenever no `"filters"` were given.
+        /// The §7 request filter rules, in config order (evaluated top-down).
+        /// Empty on the L4 path and whenever no `"request_filters"` were given.
         /// Compiled and interpreted by `http/filter.zig`.
-        filters: []const filter.Rule = &.{},
+        request_filters: []const filter.Rule = &.{},
         protocol: Protocol,
         /// How this listener tells the origin who the client is (§7), or
         /// null to leave `X-Forwarded-For` exactly as it arrived — the
@@ -367,7 +367,7 @@ pub const ValidationError = error{
     RoutePrefixNotCanonical,
     RouteHostNotCanonical,
     RouteDuplicate,
-    ListenerL4Filters,
+    ListenerL4RequestFilters,
     ListenerL4Forwarded,
     ListenerForwardedModeUnknown,
     ListenerHttpProxyProtocol,
@@ -839,8 +839,8 @@ pub const ListenerJson = struct {
     /// `routes` (an explicit §7 path table) must be present.
     cluster: ?[]const u8 = null,
     routes: ?[]const RouteJson = null,
-    /// Optional §7 filter rules; absent means none. HTTP-only.
-    filters: ?[]const FilterJson = null,
+    /// Optional §7 request filter rules; absent means none. HTTP-only.
+    request_filters: ?[]const FilterJson = null,
     /// Optional: absent means `l4`, keeping pre-L7 configs valid.
     protocol: []const u8 = "l4",
     /// Optional §7 client-address forwarding; absent leaves the header
@@ -860,7 +860,7 @@ pub const ListenerJson = struct {
             .desc = "Explicit longest-prefix route table (http listeners only).",
             .min_items = 1,
         },
-        .filters = .{
+        .request_filters = .{
             .desc = "Request filter rules, evaluated top-down (http listeners only).",
         },
         .protocol = .{
@@ -1614,7 +1614,7 @@ fn resolveListeners(
         listeners[index] = .{
             .bind_address = bind_address,
             .routes = try resolveRoutes(arena, &listener_json, clusters, protocol, head_buffer_bytes),
-            .filters = try resolveFilters(arena, &listener_json, protocol, head_buffer_bytes),
+            .request_filters = try resolveRequestFilters(arena, &listener_json, protocol, head_buffer_bytes),
             .protocol = protocol,
             .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
             .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
@@ -1671,18 +1671,18 @@ fn bindOrder(address: std.Io.net.IpAddress) u160 {
 /// keys are validated canonical so a filter and the router agree
 /// byte-for-byte, and each action is validated at load, so the request-
 /// time interpreter is bounded loops over trusted data.
-fn resolveFilters(
+fn resolveRequestFilters(
     arena: std.mem.Allocator,
     listener_json: *const ListenerJson,
     protocol: Config.Listener.Protocol,
     head_buffer_bytes: u32,
 ) ParseError![]const filter.Rule {
-    const filters_json = listener_json.filters orelse return &.{};
-    // Any `filters` key on an l4 listener is a mistake — l4 relays bytes,
+    const filters_json = listener_json.request_filters orelse return &.{};
+    // Any `request_filters` key on an l4 listener is a mistake — l4 relays bytes,
     // there is no head to match on — so reject it whether the array is
     // populated or (vacuously) empty, before the empty-array shortcut.
     if (protocol == .l4) {
-        return error.ListenerL4Filters;
+        return error.ListenerL4RequestFilters;
     }
     if (filters_json.len == 0) {
         return &.{};
@@ -2155,7 +2155,7 @@ fn resolveMaxInflight(max_inflight: ?u32) ParseError!?u32 {
 /// a `forwarded` block on an `l4` listener is rejected rather than
 /// ignored — a byte relay has no header to carry an address, so asking
 /// for one there describes a proxy that is not running, exactly like
-/// `filters` and `routes` on the same listener.
+/// `request_filters` and `routes` on the same listener.
 fn resolveForwarded(
     forwarded_json: ?ForwardedJson,
     protocol: Config.Listener.Protocol,
@@ -2692,7 +2692,7 @@ test "config: filters compile into rules with matches and actions" {
     var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
     const parsed = try expectParseOk(&arena_state,
-        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","filters":[
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","request_filters":[
         \\   {"match":{"method":["GET","POST"],"path_prefix":"/admin",
         \\             "headers":[{"name":"X-Env","equals":"prod"}]},
         \\    "actions":[{"reject":403}]},
@@ -2702,7 +2702,7 @@ test "config: filters compile into rules with matches and actions" {
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
     );
-    const filters = parsed.listeners[0].filters;
+    const filters = parsed.listeners[0].request_filters;
     try std.testing.expectEqual(@as(usize, 2), filters.len);
 
     // Rule 0: method set + path prefix + one header-equals match, reject 403.
@@ -2731,14 +2731,14 @@ test "config: filter schema rejects malformed rules" {
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
     ;
-    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"filters\":[";
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"request_filters\":[";
     // L4 listener may not carry filters.
-    try expectParseError(error.ListenerL4Filters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
-        "\"filters\":[{\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.ListenerL4RequestFilters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"request_filters\":[{\"actions\":[{\"reject\":403}]}]}]," ++ tail);
     // Even a vacuously empty filters array on l4 is a mistake — the key is
     // meaningless there, and an empty array must not slip past the guard.
-    try expectParseError(error.ListenerL4Filters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
-        "\"filters\":[]}]," ++ tail);
+    try expectParseError(error.ListenerL4RequestFilters, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"l4\",\"cluster\":\"a\"," ++
+        "\"request_filters\":[]}]," ++ tail);
     // A rule with no actions.
     try expectParseError(error.FilterActionsEmpty, head ++ "{\"actions\":[]}]}]," ++ tail);
     // An action object with no kind set.
@@ -2791,7 +2791,7 @@ test "config: a filter set over the header-edit budget is rejected" {
         break :blk s;
     };
     const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
-        "\"cluster\":\"a\",\"filters\":[" ++ rules ++ "]}]," ++ tail;
+        "\"cluster\":\"a\",\"request_filters\":[" ++ rules ++ "]}]," ++ tail;
     try expectParseError(error.FilterHeaderEditsOverLimit, json);
 }
 
@@ -3239,7 +3239,7 @@ test "config: a table far past the old caps parses, and is bounded only by itsel
                 "\"actions\":[{\"reject\":404}]}";
         }
         break :blk "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
-            "\"routes\":[" ++ routes ++ "],\"filters\":[" ++ filters ++ "]}]," ++
+            "\"routes\":[" ++ routes ++ "],\"request_filters\":[" ++ filters ++ "]}]," ++
             "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
             "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
     };
@@ -3247,7 +3247,7 @@ test "config: a table far past the old caps parses, and is bounded only by itsel
     defer arena_state.deinit();
     const parsed = try expectParseOk(&arena_state, json);
     try std.testing.expectEqual(@as(usize, route_count), parsed.listeners[0].routes.len);
-    try std.testing.expectEqual(@as(usize, route_count), parsed.listeners[0].filters.len);
+    try std.testing.expectEqual(@as(usize, route_count), parsed.listeners[0].request_filters.len);
 }
 
 test "config: strictness rejects unknown and duplicate fields" {
@@ -3851,7 +3851,7 @@ test "config: the forwarded block resolves a mode, and is http-only" {
     }
 
     // An l4 listener has no header to carry an address, so asking for one
-    // describes a proxy that is not running — rejected, like `filters`.
+    // describes a proxy that is not running — rejected, like `request_filters`.
     try expectParseError(
         error.ListenerL4Forwarded,
         head ++ ",\"forwarded\":{\"mode\":\"replace\"}" ++ tail,
@@ -3973,7 +3973,7 @@ test "config: a filter may not name the header zoxy manages" {
     // encodes one fixed address for every client — it looks like client
     // forwarding and is the opposite of it. Reserved unconditionally, not
     // only on listeners that set it, so one mechanism owns the header.
-    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"filters\":[";
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"request_filters\":[";
     const tail = "]}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
         "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
 
@@ -3992,6 +3992,6 @@ test "config: a filter may not name the header zoxy manages" {
         defer arena_state.deinit();
         const parsed = try expectParseOk(&arena_state, head ++
             "{\"actions\":[{\"header_set\":{\"name\":\"X-Forwarded-Proto\",\"value\":\"https\"}}]}" ++ tail);
-        try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].filters.len);
+        try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].request_filters.len);
     }
 }

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -235,6 +235,18 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
                 try out.write("string");
             }
         },
+        // An integer element (the response-match `status` list, #175):
+        // the bounds come from the field's own metadata, exactly as a
+        // scalar integer field's do.
+        .int => {
+            comptime assert(meta.minimum <= meta.maximum);
+            try out.objectField("type");
+            try out.write("integer");
+            try out.objectField("minimum");
+            try out.write(meta.minimum);
+            try out.objectField("maximum");
+            try out.write(meta.maximum);
+        },
         else => comptime unreachable,
     }
 }
@@ -430,6 +442,33 @@ test "config_schema: endpoint items accept both spellings" {
         weight.get("maximum").?.integer,
     );
     try std.testing.expectEqual(@as(i64, 0), weight.get("minimum").?.integer);
+}
+
+test "config_schema: response filter status bounds and class vocabulary" {
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer parsed.deinit();
+
+    const listener = parsed.value.object.get("properties").?.object
+        .get("listeners").?.object.get("items").?.object;
+    const response_filters = listener.get("properties").?.object
+        .get("response_filters").?.object;
+    const match = response_filters.get("items").?.object.get("properties").?.object
+        .get("match").?.object;
+    // The status list's items carry the loader's own bounds — the schema
+    // cannot promise a status the parser can never produce.
+    const status_items = match.get("properties").?.object
+        .get("status").?.object.get("items").?.object;
+    try std.testing.expectEqualStrings("integer", status_items.get("type").?.string);
+    try std.testing.expectEqual(@as(i64, 100), status_items.get("minimum").?.integer);
+    try std.testing.expectEqual(@as(i64, 599), status_items.get("maximum").?.integer);
+    // The class vocabulary is the closed enum, "1xx" through "5xx".
+    const class_values = match.get("properties").?.object
+        .get("status_class").?.object.get("enum").?.array;
+    try std.testing.expectEqual(@as(usize, 5), class_values.items.len);
+    try std.testing.expectEqualStrings("1xx", class_values.items[0].string);
+    try std.testing.expectEqualStrings("5xx", class_values.items[4].string);
 }
 
 test "config_schema: the method enum matches what the parser accepts" {

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -90,6 +90,109 @@ pub const AppliedHeaderEdit = struct {
     pub const Kind = enum(u8) { set, add, remove };
 };
 
+/// A response rule's match (#175): a conjunction over the origin's
+/// response, mirroring `Match`'s "every present predicate must hold" —
+/// an all-empty match is an unconditional rule. There is no method, host
+/// or path here: those are request facts, and a response rule runs after
+/// an await against the parsed *response* head only.
+pub const ResponseMatch = struct {
+    /// Exact statuses the rule applies to; empty = any status.
+    statuses: []const u16 = &.{},
+    /// A status class (the "5xx" spelling), or null for any. Compiled to
+    /// the class digit so the check is one integer divide.
+    status_class: ?u8 = null,
+    headers: []const HeaderMatch = &.{},
+};
+
+/// The `status_class` vocabulary (#175): the five RFC 9110 classes, field
+/// names being the JSON tokens exactly as `Pick`'s are. The loader
+/// resolves one to its digit; the schema emits the closed set.
+pub const StatusClass = enum(u8) {
+    @"1xx" = 1,
+    @"2xx" = 2,
+    @"3xx" = 3,
+    @"4xx" = 4,
+    @"5xx" = 5,
+};
+
+/// One compiled response rule (#175). The actions compile straight to
+/// the renderer's `AppliedHeaderEdit` contract rather than to `Action`:
+/// reject and rewrite have no meaning on the way out, so the response
+/// action set is exactly the three header verbs, and the load-time
+/// rejection of the other arms is what lets this skip the union.
+pub const ResponseRule = struct {
+    match: ResponseMatch,
+    edits: []const AppliedHeaderEdit,
+};
+
+/// The parsed response head a response rule matches against: the status
+/// the origin answered and its headers (zero-copy slices, the request
+/// side's own `parser.Header` shape).
+pub const ResponseView = struct {
+    status: u16,
+    headers: []const parser.Header,
+};
+
+/// One pass over the response rules (#175), gathering every matched
+/// rule's edits in rule-then-action order — `collectForward`'s shape
+/// minus the concerns that do not exist on the way out (no reject: it
+/// ran request-side; no rewrite: there is no path). The caller sizes
+/// `out` at `header_edits_max`, which config caps a listener's response
+/// edits at, so a matching subset always fits. Bounded loops over
+/// immutable arena data; no allocation.
+pub fn collectResponseEdits(
+    rules: []const ResponseRule,
+    view: ResponseView,
+    out: []AppliedHeaderEdit,
+) []const AppliedHeaderEdit {
+    assert(out.len <= constants.header_edits_max);
+    var count: usize = 0;
+    for (rules) |rule| {
+        if (!responseMatches(rule.match, view)) {
+            continue;
+        }
+        for (rule.edits) |edit| {
+            assert(count < out.len);
+            out[count] = edit;
+            count += 1;
+        }
+    }
+    assert(count <= out.len);
+    return out[0..count];
+}
+
+/// Whether a response rule's conjunction holds. No assertion on the
+/// status's range: it is the origin's byte sequence, and a 999 from a
+/// misbehaving origin must fail predicates, not the proxy — 999/100 is
+/// 9, which equals no class.
+fn responseMatches(match: ResponseMatch, view: ResponseView) bool {
+    assert(view.headers.len <= constants.headers_max);
+    if (match.statuses.len >= 1) {
+        var found = false;
+        for (match.statuses) |status| {
+            if (status == view.status) {
+                found = true;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    if (match.status_class) |class| {
+        assert(class >= 1);
+        assert(class <= 5);
+        if (view.status / 100 != class) {
+            return false;
+        }
+    }
+    for (match.headers) |header_match| {
+        if (!headerMatches(header_match, view.headers)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /// The statuses a `reject` action may name — a subset of the §8 static
 /// responses that make sense as a policy verdict. This array is the single
 /// source of truth: config rejects any other value at load, the proxy's
@@ -547,6 +650,76 @@ test "filter: rewritePath is a segment-correct prefix replacement" {
         const recanon = try parser.canonicalTarget(got, &canon);
         try std.testing.expectEqualStrings(got, recanon.path);
     }
+}
+
+test "filter: response rules match on status, class and headers" {
+    const H = parser.Header;
+    const rules = [_]ResponseRule{
+        // Unconditional: every response sheds its Server header.
+        .{ .match = .{}, .edits = &.{
+            .{ .kind = .remove, .name = "Server", .value = "" },
+        } },
+        // Class-scoped: 5xx answers advertise a retry.
+        .{ .match = .{ .status_class = 5 }, .edits = &.{
+            .{ .kind = .set, .name = "Retry-After", .value = "1" },
+        } },
+        // Exact statuses and a header predicate, conjoined.
+        .{ .match = .{
+            .statuses = &.{ 301, 302 },
+            .headers = &.{.{ .name = "Location", .kind = .contains, .value = "http:" }},
+        }, .edits = &.{
+            .{ .kind = .add, .name = "X-Insecure-Redirect", .value = "1" },
+        } },
+    };
+    var out: [constants.header_edits_max]AppliedHeaderEdit = undefined;
+
+    // A 200 matches only the unconditional rule.
+    const ok = collectResponseEdits(&rules, .{ .status = 200, .headers = &.{} }, &out);
+    try std.testing.expectEqual(@as(usize, 1), ok.len);
+    try std.testing.expectEqualStrings("Server", ok[0].name);
+
+    // A 503 gathers the unconditional and the class rule, in rule order.
+    const shed = collectResponseEdits(&rules, .{ .status = 503, .headers = &.{} }, &out);
+    try std.testing.expectEqual(@as(usize, 2), shed.len);
+    try std.testing.expectEqualStrings("Retry-After", shed[1].name);
+    // The class boundaries are the RFC's: 499 is not a 5xx, 599 is.
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        collectResponseEdits(&rules, .{ .status = 499, .headers = &.{} }, &out).len,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        collectResponseEdits(&rules, .{ .status = 599, .headers = &.{} }, &out).len,
+    );
+
+    // The third rule's conjunction: status in the exact list AND the
+    // header predicate. An https redirect keeps only the unconditional
+    // edit; an http one gains the marker; a 303 is off the list.
+    const insecure = [_]H{H.init("location", "http://x/")};
+    const secure = [_]H{H.init("Location", "https://x/")};
+    try std.testing.expectEqual(
+        @as(usize, 2),
+        collectResponseEdits(&rules, .{ .status = 301, .headers = &insecure }, &out).len,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        collectResponseEdits(&rules, .{ .status = 301, .headers = &secure }, &out).len,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        collectResponseEdits(&rules, .{ .status = 303, .headers = &insecure }, &out).len,
+    );
+}
+
+test "filter: the status-class vocabulary maps each token to its digit" {
+    // The enum's field names ARE the JSON tokens and its values the
+    // class digits — the loader leans on both, so pin the pairing.
+    try std.testing.expectEqual(@as(u8, 1), @intFromEnum(StatusClass.@"1xx"));
+    try std.testing.expectEqual(@as(u8, 2), @intFromEnum(StatusClass.@"2xx"));
+    try std.testing.expectEqual(@as(u8, 3), @intFromEnum(StatusClass.@"3xx"));
+    try std.testing.expectEqual(@as(u8, 4), @intFromEnum(StatusClass.@"4xx"));
+    try std.testing.expectEqual(@as(u8, 5), @intFromEnum(StatusClass.@"5xx"));
+    try std.testing.expectEqual(@as(usize, 5), @typeInfo(StatusClass).@"enum".fields.len);
 }
 
 test "filter: rewritePath reports Oversize when the result would not fit" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -435,7 +435,7 @@ pub fn Proxy(comptime IoType: type) type {
         ) error{Oversize}!Forwarded {
             const base = views.forward;
             assert(base.path.len >= 1);
-            if (conn.filters.len == 0) {
+            if (conn.request_filters.len == 0) {
                 return .{ .target = base, .edits = &.{} };
             }
             // The canonical *host* is still recomputed here, unlike the
@@ -460,7 +460,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .headers = request.headers,
             };
             // One scan yields both the rewrite and the header edits (§7).
-            const forward = filter.collectForward(conn.filters, view, edit_buffer);
+            const forward = filter.collectForward(conn.request_filters, view, edit_buffer);
             // Rewrite only origin-form targets; asterisk-form names no path.
             var target = base;
             if (views.origin_form) {
@@ -578,7 +578,7 @@ pub fn Proxy(comptime IoType: type) type {
             captureTarget(conn, keys.host, keys.views.match);
             // §7 filters run before routing: a policy reject stops the
             // request whether or not it would have routed.
-            if (filter.firstReject(conn.filters, .{
+            if (filter.firstReject(conn.request_filters, .{
                 .method = request.method,
                 .host = keys.host,
                 .path = keys.views.match,

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1343,6 +1343,24 @@ pub fn Proxy(comptime IoType: type) type {
         /// head has vacated it) and forward the coalesced body excess
         /// straight from upstream.head — never copied through a relay
         /// buffer, so an oversized coalesced body is fine.
+        /// The #175 response edits for this exchange, gathered into the
+        /// caller's buffer: matched against the status and headers the
+        /// origin actually answered, and consumed by the render in the
+        /// same frame — the request side's `edit_buffer` discipline,
+        /// isolated here the way `planForward` isolates its half.
+        fn responseEdits(
+            conn: *const ConnType,
+            response: *const parser.ResponseHead,
+            out: []filter.AppliedHeaderEdit,
+        ) []const filter.AppliedHeaderEdit {
+            assert(out.len == constants.header_edits_max);
+            assert(conn.state == .l7_exchanging);
+            return filter.collectResponseEdits(conn.response_filters, .{
+                .status = response.status,
+                .headers = response.headers,
+            }, out);
+        }
+
         fn renderResponse(
             server: *ServerType,
             conn: *ConnType,
@@ -1356,11 +1374,17 @@ pub fn Proxy(comptime IoType: type) type {
             const keep_downstream = downstreamKeepAlive(server, conn, response);
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
+            var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
             const rendered = render.renderResponseHead(
                 response,
                 !keep_downstream,
+                responseEdits(conn, response, &edit_buffer),
                 headBytes(server, conn),
             ) catch {
+                // The head no longer fits — after the #175 edits, or
+                // never did: an origin response the proxy cannot
+                // re-render is not the client's fault, so 502, the
+                // same verdict an unparseable origin head earns.
                 upstreamFailed(server, conn);
                 return;
             };

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -2,11 +2,13 @@
 //! *rendered* into a fixed staging buffer, never edited in place — the
 //! zero-copy slices of the source head stay valid throughout. Rendering
 //! strips hop-by-hop headers both ways (RFC 9110 §7.6.1), injects
-//! `Connection: close` when the proxy will close, and applies the §7
-//! filter header edits that matched the request. A head that no longer
-//! fits after rendering is oversize — 431 downstream, teardown upstream
-//! (§7) — which now includes a head that outgrows the buffer only once the
-//! edits are applied (the oversize-after-edits verdict).
+//! `Connection: close` when the proxy will close, and applies the filter
+//! header edits that matched — the §7 request rules on the way in, the
+//! #175 response rules on the way out, through one suppress-and-append
+//! mechanism. A head that no longer fits after rendering is oversize:
+//! 431 for a request (the client sent it), 502 for a response (the
+//! origin's answer is not the client's fault) — including a head that
+//! outgrows the buffer only once the edits are applied.
 
 const std = @import("std");
 const constants = @import("../constants.zig");
@@ -144,14 +146,21 @@ pub fn renderRequestHead(
 /// Renders the downstream status line and end-to-end headers. The
 /// origin's version and reason phrase are preserved verbatim;
 /// `inject_close` announces that the proxy will close the downstream
-/// connection after this response (§7).
+/// connection after this response (§7). `edits` are the matched
+/// response filters' header edits (#175), applied by the same
+/// suppress-and-append machinery the request render uses — empty when
+/// the listener configured none, which is most listeners. Overflow is
+/// the caller's 502: an origin response that cannot be re-rendered
+/// after edits is not the client's fault.
 pub fn renderResponseHead(
     response: *const parser.ResponseHead,
     inject_close: bool,
+    edits: []const filter.AppliedHeaderEdit,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     assert(response.status >= 100);
     assert(response.status <= 599);
+    assert(edits.len <= constants.header_edits_max);
     assert(buffer.len <= std.math.maxInt(u32));
 
     var staging = Staging{ .buffer = buffer };
@@ -165,12 +174,11 @@ pub fn renderResponseHead(
         try staging.append(message);
     }
     try staging.append("\r\n");
-    // Filters are request-side only (§7); the response carries no edits.
     try appendEndToEndHeaders(
         &staging,
         response.headers,
         response.connection_nominates_header,
-        &.{},
+        edits,
         false,
     );
     if (inject_close) {
@@ -584,17 +592,54 @@ test "render: response preserves status line and strips hop-by-hop" {
     const response = try parser.parseResponseHead(head, false, &storage, .get);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderResponseHead(&response, false, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderResponseHead(&response, true, &buffer);
+    const closed = try renderResponseHead(&response, true, &.{}, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n" ++
             "Connection: close\r\n\r\n",
         closed,
+    );
+}
+
+test "render: response edits suppress, replace and append (#175)" {
+    const head = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
+        "Server: origin/1.0\r\nX-Keep: yes\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const response = try parser.parseResponseHead(head, false, &storage, .get);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+
+    // A remove drops the origin's copy; a set replaces it at the append
+    // position; an add appends beside whatever survives — the same
+    // suppress-and-append machinery the request render proved.
+    const edits = [_]filter.AppliedHeaderEdit{
+        .{ .kind = .remove, .name = "server", .value = "" },
+        .{ .kind = .set, .name = "X-Keep", .value = "edited" },
+        .{ .kind = .add, .name = "Strict-Transport-Security", .value = "max-age=63072000" },
+    };
+    const rendered = try renderResponseHead(&response, false, &edits, &buffer);
+    try testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
+            "X-Keep: edited\r\n" ++
+            "Strict-Transport-Security: max-age=63072000\r\n\r\n",
+        rendered,
+    );
+
+    // The close injection lands after the edits, exactly as it lands
+    // after the origin's own headers.
+    const closed = try renderResponseHead(&response, true, &edits, &buffer);
+    try testing.expect(std.mem.endsWith(u8, closed, "Connection: close\r\n\r\n"));
+
+    // Growth from edits is a real overflow: the same head with an added
+    // header must report Oversize into a buffer sized for the original.
+    var tight: [head.len - 1]u8 = undefined;
+    try testing.expectError(
+        error.Oversize,
+        renderResponseHead(&response, false, &edits, &tight),
     );
 }
 
@@ -603,7 +648,7 @@ test "render: bare status line without a reason phrase round-trips" {
     const response = try parser.parseResponseHead("HTTP/1.0 204\r\n\r\n", false, &storage, .get);
     try testing.expectEqual(@as(?[]const u8, null), response.status_message);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderResponseHead(&response, false, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, &buffer);
     try testing.expectEqualStrings("HTTP/1.0 204\r\n\r\n", rendered);
 }
 
@@ -720,7 +765,7 @@ fn checkResponseRender(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
     const response = parser.parseResponseHead(input, false, &storage, .get) catch return;
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderResponseHead(&response, false, &buffer) catch unreachable;
+    const rendered = renderResponseHead(&response, false, &.{}, &buffer) catch unreachable;
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = parser.parseResponseHead(rendered, false, &reparse_storage, .get) catch unreachable;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -515,7 +515,7 @@ const Http1Bed = struct {
         /// The listener's §7 filter rules; empty by default so existing
         /// scenarios are unfiltered. A test supplies compiled rules to
         /// drive the filter reject/edit paths.
-        filters: []const filter.Rule = &.{},
+        request_filters: []const filter.Rule = &.{},
         /// The §7 client-address forwarding mode; null (the default)
         /// leaves `X-Forwarded-For` untouched, as every pre-existing
         /// scenario expects.
@@ -560,7 +560,7 @@ const Http1Bed = struct {
         bed.listeners = .{.{
             .bind_address = bindAddress(),
             .routes = &bed.routes,
-            .filters = options.filters,
+            .request_filters = options.request_filters,
             .protocol = .http,
             .forwarded = options.forwarded,
         }};
@@ -793,7 +793,7 @@ test "l7: a head that fits on arrival but not after forwarding is 431" {
         var bed: Http1Bed = undefined;
         try bed.setUp(std.testing.allocator, .{
             .seed = 5,
-            .filters = &rules,
+            .request_filters = &rules,
             .route_prefix = "/api",
             .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         });
@@ -817,7 +817,7 @@ test "l7: a head that fits on arrival but not after forwarding is 431" {
         var bed: Http1Bed = undefined;
         try bed.setUp(std.testing.allocator, .{
             .seed = 11,
-            .filters = &rules,
+            .request_filters = &rules,
             .route_prefix = "/r",
             .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         });
@@ -1048,7 +1048,7 @@ test "l7: a filter reject answers its policy status before the origin is dialed"
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 27,
-        .filters = &rules,
+        .request_filters = &rules,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
     });
     defer bed.tearDown();
@@ -1079,7 +1079,7 @@ test "l7: a request the filter does not match is proxied untouched" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 28,
-        .filters = &rules,
+        .request_filters = &rules,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
     });
     defer bed.tearDown();
@@ -1107,7 +1107,7 @@ test "l7: a filter reject survives 1-byte adversarial delivery across seeds" {
         try bed.setUp(std.testing.allocator, .{
             .seed = seed,
             .partial_io = true,
-            .filters = &rules,
+            .request_filters = &rules,
             .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         });
         defer bed.tearDown();
@@ -1374,7 +1374,7 @@ test "l7: a reject closes when the client pipelined the next request" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 62,
-        .filters = &rules,
+        .request_filters = &rules,
         .inbox_bytes = 4096,
     });
     defer bed.tearDown();
@@ -1411,7 +1411,7 @@ test "l7: a reject closes when the body has not arrived with the head" {
         try bed.setUp(std.testing.allocator, .{
             .seed = seed,
             .partial_io = true,
-            .filters = &rules,
+            .request_filters = &rules,
         });
         defer bed.tearDown();
 
@@ -1441,7 +1441,7 @@ test "l7: a drain closes a reject that would otherwise be kept" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 69,
-        .filters = &rules,
+        .request_filters = &rules,
         .send_delay_ms = 100,
     });
     defer bed.tearDown();
@@ -1479,7 +1479,7 @@ test "l7: relay pressure closes a reject that would otherwise be kept" {
         .seed = 68,
         .relay_buffers = 1,
         .origin_mute = true,
-        .filters = &rules,
+        .request_filters = &rules,
     });
     defer bed.tearDown();
 
@@ -1513,7 +1513,7 @@ test "l7: a reject closes when the request carries a body" {
         .actions = &.{.{ .reject = 403 }},
     }};
     var bed: Http1Bed = undefined;
-    try bed.setUp(std.testing.allocator, .{ .seed = 61, .filters = &rules });
+    try bed.setUp(std.testing.allocator, .{ .seed = 61, .request_filters = &rules });
     defer bed.tearDown();
 
     try bed.exchange("POST /admin HTTP/1.1\r\nHost: o\r\nContent-Length: 4\r\n\r\nbody");
@@ -1542,7 +1542,7 @@ test "l7: filter header edits reach the origin, applied once" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 29,
-        .filters = &rules,
+        .request_filters = &rules,
         .route_prefix = "/api",
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
     });
@@ -1581,7 +1581,7 @@ test "l7: a filter rewrite changes only the forwarded path, not the route" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 30,
-        .filters = &rules,
+        .request_filters = &rules,
         .route_prefix = "/old",
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
     });
@@ -1614,7 +1614,7 @@ test "l7: a header edit reaches the origin exactly once under adversarial delive
         try bed.setUp(std.testing.allocator, .{
             .seed = seed,
             .partial_io = true,
-            .filters = &rules,
+            .request_filters = &rules,
             .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         });
         defer bed.tearDown();
@@ -1644,7 +1644,7 @@ test "l7: a path rewrite forwards the rewritten path under adversarial delivery"
         try bed.setUp(std.testing.allocator, .{
             .seed = seed,
             .partial_io = true,
-            .filters = &rules,
+            .request_filters = &rules,
             .route_prefix = "/old",
             .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         });

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -512,10 +512,13 @@ const Http1Bed = struct {
         /// The single route's host scope; null is any-host. A canonical
         /// host lets a test drive host routing and its 404 (§7).
         route_host: ?[]const u8 = null,
-        /// The listener's §7 filter rules; empty by default so existing
-        /// scenarios are unfiltered. A test supplies compiled rules to
-        /// drive the filter reject/edit paths.
+        /// The listener's §7 request filter rules; empty by default so
+        /// existing scenarios are unfiltered. A test supplies compiled
+        /// rules to drive the filter reject/edit paths.
         request_filters: []const filter.Rule = &.{},
+        /// The listener's #175 response filter rules; empty by default
+        /// on the same terms.
+        response_filters: []const filter.ResponseRule = &.{},
         /// The §7 client-address forwarding mode; null (the default)
         /// leaves `X-Forwarded-For` untouched, as every pre-existing
         /// scenario expects.
@@ -561,6 +564,7 @@ const Http1Bed = struct {
             .bind_address = bindAddress(),
             .routes = &bed.routes,
             .request_filters = options.request_filters,
+            .response_filters = options.response_filters,
             .protocol = .http,
             .forwarded = options.forwarded,
         }};
@@ -2010,6 +2014,114 @@ test "l7: an origin head that no longer fits once the close is injected is 502" 
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
     try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
+    try bed.expectDrained();
+}
+
+test "l7: response filters edit the origin's head on the way out (#175)" {
+    // An unconditional rule sheds the Server banner and adds HSTS; a
+    // 5xx-scoped rule must stay silent on this 200. The whole rendered
+    // head is pinned byte-exact: origin order minus the removed header,
+    // the appended edit, then the close the request announced — proving
+    // the edits land between the origin's headers and the injection.
+    const rules = [_]filter.ResponseRule{
+        .{ .match = .{}, .edits = &.{
+            .{ .kind = .remove, .name = "Server", .value = "" },
+            .{ .kind = .add, .name = "Strict-Transport-Security", .value = "max-age=63072000" },
+        } },
+        .{ .match = .{ .status_class = 5 }, .edits = &.{
+            .{ .kind = .set, .name = "Retry-After", .value = "1" },
+        } },
+    };
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 21,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nServer: origin/1\r\n\r\nhi",
+        .response_filters = &rules,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n" ++
+            "Strict-Transport-Security: max-age=63072000\r\n" ++
+            "Connection: close\r\n\r\nhi",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: a 5xx-scoped response filter fires on the status that names it (#175)" {
+    // The issue's own deciding case: `header_set` on 5xx only. The same
+    // rule set as above, against an origin answering 503.
+    const rules = [_]filter.ResponseRule{
+        .{ .match = .{ .status_class = 5 }, .edits = &.{
+            .{ .kind = .set, .name = "Retry-After", .value = "1" },
+        } },
+    };
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 22,
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .response_filters = &rules,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // The origin's 503 forwards — a response filter edits, never
+    // rewrites the verdict — and the edit rides along.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            "Retry-After: 1\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try bed.expectDrained();
+}
+
+test "l7: an origin head that no longer fits after response edits is 502 (#175)" {
+    // The origin's head is legal and would render as-is; the configured
+    // edit adds bytes the buffer does not have. An origin response the
+    // proxy cannot re-render is not the client's fault — 502, the same
+    // verdict the close-injection overflow earns (#87).
+    const rules = [_]filter.ResponseRule{
+        .{ .match = .{}, .edits = &.{
+            .{ .kind = .add, .name = "Strict-Transport-Security", .value = "max-age=63072000" },
+        } },
+    };
+    const prefix = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nX-Pad: ";
+    const suffix = "\r\n\r\n";
+    // Ten bytes of slack: enough for the head itself, nowhere near the
+    // ~46 the edit appends.
+    var response_bytes: [constants.head_buffer_bytes_default - 10]u8 = undefined;
+    @memcpy(response_bytes[0..prefix.len], prefix);
+    @memset(
+        response_bytes[prefix.len..][0 .. response_bytes.len - prefix.len - suffix.len],
+        'p',
+    );
+    @memcpy(response_bytes[response_bytes.len - suffix.len ..][0..suffix.len], suffix);
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 23,
+        .origin_response = &response_bytes,
+        .response_filters = &rules,
+    });
+    defer bed.tearDown();
+
+    // Keep-alive request: no close injection, so the overflow is the
+    // edit's alone.
+    try bed.exchange("GET /pad HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
     try bed.expectDrained();
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -301,9 +301,14 @@ pub fn Conn(comptime IoType: type) type {
         /// it has no path to match. Set once at admission and constant for
         /// the connection's life, so it survives keep-alive turnarounds.
         routes: []const router.Route,
-        /// The listener's §7 filter rules, same lifetime as `routes`
-        /// (empty on L4 and when no filters are configured).
+        /// The listener's §7 request filter rules, same lifetime as
+        /// `routes` (empty on L4 and when no request filters are
+        /// configured).
         request_filters: []const filter.Rule,
+        /// The listener's #175 response filter rules, same lifetime:
+        /// matched against the origin's parsed response head at the
+        /// re-render (empty on L4 and when none are configured).
+        response_filters: []const filter.ResponseRule,
         /// The listener's §7 client-address forwarding mode, same lifetime
         /// as `routes`; null leaves `X-Forwarded-For` untouched.
         forwarded: ?config_module.Config.Listener.Forwarded,
@@ -595,6 +600,7 @@ pub fn Conn(comptime IoType: type) type {
             // listener's real tables (§7); L4 never reads them.
             conn.routes = &.{};
             conn.request_filters = &.{};
+            conn.response_filters = &.{};
             conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -303,7 +303,7 @@ pub fn Conn(comptime IoType: type) type {
         routes: []const router.Route,
         /// The listener's §7 filter rules, same lifetime as `routes`
         /// (empty on L4 and when no filters are configured).
-        filters: []const filter.Rule,
+        request_filters: []const filter.Rule,
         /// The listener's §7 client-address forwarding mode, same lifetime
         /// as `routes`; null leaves `X-Forwarded-For` untouched.
         forwarded: ?config_module.Config.Listener.Forwarded,
@@ -594,7 +594,7 @@ pub fn Conn(comptime IoType: type) type {
             // Placeholders until the admission tail installs the
             // listener's real tables (§7); L4 never reads them.
             conn.routes = &.{};
-            conn.filters = &.{};
+            conn.request_filters = &.{};
             conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;


### PR DESCRIPTION
Four slices, each gated by the full `zig build ci` (unit + fuzz corpus, 4096-seed sim, Tier-0.5 live gate) and a tiger-style review.

Closes #175.

## The config surface question, settled

The issue left open whether response rules should be a separate block or a scope marker on the existing rules. Separate block, and the issue's own example decides it: a response rule's deciding predicate is the response's **status** (`header_set` on 5xx only), which is temporally impossible to evaluate in a table that runs before any response exists. A shared table with a `scope` field would carry match fields that cannot be evaluated at their own application point — the conditionally-dead-fields hole this loader refuses everywhere else.

## What landed

- **`filters` → `request_filters`**, a hard rename with no alias: there are no deployed configs to migrate, the strict parser turns any stale spelling into a loud `UnknownField`, and the pair should read symmetrically from the first release that has both.
- **`response_filters`** beside it: matches on exact `status` codes, `status_class` (`"1xx"`–`"5xx"`), and response-header predicates — the request side's own header vocabulary, evaluated by the same code. Actions reuse `ActionJson` for one muscle memory, with `reject` and `rewrite_prefix` refused **by name** (`ResponseFilterReject` / `ResponseFilterRewrite`): an operator is told which idea does not transfer. The surviving three header verbs compile straight to the renderer's flattened contract — with no reject to interleave, there is nothing for the `Action` union to carry.
- **Application at the re-render**, through the same suppress-and-append machinery the request render proved — the response render already passed a hard-coded empty edit list to it, so the edits ride a render every response already paid for. Same `header_edits_max` bound on the table's total, same stack-buffer discipline per exchange.
- **Guardrails shared, not duplicated**: the proxy-managed names (`Content-Length`, `Transfer-Encoding`, `Connection` + hop-by-hop, `X-Forwarded-For`) stay barred by the same load-time validator in both directions — a hand-written `Content-Length` would desynchronise the relay.
- **Oversize after edits is 502, not 431** — an origin response the proxy cannot re-render is not the client's fault — and it takes the exact path the close-injection overflow already took. No new counter, deliberately: response edits reject nothing and shed nothing, and the render they ride is witnessed by `l7_responses`. DESIGN.md records that as a decision rather than an accident.

## Held from outside

The sim configures an always-on stamp plus a 5xx rule that can never legitimately fire, and its client oracle holds the boundary under all 4096 adversarial schedules: a 200 without the stamp means the edit path did not run; a static carrying it means the shed render grew filter edits; the 5xx rule's edit anywhere means the class predicate misfired. The live gate asserts both directions per listener on the real wire — the http leg must carry the stamp, and the l4 leg must **not**: byte transparency is that leg's whole claim, and it now has its own witness (the assertion exists because a naive version tripped on exactly that leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)