### PR TITLE
feat: filters match the client and answer redirects (#176, #177)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -381,8 +381,12 @@ only by the loop thread:
    (§4, single-shot buffer-select) arms with *no* buffer, and the kernel
    binds one from the registered ring only when the client actually
    speaks. Bound at the first byte of a request, returned at the
-   keep-alive turnaround, before a static response goes out, and at
-   teardown — so an idle connection holds no head bytes at all, an L4
+   keep-alive turnaround, before a static response goes out, at
+   teardown — and, the one held-through-a-send case, after a #176
+   redirect delivers: its response renders *into* the buffer (the
+   Location may carry the request's own path), so the buffer goes back
+   in the write continuation instead of before the arm — so an idle
+   connection holds no head bytes at all, an L4
    connection never binds one, and the ring is sized for concurrent
    *request heads*, not for open connections. Returning a buffer is a
    tail bump, no syscall. The ring empty at a client's first byte is the
@@ -852,6 +856,43 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   with unbounded fuel or an embedded allocator cannot satisfy the gate);
   anything beyond the closed action enum is a Zig function added to the
   owning phase module at compile time.
+- **A filter can match on who is connecting** (#177, settled
+  2026-08-03). `match.client` is a CIDR list, any-of across the list
+  and conjoined with the rest — "/admin from the office range and
+  nowhere else" is one rule with a reject beneath it. It matches the
+  connection's client address, which is §6's settled principle rather
+  than a new trust decision: the observed peer, or the PROXY-announced
+  client on a `proxy_protocol` listener — never an `X-Forwarded-For`
+  chain, because an allowlist keyed on client-supplied text is not an
+  allowlist. The prefix is mandatory and bounded per family — /32 for
+  IPv4, **/64 for IPv6**, the same client identity `hash.key:
+  source_ip` keys on, so two features cannot disagree about what a
+  client is — and host bits past the prefix are refused: `10.0.0.1/8`
+  is a typo for one of two different ranges, and the loader cannot know
+  which. Containment is a masked-prefix compare over the compiled
+  table, family-strict; the accept and PROXY paths both normalize
+  mapped v6 forms before storage.
+- **A filter can answer with a redirect** (#176, settled 2026-08-03).
+  `redirect` beside `reject`, closed status set `301/302/307/308` —
+  the four with distinct permanent/temporary × method-preserving
+  semantics — and a target in one of two forms: a fixed `location`
+  sent verbatim, or a composed one, `scheme` (required) and optionally
+  `host` replaced with the request's own canonical path and query
+  carried through, so `www` → apex and HTTP → HTTPS are one rule each
+  and the config never restates the path. The scheme is never guessed:
+  behind a TLS terminator every hop this proxy sees is plaintext, and
+  a guess is wrong exactly when it matters. The first terminal action
+  — reject or redirect — wins, top-down. The redirect is the one
+  response this proxy originates whose bytes are not comptime-static,
+  so it renders into the connection's own head buffer (§5, §8) and
+  holds it through the send; a composed Location the buffer cannot
+  carry is `414` — the URI's own fault, answered on a clean message
+  boundary the ordinary keep rule then reads — and a composed target
+  on a request with no authority (HTTP/1.0, no Host) is `400`.
+  `l7_redirected` counts it and the access log says `redirected`,
+  deliberately apart from `l7_filtered`/`rejected`: "policy refused
+  this" and "policy relocated this" are opposite directions on a
+  dashboard.
 - **Response filters are a second table, not a scope marker** (#175,
   settled 2026-08-03). `request_filters` (né `filters`, hard-renamed
   while no deployed config existed to break) runs before routing;
@@ -1080,7 +1121,11 @@ origin, not one this proxy can pick for them.
   staged through
   the connection's head buffer, whose bytes the parsed head's zero-copy
   slices may still reference (§7). Shedding costs one send, no
-  allocation, no copy.
+  allocation, no copy. The #176 redirect is the one proxy-originated
+  response that *does* stage through the head buffer — its Location is
+  per-request — and it may do so only because its render runs after
+  every read of those bytes: the Location is composed first, into the
+  rewrite scratch, so nothing aliases what the render overwrites (§7).
 - **A shed keeps the connection when it can.** Closing is not free: it
   costs the client a handshake and this proxy an accept, a conn slot and
   an admission — so an always-closing shed is *more* expensive per

--- a/docs/README.md
+++ b/docs/README.md
@@ -449,14 +449,60 @@ the list but the file you write.
 ]
 ```
 
-Match on `method`, `host`, `path_prefix`, and header predicates
-(`present` / `equals` / `contains`). Actions are `reject` with a status,
-`header_set` / `header_add` / `header_remove`, and `rewrite_prefix`.
+Match on `method`, `host`, `path_prefix`, header predicates
+(`present` / `equals` / `contains`), and `client` — CIDR ranges the
+connection's address must fall inside. Actions are `reject` with a status,
+`redirect`, `header_set` / `header_add` / `header_remove`, and
+`rewrite_prefix`.
 
 Rules compile into immutable tables at load time and are interpreted with
 bounded loops — no plugins, no scripting, nothing that can allocate or run
 unbounded. A rewrite changes only what is *forwarded*: routing already chose
 the cluster from the original path, so a rewrite never re-routes.
+
+#### Matching the client address
+
+The standard rule — `/admin` from the office range and nowhere else — is a
+`client` list on the allow rule and a reject beneath it:
+
+```json
+"request_filters": [
+    { "match": { "path_prefix": "/admin",
+                 "client": ["10.0.0.0/8", "192.168.1.0/24"] },
+      "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] },
+    { "match": { "path_prefix": "/admin" }, "actions": [{ "reject": 403 }] }
+]
+```
+
+The address matched is the one zoxy actually believes: the TCP peer, or the
+PROXY-protocol-announced client on a listener that requires the header —
+never an `X-Forwarded-For` chain, which any client can write. Prefixes run
+to `/32` for IPv4 and `/64` for IPv6 (a client's IPv6 identity is its /64,
+the same rule sticky hashing uses), the `/len` is mandatory, and host bits
+past the prefix are rejected — `10.0.0.1/8` is a typo for one of two
+different ranges, and zoxy will not guess which.
+
+#### Redirects
+
+The two most common edge rules are one action each — no second server
+needed in front of a load balancer to answer them:
+
+```json
+"request_filters": [
+    { "actions": [{ "redirect": { "status": 301, "scheme": "https" } }] },
+    { "match": { "host": "www.example.com" },
+      "actions": [{ "redirect": { "status": 308, "scheme": "https",
+                                  "host": "example.com" } }] }
+]
+```
+
+A composed target replaces the scheme (required — zoxy never guesses it,
+since behind a TLS terminator every hop it sees is plaintext) and
+optionally the host; the request's own path and query are carried through.
+A fixed `location` is the other form, sent verbatim. Statuses are `301`,
+`302`, `307`, `308`. Redirects count as `zoxy_l7_redirected` and log as
+`redirected` — separate from rejects on purpose, so refused traffic and
+relocated traffic never blur.
 
 #### Response filters
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -69,7 +69,7 @@ weights_http: [1]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
-request_filters_http: [3]zoxy.http.filter.Rule,
+request_filters_http: [4]zoxy.http.filter.Rule,
 /// The #175 response rules beside them: the always-on stamp the client
 /// oracle requires on every proxied 200, and the 5xx rule whose edit
 /// must never appear (the scripted origin answers no 5xx).
@@ -653,6 +653,15 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .actions = &.{.{ .reject = 403 }},
         },
         .{
+            // #176: composed target, no host override — the Location the
+            // client oracle demands is scheme + the request's own host +
+            // its canonical path, `l7.canon.redirect_location` exactly.
+            .match = .{ .path_prefix = "/redirect" },
+            .actions = &.{.{ .redirect = .{ .status = 301, .target = .{ .composed = .{
+                .scheme = .https,
+            } } } }},
+        },
+        .{
             .match = .{ .path_prefix = "/edit" },
             .actions = &.{.{ .header_set = .{ .name = "X-Sim-Filter", .value = "on" } }},
         },
@@ -1154,6 +1163,7 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_not_implemented",
         "l7_no_route",
         "l7_filtered",
+        "l7_redirected",
         "l7_shed_relay_buffers",
         "l7_shed_upstream_slots",
         "l7_shed_endpoint_inflight",

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -27,6 +27,12 @@ pub const response_edit_name = "X-Sim-Response";
 pub const response_edit_value = "on";
 pub const response_never_name = "X-Sim-Never";
 
+/// The one Location a sim 301 may carry (#176): the harness's redirect
+/// rule composes scheme + the request's own host and canonical path,
+/// and `filter_redirect` is the only script that earns a 301 — so the
+/// client oracle demands this exact value on every one it parses.
+pub const redirect_location = "https://sim/redirect";
+
 /// A parseable head that cannot survive the render: 8190 bytes fits the
 /// proxy's 8 KiB response buffer, but no Content-Length and no
 /// Transfer-Encoding makes it until-close framing, which forces a

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -43,6 +43,9 @@ pub const ClientError = error{
     /// A proxied 200 arrived without the #175 response-filter stamp the
     /// harness configures unconditionally: the edit path did not run.
     ResponseEditMissing,
+    /// A 301 without the exact Location the harness's one redirect rule
+    /// composes (#176): the per-request render carried the wrong target.
+    RedirectLocationWrong,
     /// A response carried an edit it must not: the stamp on a static
     /// (which bypasses the response render), or the 5xx rule's edit
     /// anywhere (the scripted origin answers no 5xx) — either way a
@@ -393,6 +396,16 @@ pub fn Client(comptime IoType: type) type {
                 if (responseEditViolation(&response)) |violation| {
                     walk.violation = violation;
                     return walk;
+                }
+                // The #176 oracle: `filter_redirect` is the only script
+                // that earns a 301, its rule composes from the request's
+                // own host and canonical path, and both are fixed — so
+                // every 301 must carry exactly the canonical Location.
+                if (response.status == 301) {
+                    if (!headerEquals(response.headers, "Location", canon.redirect_location)) {
+                        walk.violation = ClientError.RedirectLocationWrong;
+                        return walk;
+                    }
                 }
                 const body = bytes[walk.offset + response.head_len ..];
                 const verdict = walkBody(response, body) orelse return walk;

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -63,6 +63,12 @@ pub const Script = enum(u8) {
     /// resource is acquired or origin dialed. The golden outcome is exactly
     /// that 403, and the origin must never see the request.
     filter_reject,
+    /// A GET under `/redirect`: a §7 filter answers 301 with a Location
+    /// composed from the request's own host and path (#176), before any
+    /// resource is acquired or origin dialed — `filter_reject`'s shape
+    /// with the one response this proxy renders per request instead of
+    /// serving from static memory.
+    filter_redirect,
     /// A GET under `/edit`: a §7 filter adds a header to the forwarded
     /// request. It routes and succeeds (200); the origin's §7 oracle proves
     /// the edited head still forwards canonical.
@@ -342,6 +348,19 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 403,
         .method = .get,
         .allowed_statuses = &.{ 403, 503 },
+    },
+    .filter_redirect = .{
+        // `filter_reject`'s timing exactly — answered before any
+        // post-parse resource — so the same one preemption applies: the
+        // §5 head ring's 503. The 301's Location is asserted by the
+        // client's own walk (#176), composed from this request's host
+        // and path.
+        .request = "GET /redirect HTTP/1.1\r\nHost: sim\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 301,
+        .method = .get,
+        .allowed_statuses = &.{ 301, 503 },
     },
     .filter_edit = .{
         // Routes and forwards like a plain GET, so the §8 rungs and a

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -54,6 +54,11 @@ pub const Outcome = enum(u8) {
     /// zoxy refused the request itself (§7): malformed, oversize,
     /// unroutable, unsupported, or stopped by a filter rule.
     rejected,
+    /// A filter rule answered the request with a redirect (#176). Not
+    /// `rejected`, deliberately: an operator grepping for refused
+    /// traffic must not fish redirects out of it, and one grepping for
+    /// redirect volume must not see refusals.
+    redirected,
     /// zoxy ran out of a resource and answered `503` (§8) — a relay buffer
     /// or an upstream slot the request needed.
     shed,

--- a/src/config.zig
+++ b/src/config.zig
@@ -389,6 +389,11 @@ pub const ValidationError = error{
     FilterHeaderNameInvalid,
     FilterHeaderNameReserved,
     FilterHeaderValueInvalid,
+    FilterClientEmpty,
+    FilterClientCidrInvalid,
+    FilterClientPrefixInvalid,
+    FilterClientPrefixTooNarrow,
+    FilterClientCidrHostBits,
     FilterActionsEmpty,
     FilterActionKind,
     FilterRejectStatus,
@@ -959,6 +964,8 @@ pub const MatchJson = struct {
     host: ?[]const u8 = null,
     path_prefix: ?[]const u8 = null,
     headers: ?[]const HeaderMatchJson = null,
+    /// Optional #177 client-address predicate: CIDR literals, any-of.
+    client: ?[]const []const u8 = null,
 
     pub const schema_doc = "Request-match predicate; every absent field matches anything.";
     pub const schema_fields = .{
@@ -971,6 +978,14 @@ pub const MatchJson = struct {
         .path_prefix = .{ .desc = "Canonical origin-form path prefix; must start with a slash." },
         .headers = .{
             .desc = "Header predicates; all must match.",
+        },
+        .client = .{
+            .desc = "CIDR prefixes the connection's client address must fall inside " ++
+                "(any-of): \"10.0.0.0/8\", up to /32 for IPv4 and /64 for IPv6 — a " ++
+                "client's IPv6 identity is its /64, like hash source_ip. Matched " ++
+                "against the observed peer (the PROXY-announced client on a " ++
+                "proxy_protocol listener), never an X-Forwarded-For chain.",
+            .min_items = 1,
         },
     };
 };
@@ -1946,7 +1961,101 @@ fn resolveMatch(
     if (match_json.headers) |headers_json| {
         match.headers = try resolveHeaderMatches(arena, headers_json);
     }
+    if (match_json.client) |cidr_literals| {
+        match.clients = try resolveClientCidrs(arena, cidr_literals);
+    }
     return match;
+}
+
+/// Compile a `client` predicate's CIDR list (#177). An explicitly empty
+/// list is a mistake — absence already says "any client", unambiguously
+/// (the `FilterMethodEmpty` rule).
+fn resolveClientCidrs(
+    arena: std.mem.Allocator,
+    literals: []const []const u8,
+) ParseError![]const filter.Cidr {
+    if (literals.len == 0) {
+        return error.FilterClientEmpty;
+    }
+    assert(literals.len >= 1); // Past the empty guard.
+    const cidrs = try arena.alloc(filter.Cidr, literals.len);
+    for (literals, cidrs) |literal, *cidr| {
+        cidr.* = try resolveClientCidr(literal);
+    }
+    assert(cidrs.len == literals.len);
+    return cidrs;
+}
+
+/// One CIDR literal to its compiled prefix. The `/len` is mandatory — a
+/// bare address has no single meaning across families (an exact IPv4
+/// host is /32, but an exact IPv6 *client* is its /64), so the spelling
+/// that would need per-family folklore is refused instead. Host bits
+/// past the prefix must be zero: `10.0.0.1/8` is a typo for either
+/// `10.0.0.0/8` or `10.0.0.1/32`, and the loader cannot know which.
+fn resolveClientCidr(literal: []const u8) ParseError!filter.Cidr {
+    const slash = std.mem.indexOfScalar(u8, literal, '/') orelse
+        return error.FilterClientCidrInvalid;
+    const address_text = literal[0..slash];
+    const prefix_text = literal[slash + 1 ..];
+    if (prefix_text.len == 0) {
+        return error.FilterClientPrefixInvalid;
+    }
+    const prefix_len = std.fmt.parseUnsigned(u8, prefix_text, 10) catch
+        return error.FilterClientPrefixInvalid;
+    const address = std.Io.net.IpAddress.parse(address_text, 0) catch
+        return error.FilterClientCidrInvalid;
+    switch (address) {
+        .ip4 => |v4| {
+            if (prefix_len > 32) {
+                return error.FilterClientPrefixTooNarrow;
+            }
+            assert(prefix_len <= 32);
+            const bits = std.mem.readInt(u32, &v4.bytes, .big);
+            if (hostBitsSet(u32, bits, prefix_len)) {
+                return error.FilterClientCidrHostBits;
+            }
+        },
+        .ip6 => |v6| {
+            // A client's IPv6 identity is its /64 (`hash.key:
+            // source_ip`, §7): RFC 8981 rotates the interface half on a
+            // timer, so a narrower prefix names bits that will not mean
+            // the same client in an hour.
+            if (prefix_len > 64) {
+                return error.FilterClientPrefixTooNarrow;
+            }
+            assert(prefix_len <= 64);
+            const high = std.mem.readInt(u64, v6.bytes[0..8], .big);
+            const low = std.mem.readInt(u64, v6.bytes[8..16], .big);
+            if (low != 0) {
+                return error.FilterClientCidrHostBits;
+            }
+            assert(low == 0);
+            if (hostBitsSet(u64, high, prefix_len)) {
+                return error.FilterClientCidrHostBits;
+            }
+        },
+    }
+    // The compiled prefix `Cidr.contains` and `clientMatches` assert on
+    // their side of the seam, proven where it is produced.
+    assert(prefix_len <= 64 or address == .ip4);
+    return .{ .address = address, .prefix_len = prefix_len };
+}
+
+/// Whether any bit below the prefix is set — the host half that a
+/// canonical CIDR keeps zero.
+fn hostBitsSet(comptime T: type, bits: T, prefix_len: u8) bool {
+    const width = @bitSizeOf(T);
+    assert(prefix_len <= width);
+    if (prefix_len == 0) {
+        return bits != 0;
+    }
+    if (prefix_len == width) {
+        return false;
+    }
+    assert(prefix_len >= 1);
+    const shift: std.math.Log2Int(T) = @intCast(prefix_len);
+    const host_mask = (@as(T, std.math.maxInt(T)) >> shift);
+    return (bits & host_mask) != 0;
 }
 
 fn resolveHeaderMatches(
@@ -2994,6 +3103,62 @@ test "config: a filter set over the header-edit budget is rejected" {
     try expectParseError(error.FilterHeaderEditsOverLimit, json);
 }
 
+test "config: client CIDR predicates compile with their prefixes" {
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","request_filters":[
+        \\   {"match":{"path_prefix":"/admin","client":["10.0.0.0/8","192.168.1.0/24","2001:db8::/32"]},
+        \\    "actions":[{"reject":403}]},
+        \\   {"match":{"client":["0.0.0.0/0","::/0"]},
+        \\    "actions":[{"header_set":{"name":"X-Any","value":"1"}}]}
+        \\ ]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const clients = parsed.listeners[0].request_filters[0].match.clients;
+    try std.testing.expectEqual(@as(usize, 3), clients.len);
+    try std.testing.expectEqual(@as(u8, 8), clients[0].prefix_len);
+    try std.testing.expectEqual(@as(u8, 24), clients[1].prefix_len);
+    try std.testing.expectEqual(@as(u8, 32), clients[2].prefix_len);
+    // The /0 edge parses in both families: an explicit everyone, whose
+    // host-bits rule still demands an all-zero address.
+    const any = parsed.listeners[0].request_filters[1].match.clients;
+    try std.testing.expectEqual(@as(u8, 0), any[0].prefix_len);
+    try std.testing.expectEqual(@as(u8, 0), any[1].prefix_len);
+    // The compiled prefixes admit and refuse — proving address bytes
+    // survived the parse, not only the lengths.
+    const office = std.Io.net.IpAddress.parseLiteral("10.9.8.7:1") catch unreachable;
+    const stranger = std.Io.net.IpAddress.parseLiteral("11.0.0.1:1") catch unreachable;
+    try std.testing.expect(clients[0].contains(&office));
+    try std.testing.expect(!clients[0].contains(&stranger));
+}
+
+test "config: client CIDR validation has its own errors" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"request_filters\":[";
+    // An explicitly empty list: absence already says "any client".
+    try expectParseError(error.FilterClientEmpty, head ++ "{\"match\":{\"client\":[]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // A bare address has no single meaning across families (an exact
+    // IPv4 host is /32, an exact IPv6 client is its /64): the prefix is
+    // mandatory.
+    try expectParseError(error.FilterClientCidrInvalid, head ++ "{\"match\":{\"client\":[\"10.0.0.1\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.FilterClientCidrInvalid, head ++ "{\"match\":{\"client\":[\"office/8\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.FilterClientPrefixInvalid, head ++ "{\"match\":{\"client\":[\"10.0.0.0/\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.FilterClientPrefixInvalid, head ++ "{\"match\":{\"client\":[\"10.0.0.0/eight\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // Past the family's bound: /32 for v4; /64 for v6, where the low
+    // half is interface identity that rotates (RFC 8981).
+    try expectParseError(error.FilterClientPrefixTooNarrow, head ++ "{\"match\":{\"client\":[\"10.0.0.0/33\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.FilterClientPrefixTooNarrow, head ++ "{\"match\":{\"client\":[\"2001:db8::/65\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    // Host bits set past the prefix: a typo for one of two different
+    // ranges, and the loader cannot know which.
+    try expectParseError(error.FilterClientCidrHostBits, head ++ "{\"match\":{\"client\":[\"10.0.0.1/8\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.FilterClientCidrHostBits, head ++ "{\"match\":{\"client\":[\"2001:db8::1/48\"]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
+}
+
 test "config: response filters compile into rules with matches and edits" {
     var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
@@ -3803,6 +3968,7 @@ var fuzz_arena_buffer: [1 << 20]u8 = undefined;
 /// `drain_deadline_ms` gives it no path to that branch of the parser.
 const fuzz_seed_json =
     \\{"listeners":[{"bind":"127.0.0.1:8080","routes":[{"prefix":"/","cluster":"o"}],
+    \\ "request_filters":[{"match":{"client":["10.0.0.0/8"]},"actions":[{"reject":403}]}],
     \\ "protocol":"http"}],
     \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000",
     \\ {"address":"127.0.0.1:9001","weight":3}],"pick":"p2c","max_inflight":8,

--- a/src/config.zig
+++ b/src/config.zig
@@ -397,8 +397,12 @@ pub const ValidationError = error{
     FilterActionsEmpty,
     FilterActionKind,
     FilterRejectStatus,
+    FilterRedirectStatus,
+    FilterRedirectTarget,
+    FilterRedirectSchemeUnknown,
     FilterHeaderEditsOverLimit,
     ResponseFilterReject,
+    ResponseFilterRedirect,
     ResponseFilterRewrite,
     ResponseFilterStatusInvalid,
     ResponseFilterStatusClassUnknown,
@@ -1019,6 +1023,7 @@ pub const HeaderMatchJson = struct {
 /// cluster/routes fork uses — no JSON union parsing.
 pub const ActionJson = struct {
     reject: ?u16 = null,
+    redirect: ?RedirectJson = null,
     header_set: ?HeaderEditJson = null,
     header_add: ?HeaderEditJson = null,
     header_remove: ?[]const u8 = null,
@@ -1032,10 +1037,50 @@ pub const ActionJson = struct {
             .desc = "Reject the request with this status code.",
             .int_values = &filter.reject_statuses,
         },
+        .redirect = .{
+            .desc = "Answer the request with a redirect instead of forwarding it.",
+        },
         .header_set = .{ .desc = "Set (replace) a request header." },
         .header_add = .{ .desc = "Append a request header." },
         .header_remove = .{ .desc = "Remove a request header by name." },
         .rewrite_prefix = .{ .desc = "Rewrite the request path prefix before proxying." },
+    };
+};
+
+/// A `redirect` action's target (#176): a fixed `location` sent
+/// verbatim, or a composed one — scheme (required) and optionally host
+/// replaced, the request's own canonical path and query carried through
+/// so the config never restates them. Exactly one form.
+pub const RedirectJson = struct {
+    status: u16 = 301,
+    location: ?[]const u8 = null,
+    scheme: ?[]const u8 = null,
+    host: ?[]const u8 = null,
+
+    pub const schema_doc =
+        "Where a redirect sends the client: a fixed `location`, or a " ++
+        "composed target (`scheme` and optionally `host`) that carries the " ++
+        "request's own path and query through.";
+    pub const schema_fields = .{
+        .status = .{
+            .desc = "Redirect status: permanent/temporary x method-preserving.",
+            .int_values = &filter.redirect_statuses,
+        },
+        .location = .{
+            .desc = "Fixed Location value, sent verbatim; mutually exclusive " ++
+                "with scheme/host.",
+            .min_length = 1,
+        },
+        .scheme = .{
+            .desc = "Replacement scheme for a composed target. Required there — " ++
+                "never guessed, since behind a TLS terminator every hop this " ++
+                "proxy sees is plaintext.",
+            .enum_type = filter.Redirect.Scheme,
+        },
+        .host = .{
+            .desc = "Replacement canonical host for a composed target; absent " ++
+                "keeps the request's own.",
+        },
     };
 };
 
@@ -1523,7 +1568,7 @@ pub const dto_types = .{
     RewriteJson,        ClusterJson,       TimeoutsJson,             LimitsJson,
     AdminJson,          AccessLogJson,     CheckJson,                ClusterHashJson,
     ForwardedJson,      ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
-    ResponseFilterJson, ResponseMatchJson,
+    ResponseFilterJson, ResponseMatchJson, RedirectJson,
 };
 
 comptime {
@@ -1804,7 +1849,7 @@ fn countHeaderEdits(actions: []const filter.Action) u32 {
     for (actions) |action| {
         switch (action) {
             .header_set, .header_add, .header_remove => count += 1,
-            .reject, .rewrite_prefix => {},
+            .reject, .redirect, .rewrite_prefix => {},
         }
     }
     assert(count <= actions.len); // Edits are a subset of the actions.
@@ -1917,6 +1962,12 @@ fn resolveResponseEdit(action_json: *const ActionJson) ParseError!filter.Applied
     try requireOneActionKind(action_json);
     if (action_json.reject != null) {
         return error.ResponseFilterReject;
+    }
+    if (action_json.redirect != null) {
+        // A redirect is a request-side answer (#176): the client asked
+        // and is sent elsewhere. An origin response already exists by
+        // the time these rules run.
+        return error.ResponseFilterRedirect;
     }
     if (action_json.rewrite_prefix != null) {
         return error.ResponseFilterRewrite;
@@ -2117,15 +2168,16 @@ fn resolveActions(
 }
 
 /// Exactly one action field may carry the kind — the "exactly one of"
-/// fork both action resolvers share, so a sixth kind cannot be counted
-/// in one table and forgotten in the other.
+/// fork both action resolvers share, so a seventh kind cannot be
+/// counted in one table and forgotten in the other.
 fn requireOneActionKind(action_json: *const ActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
+        @intFromBool(action_json.redirect != null) +
         @intFromBool(action_json.header_set != null) +
         @intFromBool(action_json.header_add != null) +
         @intFromBool(action_json.header_remove != null) +
         @intFromBool(action_json.rewrite_prefix != null);
-    assert(set <= 5); // The action object has five kind fields.
+    assert(set <= 6); // The action object has six kind fields.
     if (set != 1) {
         return error.FilterActionKind;
     }
@@ -2139,6 +2191,9 @@ fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseEr
             return error.FilterRejectStatus;
         }
         return .{ .reject = status };
+    }
+    if (action_json.redirect) |redirect_json| {
+        return .{ .redirect = try resolveRedirect(&redirect_json) };
     }
     if (action_json.header_set) |edit| {
         return .{ .header_set = try resolveHeaderEdit(&edit) };
@@ -2154,6 +2209,46 @@ fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseEr
     try validateRoutePrefix(rewrite.from, head_buffer_bytes);
     try validateRoutePrefix(rewrite.to, head_buffer_bytes);
     return .{ .rewrite_prefix = .{ .from = rewrite.from, .to = rewrite.to } };
+}
+
+/// Resolve a `redirect` action (#176). The target fork is exactly-one:
+/// a fixed `location`, or a composed target whose `scheme` is required
+/// — a host alone would leave the scheme guessed, and behind a TLS
+/// terminator the guess is wrong exactly when it matters.
+fn resolveRedirect(redirect_json: *const RedirectJson) ParseError!filter.Redirect {
+    if (!filter.isRedirectStatus(redirect_json.status)) {
+        return error.FilterRedirectStatus;
+    }
+    assert(filter.isRedirectStatus(redirect_json.status));
+    const has_location = redirect_json.location != null;
+    const has_composed = redirect_json.scheme != null or redirect_json.host != null;
+    if (has_location == has_composed) {
+        // Neither form, or both at once.
+        return error.FilterRedirectTarget;
+    }
+    if (redirect_json.location) |location| {
+        if (location.len == 0) {
+            return error.FilterRedirectTarget;
+        }
+        // A Location is a header value the render emits verbatim: the
+        // same injection-safety the header edits prove at load.
+        try validateHeaderValue(location);
+        return .{ .status = redirect_json.status, .target = .{ .location = location } };
+    }
+    const scheme_literal = redirect_json.scheme orelse {
+        // Host without scheme: half a composed target.
+        return error.FilterRedirectTarget;
+    };
+    const scheme = std.meta.stringToEnum(filter.Redirect.Scheme, scheme_literal) orelse
+        return error.FilterRedirectSchemeUnknown;
+    var composed: filter.Redirect.Composed = .{ .scheme = scheme };
+    if (redirect_json.host) |host| {
+        // Canonical like a route host: the Location's authority is a
+        // name the operator writes, and the same validation keeps it
+        // one the render can emit without a second look.
+        composed.host = try validateRouteHost(host);
+    }
+    return .{ .status = redirect_json.status, .target = .{ .composed = composed } };
 }
 
 /// Validate a name/value header edit shared by `header_set` and
@@ -3101,6 +3196,62 @@ test "config: a filter set over the header-edit budget is rejected" {
     const json = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\"," ++
         "\"cluster\":\"a\",\"request_filters\":[" ++ rules ++ "]}]," ++ tail;
     try expectParseError(error.FilterHeaderEditsOverLimit, json);
+}
+
+test "config: redirect actions compile in both target forms" {
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","protocol":"http","cluster":"a","request_filters":[
+        \\   {"match":{"host":"www.example.com"},
+        \\    "actions":[{"redirect":{"status":308,"scheme":"https","host":"example.com"}}]},
+        \\   {"actions":[{"redirect":{"scheme":"https"}}]},
+        \\   {"match":{"path_prefix":"/gone"},
+        \\    "actions":[{"redirect":{"status":302,"location":"https://status.example.com/"}}]}
+        \\ ]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const rules = parsed.listeners[0].request_filters;
+    const canonical = rules[0].actions[0].redirect;
+    try std.testing.expectEqual(@as(u16, 308), canonical.status);
+    try std.testing.expectEqual(filter.Redirect.Scheme.https, canonical.target.composed.scheme);
+    try std.testing.expectEqualStrings("example.com", canonical.target.composed.host.?);
+    // Scheme-only composed, and the status defaults to the permanent one.
+    const to_https = rules[1].actions[0].redirect;
+    try std.testing.expectEqual(@as(u16, 301), to_https.status);
+    try std.testing.expectEqual(@as(?[]const u8, null), to_https.target.composed.host);
+    const fixed = rules[2].actions[0].redirect;
+    try std.testing.expectEqual(@as(u16, 302), fixed.status);
+    try std.testing.expectEqualStrings("https://status.example.com/", fixed.target.location);
+}
+
+test "config: redirect validation has its own errors" {
+    const tail =
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\",\"request_filters\":[";
+    // Outside the closed set — 303 changes the method's meaning and has
+    // no proxy semantics here.
+    try expectParseError(error.FilterRedirectStatus, head ++ "{\"actions\":[{\"redirect\":{\"status\":303,\"scheme\":\"https\"}}]}]}]," ++ tail);
+    // Neither target form, both at once, half a composed one, and an
+    // empty literal: each is FilterRedirectTarget.
+    try expectParseError(error.FilterRedirectTarget, head ++ "{\"actions\":[{\"redirect\":{\"status\":301}}]}]}]," ++ tail);
+    try expectParseError(error.FilterRedirectTarget, head ++ "{\"actions\":[{\"redirect\":{\"location\":\"https://x/\",\"scheme\":\"https\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterRedirectTarget, head ++ "{\"actions\":[{\"redirect\":{\"host\":\"example.com\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterRedirectTarget, head ++ "{\"actions\":[{\"redirect\":{\"location\":\"\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterRedirectSchemeUnknown, head ++ "{\"actions\":[{\"redirect\":{\"scheme\":\"ftp\"}}]}]}]," ++ tail);
+    // The composed host is a route host: canonical or refused.
+    try expectParseError(error.RouteHostNotCanonical, head ++ "{\"actions\":[{\"redirect\":{\"scheme\":\"https\",\"host\":\"WWW.Example.com\"}}]}]}]," ++ tail);
+    // A literal Location is a header value the render emits verbatim:
+    // injection-safety is proven at load.
+    try expectParseError(error.FilterHeaderValueInvalid, head ++ "{\"actions\":[{\"redirect\":{\"location\":\"https://x/\\r\\nSet-Cookie: a\"}}]}]}]," ++ tail);
+    // Two kinds is still a kind error; a redirect on the way out is
+    // refused by name.
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"redirect\":{\"scheme\":\"https\"},\"reject\":403}]}]}]," ++ tail);
+    try expectParseError(error.ResponseFilterRedirect, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"protocol\":\"http\",\"cluster\":\"a\"," ++
+        "\"response_filters\":[{\"actions\":[{\"redirect\":{\"scheme\":\"https\"}}]}]}]," ++ tail);
 }
 
 test "config: client CIDR predicates compile with their prefixes" {

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -52,9 +52,12 @@ pub const Counters = struct {
     /// sum; these are pure observability.
     ///
     /// They do not share one persistence rule, because they do not share
-    /// one cause. `l7_uri_too_long` and `l7_headers_too_large` always
-    /// close: the parser could not find the message boundary, so neither
-    /// can the turnaround. `l7_not_implemented` answers a head that parsed
+    /// one cause. `l7_uri_too_long` and `l7_headers_too_large` close
+    /// when the parser could not find the message boundary — their
+    /// original spelling — with one #176 exception on the first: a
+    /// redirect whose composed Location cannot be carried answers 414
+    /// from a request that *did* parse, a clean boundary the ordinary
+    /// keep-or-close decision then reads (§8). `l7_not_implemented` answers a head that parsed
     /// cleanly and follows the general keep rule (§8). `l7_bad_request`
     /// covers both — a parser-rejected head, which closes, and a head that
     /// parsed but whose target would not canonicalize, which keeps. The
@@ -73,6 +76,14 @@ pub const Counters = struct {
     /// (403/404/429/400). A reject, not a shed; same persistence rule as
     /// `l7_no_route`.
     l7_filtered: Value = Value.init(0),
+    /// A §7 filter rule answered the request with a redirect (#176):
+    /// one of the closed statuses plus a Location rendered per request.
+    /// `l7_filtered`'s sibling — admitted and answered, so outside
+    /// `reconcile`'s shed sum — but not folded into it: "policy refused
+    /// this" and "policy sent this elsewhere" are opposite directions
+    /// on a dashboard, and a redirect storm is a different diagnosis
+    /// from a reject storm.
+    l7_redirected: Value = Value.init(0),
     /// §8 rungs at the L7 request level, answered 503: relay buffers or
     /// upstream slots exhausted when a valid request needed them. Like the
     /// reject counters, the connection was admitted, so these stay out of

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -6,7 +6,7 @@
 //! ordered action list drawn from a closed enum. Cluster selection is NOT
 //! an action: the route table owns the backend decision (§7), so filters
 //! never compete with routing. This module holds the compiled shapes and
-//! the interpreter (`firstReject`, `collectForward`); the config-load
+//! the interpreter (`firstVerdict`, `collectForward`); the config-load
 //! compiler lives in `config.zig`.
 
 const std = @import("std");
@@ -116,12 +116,70 @@ pub const Rewrite = struct {
     to: []const u8,
 };
 
+/// A redirect verdict (#176): a closed status and where to send the
+/// client. Terminal like `reject` — the request is answered, never
+/// forwarded — but unlike a reject its response is rendered per
+/// request: the `Location` may depend on what was asked.
+pub const Redirect = struct {
+    status: u16,
+    target: Target,
+
+    pub const Target = union(enum) {
+        /// A fixed `Location` value, sent verbatim — for targets that do
+        /// not depend on the request.
+        location: []const u8,
+        /// Scheme (and optionally host) replaced; the request's own
+        /// canonical path and query are carried through, so the config
+        /// never restates what §7 already computed.
+        composed: Composed,
+    };
+
+    pub const Composed = struct {
+        /// Required, never guessed: behind a TLS terminator "keep the
+        /// request's scheme" is wrong exactly when it matters, since
+        /// every hop this proxy sees is plaintext (§1).
+        scheme: Scheme,
+        /// Replacement canonical host, or null to keep the request's.
+        host: ?[]const u8 = null,
+    };
+
+    pub const Scheme = enum(u1) {
+        http,
+        https,
+
+        pub fn prefix(scheme: Scheme) []const u8 {
+            return switch (scheme) {
+                .http => "http://",
+                .https => "https://",
+            };
+        }
+    };
+};
+
+/// The statuses a `redirect` action may name — the four with distinct
+/// proxy-meaningful semantics (permanent/temporary × method-preserving),
+/// on `reject_statuses`' single-source rule: config rejects any other
+/// value at load and the responder renders exactly this set.
+pub const redirect_statuses = [_]u16{ 301, 302, 307, 308 };
+
+pub fn isRedirectStatus(status: u16) bool {
+    for (redirect_statuses) |candidate| {
+        if (candidate == status) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /// The closed action enum (§7): no `pick cluster` (routing owns the
 /// backend), no scripting. Anything past this is a Zig function in the
 /// owning phase module, added at compile time.
 pub const Action = union(enum) {
     /// Answer a static status and stop (§8 static-response machinery).
     reject: u16,
+    /// Answer a redirect and stop (#176): rendered per request, since
+    /// its `Location` may carry the request's own path.
+    redirect: Redirect,
     /// Set (replacing any existing), add (append), or remove a header on
     /// the forwarded request, applied during the head render.
     header_set: HeaderEdit,
@@ -286,27 +344,40 @@ pub const RequestView = struct {
     client: *const std.Io.net.IpAddress,
 };
 
-/// The reject status of the first matching rule that carries a `reject`
-/// action, or null to proceed (§7). Rules are evaluated top-down and
-/// actions in order, so the first reject reached wins — and because a
-/// matched rule's reject stops the request, any header/rewrite edits are
-/// then moot (they apply only to a request that forwards, handled at the
-/// render). Bounded loops over immutable arena data; no allocation.
-pub fn firstReject(rules: []const Rule, view: RequestView) ?u16 {
+/// A terminal filter answer: the request is responded to here and never
+/// forwarded. The redirect rides by pointer — it lives in the rule's
+/// arena and outlives the scan, and copying its slices buys nothing.
+pub const Verdict = union(enum) {
+    reject: u16,
+    redirect: *const Redirect,
+};
+
+/// The verdict of the first matching rule that carries a terminal
+/// action — `reject` or `redirect` (#176) — or null to proceed (§7).
+/// Rules are evaluated top-down and actions in order, so the first
+/// terminal reached wins — and because it stops the request, any
+/// header/rewrite edits are then moot (they apply only to a request
+/// that forwards, handled at the render). Bounded loops over immutable
+/// arena data; no allocation.
+pub fn firstVerdict(rules: []const Rule, view: RequestView) ?Verdict {
     assert(view.path.len >= 1);
     assert(view.path[0] == '/');
     for (rules) |rule| {
         if (!matches(rule.match, view)) {
             continue;
         }
-        for (rule.actions) |action| {
-            switch (action) {
+        for (rule.actions) |*action| {
+            switch (action.*) {
                 .reject => |status| {
                     assert(isRejectStatus(status));
-                    return status;
+                    return .{ .reject = status };
+                },
+                .redirect => |*redirect| {
+                    assert(isRedirectStatus(redirect.status));
+                    return .{ .redirect = redirect };
                 },
                 // Edits apply at the render, only when the request
-                // forwards; a reject anywhere in a matched rule stops it.
+                // forwards; a terminal anywhere in a matched rule stops it.
                 .header_set, .header_add, .header_remove, .rewrite_prefix => {},
             }
         }
@@ -365,7 +436,7 @@ pub fn collectForward(
                     rewrite = candidate;
                 }
             },
-            .reject => {},
+            .reject, .redirect => {},
         };
     }
     assert(count <= out.len);
@@ -379,7 +450,7 @@ fn appliedEdit(action: Action) AppliedHeaderEdit {
         .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
         .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
         .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
-        .reject, .rewrite_prefix => unreachable,
+        .reject, .redirect, .rewrite_prefix => unreachable,
     };
 }
 
@@ -529,7 +600,7 @@ test "filter: isRejectStatus admits exactly the reject_statuses set" {
     try std.testing.expectEqualSlices(u16, &.{ 400, 403, 404, 429 }, &reject_statuses);
 }
 
-test "filter: firstReject matches on method, host, path, header" {
+test "filter: firstVerdict matches on method, host, path, header" {
     const H = parser.Header;
     const rules = [_]Rule{
         // Reject a POST to /admin from a specific host with a header set.
@@ -551,36 +622,36 @@ test "filter: firstReject matches on method, host, path, header" {
     const dev = [_]H{H.init("X-Env", "dev")};
 
     // Full match → 403.
-    try std.testing.expectEqual(@as(?u16, 403), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(u16, 403), firstVerdict(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/admin/users",
         .headers = &prod,
         .client = &test_view_client,
-    }));
+    }).?.reject);
     // Wrong method, host, path, or header value → no reject.
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .get, // not POST
         .host = "api.example",
         .path = "/admin",
         .headers = &prod,
         .client = &test_view_client,
     }));
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .post,
         .host = "other.example", // wrong host
         .path = "/admin",
         .headers = &prod,
         .client = &test_view_client,
     }));
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/public", // not under /admin
         .headers = &prod,
         .client = &test_view_client,
     }));
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/admin",
@@ -588,7 +659,7 @@ test "filter: firstReject matches on method, host, path, header" {
         .client = &test_view_client,
     }));
     // A segment-splitting path must not match the /admin prefix.
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/administrator",
@@ -606,7 +677,7 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
     };
     const empty: []const parser.Header = &.{};
     // The edit-only rule matches everything but does not reject.
-    try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
         .method = .get,
         .host = null,
         .path = "/anything",
@@ -614,13 +685,59 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
         .client = &test_view_client,
     }));
     // The second rule rejects its prefix.
-    try std.testing.expectEqual(@as(?u16, 404), firstReject(&rules, .{
+    try std.testing.expectEqual(@as(u16, 404), firstVerdict(&rules, .{
         .method = .get,
         .host = null,
         .path = "/blocked/x",
         .headers = empty,
         .client = &test_view_client,
+    }).?.reject);
+}
+
+test "filter: a redirect is a terminal verdict, first one wins" {
+    const rules = [_]Rule{
+        // An edit-only rule matches first and must not terminate.
+        .{ .match = .{}, .actions = &.{
+            .{ .header_set = .{ .name = "X-Via", .value = "zoxy" } },
+        } },
+        .{ .match = .{ .host = "www.example" }, .actions = &.{
+            .{ .redirect = .{ .status = 301, .target = .{ .composed = .{
+                .scheme = .https,
+                .host = "example",
+            } } } },
+        } },
+        // A later reject on the same host must never be reached.
+        .{ .match = .{ .host = "www.example" }, .actions = &.{.{ .reject = 403 }} },
+    };
+    const empty: []const parser.Header = &.{};
+    const verdict = firstVerdict(&rules, .{
+        .method = .get,
+        .host = "www.example",
+        .path = "/",
+        .headers = empty,
+        .client = &test_view_client,
+    }).?;
+    try std.testing.expectEqual(@as(u16, 301), verdict.redirect.status);
+    try std.testing.expectEqualStrings("example", verdict.redirect.target.composed.host.?);
+    // Another host sails past both terminal rules.
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
+        .method = .get,
+        .host = "api.example",
+        .path = "/",
+        .headers = empty,
+        .client = &test_view_client,
     }));
+}
+
+test "filter: isRedirectStatus admits exactly the redirect_statuses set" {
+    for (redirect_statuses) |status| {
+        try std.testing.expect(isRedirectStatus(status));
+    }
+    try std.testing.expect(!isRedirectStatus(200));
+    try std.testing.expect(!isRedirectStatus(303)); // See Other: no proxy semantics here.
+    try std.testing.expect(!isRedirectStatus(403));
+    // Pin the documented set, `reject_statuses`' own rule.
+    try std.testing.expectEqualSlices(u16, &.{ 301, 302, 307, 308 }, &redirect_statuses);
 }
 
 test "filter: collectForward gathers matching rules' edits in order" {

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -28,6 +28,60 @@ pub const HeaderMatch = struct {
     pub const Kind = enum(u8) { present, equals, contains };
 };
 
+/// One CIDR prefix a `client` predicate admits (#177). The address is
+/// canonical for its prefix — host bits are rejected at load — so
+/// containment is a masked-prefix compare, never a normalization.
+pub const Cidr = struct {
+    address: std.Io.net.IpAddress,
+    /// Prefix bits: 0..32 for IPv4, 0..64 for IPv6 — a client's IPv6
+    /// identity is its /64, the same rule `hash.key: source_ip` keys on
+    /// (§7): RFC 8981 rotates the low bits on a timer, and two features
+    /// must not disagree about what a client is. The loader enforces
+    /// both bounds.
+    prefix_len: u8,
+
+    /// Whether `client` falls inside this prefix. Family-strict: a v4
+    /// client never matches a v6 prefix or vice versa — the accept path
+    /// produces no mapped forms.
+    pub fn contains(cidr: *const Cidr, client: *const std.Io.net.IpAddress) bool {
+        return switch (cidr.address) {
+            .ip4 => |prefix| switch (client.*) {
+                .ip4 => |candidate| prefixBitsMatch(
+                    u32,
+                    std.mem.readInt(u32, &prefix.bytes, .big),
+                    std.mem.readInt(u32, &candidate.bytes, .big),
+                    cidr.prefix_len,
+                ),
+                .ip6 => false,
+            },
+            .ip6 => |prefix| switch (client.*) {
+                .ip4 => false,
+                .ip6 => |candidate| prefixBitsMatch(
+                    u64,
+                    std.mem.readInt(u64, prefix.bytes[0..8], .big),
+                    std.mem.readInt(u64, candidate.bytes[0..8], .big),
+                    cidr.prefix_len,
+                ),
+            },
+        };
+    }
+};
+
+/// The top `prefix_len` bits of two addresses compare equal. A zero
+/// prefix admits everything — handled before the shift, whose amount
+/// would otherwise be the type's whole width (illegal in Zig, and the
+/// mathematical answer is "no bits compared" anyway).
+fn prefixBitsMatch(comptime T: type, prefix: T, candidate: T, prefix_len: u8) bool {
+    const width = @bitSizeOf(T);
+    assert(prefix_len <= width);
+    if (prefix_len == 0) {
+        return true;
+    }
+    assert(prefix_len >= 1);
+    const shift: std.math.Log2Int(T) = @intCast(width - prefix_len);
+    return (prefix >> shift) == (candidate >> shift);
+}
+
 /// A rule's match: every present predicate must hold (a conjunction). A
 /// null/empty field is "any", so an all-null match is an unconditional
 /// rule. Host and path prefix are already canonical (§7), compared
@@ -38,6 +92,13 @@ pub const Match = struct {
     host: ?[]const u8 = null,
     path_prefix: ?[]const u8 = null,
     headers: []const HeaderMatch = &.{},
+    /// CIDR prefixes the connection's client address must fall inside —
+    /// any-of across the list, conjoined with the rest (#177). Empty =
+    /// any client. Matched against the same address every other
+    /// consumer reads (§6): the observed peer, or the PROXY-announced
+    /// client on a `proxy_protocol` listener — never an
+    /// `X-Forwarded-For` chain, which is client-supplied text.
+    clients: []const Cidr = &.{},
 };
 
 /// One header edit's name and value (value unused for a remove).
@@ -218,6 +279,11 @@ pub const RequestView = struct {
     host: ?[]const u8,
     path: []const u8,
     headers: []const parser.Header,
+    /// The connection's client address (#177), by pointer like every
+    /// address here (32 bytes, past TIGER_STYLE's by-value threshold).
+    /// No default: a site that forgot to wire it must not compile, or a
+    /// `client` allowlist would silently judge a zero address.
+    client: *const std.Io.net.IpAddress,
 };
 
 /// The reject status of the first matching rule that carries a `reject`
@@ -398,7 +464,26 @@ fn matches(match: Match, view: RequestView) bool {
             return false;
         }
     }
+    if (match.clients.len >= 1) {
+        if (!clientMatches(match.clients, view.client)) {
+            return false;
+        }
+    }
     return true;
+}
+
+/// Whether any prefix admits the client (#177) — the one any-of among
+/// the conjunction's predicates, because a `client` list reads as "from
+/// these ranges" and a client holds exactly one address.
+fn clientMatches(cidrs: []const Cidr, client: *const std.Io.net.IpAddress) bool {
+    assert(cidrs.len >= 1);
+    for (cidrs) |*cidr| {
+        assert(cidr.prefix_len <= 64);
+        if (cidr.contains(client)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /// Whether some header satisfies the predicate. Name comparison is
@@ -425,6 +510,11 @@ fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool
     }
     return false;
 }
+
+/// The client address the pre-#177 view tests pass and ignore — no rule
+/// in them carries a `clients` list, so nothing reads it. The CIDR tests
+/// build their own.
+const test_view_client = std.Io.net.IpAddress.parseLiteral("203.0.113.9:50000") catch unreachable;
 
 test "filter: isRejectStatus admits exactly the reject_statuses set" {
     // Every member of the single-source-of-truth set is admitted.
@@ -466,6 +556,7 @@ test "filter: firstReject matches on method, host, path, header" {
         .host = "api.example",
         .path = "/admin/users",
         .headers = &prod,
+        .client = &test_view_client,
     }));
     // Wrong method, host, path, or header value → no reject.
     try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
@@ -473,24 +564,28 @@ test "filter: firstReject matches on method, host, path, header" {
         .host = "api.example",
         .path = "/admin",
         .headers = &prod,
+        .client = &test_view_client,
     }));
     try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
         .method = .post,
         .host = "other.example", // wrong host
         .path = "/admin",
         .headers = &prod,
+        .client = &test_view_client,
     }));
     try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/public", // not under /admin
         .headers = &prod,
+        .client = &test_view_client,
     }));
     try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
         .method = .post,
         .host = "api.example",
         .path = "/admin",
         .headers = &dev, // header value mismatch
+        .client = &test_view_client,
     }));
     // A segment-splitting path must not match the /admin prefix.
     try std.testing.expectEqual(@as(?u16, null), firstReject(&rules, .{
@@ -498,6 +593,7 @@ test "filter: firstReject matches on method, host, path, header" {
         .host = "api.example",
         .path = "/administrator",
         .headers = &prod,
+        .client = &test_view_client,
     }));
 }
 
@@ -515,6 +611,7 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
         .host = null,
         .path = "/anything",
         .headers = empty,
+        .client = &test_view_client,
     }));
     // The second rule rejects its prefix.
     try std.testing.expectEqual(@as(?u16, 404), firstReject(&rules, .{
@@ -522,6 +619,7 @@ test "filter: an all-any match is unconditional; edit-only rules never reject" {
         .host = null,
         .path = "/blocked/x",
         .headers = empty,
+        .client = &test_view_client,
     }));
 }
 
@@ -548,6 +646,7 @@ test "filter: collectForward gathers matching rules' edits in order" {
         .host = null,
         .path = "/public",
         .headers = empty,
+        .client = &test_view_client,
     }, &buffer);
     try std.testing.expectEqual(@as(?Rewrite, null), public.rewrite);
     try std.testing.expectEqual(@as(usize, 2), public.edits.len);
@@ -563,6 +662,7 @@ test "filter: collectForward gathers matching rules' edits in order" {
         .host = null,
         .path = "/api/v1",
         .headers = empty,
+        .client = &test_view_client,
     }, &buffer);
     try std.testing.expectEqual(@as(usize, 3), api.edits.len);
     try std.testing.expectEqualStrings("X-Via", api.edits[0].name);
@@ -594,6 +694,7 @@ test "filter: collectForward picks the first applicable rewrite only" {
         .host = null,
         .path = "/api/users",
         .headers = empty,
+        .client = &test_view_client,
     }, &buffer);
     try std.testing.expect(hit.rewrite != null);
     try std.testing.expectEqualStrings("/api", hit.rewrite.?.from);
@@ -606,6 +707,7 @@ test "filter: collectForward picks the first applicable rewrite only" {
         .host = null,
         .path = "/public",
         .headers = empty,
+        .client = &test_view_client,
     }, &buffer);
     try std.testing.expectEqual(@as(?Rewrite, null), miss.rewrite);
 }
@@ -650,6 +752,112 @@ test "filter: rewritePath is a segment-correct prefix replacement" {
         const recanon = try parser.canonicalTarget(got, &canon);
         try std.testing.expectEqualStrings(got, recanon.path);
     }
+}
+
+test "filter: cidr containment is a masked prefix compare, family-strict" {
+    const office: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("10.0.0.0", 0) catch unreachable,
+        .prefix_len = 8,
+    };
+    const exact: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("192.168.1.7", 0) catch unreachable,
+        .prefix_len = 32,
+    };
+    const any4: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("0.0.0.0", 0) catch unreachable,
+        .prefix_len = 0,
+    };
+    const site6: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("2001:db8:1::", 0) catch unreachable,
+        .prefix_len = 48,
+    };
+
+    const inside = std.Io.net.IpAddress.parseLiteral("10.255.0.1:1") catch unreachable;
+    const outside = std.Io.net.IpAddress.parseLiteral("11.0.0.1:1") catch unreachable;
+    const the_host = std.Io.net.IpAddress.parseLiteral("192.168.1.7:9") catch unreachable;
+    const neighbor = std.Io.net.IpAddress.parseLiteral("192.168.1.8:9") catch unreachable;
+    const v6_inside = std.Io.net.IpAddress.parseLiteral("[2001:db8:1:2::5]:1") catch unreachable;
+    const v6_outside = std.Io.net.IpAddress.parseLiteral("[2001:db8:2::5]:1") catch unreachable;
+
+    // The /8 boundary: the top byte decides, the rest is host space.
+    try std.testing.expect(office.contains(&inside));
+    try std.testing.expect(!office.contains(&outside));
+    // /32 is one host exactly.
+    try std.testing.expect(exact.contains(&the_host));
+    try std.testing.expect(!exact.contains(&neighbor));
+    // /0 admits every address of its family — and only its family:
+    // the port is irrelevant and a v6 client is not a v4 one.
+    try std.testing.expect(any4.contains(&inside));
+    try std.testing.expect(any4.contains(&neighbor));
+    try std.testing.expect(!any4.contains(&v6_inside));
+    // A v6 site prefix, judged on the upper 64 bits.
+    try std.testing.expect(site6.contains(&v6_inside));
+    try std.testing.expect(!site6.contains(&v6_outside));
+    try std.testing.expect(!site6.contains(&inside));
+}
+
+test "filter: a client predicate is any-of, conjoined with the rest" {
+    const office: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("10.0.0.0", 0) catch unreachable,
+        .prefix_len = 8,
+    };
+    const lab: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("192.168.1.0", 0) catch unreachable,
+        .prefix_len = 24,
+    };
+    // The issue's own rule: /admin from the office ranges and nowhere
+    // else — spelled as a reject of everything the allowlist misses,
+    // conjoined with the path.
+    const rules = [_]Rule{
+        .{
+            .match = .{ .path_prefix = "/admin", .clients = &.{ office, lab } },
+            .actions = &.{.{ .header_set = .{ .name = "X-Office", .value = "1" } }},
+        },
+        .{ .match = .{ .path_prefix = "/admin" }, .actions = &.{.{ .reject = 403 }} },
+    };
+    const empty: []const parser.Header = &.{};
+    const office_client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:40000") catch unreachable;
+    const lab_client = std.Io.net.IpAddress.parseLiteral("192.168.1.9:40000") catch unreachable;
+    const stranger = std.Io.net.IpAddress.parseLiteral("203.0.113.9:40000") catch unreachable;
+
+    // Everyone hits the 403 rule on /admin — it carries no client list —
+    // so the reject-first scan reads it for all three; what the CIDR
+    // predicate decides is whether the *first* rule matched too, visible
+    // through its edit below.
+    var buffer: [constants.header_edits_max]AppliedHeaderEdit = undefined;
+    const from_office = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &office_client,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 1), from_office.edits.len);
+    const from_lab = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &lab_client,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 1), from_lab.edits.len);
+    const from_stranger = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &stranger,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 0), from_stranger.edits.len);
+    // Off the path, the client list alone matches nothing: conjunction.
+    const off_path = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/public",
+        .headers = empty,
+        .client = &office_client,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 0), off_path.edits.len);
 }
 
 test "filter: response rules match on status, class and headers" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -577,16 +577,22 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 400, "l7_bad_request");
             };
             captureTarget(conn, keys.host, keys.views.match);
-            // §7 filters run before routing: a policy reject stops the
-            // request whether or not it would have routed.
-            if (filter.firstReject(conn.request_filters, .{
+            // §7 filters run before routing: a terminal verdict — reject
+            // or redirect (#176) — stops the request whether or not it
+            // would have routed.
+            if (filter.firstVerdict(conn.request_filters, .{
                 .method = request.method,
                 .host = keys.host,
                 .path = keys.views.match,
                 .headers = request.headers,
                 .client = &conn.client_address,
-            })) |status| {
-                return respondFilter(server, conn, status);
+            })) |verdict| {
+                switch (verdict) {
+                    .reject => |status| return respondFilter(server, conn, status),
+                    .redirect => |redirect| {
+                        return respondRedirect(server, conn, redirect, keys.host, keys.views.forward);
+                    },
+                }
             }
             conn.cluster_index = router.route(conn.routes, keys.host, keys.views.match) orelse {
                 return respond(server, conn, 404, "l7_no_route");
@@ -1502,6 +1508,12 @@ pub fn Proxy(comptime IoType: type) type {
                 // The two static-response endings share one state: `respond`
                 // is the only writer of either, and it always sets it.
                 .lingering_close, .next_request => assert(conn.state == .l7_responding),
+                // The redirect pair likewise — and the buffer it rendered
+                // into is still bound, which is the pair's whole reason.
+                .redirect_next_request, .redirect_lingering_close => {
+                    assert(conn.state == .l7_responding);
+                    assert(conn.head_buffer_id != ConnType.head_buffer_none);
+                },
             }
             switch (write.then) {
                 .response_excess => sendResponseExcess(server, conn),
@@ -1519,6 +1531,20 @@ pub fn Proxy(comptime IoType: type) type {
                     beginLingeringClose(server, conn);
                 },
                 .next_request => {
+                    server.logExchange(conn);
+                    resumeAfterStaticResponse(server, conn);
+                },
+                // A #176 redirect is fully delivered: return the head
+                // buffer it rendered into — held through the send, unlike
+                // a static answer's — then the static pair's own endings,
+                // whose continuations assert the buffer is gone.
+                .redirect_lingering_close => {
+                    server.returnHeadBuffer(conn);
+                    server.logExchange(conn);
+                    beginLingeringClose(server, conn);
+                },
+                .redirect_next_request => {
+                    server.returnHeadBuffer(conn);
                     server.logExchange(conn);
                     resumeAfterStaticResponse(server, conn);
                 },
@@ -2115,6 +2141,120 @@ pub fn Proxy(comptime IoType: type) type {
                 armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
             } else {
                 armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
+            }
+        }
+
+        /// The #176 Location for a redirect verdict. A literal target is
+        /// the config's own arena slice; a composed one is built in the
+        /// rewrite scratch — free at routing time, and consumed before
+        /// this frame returns, the same single-threaded no-suspend
+        /// argument the canonicalization scratches make (§7) — from the
+        /// configured scheme, the replacement or request host, and the
+        /// request's canonical path with its verbatim query.
+        fn composeLocation(
+            server: *ServerType,
+            redirect: *const filter.Redirect,
+            request_host: ?[]const u8,
+            forward: parser.CanonicalTarget,
+        ) error{ Oversize, NoHost }![]const u8 {
+            assert(filter.isRedirectStatus(redirect.status));
+            switch (redirect.target) {
+                .location => |literal| {
+                    assert(literal.len >= 1); // Config rejects an empty literal.
+                    return literal;
+                },
+                .composed => |composed| {
+                    const host = composed.host orelse request_host orelse {
+                        // No replacement host and the request carried no
+                        // usable authority: there is nothing to compose
+                        // the target from.
+                        return error.NoHost;
+                    };
+                    assert(host.len >= 1);
+                    const scheme = composed.scheme.prefix();
+                    const out = server.rewrite_scratch;
+                    const total = scheme.len + host.len + forward.path.len + forward.query.len;
+                    if (total > out.len) {
+                        return error.Oversize;
+                    }
+                    var cursor: usize = 0;
+                    @memcpy(out[cursor..][0..scheme.len], scheme);
+                    cursor += scheme.len;
+                    @memcpy(out[cursor..][0..host.len], host);
+                    cursor += host.len;
+                    @memcpy(out[cursor..][0..forward.path.len], forward.path);
+                    cursor += forward.path.len;
+                    @memcpy(out[cursor..][0..forward.query.len], forward.query);
+                    cursor += forward.query.len;
+                    assert(cursor == total);
+                    return out[0..total];
+                },
+            }
+        }
+
+        /// Answer a #176 redirect verdict. `respond`'s discipline with
+        /// one structural difference: the bytes cannot come from static
+        /// memory — the Location may carry the request's own path — so
+        /// the response is rendered into the connection's head buffer,
+        /// whose request bytes are done being read once the Location is
+        /// composed (into the rewrite scratch, never aliasing what it
+        /// copies). The buffer is therefore *held* through the send,
+        /// unlike a static answer, and returned by the redirect write
+        /// continuations before the connection resumes or drains.
+        fn respondRedirect(
+            server: *ServerType,
+            conn: *ConnType,
+            redirect: *const filter.Redirect,
+            request_host: ?[]const u8,
+            forward: parser.CanonicalTarget,
+        ) void {
+            assert(conn.state == .l7_reading_head);
+            // The same contract `respond` states: both data ops free, so
+            // the send and any lingering drain have their completions.
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.l7.response_started);
+            // Routing has acquired nothing yet: a redirect never touches
+            // the relay or upstream pools, which is what keeps it out of
+            // every shed rung past the head ring.
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            const location = composeLocation(server, redirect, request_host, forward) catch |err|
+                switch (err) {
+                    // The request's own target made the Location too long
+                    // to carry: the URI's fault, the URI's status.
+                    error.Oversize => return respond(server, conn, 414, "l7_uri_too_long"),
+                    // A composed target with no authority to compose from
+                    // (HTTP/1.0 without Host): the request lacks what the
+                    // answer requires.
+                    error.NoHost => return respond(server, conn, 400, "l7_bad_request"),
+                };
+            // The same three brakes `respond` honors, decided before the
+            // render because the close is announced inside it (§7).
+            const keep = staticResponseResyncable(conn) and
+                conn.l7.client_keep_alive and
+                !server.draining and
+                !server.keepAliveSuppressed();
+            const rendered = render.renderRedirectHead(
+                redirect.status,
+                location,
+                !keep,
+                headBytes(server, conn),
+            ) catch {
+                // The Location fit the scratch but head + Location does
+                // not fit the buffer: same fault, same status.
+                return respond(server, conn, 414, "l7_uri_too_long");
+            };
+            ServerType.clearRequestDeadline(conn);
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            server.counters.increment("l7_redirected");
+            conn.log.status = redirect.status;
+            conn.log.outcome = .redirected;
+            conn.state = .l7_responding;
+            if (keep) {
+                armClientWrite(server, conn, rendered, .redirect_next_request);
+            } else {
+                armClientWrite(server, conn, rendered, .redirect_lingering_close);
             }
         }
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -458,6 +458,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .host = host,
                 .path = views.match,
                 .headers = request.headers,
+                .client = &conn.client_address,
             };
             // One scan yields both the rewrite and the header edits (§7).
             const forward = filter.collectForward(conn.request_filters, view, edit_buffer);
@@ -583,6 +584,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .host = keys.host,
                 .path = keys.views.match,
                 .headers = request.headers,
+                .client = &conn.client_address,
             })) |status| {
                 return respondFilter(server, conn, status);
             }

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -189,6 +189,50 @@ pub fn renderResponseHead(
     return staging.buffer[0..staging.len];
 }
 
+/// Renders a #176 redirect response head into `buffer`: the status
+/// line, the Location, an explicit zero length, and the close
+/// announcement when the connection will not be kept. The one response
+/// this proxy *originates* whose bytes are not comptime-static — the
+/// Location may carry the request's own path — which is why it renders
+/// here beside the other two heads rather than living in `shed.zig`.
+pub fn renderRedirectHead(
+    status: u16,
+    location: []const u8,
+    inject_close: bool,
+    buffer: []u8,
+) error{Oversize}![]const u8 {
+    assert(filter.isRedirectStatus(status));
+    assert(location.len >= 1);
+    assert(buffer.len <= std.math.maxInt(u32));
+    var staging = Staging{ .buffer = buffer };
+    try staging.append("HTTP/1.1 ");
+    try staging.append(&statusDigits(status));
+    try staging.append(" ");
+    try staging.append(redirectReason(status));
+    try staging.append("\r\nLocation: ");
+    try staging.append(location);
+    try staging.append("\r\nContent-Length: 0\r\n");
+    if (inject_close) {
+        try staging.append("Connection: close\r\n");
+    }
+    try staging.append("\r\n");
+    assert(staging.len >= 1);
+    return staging.buffer[0..staging.len];
+}
+
+/// The reason phrases for `filter.redirect_statuses` — a closed switch
+/// on `shed.reasonPhrase`'s terms: an unlisted status is a bug at the
+/// call site, not a phrase to invent.
+fn redirectReason(status: u16) []const u8 {
+    return switch (status) {
+        301 => "Moved Permanently",
+        302 => "Found",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        else => unreachable, // isRedirectStatus gates every caller.
+    };
+}
+
 /// Bounded append cursor over the caller's staging buffer; overflowing
 /// it is the `Oversize` verdict, never a wider write.
 const Staging = struct {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -2017,6 +2017,147 @@ test "l7: an origin head that no longer fits once the close is injected is 502" 
     try bed.expectDrained();
 }
 
+test "l7: a redirect composes Location from the request and keeps serving (#176)" {
+    // Scheme-only composed target: the Location is the configured
+    // scheme plus the request's own host, canonical path and verbatim
+    // query. Keep-alive holds — a redirect is an answer, not a fault —
+    // so the same connection's next request reaches the origin.
+    const rules = [_]filter.Rule{
+        .{ .match = .{ .path_prefix = "/old" }, .actions = &.{
+            .{ .redirect = .{ .status = 301, .target = .{ .composed = .{ .scheme = .https } } } },
+        } },
+    };
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 31,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .request_filters = &rules,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /fresh HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /old/path?q=1 HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 301 Moved Permanently\r\n" ++
+            "Location: https://o/old/path?q=1\r\n" ++
+            "Content-Length: 0\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_redirected"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    // The redirected request never reached the origin; the second did.
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
+    try bed.expectDrained();
+}
+
+test "l7: a redirect can replace the host, or name a fixed target (#176)" {
+    const rules = [_]filter.Rule{
+        .{ .match = .{ .path_prefix = "/www" }, .actions = &.{
+            .{ .redirect = .{ .status = 308, .target = .{ .composed = .{
+                .scheme = .https,
+                .host = "example.com",
+            } } } },
+        } },
+        .{ .match = .{ .path_prefix = "/gone" }, .actions = &.{
+            .{ .redirect = .{ .status = 302, .target = .{
+                .location = "https://status.example.com/",
+            } } },
+        } },
+    };
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 32, .request_filters = &rules });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /gone HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /www?keep=1 HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // The composed host replaces the request's; the literal is sent
+    // verbatim, carrying nothing of the request.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 308 Permanent Redirect\r\n" ++
+            "Location: https://example.com/www?keep=1\r\n" ++
+            "Content-Length: 0\r\n\r\n" ++
+            "HTTP/1.1 302 Found\r\n" ++
+            "Location: https://status.example.com/\r\n" ++
+            "Content-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_redirected"));
+    // Neither request touched the origin.
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.accepted_count);
+    try bed.expectDrained();
+}
+
+test "l7: a composed redirect with no authority to compose from is 400 (#176)" {
+    const rules = [_]filter.Rule{
+        .{ .match = .{}, .actions = &.{
+            .{ .redirect = .{ .status = 301, .target = .{ .composed = .{ .scheme = .https } } } },
+        } },
+    };
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 33, .request_filters = &rules });
+    defer bed.tearDown();
+
+    // HTTP/1.0 without Host: no replacement host on the rule and no
+    // authority on the request — nothing to compose the target from.
+    try bed.exchange("GET /anything HTTP/1.0\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_redirected"));
+    try bed.expectDrained();
+}
+
+test "l7: a redirect whose Location cannot be carried is 414 (#176)" {
+    // The request's own target is what makes the composed Location too
+    // long for the head buffer: the URI's fault, the URI's status.
+    const rules = [_]filter.Rule{
+        .{ .match = .{}, .actions = &.{
+            .{ .redirect = .{ .status = 301, .target = .{ .composed = .{ .scheme = .https } } } },
+        } },
+    };
+    const head_buffer_bytes: u32 = 1024;
+    const prefix = "GET /";
+    const suffix = " HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    // A path long enough that the response head overflows the buffer,
+    // while the request itself still fits it. Announcing close keeps
+    // the assertion on the close spelling of the 414 — unlike the
+    // parse-time 414 this one arrives on a clean message boundary, so
+    // a keep-alive request would legitimately be kept.
+    var request: [prefix.len + 960 + suffix.len]u8 = undefined;
+    @memcpy(request[0..prefix.len], prefix);
+    @memset(request[prefix.len..][0..960], 'p');
+    @memcpy(request[prefix.len + 960 ..][0..suffix.len], suffix);
+    comptime assert(prefix.len + 960 + suffix.len <= head_buffer_bytes);
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 34,
+        .request_filters = &rules,
+        .head_buffer_bytes = head_buffer_bytes,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(&request);
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_redirected"));
+    try bed.expectDrained();
+}
+
 test "l7: response filters edit the origin's head on the way out (#175)" {
     // An unconditional rule sheds the Server banner and adds HSTS; a
     // 5xx-scoped rule must stay silent on this 200. The whole rendered

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -134,6 +134,14 @@ pub const ClientWrite = struct {
         /// pressure" — see `proxy.staticResponseResyncable` for what
         /// earns it.
         next_request,
+        /// A #176 redirect is out. The two arms mirror the static pair
+        /// above with one extra obligation: the redirect rendered into
+        /// the connection's head buffer and *held* it through the send
+        /// — a static answer returns it before arming — so the buffer
+        /// goes back to the ring here, before the continuation whose
+        /// asserts require it gone.
+        redirect_next_request,
+        redirect_lingering_close,
     };
 };
 


### PR DESCRIPTION
Three commits, each gated by the full `zig build ci` (unit + fuzz corpus, 4096-seed sim, Tier-0.5 live gate) and a tiger-style review.

Closes #176. Closes #177.

## #177 — Client CIDR matching

- `match.client` takes CIDR literals, any-of across the list and conjoined with the other predicates — the issue's own rule, "`/admin` from the office range and nowhere else," is one allow rule with a reject beneath it.
- **The "which address" question settled as *not a new decision***: the predicate matches `conn.client_address`, the same value every other consumer reads under §6's PROXY-protocol principle — the observed peer, or the announced client on a `proxy_protocol` listener that required the header — and never an `X-Forwarded-For` chain, because an allowlist keyed on client-supplied text is not an allowlist.
- Prefixes are mandatory and bounded per family: `/32` for IPv4, **`/64` for IPv6** — the same client identity `hash.key: source_ip` keys on, so the two features cannot disagree about what a client is, and a bare address is refused rather than given per-family folklore (exact-v4 would be /32, but an exact v6 *client* is its /64). Host bits past the prefix are refused: `10.0.0.1/8` is a typo for one of two different ranges, and the loader will not guess which.
- Containment is a masked-prefix compare over the compiled table, family-strict — sound because both the accept and PROXY paths normalize mapped-v6 forms before storage.

## #176 — Redirect action

- `redirect` beside `reject`: closed status set `301/302/307/308`, and a target in one of two forms — a fixed `location` sent verbatim, or composed: `scheme` (required) and optionally `host` replaced, the request's own canonical path and query carried through. HTTP→HTTPS and `www`→apex are one rule each, and the config never restates the path. The scheme is never guessed: behind a TLS terminator every hop this proxy sees is plaintext, and a guess is wrong exactly when it matters.
- `firstReject` widens to `firstVerdict`: the first terminal action — reject or redirect — wins, top-down, exactly as before.
- The engineering center: this is the one response zoxy originates whose bytes are not comptime-static (the `Location` may carry the request's path), so it renders into the connection's own head buffer — after the Location is composed into the rewrite scratch, never aliasing what the render overwrites — and **holds that buffer through the send**, returned by two new write continuations before the static-response endings run. DESIGN.md §5/§8's buffer-lifecycle enumerations record the new case and the composed-first argument that makes it sound.
- Verdicts at the edges: a composed Location the buffer cannot carry is `414` — the URI's own fault, answered on a clean message boundary the ordinary keep rule then reads (that counter's one keep-capable spelling, documented) — and a composed target on a request with no authority (HTTP/1.0 without Host) is `400`.
- `zoxy_l7_redirected` counts it and the access log says `redirected`, deliberately apart from rejects: refused traffic and relocated traffic never blur. A new sim script drives the path under the coverage census, with a client oracle demanding the exact composed Location on every 301 across all 4096 seeds; directed tests pin both target forms byte-exact, the keep-alive turnaround after a redirect, and both edge verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)