### PR TITLE
feat: cookie stickiness, and a pick that names its key (#178)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -865,8 +865,8 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   client on a `proxy_protocol` listener — never an `X-Forwarded-For`
   chain, because an allowlist keyed on client-supplied text is not an
   allowlist. The prefix is mandatory and bounded per family — /32 for
-  IPv4, **/64 for IPv6**, the same client identity `hash.key:
-  source_ip` keys on, so two features cannot disagree about what a
+  IPv4, **/64 for IPv6**, the same client identity a `source_ip`-keyed
+  hash pick keys on, so two features cannot disagree about what a
   client is — and host bits past the prefix are refused: `10.0.0.1/8`
   is a typo for one of two different ranges, and the loader cannot know
   which. Containment is a masked-prefix compare over the compiled
@@ -910,7 +910,10 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   way out, and the loader refuses those arms by name rather than
   ignoring them. Edits apply during the downstream re-render through
   the same suppress-and-append machinery, under the same
-  `header_edits_max` bound on the table's total; the proxy-managed
+  `header_edits_max` bound on the table's total — the render accepts
+  one slot past it (`response_edits_max`), reserved for #178's
+  Set-Cookie stamp, which rides this machinery rather than owning a
+  second injection path; the proxy-managed
   names (framing, hop-by-hop, `X-Forwarded-For`) stay barred by the
   same validator, since a hand-written `Content-Length` would
   desynchronise the relay. A head that no longer fits after edits is
@@ -946,7 +949,13 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   the lower **in-flight total** wins: L7 leases and live L4 connections
   summed, since both are work the origin is carrying) by default, `rr`
   for smooth weighted rotation (strict rotation at equal weights),
-  `hash` for stickiness. Cluster endpoints are
+  `hash` for stickiness. `pick` takes two spellings (#178): the bare
+  policy string for the keyless policies, or an object —
+  `{ "policy": "hash", "key": …, "name": … }` — that names what a
+  `hash` cluster is sticky on. A bare `"hash"` is rejected at load:
+  the old source_ip default read as "sticky" and quietly was not
+  behind NAT, so the key is the operator's sentence to write.
+  Cluster endpoints are
   static socket addresses resolved once at config load, never on the
   loop (dynamic DNS is a non-goal, §1), each optionally weighted — two
   bullets below.
@@ -1000,10 +1009,23 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   So the endpoint is a *pure function* of the key and the eligible set:
   every process computes the same answer with nothing shared, which is
   what makes stickiness correct under this process model rather than
-  merely cheap. `hash.key` names the identity — `source_ip` today, all
-  four bytes of an IPv4 address and the **/64 prefix** of an IPv6 one,
-  since RFC 8981 privacy addressing rotates the interface identifier and
-  hashing it whole would re-home mobile clients on a timer.
+  merely cheap. The pick object's `key` names the identity. `source_ip`
+  is all four bytes of an IPv4 address and the **/64 prefix** of an
+  IPv6 one, since RFC 8981 privacy addressing rotates the interface
+  identifier and hashing it whole would re-home mobile clients on a
+  timer. `header` is rendezvous over the named header's value (a
+  pinned FNV-1a folded through the same pinned finalizer — `std.hash`
+  makes no cross-version promise, and a rolling restart runs two
+  builds side by side): stickiness on an identity the client *states*
+  — a tenant, a user id — which survives NAT, the exact place
+  `source_ip` fails. `cookie` is the third key and its own bullet
+  below. The request-derived keys read a parsed head, so the loader
+  rejects them on clusters any `l4` listener routes to — the
+  `proxy_protocol` reachability rule in the other direction — and a
+  request *missing* its keyed material (no such header, first request
+  of a cookie session) is placed by load instead, the same weighted
+  two-choice draw `p2c` runs: cross-process agreement is not needed
+  there, because a keyless population has no identity to be sticky on.
   Rendezvous rather than a ring or Maglev because both of those answer
   from a precomputed table, and a table must be *rebuilt* whenever
   membership changes — which here is every health-check ejection and
@@ -1026,12 +1048,47 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   opens a divergence window — confined, by the same 1/n property, to the
   clients of the flapping endpoint, who are already affected by it.
   And source-IP hashing balances by *client*, not by request: NAT puts
-  many clients on one address, and one heavy client cannot be split.
+  many clients on one address, and one heavy client cannot be split —
+  which is what the `cookie` key exists for, next bullet.
   It also balances by the *observed* client: behind another proxy every
   connection carries that proxy's address, so the key is one value and
   the whole cluster hashes to a single endpoint — stickiness inverted,
   not degraded. `proxy_protocol` on the listener (§6) is what makes
   `source_ip` mean the real client there.
+- **Cookie stickiness: the client holds the assignment** (#178, settled
+  2026-08-03). Where `source_ip` breaks — corporate NAT, CGNAT, mobile
+  carriers, exactly where stickiness is most wanted — the standard
+  answer is a cookie the proxy sets (HAProxy's `cookie SRV insert`),
+  and it fits this design unusually well: §3's argument against a
+  stickiness table is that no process can share one, and a cookie is
+  the client carrying the state instead, the table-free property
+  rendezvous has, achieved a second way. The named cookie holds an
+  **endpoint tag**: 16 lowercase hex of the endpoint's rendezvous
+  identity — a function of its address, so it is stable across
+  restarts, processes and config reordering, and leaks a hash rather
+  than the address. A request whose tag names a healthy,
+  under-capacity endpoint goes there, whatever the load says —
+  stickiness is the point, and load had its say at placement. A
+  request with no usable tag is placed by load (the first request of a
+  session deserves the calmest endpoint), and one naming an ejected,
+  drained, capped or removed endpoint re-homes the same way. Then the
+  response answers: `Set-Cookie: <name>=<tag>; Path=/; HttpOnly`, as
+  one `add` edit riding the #175 render machinery (an origin's own
+  Set-Cookie rides beside it), on every exchange whose request did not
+  already name the endpoint that served it — and *only* those, so a
+  settled session is never re-stamped. No `Secure` attribute: this
+  proxy does not terminate TLS (§1), so it cannot know the
+  client-facing scheme. Three counters partition a cookie cluster's
+  forwarded responses — `l7_sticky_followed` / `assigned` /
+  `repicked` — and a repick *rate* is the operational signal:
+  endpoints flapping under a sticky population. Forgery is priced
+  consciously: a tag is not signed, because a client can only choose
+  which backend serves *itself*, and only from the eligible set — a
+  keyed variant is a config knob for later if that ever matters. The
+  tag grammar is strict (exactly the minted spelling parses), the mint
+  is pinned by test vectors and re-proved by the simulator against a
+  frozen literal, and the live gate round-trips assignment, echo and
+  forgery against the shipped binary.
 - **Active health checks** are per-cluster opt-in (a `check` block —
   HAProxy's model) so a request is not routed to an endpoint known to be
   down:

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,7 +195,12 @@ by a compiled ceiling — the startup banner prints what the endpoint tables cos
 |---|---|
 | `p2c` *(default)* | two weight-biased candidates; the one carrying less in-flight work wins — HTTP requests and L4 connections both count |
 | `rr` | smooth weighted rotation — exact rotation at equal weights, predictable spread, useful for cache warming |
-| `hash` | the same client always reaches the same endpoint, with traffic split by weight |
+| `hash` | the same key always reaches the same endpoint — object form only, naming what the cluster is sticky on |
+
+`pick` is either a bare policy string or an object carrying the policy
+and its settings. `hash` takes only the object form — you name its key
+explicitly (`source_ip`, `header`, or `cookie`), because which identity
+a cluster is sticky on is a decision, not a default.
 
 Upstream connections are pooled process-wide and reusable by any request,
 which is the single largest throughput lever in this design.
@@ -219,14 +224,13 @@ must hold weight, or the config is rejected.
 
 ### Sticky sessions
 
-`pick: "hash"` is **rendezvous hashing over the healthy endpoints**, keyed on
-the client address:
+`pick: {"policy": "hash", ...}` keeps clients on one backend, and its
+`key` names what "one client" means:
 
 ```json
 "api": {
     "endpoints": ["10.0.0.1:8080", "10.0.0.2:8080"],
-    "pick": "hash",
-    "hash": { "key": "source_ip" }
+    "pick": { "policy": "hash", "key": "source_ip" }
 }
 ```
 
@@ -241,14 +245,56 @@ it recovers. `source_ip` uses all four bytes of an IPv4 address and the /64
 prefix of an IPv6 one, so stickiness survives privacy-address rotation.
 
 The tradeoff is inherent to hashing on client address: NAT hides many clients
-behind one address, and one heavy client cannot be split. Prefer `p2c` where
-even load matters more than stickiness.
+behind one address, and one heavy client cannot be split. That is what the
+other two keys are for — and where even load matters more than stickiness,
+prefer `p2c`.
 
 The key is the *observed* client address, so behind another proxy or LB
 every connection carries that machine's address and the whole cluster
 hashes to one endpoint. See
 [Learning who the client is](#learning-who-the-client-is-proxy-protocol)
 for how an `l4` listener recovers the real client.
+
+#### Sticky on a header
+
+```json
+"pick": { "policy": "hash", "key": "header", "name": "x-tenant" }
+```
+
+Hashes the named header's value: stickiness on an identity the client
+*states* — a tenant, a user id, an API key — which survives NAT. A
+request without the header is placed by load like a `p2c` pick. Only
+`http` listeners can route to a header- or cookie-keyed cluster; an
+`l4` listener never parses a request to read one from.
+
+#### Sticky on a cookie
+
+```json
+"api": {
+    "endpoints": ["10.0.0.1:8080", "10.0.0.2:8080"],
+    "pick": { "policy": "hash", "key": "cookie", "name": "srv_id" }
+}
+```
+
+The named cookie carries the assignment itself: a 16-hex **endpoint
+tag** zoxy mints from the endpoint's address, stable across restarts,
+processes, and config reordering. A request with no cookie is placed on
+the calmest backend and the response sets one
+(`Set-Cookie: srv_id=<tag>; Path=/; HttpOnly` — no expiry, a session
+cookie); a request whose tag names a healthy, under-capacity backend
+goes there and is **not** re-stamped; a tag naming an ejected, drained
+or removed backend is re-placed and the response re-announces. This is
+the strongest answer to NAT: every user behind one address carries
+their own assignment.
+
+Pick a cookie name your application does not use — zoxy adds its
+Set-Cookie beside the origin's, never in place of them. The tag is not
+signed: a forged cookie can only choose which of *your* backends serves
+that client, never one outside the eligible set.
+
+Three counters watch it: `zoxy_l7_sticky_followed`, `..._assigned`, and
+`..._repicked` partition a cookie cluster's responses. A rising repick
+rate means backends are flapping under a sticky population.
 
 ### Health checks
 
@@ -341,8 +387,8 @@ client — which looks like forwarding and is the opposite of it.
 ### Learning who the client is (PROXY protocol)
 
 The mirror problem: put a load balancer in front of zoxy and *zoxy* sees
-only the balancer. That breaks more than logging — `pick: "hash"` keys
-on the client address, so behind an LB every connection hashes alike and
+only the balancer. That breaks more than logging — a `source_ip`-keyed
+hash pick reads the client address, so behind an LB every connection hashes alike and
 the whole fleet lands on one endpoint. An `l4` listener can instead
 require each connection to open with a PROXY protocol header (v1 or v2 —
 what AWS NLB, GCP and HAProxy emit) announcing the real client:

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -103,6 +103,11 @@ ended_count: u8,
 /// Clean seeds run without the adversary and with a well-behaved
 /// origin, so the L7 oracles demand exact golden outcomes.
 clean: bool,
+/// The seed drew the #178 cookie-keyed http cluster: the pick is
+/// forced to `hash` on `canon.sticky_cookie_name`, every L7 client
+/// runs the stamp oracle, and `verify` holds the sticky counters to
+/// the responses they annotate.
+sticky_http: bool,
 /// Decided before `io.init` (the ring the sim registers must equal the
 /// limit the server accounts against — Server.init asserts the match),
 /// consumed by `startServerAndOrigins` for the rest of the pool shape.
@@ -414,7 +419,8 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     // by `balancer.zig`'s own tests, which can hold thousands of distinct
     // clients against a multi-endpoint cluster as a scenario cannot.
     const pick_l4 = randomPick(random);
-    const pick_http = randomPick(random);
+    const http_hash_key = deriveSticky(harness, random);
+    const pick_http = if (harness.sticky_http) .hash else randomPick(random);
     // Each cluster draws §7 active health checks independently, so the
     // prober runs its whole lifecycle — sweeps, fall/rise transitions
     // under the adversary's connect fates, parked-close on ejection, and
@@ -451,6 +457,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
             .endpoints = &harness.endpoints_http,
             .weights = if (random.boolean()) &harness.weights_http else null,
             .pick = pick_http,
+            .hash_key = http_hash_key,
             .check = health.check_http,
             .max_inflight = deriveMaxInflight(harness.clean, random),
         },
@@ -459,6 +466,21 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
     harness.proxy_protocol_l4 = deriveProxyProtocol(random);
     harness.wireListeners(deriveForwarded(random));
+    harness.deriveServerConfig(random, connect_timeout_ms, health.interval_ms);
+}
+
+/// The top-level `Config` draw — the timeouts, the deadlines, and the
+/// access-log coin — split from `deriveTopology` when the #178 draw
+/// pushed that one past the length limit; the cluster and listener
+/// tables it points at are the caller's, already wired.
+fn deriveServerConfig(
+    harness: *Harness,
+    random: std.Random,
+    connect_timeout_ms: u32,
+    health_interval_ms: u32,
+) void {
+    assert(connect_timeout_ms >= 1);
+    assert(health_interval_ms >= 1);
     harness.config = .{
         .listeners = &harness.listener_configs,
         .clusters = &harness.clusters,
@@ -479,8 +501,33 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         // schedule fuzz; the fourth leaves it off, which is the shape
         // that must reserve nothing and read no clock (§5, §8).
         .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
-        .health_interval_ms = health.interval_ms,
+        .health_interval_ms = health_interval_ms,
     };
+}
+
+/// The #178 draw: a quarter of seeds key the http cluster on the sim
+/// cookie, forcing `hash` (a cookie key rides no other policy). The
+/// rest draw their pick freely, where `hash` means source_ip — so both
+/// hash keys, and every keyless policy, flow through the schedule fuzz.
+/// The sticky scripts run on every seed either way; on a non-sticky one
+/// their cookies are inert bytes, which is itself the oracle. Also
+/// re-proves the pinned tag: what the scripts send and the client
+/// oracle demands must be what the running mint spells for the one http
+/// endpoint, so a hash change fails the sweep loudly instead of quietly
+/// re-homing cookie holders.
+fn deriveSticky(harness: *Harness, random: std.Random) zoxy.config.Config.Cluster.HashKey {
+    harness.sticky_http = random.uintLessThan(u8, 4) == 0;
+    var minted_tag: [zoxy.balancer.Balancer.endpoint_tag_len]u8 = undefined;
+    zoxy.balancer.Balancer.formatEndpointTag(
+        zoxy.balancer.Balancer.addressIdentity(&harness.endpoints_http[0]),
+        &minted_tag,
+    );
+    assert(std.mem.eql(u8, &minted_tag, l7.canon.sticky_tag));
+    assert(l7.canon.sticky_cookie_name.len >= 1);
+    if (harness.sticky_http) {
+        return .{ .cookie = l7.canon.sticky_cookie_name };
+    }
+    return .source_ip;
 }
 
 /// The §8 per-endpoint cap for one cluster, or null for uncapped.
@@ -799,6 +846,7 @@ fn populateClients(harness: *Harness, random: std.Random) void {
                 httpBindAddress(),
                 random.enumValue(l7.Script),
                 harness.clean,
+                harness.sticky_http,
             );
             client.on_ended = clientEndedHook;
             client.context = harness;
@@ -966,6 +1014,7 @@ pub fn verify(harness: *Harness) !void {
         return error.OriginSawInvalidProxyHeader;
     }
     try harness.verifyUpstreamIdentities();
+    try harness.verifyStickyCounters();
     try harness.verifyAccessLog();
     for (harness.clients[0..harness.l4_count]) |*client| {
         try client.verifyIntegrity();
@@ -973,6 +1022,27 @@ pub fn verify(harness: *Harness) !void {
     for (harness.l7_clients[0..harness.l7_count]) |*client| {
         try client.verify();
     }
+}
+
+/// #178, every seed: the sticky verdicts move only when the cookie
+/// cluster was drawn, and then at least once per completed forwarded
+/// response — every `l7_responses` increment passed through the render
+/// commit that credits exactly one verdict. Not an equality: the credit
+/// lands at the render commit and `l7_responses` at the exchange's
+/// finish, so an adversary cutting between them legally leaves a
+/// credited verdict with no finished response. The exact-bytes demand
+/// lives in the client's per-response stamp oracle; this holds the
+/// *counters* to the responses they annotate.
+fn verifyStickyCounters(harness: *const Harness) !void {
+    const counters = &harness.server.counters;
+    const total = counters.get("l7_sticky_followed") +
+        counters.get("l7_sticky_assigned") +
+        counters.get("l7_sticky_repicked");
+    if (!harness.sticky_http) {
+        if (total != 0) return error.StickyCountersDiverged;
+        return;
+    }
+    if (total < counters.get("l7_responses")) return error.StickyCountersDiverged;
 }
 
 /// #142 send, every seed: whatever identity the origin heard must be one

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -33,6 +33,20 @@ pub const response_never_name = "X-Sim-Never";
 /// client oracle demands this exact value on every one it parses.
 pub const redirect_location = "https://sim/redirect";
 
+/// The #178 cookie name a sticky seed's http cluster is keyed on, and
+/// the exact tag of the one http endpoint (127.0.0.1:9001). The tag is
+/// *pinned* — computed once from `endpointId`'s published formula and
+/// frozen here, with the harness asserting the running balancer still
+/// mints it at every setup — so the client oracle demands the stamp's
+/// bytes the way it demands `redirect_location`'s, and a silent remap
+/// of the mint fails the sweep instead of quietly re-homing a fleet.
+pub const sticky_cookie_name = "zoxy-sim-srv";
+pub const sticky_tag = "b4a7ea22f14bfcac";
+/// The whole Set-Cookie value a sticky stamp carries, attributes
+/// included — one spelling shared by the oracle so it cannot drift.
+pub const sticky_set_cookie_value =
+    sticky_cookie_name ++ "=" ++ sticky_tag ++ "; Path=/; HttpOnly";
+
 /// A parseable head that cannot survive the render: 8190 bytes fits the
 /// proxy's 8 KiB response buffer, but no Content-Length and no
 /// Transfer-Encoding makes it until-close framing, which forces a
@@ -43,6 +57,7 @@ pub const redirect_location = "https://sim/redirect";
 pub const oversize_head = "HTTP/1.1 200 OK\r\nx-pad: " ++ ("p" ** 8162) ++ "\r\n\r\n";
 
 comptime {
+    assert(sticky_tag.len == 16);
     assert(sized_body.len == 32);
     assert(chunked_wire[0] == '1' and chunked_wire[1] == '0');
     assert(chunked_wire.len == 4 + 16 + 2 + 5);

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -51,6 +51,16 @@ pub const ClientError = error{
     /// anywhere (the scripted origin answers no 5xx) — either way a
     /// predicate fired where it could not have.
     ResponseEditForged,
+    /// A sticky seed's proxied 200 arrived without the exact #178
+    /// Set-Cookie stamp the drawn cookie cluster owes it — every routed
+    /// request but `sticky_follow`'s is assigned or repicked, and the
+    /// one endpoint's tag is pinned, so the whole value is demanded.
+    StickyStampMissing,
+    /// The #178 stamp where it must not be: on `sticky_follow`'s 200
+    /// (the request already named the endpoint — idempotence is the
+    /// contract), on a static, or on any response of a seed that never
+    /// drew a cookie cluster.
+    StickyStampForged,
 };
 
 pub fn Client(comptime IoType: type) type {
@@ -63,6 +73,9 @@ pub fn Client(comptime IoType: type) type {
         /// Clean seeds harden the prefix oracle to the exact golden
         /// outcome — nothing may be cut, shed, or silently torn down.
         clean: bool = false,
+        /// The seed drew the #178 cookie-keyed http cluster, so the
+        /// stamp oracle runs over every parsed response head.
+        sticky: bool = false,
         connect_completion: IoType.Completion = .{},
         connect_cancel_completion: IoType.Completion = .{},
         recv_completion: IoType.Completion = .{},
@@ -115,11 +128,13 @@ pub fn Client(comptime IoType: type) type {
             address: std.Io.net.IpAddress,
             script: Script,
             clean: bool,
+            sticky: bool,
         ) void {
             client.io = io;
             client.address = address;
             client.script = script;
             client.clean = clean;
+            client.sticky = sticky;
             const bytes = scripts.spec(script).request;
             assert(bytes.len <= client.request.len);
             @memcpy(client.request[0..bytes.len], bytes);
@@ -216,6 +231,7 @@ pub fn Client(comptime IoType: type) type {
             const walk = walkResponses(
                 client.receive_buffer[0..client.received_len],
                 client.script,
+                client.sticky,
             );
             client.maybeSendSecondRequest(&walk);
             if (walk.violation == null and walk.complete_count >= responsesTarget(client.script, &walk)) {
@@ -324,7 +340,7 @@ pub fn Client(comptime IoType: type) type {
             assert(client.received_len <= client.receive_buffer.len);
             if (client.overrun) return ClientError.ResponseOverrun;
             const bytes = client.receive_buffer[0..client.received_len];
-            const walk = walkResponses(bytes, client.script);
+            const walk = walkResponses(bytes, client.script, client.sticky);
             if (walk.violation) |violation| return violation;
             assert(walk.offset <= client.received_len);
             if (client.clean) {
@@ -364,7 +380,7 @@ pub fn Client(comptime IoType: type) type {
         /// a legal prefix (the adversary cuts mid-anything); bytes that
         /// can never extend to a legal transcript — or one complete
         /// response more than the transcript contains — are a violation.
-        fn walkResponses(bytes: []const u8, script: Script) Walk {
+        fn walkResponses(bytes: []const u8, script: Script, sticky: bool) Walk {
             const entry = scripts.spec(script);
             var walk = Walk{
                 .complete_count = 0,
@@ -394,6 +410,10 @@ pub fn Client(comptime IoType: type) type {
                     return walk;
                 }
                 if (responseEditViolation(&response)) |violation| {
+                    walk.violation = violation;
+                    return walk;
+                }
+                if (stickyViolation(sticky, script, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
                 }
@@ -457,6 +477,58 @@ pub fn Client(comptime IoType: type) type {
                 return ClientError.ResponseEditForged;
             }
             return null;
+        }
+
+        /// The #178 oracle over one parsed head. On a sticky seed the
+        /// drawn cookie cluster serves every routed request, so every
+        /// proxied 200 owes the client the exact pinned stamp — except
+        /// `sticky_follow`'s, whose request already named the endpoint
+        /// (idempotence is the contract). A non-200 here is a static or
+        /// a per-request redirect, neither of which runs the response
+        /// render's stamp path, so the cookie's *name* appearing at all
+        /// is forged — and on a seed that drew no cookie cluster, so is
+        /// any appearance anywhere. Like `responseEditViolation`, this
+        /// distinguishes the render paths from outside the process,
+        /// under every schedule the adversary produces.
+        fn stickyViolation(
+            sticky: bool,
+            script: Script,
+            response: *const parser.ResponseHead,
+        ) ?ClientError {
+            assert(response.status >= 100);
+            assert(response.headers.len <= zoxy.constants.headers_max);
+            const named = stickyNamePresent(response.headers);
+            if (!sticky) {
+                if (named) return ClientError.StickyStampForged;
+                return null;
+            }
+            if (response.status != 200) {
+                if (named) return ClientError.StickyStampForged;
+                return null;
+            }
+            switch (script) {
+                .sticky_follow => if (named) return ClientError.StickyStampForged,
+                else => if (!headerEquals(
+                    response.headers,
+                    "set-cookie",
+                    canon.sticky_set_cookie_value,
+                )) return ClientError.StickyStampMissing,
+            }
+            return null;
+        }
+
+        /// Any Set-Cookie line claiming the #178 name, whatever its
+        /// value — the must-not-appear direction's test, looser than
+        /// the exact-value demand so a wrong-tag stamp cannot pass as
+        /// absent.
+        fn stickyNamePresent(headers: []const parser.Header) bool {
+            assert(headers.len <= zoxy.constants.headers_max);
+            const prefix = canon.sticky_cookie_name ++ "=";
+            for (headers) |header| {
+                if (!std.ascii.eqlIgnoreCase(header.name, "set-cookie")) continue;
+                if (std.mem.startsWith(u8, header.value, prefix)) return true;
+            }
+            return false;
         }
 
         fn headerEquals(headers: []const parser.Header, name: []const u8, value: []const u8) bool {

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 
 const zoxy = @import("zoxy");
 
+const canon = @import("canon.zig");
 const constants = zoxy.constants;
 const parser = zoxy.http.parser;
 
@@ -92,6 +93,17 @@ pub const Script = enum(u8) {
     /// (§7). Only seeds that drew `append` reach the rung, and
     /// `forwarded_chain_dropped` witnesses it.
     forwarded_oversize,
+    /// A GET carrying the pinned #178 tag of the one http endpoint. On
+    /// a sticky seed it is *followed* — the client oracle demands the
+    /// response carry no re-stamp, the idempotence half — and
+    /// `l7_sticky_followed` fires. On any other seed the cookie is
+    /// inert bytes the origin sees verbatim.
+    sticky_follow,
+    /// A GET carrying a well-formed tag (the minted grammar) that names
+    /// no endpoint of any cluster. Served like any GET; on a sticky
+    /// seed the response must re-announce (`l7_sticky_repicked`) — the
+    /// forged-cookie / shrunk-config shape.
+    sticky_repick,
 };
 
 /// Everything the client's oracles need to know about one script. The
@@ -398,6 +410,30 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     },
     .forwarded_oversize = .{
         .request = forwarded_oversize_head,
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+    },
+    // #178: both route and forward like a plain GET, so the §8 rungs and
+    // a killed dial can precede the 200. What they change is the sticky
+    // verdict, which the client's stamp oracle reads off every response
+    // head — and on non-sticky seeds they degrade to `get` with inert
+    // cookie bytes, which is itself worth sweeping (a cookie must never
+    // do anything on a cluster that is not keyed on it).
+    .sticky_follow = .{
+        .request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++
+            "Cookie: " ++ canon.sticky_cookie_name ++ "=" ++ canon.sticky_tag ++ "\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+    },
+    .sticky_repick = .{
+        .request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++
+            "Cookie: " ++ canon.sticky_cookie_name ++ "=ffffffffffffffff\r\n\r\n",
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 200,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -157,6 +157,25 @@ const uncovered = [_]Uncovered{
             "live gate counts it against a real one",
     },
     .{
+        .name = "l7_sticky_followed",
+        .why = .unreached,
+        .reason = "the sweep draws no cookie-keyed cluster yet (#178 — the draw " ++
+            "and its echoing scripts are the next slice); " ++
+            "src/http_proxy_test.zig covers all three verdicts",
+    },
+    .{
+        .name = "l7_sticky_assigned",
+        .why = .unreached,
+        .reason = "same as l7_sticky_followed: no cookie-keyed cluster in the " ++
+            "sweep yet (#178); src/http_proxy_test.zig covers the stamp",
+    },
+    .{
+        .name = "l7_sticky_repicked",
+        .why = .unreached,
+        .reason = "same as l7_sticky_followed: no cookie-keyed cluster in the " ++
+            "sweep yet (#178); src/http_proxy_test.zig covers the forged tag",
+    },
+    .{
         .name = "admin_served",
         .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -157,25 +157,6 @@ const uncovered = [_]Uncovered{
             "live gate counts it against a real one",
     },
     .{
-        .name = "l7_sticky_followed",
-        .why = .unreached,
-        .reason = "the sweep draws no cookie-keyed cluster yet (#178 — the draw " ++
-            "and its echoing scripts are the next slice); " ++
-            "src/http_proxy_test.zig covers all three verdicts",
-    },
-    .{
-        .name = "l7_sticky_assigned",
-        .why = .unreached,
-        .reason = "same as l7_sticky_followed: no cookie-keyed cluster in the " ++
-            "sweep yet (#178); src/http_proxy_test.zig covers the stamp",
-    },
-    .{
-        .name = "l7_sticky_repicked",
-        .why = .unreached,
-        .reason = "same as l7_sticky_followed: no cookie-keyed cluster in the " ++
-            "sweep yet (#178); src/http_proxy_test.zig covers the forged tag",
-    },
-    .{
         .name = "admin_served",
         .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -38,6 +38,12 @@ pub const Response = struct {
     /// config sets unconditionally (`X-Zoxy-Smoke: 1`) — the live gate's
     /// witness that the response edit path ran on this very hop.
     edited: bool,
+    /// The #178 endpoint tag the head's Set-Cookie announced, or null
+    /// when no line claimed the smoke cookie's name. The reader enforces
+    /// the whole minted grammar — sixteen tag bytes and the exact
+    /// attributes — so a present-but-mangled stamp fails the read
+    /// instead of passing as either presence or absence.
+    sticky_tag: ?[16]u8,
 };
 
 /// What a request says about its connection's future. HTTP/1.1's default
@@ -107,14 +113,26 @@ pub const Client = struct {
         host: []const u8,
         target: []const u8,
         persistence: Persistence,
+        /// A whole `name=value` Cookie line to send, or null for none —
+        /// the #178 leg's echo half. Explicit at every call site, like
+        /// `persistence`, so a request's bytes are readable off it.
+        cookie: ?[]const u8,
     ) !Response {
         assert(client.connected);
         assert(target.len >= 1);
         assert(target[0] == '/');
-        try client.writer.interface.print(
-            "GET {s} HTTP/1.1\r\nHost: {s}\r\n{s}\r\n",
-            .{ target, host, persistence.header() },
-        );
+        if (cookie) |crumb| {
+            assert(crumb.len >= 1);
+            try client.writer.interface.print(
+                "GET {s} HTTP/1.1\r\nHost: {s}\r\nCookie: {s}\r\n{s}\r\n",
+                .{ target, host, crumb, persistence.header() },
+            );
+        } else {
+            try client.writer.interface.print(
+                "GET {s} HTTP/1.1\r\nHost: {s}\r\n{s}\r\n",
+                .{ target, host, persistence.header() },
+            );
+        }
         try client.writer.interface.flush();
         client.requests += 1;
         const response = try readResponse(&client.reader.interface);
@@ -130,7 +148,12 @@ fn readResponse(reader: *Io.Reader) !Response {
     const head = try readHeaders(reader);
     assert(head.body_bytes <= response_body_bytes_max);
     try reader.discardAll(head.body_bytes);
-    return .{ .status = status, .body_bytes = head.body_bytes, .edited = head.edited };
+    return .{
+        .status = status,
+        .body_bytes = head.body_bytes,
+        .edited = head.edited,
+        .sticky_tag = head.sticky_tag,
+    };
 }
 
 /// The three-digit status off the status line. A response that does not
@@ -149,25 +172,27 @@ fn readStatus(reader: *Io.Reader) !u16 {
     return status;
 }
 
-/// What the header walk found: the framing, and whether the #175 stamp
-/// was among the lines.
+/// What the header walk found: the framing, whether the #175 stamp was
+/// among the lines, and the #178 tag if a Set-Cookie announced one.
 const Head = struct {
     body_bytes: u32,
     edited: bool,
+    sticky_tag: ?[16]u8,
 };
 
 /// Header lines up to the blank one, returning the body length they
 /// framed. A head with no `Content-Length` is an error: the origin always
 /// sends one, so its absence means the hop reframed the response, which
 /// is exactly the kind of thing this tier exists to notice. The #175
-/// stamp is scanned for on the same walk — spelled here rather than
-/// imported, like the counter names: the gate reads what the binary
-/// *wrote*, so a drift must fail loudly.
+/// stamp and the #178 cookie are scanned for on the same walk — spelled
+/// here rather than imported, like the counter names: the gate reads
+/// what the binary *wrote*, so a drift must fail loudly.
 fn readHeaders(reader: *Io.Reader) !Head {
     const length_name = "content-length:";
     const stamp = "x-zoxy-smoke: 1";
     var body_bytes: ?u32 = null;
     var edited = false;
+    var sticky_tag: ?[16]u8 = null;
     var lines: u32 = 0;
     while (lines < response_headers_max) : (lines += 1) {
         const taken = try reader.takeDelimiter('\n');
@@ -175,10 +200,17 @@ fn readHeaders(reader: *Io.Reader) !Head {
         const trimmed = std.mem.trimEnd(u8, line, "\r");
         if (trimmed.len == 0) {
             const framed = body_bytes orelse return error.ResponseUnframed;
-            return .{ .body_bytes = framed, .edited = edited };
+            return .{ .body_bytes = framed, .edited = edited, .sticky_tag = sticky_tag };
         }
         if (std.ascii.eqlIgnoreCase(trimmed, stamp)) {
             edited = true;
+            continue;
+        }
+        if (try stickyTagOf(trimmed)) |tag| {
+            // One announcement per response: a second line naming the
+            // cookie would be the stamp path running twice.
+            if (sticky_tag != null) return error.ResponseMalformed;
+            sticky_tag = tag;
             continue;
         }
         if (trimmed.len <= length_name.len) continue;
@@ -191,4 +223,26 @@ fn readHeaders(reader: *Io.Reader) !Head {
     }
     assert(lines == response_headers_max);
     return error.ResponseMalformed;
+}
+
+/// The #178 tag a header line announces, null when the line is not a
+/// Set-Cookie for the smoke cookie — and an error when it is one but
+/// not in the whole minted grammar (`name=` plus sixteen tag bytes plus
+/// the exact attributes), because a mangled stamp must fail the gate,
+/// not read as present or absent. The header name is case-insensitive;
+/// the cookie name is not (RFC 6265), and zoxy forwards what it minted.
+fn stickyTagOf(line: []const u8) !?[16]u8 {
+    const header_name = "set-cookie:";
+    const cookie_prefix = "zoxy-smoke-srv=";
+    const attributes = "; Path=/; HttpOnly";
+    if (line.len <= header_name.len) return null;
+    if (!std.ascii.startsWithIgnoreCase(line, header_name)) return null;
+    const value = std.mem.trim(u8, line[header_name.len..], " \t");
+    if (!std.mem.startsWith(u8, value, cookie_prefix)) return null;
+    const rest = value[cookie_prefix.len..];
+    if (rest.len != 16 + attributes.len) return error.ResponseMalformed;
+    if (!std.mem.eql(u8, rest[16..], attributes)) return error.ResponseMalformed;
+    var tag: [16]u8 = undefined;
+    @memcpy(&tag, rest[0..16]);
+    return tag;
 }

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -77,10 +77,18 @@ const connections_closed_early: u8 = 2;
 /// other half of the line arithmetic.
 const l4_connections: u8 = 2;
 
+/// The #178 leg: three exchanges on one connection against the
+/// cookie-keyed cluster — assigned (no cookie), followed (the echo),
+/// repicked (a forged tag). Run *after* the counter scrapes, so the
+/// labeled-partition equality those assert still describes a run where
+/// only the `origin` cluster has served.
+const sticky_exchanges: u32 = 3;
+
 const exchanges_per_pass: u32 =
     @as(u32, keep_alive_connections) * requests_per_connection + large_requests;
 const http_exchanges: u32 = load_passes * exchanges_per_pass;
-const access_log_lines_expected: u32 = http_exchanges + l4_connections;
+const access_log_lines_expected: u32 =
+    http_exchanges + sticky_exchanges + l4_connections;
 
 /// What the resident set may grow by between the two passes. Measured at
 /// exactly zero, run after run — the tolerance is headroom for page
@@ -101,13 +109,19 @@ const rss_growth_kb_max: u64 = 64;
 /// the run. That window is microseconds wide on a port nothing advertises,
 /// and the alternative — a floor — is satisfied by a proxy accepting
 /// connections nobody made.
-const connections_expected: u32 =
-    keep_alive_connections + load_passes * large_requests + l4_connections + 1;
+const sticky_connections: u32 = 1;
+const readiness_probes: u32 = 1;
+const connections_expected: u32 = keep_alive_connections +
+    load_passes * large_requests + l4_connections + sticky_connections +
+    readiness_probes;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
-/// leased, plus the odd straggler mid-teardown.
-const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2;
+/// leased, plus the odd straggler mid-teardown — and one more for the
+/// sticky cluster, whose pool parks its own upstream connection (§5
+/// pools key by cluster, so the origin cluster's parked one is not
+/// reused for it).
+const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2 + 1;
 
 /// The drain's cap on waiting for the connections left open above. A
 /// drain cannot tell an idle keep-alive connection from one about to send
@@ -279,6 +293,9 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // Scraped before the drain: the admin listener closes with every
     // other one when SIGTERM lands (§8).
     const counters = try countersPassed(arena, io, ports.admin, origin.port);
+    // The #178 leg runs after the scrapes above on purpose — see
+    // `sticky_exchanges` — and brings its own scrape.
+    const sticky_ok = try stickyPassed(arena, io, &ports);
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
@@ -286,7 +303,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const log_ok = accessLogPassed(&lines);
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
-    const passed = log_ok and counters.passed and memory_ok and drain_ok;
+    const passed = log_ok and counters.passed and sticky_ok and memory_ok and drain_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -384,12 +401,12 @@ fn accessLogPassed(lines: *const LogCounts) bool {
     // below its own subset would mean the counter itself is wrong — which
     // no comparison below would otherwise notice.
     assert(lines.http_ok <= lines.http);
-    assert(access_log_lines_expected == http_exchanges + l4_connections);
+    assert(access_log_lines_expected == http_exchanges + sticky_exchanges + l4_connections);
     var passed = true;
-    if (lines.http != http_exchanges) {
+    if (lines.http != http_exchanges + sticky_exchanges) {
         std.debug.print(
             "FAIL: {d} http access-log lines for {d} requests (#129 is exactly this)\n",
-            .{ lines.http, http_exchanges },
+            .{ lines.http, http_exchanges + sticky_exchanges },
         );
         passed = false;
     }
@@ -608,13 +625,24 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
         );
         passed = false;
     }
-    if (accepted != connections_expected) {
+    // Minus the #178 leg, which deliberately runs after this scrape (see
+    // `sticky_exchanges`); the whole-run equality is asserted on the
+    // sticky verdict's own later scrape.
+    if (accepted != connections_expected - sticky_connections) {
         std.debug.print(
-            "FAIL: {d} connections accepted, not the {d} this run opened\n",
-            .{ accepted, connections_expected },
+            "FAIL: {d} connections accepted, not the {d} opened before this scrape\n",
+            .{ accepted, connections_expected - sticky_connections },
         );
         passed = false;
     }
+    return loadShapePassed(responses, reused, excess) and passed;
+}
+
+/// The load's own shape, read back off the same first scrape — split
+/// from `identitiesPassed` when the #178 deferral note pushed that one
+/// past the length limit.
+fn loadShapePassed(responses: u64, reused: u64, excess: u64) bool {
+    var passed = true;
     // The counter and the log describe the same exchanges, so a
     // disagreement is one of the two lying about the same run.
     if (responses != http_exchanges) {
@@ -705,7 +733,7 @@ fn runPass(io: Io, port: u16, host: []const u8, pass: u32) !void {
             // here: the same error from the first keep-alive request and
             // from the hundredth are different bugs, and the second is
             // not reproducible by staring at the first.
-            const response = client.get(host, "/", .keep_alive) catch |err| {
+            const response = client.get(host, "/", .keep_alive, null) catch |err| {
                 std.debug.print(
                     "smoke: pass {d} keep-alive connection {d} request {d}: {t}\n",
                     .{ pass, connection, request, err },
@@ -726,7 +754,7 @@ fn runPass(io: Io, port: u16, host: []const u8, pass: u32) !void {
     while (large < large_requests) : (large += 1) {
         try single_client.connect(io, port);
         defer single_client.close();
-        const response = single_client.get(host, origin_module.large_path, .close) catch |err| {
+        const response = single_client.get(host, origin_module.large_path, .close, null) catch |err| {
             std.debug.print("smoke: pass {d} bulk request {d}: {t}\n", .{ pass, large, err });
             return err;
         };
@@ -745,7 +773,7 @@ fn runL4Load(io: Io, port: u16, host: []const u8) !void {
     while (index < l4_connections) : (index += 1) {
         try single_client.connect(io, port);
         defer single_client.close();
-        const response = single_client.get(host, "/", .keep_alive) catch |err| {
+        const response = single_client.get(host, "/", .keep_alive, null) catch |err| {
             std.debug.print("smoke: l4 connection {d}: {t}\n", .{ index, err });
             return err;
         };
@@ -793,6 +821,120 @@ fn expectResponse(response: client_module.Response, body_bytes: u32, leg: Leg) !
             std.debug.print("smoke: l4-relayed response gained the X-Zoxy-Smoke stamp\n", .{});
             return error.ResponseEditForged;
         },
+    }
+    // The #178 cookie belongs to the sticky cluster alone: the `origin`
+    // cluster is not cookie-keyed, and the l4 leg is a byte relay — a
+    // tag on either means the stamp path fired for a cluster that never
+    // asked for it.
+    if (response.sticky_tag != null) {
+        std.debug.print("smoke: a non-sticky response announced an endpoint tag\n", .{});
+        return error.StickyStampForged;
+    }
+}
+
+/// The #178 live round trip: three exchanges on one keep-alive
+/// connection against the cookie-keyed cluster, each response judged on
+/// the spot, then the counters on a scrape of their own. Runs after
+/// `countersPassed` so the partition identities that scrape asserts
+/// still describe a one-cluster run.
+fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
+    assert(ports.http != 0);
+    assert(ports.admin != 0);
+    var host_buffer: [32]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
+    try single_client.connect(io, ports.http);
+    defer single_client.close();
+
+    // Cookieless: assigned, and the response must announce a tag (the
+    // reader enforced the whole grammar before handing it over).
+    const assigned = try single_client.get(host, "/sticky", .keep_alive, null);
+    try expectStickyResponse(assigned, "assigned", true);
+    const tag = assigned.sticky_tag.?;
+
+    // The echo: followed, and no re-stamp — idempotence on the wire.
+    var cookie_buffer: [64]u8 = undefined;
+    const echo = try std.fmt.bufPrint(&cookie_buffer, "zoxy-smoke-srv={s}", .{&tag});
+    const followed = try single_client.get(host, "/sticky", .keep_alive, echo);
+    try expectStickyResponse(followed, "followed", false);
+
+    // A forged well-formed tag: repicked, and the re-announcement must
+    // name the same endpoint the first exchange was assigned — there is
+    // only one, and its tag does not drift within a run.
+    const repicked = try single_client.get(
+        host,
+        "/sticky",
+        .close,
+        "zoxy-smoke-srv=ffffffffffffffff",
+    );
+    try expectStickyResponse(repicked, "repicked", true);
+    if (!std.mem.eql(u8, &repicked.sticky_tag.?, &tag)) {
+        std.debug.print("smoke: the re-announced tag differs from the assigned one\n", .{});
+        return false;
+    }
+
+    const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
+    var passed = true;
+    const verdicts = [_]struct { name: []const u8, expected: u64 }{
+        .{ .name = "l7_sticky_assigned", .expected = 1 },
+        .{ .name = "l7_sticky_followed", .expected = 1 },
+        .{ .name = "l7_sticky_repicked", .expected = 1 },
+    };
+    for (verdicts) |verdict| {
+        const value = counterOf(&scrape, verdict.name) orelse {
+            passed = false;
+            continue;
+        };
+        if (value != verdict.expected) {
+            std.debug.print(
+                "FAIL: {s} reads {d}, not {d}, after the three sticky exchanges\n",
+                .{ verdict.name, value, verdict.expected },
+            );
+            passed = false;
+        }
+    }
+    // The whole-run accept equality, deferred from `identitiesPassed`:
+    // with the sticky connection in, every accepted connection is
+    // accounted for again.
+    const accepted = counterOf(&scrape, "accepted") orelse return false;
+    if (accepted != connections_expected) {
+        std.debug.print(
+            "FAIL: {d} connections accepted, not the {d} this run opened\n",
+            .{ accepted, connections_expected },
+        );
+        passed = false;
+    }
+    return passed;
+}
+
+/// One sticky response: the ordinary http-leg checks, then the #178
+/// announcement judged present or absent by the exchange's role.
+fn expectStickyResponse(
+    response: client_module.Response,
+    role: []const u8,
+    expect_tag: bool,
+) !void {
+    assert(role.len >= 1);
+    if (response.status != 200) {
+        std.debug.print("smoke: sticky {s} exchange answered {d}, not 200\n", .{ role, response.status });
+        return error.UnexpectedStatus;
+    }
+    if (response.body_bytes != origin_module.body.len) {
+        std.debug.print("smoke: sticky {s} exchange body was {d} bytes\n", .{ role, response.body_bytes });
+        return error.UnexpectedBody;
+    }
+    // The listener's #175 stamp applies to this leg like any other —
+    // the two response-side mechanisms must coexist on one head.
+    if (!response.edited) {
+        std.debug.print("smoke: sticky {s} response carried no X-Zoxy-Smoke stamp\n", .{role});
+        return error.ResponseEditMissing;
+    }
+    if (expect_tag and response.sticky_tag == null) {
+        std.debug.print("smoke: sticky {s} response announced no tag\n", .{role});
+        return error.StickyStampMissing;
+    }
+    if (!expect_tag and response.sticky_tag != null) {
+        std.debug.print("smoke: sticky {s} response re-announced a tag it must not\n", .{role});
+        return error.StickyStampForged;
     }
 }
 
@@ -925,7 +1067,11 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
     const config_json = try std.fmt.allocPrint(arena,
         \\{{
         \\    "listeners": [
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http",
+        \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
+        \\          "routes": [
+        \\              {{ "prefix": "/", "cluster": "origin" }},
+        \\              {{ "prefix": "/sticky", "cluster": "sticky" }}
+        \\          ],
         \\          "response_filters": [
         \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
         \\          ] }},
@@ -935,6 +1081,10 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\        "origin": {{
         \\            "endpoints": ["127.0.0.1:{d}"],
         \\            "check": {{ "type": "http", "path": "/health", "timeout_ms": {d} }}
+        \\        }},
+        \\        "sticky": {{
+        \\            "endpoints": ["127.0.0.1:{d}"],
+        \\            "pick": {{ "policy": "hash", "key": "cookie", "name": "zoxy-smoke-srv" }}
         \\        }}
         \\    }},
         \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
@@ -957,6 +1107,7 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         ports.l4,
         origin_port,
         health_probe_timeout_ms,
+        origin_port,
         ports.admin,
         access_log_path,
         health_interval_ms,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1165,6 +1165,11 @@ pub fn Server(comptime IoType: type) type {
                 &server.endpointLoad(),
                 server.health.healthy,
                 &conn.client_address,
+                // L4 parses no head, so there is nothing request-derived
+                // to key on — and the loader keeps request-keyed clusters
+                // off l4 listeners (#178), so `.none` is exact, not a
+                // shrug.
+                .none,
             ) orelse {
                 // Every endpoint is at its §8 cap. An L4 listener has no
                 // way to say so — it relays bytes, and there is no

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -290,6 +290,14 @@ pub const Balancer = struct {
         return bytesKeyOf(bytes);
     }
 
+    /// `endpointId` for one address, without an instance — what the §9
+    /// gates use to compute the tag an endpoint *must* be spelled as,
+    /// from nothing but its address, so an oracle can hold the running
+    /// proxy to it from outside.
+    pub fn addressIdentity(address: *const std.Io.net.IpAddress) u64 {
+        return endpointId(address);
+    }
+
     /// The tag identity of one configured endpoint — what a cookie for
     /// it spells (#178). Consumed by the response-side stamp, the
     /// feature's serving half, once the exchange settles on an endpoint;

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -36,6 +36,21 @@
 //! same answer with nothing shared. Statelessness is what makes it correct
 //! under this process model, not just cheap.
 //!
+//! **Request-derived keys (#178).** A `hash` cluster names what it keys
+//! on. `source_ip` and a header value are true rendezvous keys — the
+//! mapping stays a pure function of key and eligible set. A cookie is
+//! not a hash at all: the client carries the *answer* — an endpoint tag
+//! in the spelling `formatEndpointTag` mints — so every process reaches
+//! the same endpoint by reading it, which is the table-free property
+//! above achieved a second way. When the keyed material is missing
+//! (first request of a cookie session, a request without the keyed
+//! header) the pick places by load instead, the same weighted two-choice
+//! draw `p2c` runs: cross-process agreement is not needed there, because
+//! #178's contract sends a cookie assignment back to the client on the
+//! response (the Set-Cookie stamp, the serving path's half of the
+//! feature), and a keyless header population has no identity to be
+//! sticky on in the first place.
+//!
 //! **Why rendezvous rather than a ring or Maglev.** Both of those answer
 //! a lookup from a precomputed table, and a table has to be *rebuilt*
 //! whenever membership changes — which here is every health-check
@@ -103,6 +118,24 @@ fn sourceKey(address: *const std.Io.net.IpAddress) u64 {
         .ip4 => |v4| mix64(std.mem.readInt(u32, &v4.bytes, .big)),
         .ip6 => |v6| mix64(std.mem.readInt(u64, v6.bytes[0..8], .big)),
     };
+}
+
+/// The §7 stickiness key for a request-carried byte string — a `hash`
+/// cluster keyed on a header value (#178). FNV-1a folded through
+/// `mix64`: FNV for the bytes because it is trivially pinned (two
+/// published constants), the finalizer because FNV's avalanche is weak
+/// and rendezvous compares whole words. Pinned for the same reason
+/// `mix64` is — this is part of the client-to-backend mapping, and a
+/// `std.hash` function makes no cross-version promise, which a rolling
+/// restart would turn into a silent re-shuffle.
+fn bytesKeyOf(bytes: []const u8) u64 {
+    assert(bytes.len >= 1); // An absent value is `.absent`, never hashed.
+    var hash: u64 = 0xCBF29CE484222325;
+    for (bytes) |byte| {
+        hash ^= byte;
+        hash *%= 0x100000001B3;
+    }
+    return mix64(hash);
 }
 
 /// An endpoint's stable identity for scoring: its address *and* port, so
@@ -190,6 +223,87 @@ pub const Balancer = struct {
     /// 64-bit golden-ratio constant, chosen for being recognizable.
     const pick_seed: u64 = 0x9E3779B97F4A7C15;
 
+    /// The request-derived half of a pick (#178): what the serving path
+    /// read off the parsed head for a request-keyed `hash` cluster. Both
+    /// data paths always pass the client address separately — it is the
+    /// whole key for `source_ip` and for every non-hash policy, which is
+    /// why those arms carry `.none` rather than an optional address.
+    pub const RequestKey = union(enum) {
+        /// No request-derived key applies: every non-hash policy, `hash`
+        /// on `source_ip`, and every L4 dial (the loader keeps the
+        /// request-keyed clusters off l4 listeners).
+        none,
+        /// `hash` on a header: the rendezvous key over the header value
+        /// (`bytesKey`).
+        key: u64,
+        /// `hash` on a cookie: the endpoint identity the cookie's tag
+        /// names (`parseEndpointTag`).
+        endpoint: u64,
+        /// The cluster is request-keyed but this request lacks usable
+        /// material — no such header, no cookie, a malformed tag: place
+        /// by load. On a cookie cluster the caller owes the client an
+        /// announcement of the assignment (#178's Set-Cookie stamp).
+        absent,
+    };
+
+    /// A cookie-borne endpoint tag (#178): the endpoint's rendezvous
+    /// identity, spelled as exactly 16 lowercase hex digits. Stable
+    /// across restarts, processes, and config reordering — it is
+    /// `endpointId`, a function of the address alone — and it leaks the
+    /// address's *hash* rather than the address, which is all a client
+    /// needs returned to it and nothing an operator minds it seeing.
+    pub const endpoint_tag_len: u16 = 16;
+
+    /// Spell `identity` as the tag a Set-Cookie carries.
+    pub fn formatEndpointTag(identity: u64, out: *[endpoint_tag_len]u8) void {
+        const spelled = std.fmt.bufPrint(out, "{x:0>16}", .{identity}) catch unreachable;
+        assert(spelled.len == endpoint_tag_len); // Zero-padded: every u64 fills the field.
+    }
+
+    /// The identity a tag spells, or null when the bytes are not exactly
+    /// the spelling `formatEndpointTag` mints — length and lowercase
+    /// both. The proxy never wrote a looser form, so accepting one would
+    /// give a forged cookie more grammar than a real one has; a mismatch
+    /// is a quiet re-pick, never an error, because a client can only
+    /// choose which backend serves *itself* (#178).
+    pub fn parseEndpointTag(bytes: []const u8) ?u64 {
+        if (bytes.len != endpoint_tag_len) {
+            return null;
+        }
+        assert(bytes.len == endpoint_tag_len);
+        var identity: u64 = 0;
+        for (bytes) |byte| {
+            const digit: u4 = switch (byte) {
+                '0'...'9' => @intCast(byte - '0'),
+                'a'...'f' => @intCast(byte - 'a' + 10),
+                else => return null,
+            };
+            identity = (identity << 4) | digit;
+        }
+        return identity;
+    }
+
+    /// The rendezvous key for a request-carried byte string — the
+    /// serving path's entry to `bytesKeyOf`, kept on the struct because
+    /// callers import `Balancer`, not this module.
+    pub fn bytesKey(bytes: []const u8) u64 {
+        return bytesKeyOf(bytes);
+    }
+
+    /// The tag identity of one configured endpoint — what a cookie for
+    /// it spells (#178). Consumed by the response-side stamp, the
+    /// feature's serving half, once the exchange settles on an endpoint;
+    /// reading the init-computed table keeps mint and match one value.
+    pub fn endpointIdentity(
+        balancer: *const Balancer,
+        cluster_index: u16,
+        endpoint_index: u16,
+    ) u64 {
+        assert(cluster_index < balancer.config.clusters.len);
+        assert(endpoint_index < balancer.config.clusters[cluster_index].endpoints.len);
+        return balancer.endpoint_hashes[balancer.keys.key(cluster_index, endpoint_index)];
+    }
+
     pub fn init(
         balancer: *Balancer,
         arena: std.mem.Allocator,
@@ -236,6 +350,12 @@ pub const Balancer = struct {
                 weight_sum += weightOf(cluster, @intCast(endpoint_index));
             }
             assert(weight_sum >= 1);
+            // The loader's contract (#178): a hash key other than the
+            // default rides only beside `pick: hash` — `pickHash` is the
+            // one reader, so anywhere else it would be silently inert.
+            if (cluster.pick != .hash) {
+                assert(std.meta.activeTag(cluster.hash_key) == .source_ip);
+            }
             if (cluster.weights) |weights| {
                 assert(weights.len == cluster.endpoints.len);
             }
@@ -253,17 +373,21 @@ pub const Balancer = struct {
 
     /// Choose the endpoint to dial for `cluster_index` under the
     /// cluster's configured policy. `load` is the per-endpoint in-flight
-    /// view (indexed by `upstream.endpointKey`), consulted by p2c and
-    /// ignored by rr; `healthy` is the §7 health mask (same index) — the
-    /// prober owns that truth the way the pool and the server own the
-    /// load. Bounded work, no allocation, and a validated config
-    /// guarantees at least one endpoint.
+    /// view (indexed by `upstream.endpointKey`), consulted by p2c —
+    /// and by a request-keyed hash cluster placing a keyless request
+    /// (#178) — and ignored by rr; `healthy` is the §7 health mask (same
+    /// index) — the prober owns that truth the way the pool and the
+    /// server own the load. `request_key` is what the serving path read
+    /// off the parsed head for a request-keyed cluster, `.none`
+    /// everywhere else. Bounded work, no allocation, and a validated
+    /// config guarantees at least one endpoint.
     pub fn pick(
         balancer: *Balancer,
         cluster_index: u16,
         load: *const upstream.Load,
         healthy: []const bool,
         client_address: *const std.Io.net.IpAddress,
+        request_key: RequestKey,
     ) ?Pick {
         assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
@@ -289,8 +413,14 @@ pub const Balancer = struct {
         }
         const chosen = switch (cluster.pick) {
             .rr => balancer.pickRoundRobin(cluster_index, eligible[0..count]),
-            .p2c => balancer.pickPowerOfTwo(cluster_index, eligible[0..count], load),
-            .hash => balancer.pickHash(cluster_index, eligible[0..count], client_address),
+            .p2c => balancer.placeByLoad(cluster_index, eligible[0..count], load),
+            .hash => balancer.pickHash(
+                cluster_index,
+                eligible[0..count],
+                load,
+                client_address,
+                request_key,
+            ),
         };
         assert(chosen < cluster.endpoints.len);
         return .{
@@ -414,14 +544,23 @@ pub const Balancer = struct {
     /// A mask narrowed to one endpoint skips the draw the way a
     /// one-endpoint cluster does — no candidates to compare, no PRNG
     /// state spent.
-    fn pickPowerOfTwo(
+    ///
+    /// This is the `.p2c` policy — and also where a request-keyed hash
+    /// cluster places a request whose key is missing or names nothing
+    /// eligible (#178). The shared spelling is deliberate: "healthy and
+    /// under-capacity, in that order" already narrowed the set, and
+    /// load-aware placement is the right first assignment for a session
+    /// the response is about to pin. A hash cluster therefore *can*
+    /// spend PRNG state — only on the keyless picks, where two
+    /// processes agreeing was never on the table.
+    fn placeByLoad(
         balancer: *Balancer,
         cluster_index: u16,
         eligible: []const u16,
         load: *const upstream.Load,
     ) u16 {
         const cluster = &balancer.config.clusters[cluster_index];
-        assert(cluster.pick == .p2c);
+        assert(cluster.pick == .p2c or cluster.pick == .hash);
         assert(eligible.len >= 1);
         if (eligible.len == 1) {
             return eligible[0];
@@ -482,6 +621,76 @@ pub const Balancer = struct {
         unreachable;
     }
 
+    /// Dispatch a `hash` cluster's pick by its configured key (§7,
+    /// #178). `source_ip` and `header` are rendezvous over different key
+    /// material; a `cookie` is not a hash of anything — the client
+    /// carries the answer, honoured when its tag names an eligible
+    /// endpoint. Keyless requests place by load (`placeByLoad`'s doc has
+    /// the argument). The `unreachable` arms are the caller reading the
+    /// wrong cluster: the L7 path derives the arm from this cluster's
+    /// own key, and the loader keeps request-keyed clusters off l4
+    /// listeners.
+    fn pickHash(
+        balancer: *Balancer,
+        cluster_index: u16,
+        eligible: []const u16,
+        load: *const upstream.Load,
+        client_address: *const std.Io.net.IpAddress,
+        request_key: RequestKey,
+    ) u16 {
+        assert(balancer.config.clusters[cluster_index].pick == .hash);
+        assert(eligible.len >= 1);
+        switch (balancer.config.clusters[cluster_index].hash_key) {
+            .source_ip => {
+                // Both data paths pass the address and pass nothing
+                // else: an L7 request need not have been parsed yet, an
+                // L4 connection has nothing to parse.
+                assert(std.meta.activeTag(request_key) == .none);
+                return balancer.rendezvous(cluster_index, eligible, sourceKey(client_address));
+            },
+            .header => switch (request_key) {
+                .key => |key| return balancer.rendezvous(cluster_index, eligible, key),
+                .absent => return balancer.placeByLoad(cluster_index, eligible, load),
+                .none, .endpoint => unreachable,
+            },
+            .cookie => switch (request_key) {
+                .endpoint => |identity| return balancer.pickTagged(
+                    cluster_index,
+                    eligible,
+                    load,
+                    identity,
+                ),
+                .absent => return balancer.placeByLoad(cluster_index, eligible, load),
+                .none, .key => unreachable,
+            },
+        }
+    }
+
+    /// The endpoint a cookie's tag names, when it is in the eligible set
+    /// — otherwise place by load: a tag naming an ejected, drained,
+    /// capped, or long-removed endpoint re-homes cleanly, and #178's
+    /// contract owes the client a re-announcement (the response-side
+    /// stamp). The scan is the eligible walk the pick already paid for;
+    /// matching by identity rather than index is what lets a config grow
+    /// or reorder without re-homing cookie holders, exactly
+    /// `endpointId`'s contract.
+    fn pickTagged(
+        balancer: *Balancer,
+        cluster_index: u16,
+        eligible: []const u16,
+        load: *const upstream.Load,
+        identity: u64,
+    ) u16 {
+        assert(std.meta.activeTag(balancer.config.clusters[cluster_index].hash_key) == .cookie);
+        assert(eligible.len >= 1);
+        for (eligible) |candidate| {
+            if (balancer.endpoint_hashes[balancer.keys.key(cluster_index, candidate)] == identity) {
+                return candidate;
+            }
+        }
+        return balancer.placeByLoad(cluster_index, eligible, load);
+    }
+
     /// Rendezvous hashing (§7): score every eligible endpoint against the
     /// client's key and take the highest. Two properties follow, and both
     /// are the point.
@@ -499,18 +708,15 @@ pub const Balancer = struct {
     /// computation, so this single pass is both.
     ///
     /// Spends no PRNG state: a draw would make two processes disagree,
-    /// which is the one thing this policy exists to prevent.
-    fn pickHash(
+    /// which is the one thing keyed stickiness exists to prevent.
+    fn rendezvous(
         balancer: *const Balancer,
         cluster_index: u16,
         eligible: []const u16,
-        client_address: *const std.Io.net.IpAddress,
+        key: u64,
     ) u16 {
         assert(balancer.config.clusters[cluster_index].pick == .hash);
         assert(eligible.len >= 1);
-        const key = switch (balancer.config.clusters[cluster_index].hash_key) {
-            .source_ip => sourceKey(client_address),
-        };
         var best = eligible[0];
         var best_score = balancer.score(key, cluster_index, best);
         for (eligible[1..]) |candidate| {
@@ -660,7 +866,7 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     counts[test_keys.key(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
         try std.testing.expectEqual(trio[want_index], picked.address);
     }
@@ -683,7 +889,7 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         try std.testing.expectEqual(solo, picked.address);
         try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
     }
@@ -713,7 +919,7 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     counts[test_keys.key(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -739,7 +945,7 @@ test "balancer: p2c spreads across endpoints under equal load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 300) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         hits[picked.endpoint_index] += 1;
     }
     for (hits) |hit_count| {
@@ -771,8 +977,8 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
-            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
+            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
+            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
         );
     }
 }
@@ -799,7 +1005,7 @@ test "balancer: rr rotates over the healthy endpoints only" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -826,7 +1032,7 @@ test "balancer: rr honors weights, and the schedule is smooth" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 0, 1, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -852,7 +1058,7 @@ test "balancer: rr weight zero drains an endpoint, past fail-open" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
     // Fail-open re-admits the ejected, never the drained: a weight of 0
@@ -861,7 +1067,7 @@ test "balancer: rr weight zero drains an endpoint, past fail-open" {
     const none_healthy = [_]bool{false} ** test_keys.count;
     var round: u32 = 0;
     while (round < 20) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &none_healthy, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &none_healthy, &test_client, .none).?;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -890,7 +1096,7 @@ test "balancer: p2c candidacy follows weight" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 400) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
         hits[picked.endpoint_index] += 1;
     }
     try std.testing.expect(hits[0] > hits[1] + hits[2]);
@@ -930,8 +1136,8 @@ test "balancer: p2c at unit weights draws exactly as the unweighted form" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            bare.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
-            spelled.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index,
+            bare.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
+            spelled.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
         );
     }
     try std.testing.expectEqual(bare.pick_state, spelled.pick_state);
@@ -961,7 +1167,7 @@ test "balancer: p2c never picks an ejected endpoint" {
     counts[test_keys.key(0, 2)] = 50;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -988,7 +1194,7 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
         try std.testing.expectEqual(@as(u16, 1), picked.endpoint_index);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
@@ -1018,7 +1224,7 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -1043,8 +1249,8 @@ test "balancer: policies keep independent state across clusters" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 1, 0 };
     for (expected) |want_index| {
-        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client).?.endpoint_index);
-        _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client);
+        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index);
+        _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client, .none);
     }
 }
 
@@ -1081,10 +1287,10 @@ test "balancer: hash sends one client to one endpoint, every time" {
 
     const counts = [_]u16{0} ** test_counts_len;
     const client = testAddress("203.0.113.9:51000");
-    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
+        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
         try std.testing.expectEqual(first, again.endpoint_index);
         try std.testing.expectEqual(endpoints[first], again.address);
     }
@@ -1094,7 +1300,7 @@ test "balancer: hash sends one client to one endpoint, every time" {
     loaded[test_keys.key(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client).?.endpoint_index,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client, .none).?.endpoint_index,
     );
 }
 
@@ -1115,7 +1321,7 @@ test "balancer: hash spends no PRNG state and needs none" {
     const counts = [_]u16{0} ** test_counts_len;
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
-        _ = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index));
+        _ = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
 }
@@ -1136,7 +1342,7 @@ test "balancer: hash spreads distinct clients across every endpoint" {
     var hits = [_]u32{0} ** 8;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index] += 1;
     }
     // Rendezvous gives each client an independent uniform choice, so the
     // spread is a balls-in-bins one: loose bounds, but every endpoint must
@@ -1170,7 +1376,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var before: [clients]u16 = undefined;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index;
+        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index;
     }
 
     const ejected: u16 = 3;
@@ -1180,7 +1386,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var moved: u32 = 0;
     index = 0;
     while (index < clients) : (index += 1) {
-        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index)).?.endpoint_index;
+        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index), .none).?.endpoint_index;
         try std.testing.expect(after != ejected);
         if (before[index] == ejected) {
             moved += 1;
@@ -1201,7 +1407,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     while (index < clients) : (index += 1) {
         try std.testing.expectEqual(
             before[index],
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index,
         );
     }
 }
@@ -1234,7 +1440,7 @@ test "balancer: hash spreads clients in proportion to weight" {
     var hits = [_]u32{0} ** 2;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index)).?.endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index] += 1;
     }
     const expected_heavy = clients * 3 / 4;
     try std.testing.expect(hits[0] > expected_heavy - 400);
@@ -1275,8 +1481,8 @@ test "balancer: re-weighting an endpoint disrupts only the clients it gains" {
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
         const client = testClientAt(index);
-        const before = flat.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
-        const after = weighted.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+        const before = flat.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
+        const after = weighted.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
         if (after != before) {
             try std.testing.expectEqual(@as(u16, 3), after);
             moved += 1;
@@ -1321,15 +1527,15 @@ test "balancer: hash weight zero drains an endpoint, past fail-open" {
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
         const client = testClientAt(index);
-        const after = drained.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index;
+        const after = drained.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
         try std.testing.expect(after != 3);
         try std.testing.expectEqual(
-            flat.pick(0, &testLoad(&counts), &ejected_mask, &client).?.endpoint_index,
+            flat.pick(0, &testLoad(&counts), &ejected_mask, &client, .none).?.endpoint_index,
             after,
         );
         // Fail-open re-admits the ejected, never the drained.
         try std.testing.expect(
-            drained.pick(0, &testLoad(&counts), &none_healthy, &client).?.endpoint_index != 3,
+            drained.pick(0, &testLoad(&counts), &none_healthy, &client, .none).?.endpoint_index != 3,
         );
     }
 }
@@ -1368,8 +1574,8 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     var index: u16 = 0;
     while (index < 1000) : (index += 1) {
         const client = testClientAt(index);
-        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
-        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client).?;
+        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
+        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
         // The *address* must match; the index deliberately need not, the
         // lists being permutations of each other.
         try std.testing.expectEqual(left_pick.address, right_pick.address);
@@ -1394,8 +1600,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     const first = testAddress("[2001:db8:1:2:aaaa:bbbb:cccc:dddd]:51000");
     const rotated = testAddress("[2001:db8:1:2:1111:2222:3333:4444]:52000");
     try std.testing.expectEqual(
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).?.endpoint_index,
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated).?.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none).?.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated, .none).?.endpoint_index,
     );
 
     // A different /64 is a different client and must be free to land
@@ -1406,8 +1612,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     while (prefix < 64) : (prefix += 1) {
         var other = first;
         other.ip6.bytes[7] = @intCast(prefix);
-        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other).?.endpoint_index !=
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first).?.endpoint_index)
+        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other, .none).?.endpoint_index !=
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none).?.endpoint_index)
         {
             differs = true;
             break;
@@ -1480,8 +1686,8 @@ test "balancer: a fully ejected hash cluster still answers, deterministically" {
         // Fail-open restores the full set, so the answer is the same one
         // the healthy cluster gives.
         try std.testing.expectEqual(
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client).?.endpoint_index,
-            balancer.pick(0, &testLoad(&counts), &none_healthy, &client).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &none_healthy, &client, .none).?.endpoint_index,
         );
     }
 }
@@ -1497,6 +1703,204 @@ fn sourceKeyOf(comptime literal: []const u8) u64 {
 fn endpointIdOf(comptime literal: []const u8) u64 {
     const address = testAddress(literal);
     return endpointId(&address);
+}
+
+test "balancer: hash on a header keys on the value, not the client" {
+    const endpoints = testHashEndpoints(8);
+    const clusters = [_]config_module.Config.Cluster{
+        .{
+            .name = "sticky",
+            .endpoints = &endpoints,
+            .pick = .hash,
+            .hash_key = .{ .header = "x-tenant" },
+        },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+    const state_before = balancer.pick_state;
+
+    const counts = [_]u16{0} ** test_counts_len;
+    const key: Balancer.RequestKey = .{ .key = Balancer.bytesKey("tenant-a") };
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, key).?.endpoint_index;
+    // A different client with the same header value is the same tenant:
+    // the address must contribute nothing to a header-keyed pick.
+    const roaming = testAddress("198.51.100.200:41000");
+    try std.testing.expectEqual(
+        first,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &roaming, key).?.endpoint_index,
+    );
+    // Load on the winner must not move the tenant, and no PRNG state may
+    // be spent: a keyed pick is a pure function, like source_ip's.
+    var loaded = [_]u16{0} ** test_counts_len;
+    loaded[test_keys.key(0, first)] = 10_000;
+    try std.testing.expectEqual(
+        first,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, key).?.endpoint_index,
+    );
+    try std.testing.expectEqual(state_before, balancer.pick_state);
+
+    // Distinct values are distinct tenants and must spread: a run of them
+    // has to reach several endpoints, or the value is not really keying.
+    var hits = [_]u32{0} ** 8;
+    var tenant: u16 = 0;
+    while (tenant < 64) : (tenant += 1) {
+        var name_buffer: [16]u8 = undefined;
+        const name = std.fmt.bufPrint(&name_buffer, "tenant-{d}", .{tenant}) catch unreachable;
+        const tenant_key: Balancer.RequestKey = .{ .key = Balancer.bytesKey(name) };
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, tenant_key).?.endpoint_index] += 1;
+    }
+    var reached: u32 = 0;
+    for (hits) |hit_count| {
+        if (hit_count >= 1) reached += 1;
+    }
+    try std.testing.expect(reached >= 4);
+}
+
+test "balancer: a request without its keyed material places by load" {
+    const endpoints = testHashEndpoints(3);
+    const clusters = [_]config_module.Config.Cluster{
+        .{
+            .name = "sticky",
+            .endpoints = &endpoints,
+            .pick = .hash,
+            .hash_key = .{ .header = "x-tenant" },
+        },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Endpoint 1 is drowning. A keyless request takes the p2c placement:
+    // any candidate pair containing the drowning endpoint also contains
+    // a calmer one, so it must never win — and the idle endpoints must
+    // both be reached, or this is not placement but a constant.
+    var counts = [_]u16{0} ** test_counts_len;
+    counts[test_keys.key(0, 1)] = 100;
+    var hits = [_]u32{0} ** 3;
+    var round: u32 = 0;
+    while (round < 200) : (round += 1) {
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .absent).?;
+        hits[picked.endpoint_index] += 1;
+    }
+    try std.testing.expectEqual(@as(u32, 0), hits[1]);
+    try std.testing.expect(hits[0] >= 1);
+    try std.testing.expect(hits[2] >= 1);
+}
+
+test "balancer: a cookie tag names its endpoint through any load" {
+    const endpoints = testHashEndpoints(8);
+    const clusters = [_]config_module.Config.Cluster{
+        .{
+            .name = "sticky",
+            .endpoints = &endpoints,
+            .pick = .hash,
+            .hash_key = .{ .cookie = "zoxy-srv" },
+        },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+    const state_before = balancer.pick_state;
+
+    // The tag is honoured wherever the load sits — stickiness is the
+    // point, and load had its say when the session was placed — and the
+    // honoured path spends no PRNG state.
+    const wanted: u16 = 5;
+    const tagged: Balancer.RequestKey = .{ .endpoint = balancer.endpointIdentity(0, wanted) };
+    var loaded = [_]u16{0} ** test_counts_len;
+    loaded[test_keys.key(0, wanted)] = 10_000;
+    var round: u32 = 0;
+    while (round < 50) : (round += 1) {
+        const picked = balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, tagged).?;
+        try std.testing.expectEqual(wanted, picked.endpoint_index);
+        try std.testing.expectEqual(endpoints[wanted], picked.address);
+    }
+    try std.testing.expectEqual(state_before, balancer.pick_state);
+}
+
+test "balancer: a tag naming nothing eligible re-homes by load" {
+    const endpoints = testHashEndpoints(3);
+    var weights = [_]u16{1} ** 3;
+    weights[2] = 0;
+    const clusters = [_]config_module.Config.Cluster{
+        .{
+            .name = "sticky",
+            .endpoints = &endpoints,
+            .pick = .hash,
+            .hash_key = .{ .cookie = "zoxy-srv" },
+            .weights = &weights,
+        },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Three ways a tag can name nothing: the endpoint was ejected (§7),
+    // the endpoint was drained (#174), or the tag was forged whole. Each
+    // re-homes among the eligible — "healthy and under-capacity, in that
+    // order" — rather than erroring or honouring the dead letter.
+    const counts = [_]u16{0} ** test_counts_len;
+    var ejected_mask = test_healthy_all;
+    ejected_mask[test_keys.key(0, 0)] = false;
+    const ejected_tag: Balancer.RequestKey = .{ .endpoint = balancer.endpointIdentity(0, 0) };
+    const drained_tag: Balancer.RequestKey = .{ .endpoint = balancer.endpointIdentity(0, 2) };
+    const forged_tag: Balancer.RequestKey = .{ .endpoint = 0xDEADBEEFDEADBEEF };
+    var round: u32 = 0;
+    while (round < 100) : (round += 1) {
+        try std.testing.expectEqual(
+            @as(u16, 1),
+            balancer.pick(0, &testLoad(&counts), &ejected_mask, &test_client, ejected_tag).?.endpoint_index,
+        );
+        try std.testing.expect(
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, drained_tag).?.endpoint_index != 2,
+        );
+        try std.testing.expect(
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, forged_tag).?.endpoint_index != 2,
+        );
+    }
+}
+
+test "balancer: endpoint tags round-trip, and only the minted spelling parses" {
+    const identities = [_]u64{ 0, 1, 0x0123456789ABCDEF, std.math.maxInt(u64) };
+    for (identities) |identity| {
+        var tag: [Balancer.endpoint_tag_len]u8 = undefined;
+        Balancer.formatEndpointTag(identity, &tag);
+        try std.testing.expectEqual(identity, Balancer.parseEndpointTag(&tag).?);
+    }
+    var spelled: [Balancer.endpoint_tag_len]u8 = undefined;
+    Balancer.formatEndpointTag(0x0123456789ABCDEF, &spelled);
+    try std.testing.expectEqualStrings("0123456789abcdef", &spelled);
+
+    // Only the exact minted spelling: the proxy never wrote the looser
+    // forms, so a parser accepting them would give a forged cookie more
+    // grammar than a real one has.
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag(""));
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag("0123456789abcde"));
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag("0123456789abcdef0"));
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag("0123456789ABCDEF"));
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag("0123456789abcdeg"));
+    try std.testing.expectEqual(@as(?u64, null), Balancer.parseEndpointTag("0x23456789abcdef"));
+}
+
+test "balancer: the header key is pinned, like every mapping hash here" {
+    // The FNV half is checked against the published FNV-1a vectors, the
+    // way `mix64` is checked against SplitMix64's published output — an
+    // external anchor, not a value read back off our own implementation.
+    try std.testing.expectEqual(mix64(0xAF63DC4C8601EC8C), bytesKeyOf("a"));
+    try std.testing.expectEqual(mix64(0x85944171F73967E8), bytesKeyOf("foobar"));
+    try std.testing.expect(bytesKeyOf("tenant-a") != bytesKeyOf("tenant-b"));
+    // Case matters: header *names* are case-insensitive, header values
+    // are not, and the key covers only the value.
+    try std.testing.expect(bytesKeyOf("Alice") != bytesKeyOf("alice"));
 }
 
 test "balancer: p2c weighs L4 connections, not only L7 leases" {
@@ -1525,7 +1929,7 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
     const load: upstream.Load = .{ .l7 = &l7_idle, .l4 = &l4 };
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index != 1);
+        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index != 1);
     }
 }
 
@@ -1559,7 +1963,7 @@ test "balancer: p2c compares the sum of both protocols" {
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 0),
-            balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index,
+            balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index,
         );
     }
 }
@@ -1588,7 +1992,7 @@ test "balancer: a capped endpoint is skipped while another has room" {
     while (round < 8) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 1),
-            balancer.pick(0, &load, &test_healthy_all, &test_client).?.endpoint_index,
+            balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index,
         );
     }
 }
@@ -1616,13 +2020,13 @@ test "balancer: a fully capped cluster refuses rather than failing open" {
     l7[test_keys.key(0, 1)] = 3;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client),
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none),
     );
     // One request completes on endpoint 1 and the cluster serves again.
     l7[test_keys.key(0, 1)] = 2;
     try std.testing.expectEqual(
         @as(u16, 1),
-        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client).?.endpoint_index,
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none).?.endpoint_index,
     );
 }
 
@@ -1649,7 +2053,7 @@ test "balancer: the cap counts both protocols, and covers one endpoint" {
     const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
-        balancer.pick(0, &load, &test_healthy_all, &test_client),
+        balancer.pick(0, &load, &test_healthy_all, &test_client, .none),
     );
     // Reading either table alone would leave room and dial anyway.
     try std.testing.expect(l7[test_keys.key(0, 0)] < 4);
@@ -1679,7 +2083,7 @@ test "balancer: capacity is judged over the endpoints health left" {
     l7[test_keys.key(0, 1)] = 1;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &healthy, &test_client),
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none),
     );
     // And when health fails open — every endpoint ejected — the caps
     // still apply to the whole set rather than being bypassed with it.
@@ -1687,6 +2091,6 @@ test "balancer: capacity is judged over the endpoints health left" {
     l7[test_keys.key(0, 0)] = 1;
     try std.testing.expectEqual(
         @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &healthy, &test_client),
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none),
     );
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -251,9 +251,12 @@ pub const Config = struct {
         /// L7 requests and live L4 connections alike (§7).
         max_inflight: ?u32 = null,
 
-        /// What a `hash` cluster keys its endpoint choice on (§7). Read
-        /// only when `pick == .hash`; the loader rejects a `hash` block
-        /// beside any other policy rather than leaving it inert.
+        /// What a `hash` cluster keys its endpoint choice on (§7, #178).
+        /// Read only when `pick == .hash`; the loader rejects key
+        /// settings beside any other policy rather than leaving them
+        /// inert — and rejects a bare `"pick": "hash"` outright, because
+        /// which identity a cluster is sticky on is a decision, not a
+        /// default.
         hash_key: HashKey = .source_ip,
 
         /// The PROXY protocol header this cluster's origins expect zoxy
@@ -277,14 +280,28 @@ pub const Config = struct {
             hash,
         };
 
-        /// The identity a `hash` cluster is sticky on. One arm today; a
-        /// closed enum rather than a bool so a request-derived key (a
-        /// header, a cookie) is a new arm rather than a new mechanism.
-        pub const HashKey = enum(u1) {
+        /// The identity a `hash` cluster is sticky on (#178). `header`
+        /// and `cookie` read the parsed request, so clusters carrying
+        /// them are unreachable from `l4` listeners — enforced where
+        /// listeners resolve, the `proxy_protocol_send` precedent in
+        /// the other direction.
+        pub const HashKey = union(enum) {
             /// The client's own address, which both data paths have —
             /// an L4 connection has nothing else, and an L7 request need
             /// not have been parsed yet.
             source_ip,
+            /// Rendezvous on the named header's value: stickiness on an
+            /// identity the client states (a tenant, an API key hash) —
+            /// which survives NAT, the exact place `source_ip` fails.
+            /// The payload is the validated header name.
+            header: []const u8,
+            /// The client holds the assignment itself (#178): the named
+            /// cookie carries an endpoint tag in the proxy's own minted
+            /// spelling, honoured when it names a healthy,
+            /// under-capacity endpoint — with the response-side stamp
+            /// owing the client a (re-)announcement everywhere else.
+            /// The payload is the validated cookie name.
+            cookie: []const u8,
         };
 
         /// Which PROXY protocol version to write (#142): a closed
@@ -366,8 +383,14 @@ pub const ValidationError = error{
     ClusterCheckHostInvalid,
     ClusterCheckStatusInvalid,
     ClusterMaxInflightOutOfRange,
-    ClusterHashKeyUnknown,
-    ClusterHashWithoutHashPick,
+    ClusterPickKeyMissing,
+    ClusterPickKeyUnknown,
+    ClusterPickKeyWithoutHash,
+    ClusterPickNameMissing,
+    ClusterPickNameUnexpected,
+    ClusterPickNameInvalid,
+    ClusterPickNameTooLong,
+    ListenerL4RequestKeyedHash,
     ListenerClusterOrRoutes,
     ListenerL4Routes,
     RoutesEmpty,
@@ -1169,16 +1192,16 @@ pub const RouteJson = struct {
 pub const ClusterJson = struct {
     endpoints: []const EndpointJson,
     /// Optional §7 pick policy; absent means `p2c` (the design's
-    /// trajectory), `rr` opts back into strict rotation.
-    pick: []const u8 = "p2c",
+    /// trajectory), `rr` opts back into strict rotation, and the object
+    /// form names a `hash` policy's key (#178) — a bare `"hash"` string
+    /// is rejected, because what the cluster is sticky on is the
+    /// operator's decision, not a default.
+    pick: PickJson = .{ .policy = "p2c" },
     /// Optional §7 active health checks; absent means off, so an
     /// unprobed cluster reserves nothing and is never skipped.
     check: ?CheckJson = null,
     /// Optional §8 per-endpoint concurrency cap; absent means uncapped.
     max_inflight: ?u32 = null,
-    /// Optional §7 hash-policy detail; only valid beside `"pick": "hash"`,
-    /// and absent there means the default key.
-    hash: ?ClusterHashJson = null,
     /// Optional PROXY protocol announcement on upstream connections
     /// (#142); absent sends none. Only valid on clusters no http
     /// listener routes to.
@@ -1192,16 +1215,12 @@ pub const ClusterJson = struct {
             .min_items = 1,
         },
         .pick = .{
-            .desc = "Endpoint-pick policy: p2c (power-of-two-choices), rr (strict " ++
-                "round-robin), or hash (rendezvous hashing on a stable key, for " ++
-                "client-to-backend stickiness).",
-            .enum_type = Config.Cluster.Pick,
+            .desc = "Endpoint-pick policy: p2c (power-of-two-choices) or rr " ++
+                "(strict round-robin) as a bare string, or an object choosing " ++
+                "hash (stickiness) and naming its key.",
         },
         .check = .{
             .desc = "Active health checks for every endpoint in this cluster; absent leaves them off.",
-        },
-        .hash = .{
-            .desc = "Hash-policy detail; only valid alongside \"pick\": \"hash\".",
         },
         .max_inflight = .{
             .desc = "Cap on concurrent in-flight work per endpoint; absent leaves the cluster uncapped.",
@@ -1290,6 +1309,97 @@ pub const EndpointJson = struct {
     }
 };
 
+/// The pick policy's two spellings (#178): the bare policy string every
+/// stateless policy needs, or an object carrying the policy *and* its
+/// settings — today, a `hash` policy's key. The two parse to this one
+/// shape, `EndpointJson`'s pattern; a bare `"hash"` never resolves,
+/// because a hash policy without a named key was the misleading default
+/// this form replaced.
+pub const PickJson = struct {
+    policy: []const u8,
+    /// Required for `hash`, rejected elsewhere: what the cluster is
+    /// sticky on.
+    key: ?[]const u8 = null,
+    /// The header or cookie name a request-derived key reads; required
+    /// there, rejected for `source_ip`.
+    name: ?[]const u8 = null,
+
+    pub const schema_doc =
+        "Endpoint-pick policy: a bare policy string (p2c, rr), or an object " ++
+        "selecting hash and naming what it keys on. The same key always " ++
+        "selects the same endpoint, and the mapping is a pure function of " ++
+        "the key and the healthy endpoint set — so every zoxy process " ++
+        "behind SO_REUSEPORT agrees without sharing any state.";
+    pub const schema_fields = .{
+        .policy = .{
+            .desc = "Pick policy: p2c (power-of-two-choices), rr (strict " ++
+                "round-robin), or hash (stickiness on an explicit key).",
+            .enum_type = Config.Cluster.Pick,
+        },
+        .key = .{
+            .desc = "What a hash cluster is sticky on: source_ip (all four bytes " ++
+                "of an IPv4 address, the /64 prefix of an IPv6 one — RFC 8981 " ++
+                "rotation survives), header (rendezvous on the named header's " ++
+                "value), or cookie (the named cookie carries the endpoint " ++
+                "assignment itself, minted by zoxy — #178).",
+            .enum_type = std.meta.Tag(Config.Cluster.HashKey),
+        },
+        .name = .{
+            .desc = "The header or cookie name a request-derived key reads; " ++
+                "required for those keys, rejected for source_ip.",
+            .min_length = 1,
+        },
+    };
+
+    /// The object form as a plain struct, so `innerParse` reads it with
+    /// the loader's own strictness (unknown fields rejected) without
+    /// recursing back into `jsonParse` below.
+    const ObjectForm = struct {
+        policy: []const u8,
+        key: ?[]const u8 = null,
+        name: ?[]const u8 = null,
+    };
+
+    comptime {
+        // The two shapes are one contract: a field added to either and
+        // forgotten on the other would let the schema advertise a key
+        // the parser rejects, or the parser accept one the schema hides.
+        const outer = @typeInfo(PickJson).@"struct".fields;
+        const inner = @typeInfo(ObjectForm).@"struct".fields;
+        assert(outer.len == inner.len);
+        for (outer, inner) |a, b| {
+            assert(std.mem.eql(u8, a.name, b.name));
+            assert(a.type == b.type);
+        }
+    }
+
+    pub fn jsonParse(
+        allocator: std.mem.Allocator,
+        source: anytype,
+        options: std.json.ParseOptions,
+    ) !PickJson {
+        switch (try source.peekNextTokenType()) {
+            .string => {
+                const token = try source.nextAlloc(allocator, .alloc_if_needed);
+                const literal: []const u8 = switch (token) {
+                    .string, .allocated_string => |slice| slice,
+                    // The peek promised a string; anything else is the
+                    // scanner disagreeing with itself.
+                    else => unreachable,
+                };
+                return .{ .policy = literal };
+            },
+            .object_begin => {
+                const object = try std.json.innerParse(ObjectForm, allocator, source, options);
+                return .{ .policy = object.policy, .key = object.key, .name = object.name };
+            },
+            // A number, bool, null, or nested array can never name a
+            // policy; reject the token rather than coercing it.
+            else => return error.UnexpectedToken,
+        }
+    }
+};
+
 pub const ClusterProxyProtocolJson = struct {
     send: []const u8,
 
@@ -1357,24 +1467,6 @@ pub const CheckJson = struct {
             .desc = "The one response status an http probe accepts as healthy.",
             .minimum = 100,
             .maximum = 599,
-        },
-    };
-};
-
-pub const ClusterHashJson = struct {
-    key: []const u8 = "source_ip",
-
-    pub const schema_doc =
-        "How a `hash` cluster identifies a client. The same key always " ++
-        "selects the same endpoint, and the mapping is a pure function of " ++
-        "the key and the healthy endpoint set — so every zoxy process " ++
-        "behind SO_REUSEPORT agrees without sharing any state.";
-    pub const schema_fields = .{
-        .key = .{
-            .desc = "What to hash. `source_ip` uses the client address: all four " ++
-                "bytes of an IPv4 address, and the /64 prefix of an IPv6 one so " ++
-                "stickiness survives privacy-address rotation (RFC 8981).",
-            .enum_type = Config.Cluster.HashKey,
         },
     };
 };
@@ -1566,7 +1658,7 @@ pub const dto_types = .{
     ConfigJson,         ListenerJson,      RouteJson,                FilterJson,
     MatchJson,          HeaderMatchJson,   ActionJson,               HeaderEditJson,
     RewriteJson,        ClusterJson,       TimeoutsJson,             LimitsJson,
-    AdminJson,          AccessLogJson,     CheckJson,                ClusterHashJson,
+    AdminJson,          AccessLogJson,     CheckJson,                PickJson,
     ForwardedJson,      ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
     ResponseFilterJson, ResponseMatchJson, RedirectJson,
 };
@@ -1606,15 +1698,15 @@ fn resolveClusters(
         if (entry.name.len > constants.cluster_name_bytes_max) {
             return error.ClusterNameTooLong;
         }
-        const pick = try pickOf(entry.cluster.pick);
+        const picked = try resolvePick(&entry.cluster.pick);
         const endpoints = try resolveEndpoints(arena, entry.cluster.endpoints);
         clusters[index] = .{
             .name = entry.name,
             .endpoints = endpoints.addresses,
             .weights = endpoints.weights,
-            .pick = pick,
+            .pick = picked.pick,
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
-            .hash_key = try hashKeyOf(pick, entry.cluster.hash),
+            .hash_key = picked.hash_key,
             .max_inflight = try resolveMaxInflight(entry.cluster.max_inflight),
             .proxy_protocol_send = try resolveClusterProxyProtocol(entry.cluster.proxy_protocol),
         };
@@ -2351,10 +2443,22 @@ fn resolveRoutes(
         return error.ListenerClusterOrRoutes; // Neither, or both.
     }
     if (has_cluster) {
+        const cluster_index = try clusterIndexOf(clusters, listener_json.cluster.?);
+        // A request-derived hash key reads the parsed head (#178), and
+        // an l4 listener never parses one: rejected as a pair, like an
+        // http route to a PROXY-sending cluster — reachability, not
+        // exclusivity, so the same cluster stays valid beside any http
+        // listener.
+        if (protocol == .l4) {
+            switch (clusters[cluster_index].hash_key) {
+                .source_ip => {},
+                .header, .cookie => return error.ListenerL4RequestKeyedHash,
+            }
+        }
         const routes = try arena.alloc(router.Route, 1);
         routes[0] = .{
             .prefix = "/",
-            .cluster_index = try clusterIndexOf(clusters, listener_json.cluster.?),
+            .cluster_index = cluster_index,
         };
         assert(routes.len == 1); // The sugar is always one catch-all route.
         return routes;
@@ -2588,11 +2692,72 @@ fn resolveProxyProtocol(
         error.ListenerProxyProtocolModeUnknown;
 }
 
-/// The closed pick-policy vocabulary; anything else is its own error so
-/// a typo ("pc2") fails loudly instead of silently balancing as p2c.
-fn pickOf(literal: []const u8) error{ClusterPickUnknown}!Config.Cluster.Pick {
-    return std.meta.stringToEnum(Config.Cluster.Pick, literal) orelse
-        error.ClusterPickUnknown;
+/// A cluster's resolved pick: the policy, and — for `hash` — the key it
+/// is sticky on, `.source_ip` (inert) everywhere else.
+const ResolvedPick = struct {
+    pick: Config.Cluster.Pick,
+    hash_key: Config.Cluster.HashKey,
+};
+
+/// Resolve either spelling of `pick` (#178). The policy vocabulary is
+/// closed — a typo ("pc2") fails loudly instead of silently balancing
+/// as p2c — and so is the key's. `hash` *requires* a key, in the object
+/// form: `source_ip` as a silent default was misleading (it reads as
+/// "sticky" and quietly is not, behind NAT), so what the cluster keys
+/// on is the operator's sentence to write. Key settings beside any
+/// other policy are rejected rather than left inert — they read as a
+/// request for stickiness the cluster would silently not provide.
+fn resolvePick(pick_json: *const PickJson) ParseError!ResolvedPick {
+    const pick = std.meta.stringToEnum(Config.Cluster.Pick, pick_json.policy) orelse
+        return error.ClusterPickUnknown;
+    if (pick != .hash) {
+        if (pick_json.key != null or pick_json.name != null) {
+            return error.ClusterPickKeyWithoutHash;
+        }
+        return .{ .pick = pick, .hash_key = .source_ip };
+    }
+    const key_literal = pick_json.key orelse return error.ClusterPickKeyMissing;
+    const key = std.meta.stringToEnum(std.meta.Tag(Config.Cluster.HashKey), key_literal) orelse
+        return error.ClusterPickKeyUnknown;
+    switch (key) {
+        .source_ip => {
+            if (pick_json.name != null) {
+                return error.ClusterPickNameUnexpected;
+            }
+            return .{ .pick = pick, .hash_key = .source_ip };
+        },
+        .header => return .{
+            .pick = pick,
+            .hash_key = .{ .header = try resolvePickName(pick_json.name) },
+        },
+        .cookie => return .{
+            .pick = pick,
+            .hash_key = .{ .cookie = try resolvePickName(pick_json.name) },
+        },
+    }
+}
+
+/// The header or cookie name a request-derived key reads (#178). One
+/// grammar for both: an RFC 9110 token, which is also RFC 6265's
+/// cookie-name grammar — and one bound, `pick_name_bytes_max`, whose
+/// job is the response-side stamp: every Set-Cookie a cookie cluster
+/// answers with re-speaks this name into a scratch sized by that
+/// constant.
+fn resolvePickName(name_json: ?[]const u8) ParseError![]const u8 {
+    const name = name_json orelse return error.ClusterPickNameMissing;
+    if (name.len == 0) {
+        return error.ClusterPickNameInvalid;
+    }
+    if (name.len > constants.pick_name_bytes_max) {
+        return error.ClusterPickNameTooLong;
+    }
+    assert(name.len >= 1);
+    for (name) |byte| {
+        if (!isTokenByte(byte)) {
+            return error.ClusterPickNameInvalid;
+        }
+    }
+    return name;
 }
 
 /// A cluster that sends PROXY protocol (#142) may only be reached by l4
@@ -2626,23 +2791,6 @@ fn resolveClusterProxyProtocol(
         Config.Cluster.ProxyProtocolSend,
         proxy_protocol.send,
     ) orelse error.ClusterProxyProtocolSendUnknown;
-}
-
-/// The §7 hash key for a cluster: its `hash` block's, or the default when
-/// the block is absent. A block beside any *other* policy is rejected
-/// rather than ignored — it reads as a request for stickiness that the
-/// cluster would silently not provide, which is exactly the mistake worth
-/// failing at load.
-fn hashKeyOf(
-    pick: Config.Cluster.Pick,
-    hash_json: ?ClusterHashJson,
-) ValidationError!Config.Cluster.HashKey {
-    const hash = hash_json orelse return .source_ip;
-    if (pick != .hash) {
-        return error.ClusterHashWithoutHashPick;
-    }
-    return std.meta.stringToEnum(Config.Cluster.HashKey, hash.key) orelse
-        error.ClusterHashKeyUnknown;
 }
 
 /// The closed protocol vocabulary; anything else is its own error so a
@@ -4122,7 +4270,8 @@ const fuzz_seed_json =
     \\ "request_filters":[{"match":{"client":["10.0.0.0/8"]},"actions":[{"reject":403}]}],
     \\ "protocol":"http"}],
     \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000",
-    \\ {"address":"127.0.0.1:9001","weight":3}],"pick":"p2c","max_inflight":8,
+    \\ {"address":"127.0.0.1:9001","weight":3}],
+    \\ "pick":{"policy":"hash","key":"cookie","name":"zoxy-srv"},"max_inflight":8,
     \\ "check":{"type":"http","path":"/health","expect_status":200,"timeout_ms":250}}},
     \\ "timeouts":{"connect_ms":5000,"idle_ms":60000,"drain_deadline_ms":10000,
     \\ "max_lifetime_ms":300000,"request_ms":30000,"health_interval_ms":2000},
@@ -4132,9 +4281,11 @@ const fuzz_seed_json =
 ;
 // The `file` arm here, `stdout` in `example_json` beside it: between the
 // two corpus entries the mutator sees every sink spelling, including the
-// `path` key only one of them may carry — and both endpoint spellings
-// (#174), so the `{address, weight}` grammar is a starting point rather
-// than a shape the mutator must blindly discover.
+// `path` key only one of them may carry — both endpoint spellings
+// (#174), and both pick spellings (#178: the object form with its
+// key/name grammar here, the bare string in the example), so each
+// grammar is a starting point rather than a shape the mutator must
+// blindly discover.
 
 test "config: the fuzz seed carrying every block parses" {
     // It is a corpus entry, so it has to be a *valid* config — an
@@ -4318,32 +4469,58 @@ test "config: a cluster name is bounded, because the access log echoes it" {
     );
 }
 
-test "config: the hash pick policy and its key resolve, or fail loudly" {
+test "config: pick resolves both spellings, and hash names its key" {
     const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}],\"clusters\":{\"a\":{";
+    const head_http = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}],\"clusters\":{\"a\":{";
     const tail = "}},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
     const endpoints = "\"endpoints\":[\"127.0.0.1:2\"]";
 
-    // `pick: hash` with no `hash` block takes the default key, so the
-    // common case needs no second line of config.
+    // The object form names the key; `source_ip` stays legal on an l4
+    // listener, since both data paths carry the client address.
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
         const parsed = try expectParseOk(
             &arena_state,
-            head ++ endpoints ++ ",\"pick\":\"hash\"" ++ tail,
+            head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\",\"key\":\"source_ip\"}" ++ tail,
         );
         try std.testing.expectEqual(Config.Cluster.Pick.hash, parsed.clusters[0].pick);
-        try std.testing.expectEqual(Config.Cluster.HashKey.source_ip, parsed.clusters[0].hash_key);
+        try std.testing.expectEqual(
+            @as(std.meta.Tag(Config.Cluster.HashKey), .source_ip),
+            std.meta.activeTag(parsed.clusters[0].hash_key),
+        );
     }
-    // Naming the key explicitly resolves to the same thing.
+    // The request-derived keys carry their name through (#178).
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
         const parsed = try expectParseOk(
             &arena_state,
-            head ++ endpoints ++ ",\"pick\":\"hash\",\"hash\":{\"key\":\"source_ip\"}" ++ tail,
+            head_http ++ endpoints ++
+                ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"zoxy-srv\"}" ++ tail,
         );
-        try std.testing.expectEqual(Config.Cluster.HashKey.source_ip, parsed.clusters[0].hash_key);
+        try std.testing.expectEqualStrings("zoxy-srv", parsed.clusters[0].hash_key.cookie);
+    }
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head_http ++ endpoints ++
+                ",\"pick\":{\"policy\":\"hash\",\"key\":\"header\",\"name\":\"x-tenant\"}" ++ tail,
+        );
+        try std.testing.expectEqualStrings("x-tenant", parsed.clusters[0].hash_key.header);
+    }
+    // The keyless policies keep the bare-string spelling, and the object
+    // spelling of the same policy resolves identically.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ endpoints ++ ",\"pick\":{\"policy\":\"rr\"}" ++ tail,
+        );
+        try std.testing.expectEqual(Config.Cluster.Pick.rr, parsed.clusters[0].pick);
     }
     // A cluster that says nothing keeps the p2c default and the default
     // key, which is inert there.
@@ -4354,33 +4531,141 @@ test "config: the hash pick policy and its key resolve, or fail loudly" {
         try std.testing.expectEqual(Config.Cluster.Pick.p2c, parsed.clusters[0].pick);
     }
 
-    // A `hash` block beside another policy is a request for stickiness the
-    // cluster would silently not provide — the mistake most worth catching
-    // at load rather than in production.
+    // A bare `"hash"` is the misleading spelling this grammar replaced
+    // (#178): which identity the cluster is sticky on is a decision, so
+    // the loader demands the object form name it.
     try expectParseError(
-        error.ClusterHashWithoutHashPick,
-        head ++ endpoints ++ ",\"pick\":\"rr\",\"hash\":{\"key\":\"source_ip\"}" ++ tail,
+        error.ClusterPickKeyMissing,
+        head ++ endpoints ++ ",\"pick\":\"hash\"" ++ tail,
     );
     try expectParseError(
-        error.ClusterHashWithoutHashPick,
-        head ++ endpoints ++ ",\"hash\":{\"key\":\"source_ip\"}" ++ tail,
+        error.ClusterPickKeyMissing,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\"}" ++ tail,
     );
-    // The key vocabulary is closed, and distinct from the policy's own
-    // error so a typo says which field it is in.
+    // Key settings beside another policy are a request for stickiness
+    // the cluster would silently not provide — the mistake most worth
+    // catching at load rather than in production.
     try expectParseError(
-        error.ClusterHashKeyUnknown,
-        head ++ endpoints ++ ",\"pick\":\"hash\",\"hash\":{\"key\":\"cookie\"}" ++ tail,
+        error.ClusterPickKeyWithoutHash,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"rr\",\"key\":\"source_ip\"}" ++ tail,
     );
+    try expectParseError(
+        error.ClusterPickKeyWithoutHash,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"p2c\",\"name\":\"zoxy-srv\"}" ++ tail,
+    );
+    // The vocabularies are closed, each with its own error so a typo
+    // says which field it is in.
     try expectParseError(
         error.ClusterPickUnknown,
         head ++ endpoints ++ ",\"pick\":\"hsah\"" ++ tail,
     );
-    // The block is strict like every other: unknown fields are rejected
-    // rather than ignored.
+    try expectParseError(
+        error.ClusterPickUnknown,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hsah\",\"key\":\"source_ip\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterPickKeyUnknown,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\",\"key\":\"session\"}" ++ tail,
+    );
+    // The object is strict like every other: unknown fields rejected.
     try expectParseError(
         error.UnknownField,
-        head ++ endpoints ++ ",\"pick\":\"hash\",\"hash\":{\"key\":\"source_ip\",\"mask\":24}" ++ tail,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\",\"key\":\"source_ip\",\"mask\":24}" ++ tail,
     );
+    // And only strings or objects can name a policy.
+    try expectParseError(
+        error.UnexpectedToken,
+        head ++ endpoints ++ ",\"pick\":2" ++ tail,
+    );
+}
+
+test "config: a request-derived pick name is required, bounded, and a token" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}],\"clusters\":{\"a\":{";
+    const tail = "}},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const endpoints = "\"endpoints\":[\"127.0.0.1:2\"]";
+
+    // `source_ip` reads nothing, so a name beside it describes a config
+    // that is not what it says — rejected, not ignored.
+    try expectParseError(
+        error.ClusterPickNameUnexpected,
+        head ++ endpoints ++
+            ",\"pick\":{\"policy\":\"hash\",\"key\":\"source_ip\",\"name\":\"x\"}" ++ tail,
+    );
+    // `header` and `cookie` read the named field, so the name is theirs
+    // to state.
+    try expectParseError(
+        error.ClusterPickNameMissing,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterPickNameMissing,
+        head ++ endpoints ++ ",\"pick\":{\"policy\":\"hash\",\"key\":\"header\"}" ++ tail,
+    );
+    // One grammar for both names: an RFC 9110 token, which is also RFC
+    // 6265's cookie-name. A space or `=` inside a cookie name would
+    // corrupt every Set-Cookie a cookie cluster answers with.
+    try expectParseError(
+        error.ClusterPickNameInvalid,
+        head ++ endpoints ++
+            ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterPickNameInvalid,
+        head ++ endpoints ++
+            ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"a=b\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ClusterPickNameInvalid,
+        head ++ endpoints ++
+            ",\"pick\":{\"policy\":\"hash\",\"key\":\"header\",\"name\":\"bad name\"}" ++ tail,
+    );
+    // The bound is exact: at `pick_name_bytes_max` the name loads, one
+    // past it fails — the stamp's Set-Cookie scratch is sized by it.
+    const at_limit = "x" ** constants.pick_name_bytes_max;
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ endpoints ++
+                ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"" ++ at_limit ++ "\"}" ++ tail,
+        );
+        try std.testing.expectEqual(
+            @as(usize, constants.pick_name_bytes_max),
+            parsed.clusters[0].hash_key.cookie.len,
+        );
+    }
+    try expectParseError(
+        error.ClusterPickNameTooLong,
+        head ++ endpoints ++
+            ",\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"" ++ at_limit ++ "x\"}" ++ tail,
+    );
+}
+
+test "config: a request-keyed hash cluster is unreachable from l4" {
+    const tail = "}},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const cookie_cluster = "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]," ++
+        "\"pick\":{\"policy\":\"hash\",\"key\":\"cookie\",\"name\":\"zoxy-srv\"}";
+
+    // An l4 listener never parses a head, so a cookie there is a promise
+    // nothing would keep — rejected as a pair, the `proxy_protocol_send`
+    // rule in the other direction.
+    try expectParseError(
+        error.ListenerL4RequestKeyedHash,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\"}]," ++ cookie_cluster ++ tail,
+    );
+    // The same cluster behind an http listener is exactly what #178 asks
+    // for.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}]," ++
+                cookie_cluster ++ tail,
+        );
+        try std.testing.expectEqualStrings("zoxy-srv", parsed.clusters[0].hash_key.cookie);
+    }
 }
 
 test "config: max_inflight resolves, defaults to uncapped, rejects the useless" {

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -110,11 +110,16 @@ fn writeFieldSchema(
     try out.write(meta.desc);
 
     switch (@typeInfo(Base)) {
-        .@"struct" => if (Base == config.ClustersJson)
-            try writeClustersMap(out)
-        else
-            // Nested object; its description is the field's, written above.
-            try writeObjectBody(out, Base, false),
+        .@"struct" => if (Base == config.ClustersJson) {
+            try writeClustersMap(out);
+        } else {
+            if (Base == config.PickJson) {
+                try writePickField(out);
+            } else {
+                // Nested object; its description is the field's, written above.
+                try writeObjectBody(out, Base, false);
+            }
+        },
         else => try writeShape(out, Base, meta),
     }
 
@@ -268,6 +273,34 @@ fn writeEndpointItems(out: *Stringify) Writer.Error!void {
     try out.endObject();
     try out.beginObject();
     try writeObjectBody(out, config.EndpointJson, true);
+    try out.endObject();
+    try out.endArray();
+}
+
+/// A cluster's pick accepts two spellings (#178) — the bare policy string
+/// (`p2c`, `rr`; a bare `hash` is rejected because its key must be named)
+/// or the `{policy, key, name}` object — so its schema is an `anyOf`,
+/// emitted by hand for the same reason `writeEndpointItems` is: the
+/// resolved DTO (`PickJson`) hides the string form inside its custom
+/// `jsonParse`. The string arm's vocabulary is deliberately narrower than
+/// `Pick`: hash without a key never resolves, so the schema must not
+/// advertise it.
+fn writePickField(out: *Stringify) Writer.Error!void {
+    try out.objectField("anyOf");
+    try out.beginArray();
+    try out.beginObject();
+    try out.objectField("type");
+    try out.write("string");
+    try out.objectField("enum");
+    try out.beginArray();
+    try out.write("p2c");
+    try out.write("rr");
+    try out.endArray();
+    try out.objectField("description");
+    try out.write("A keyless pick policy; hash takes the object form, which names its key.");
+    try out.endObject();
+    try out.beginObject();
+    try writeObjectBody(out, config.PickJson, true);
     try out.endObject();
     try out.endArray();
 }
@@ -442,6 +475,48 @@ test "config_schema: endpoint items accept both spellings" {
         weight.get("maximum").?.integer,
     );
     try std.testing.expectEqual(@as(i64, 0), weight.get("minimum").?.integer);
+}
+
+test "config_schema: pick accepts both spellings, and only the object names hash" {
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, text, .{});
+    defer parsed.deinit();
+
+    const clusters = parsed.value.object.get("properties").?.object.get("clusters").?.object;
+    const cluster_schema = clusters.get("additionalProperties").?.object;
+    const pick = cluster_schema.get("properties").?.object.get("pick").?.object;
+    const arms = pick.get("anyOf").?.array;
+    try std.testing.expectEqual(@as(usize, 2), arms.items.len);
+
+    // The string arm must not advertise `hash`: a bare hash never
+    // resolves (#178 — its key is the operator's to name).
+    const string_arm = arms.items[0].object;
+    try std.testing.expectEqualStrings("string", string_arm.get("type").?.string);
+    const literals = string_arm.get("enum").?.array;
+    try std.testing.expectEqual(@as(usize, 2), literals.items.len);
+    for (literals.items) |literal| {
+        try std.testing.expect(!std.mem.eql(u8, literal.string, "hash"));
+    }
+
+    // The object arm requires exactly `policy` and closes both
+    // vocabularies: every `Pick` policy, every `HashKey` key.
+    const object_arm = arms.items[1].object;
+    try std.testing.expectEqualStrings("object", object_arm.get("type").?.string);
+    const required = object_arm.get("required").?.array;
+    try std.testing.expectEqual(@as(usize, 1), required.items.len);
+    try std.testing.expectEqualStrings("policy", required.items[0].string);
+    const properties = object_arm.get("properties").?.object;
+    const policies = properties.get("policy").?.object.get("enum").?.array;
+    try std.testing.expectEqual(
+        @typeInfo(config.Config.Cluster.Pick).@"enum".fields.len,
+        policies.items.len,
+    );
+    const keys = properties.get("key").?.object.get("enum").?.array;
+    try std.testing.expectEqual(
+        @typeInfo(std.meta.Tag(config.Config.Cluster.HashKey)).@"enum".fields.len,
+        keys.items.len,
+    );
 }
 
 test "config_schema: response filter status bounds and class vocabulary" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -366,6 +366,15 @@ pub const health_check_request_bytes_max: u32 =
 /// over this, so the render buffer can never overflow.
 pub const header_edits_max: u16 = 16;
 
+/// Upper bound on the header or cookie name a request-keyed `hash`
+/// cluster reads (#178) — the same fixed-buffer rule as
+/// `header_edits_max`: the response-side stamp composes
+/// `name=<tag>` plus attributes into a stack scratch, and this bound is
+/// what lets that scratch be sized at comptime. 64 covers every real
+/// cookie or header name with room over (`__Host-`-prefixed names
+/// included).
+pub const pick_name_bytes_max: u16 = 64;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -768,6 +777,10 @@ comptime {
     assert(endpoint_inflight_max >= conn_slots_max);
     assert(endpoint_inflight_max >= upstream_slots_max);
     assert(header_edits_max >= 1);
+    assert(pick_name_bytes_max >= 1);
+    // A pick name is a header-adjacent identifier; keeping it under the
+    // host bound is the sanity relation "this is a name, not a payload".
+    assert(pick_name_bytes_max <= host_bytes_max);
     assert(loop_completions_per_tick_max >= 1);
     assert(timeout_ms_max >= 1000);
     // The two defaulted deadlines must themselves be configs the loader

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -375,6 +375,12 @@ pub const header_edits_max: u16 = 16;
 /// included).
 pub const pick_name_bytes_max: u16 = 64;
 
+/// A response render's edit ceiling (#178): the configured filter edits
+/// plus the one slot the Set-Cookie stamp reserves. The renderer's
+/// asserts and the proxy's edit buffers all speak this name, so the
+/// reserved slot cannot drift out of any of them.
+pub const response_edits_max: u16 = header_edits_max + 1;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -777,6 +783,7 @@ comptime {
     assert(endpoint_inflight_max >= conn_slots_max);
     assert(endpoint_inflight_max >= upstream_slots_max);
     assert(header_edits_max >= 1);
+    assert(response_edits_max == header_edits_max + 1);
     assert(pick_name_bytes_max >= 1);
     // A pick name is a header-adjacent identifier; keeping it under the
     // host bound is the sanity relation "this is a name, not a payload".

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -84,6 +84,20 @@ pub const Counters = struct {
     /// on a dashboard, and a redirect storm is a different diagnosis
     /// from a reject storm.
     l7_redirected: Value = Value.init(0),
+    /// #178 cookie stickiness, counted once per forwarded response on a
+    /// cookie-keyed cluster — at the response render, so a replayed try
+    /// counts once and a torn-down exchange not at all. The three
+    /// partition those responses. `followed`: the request's tag named
+    /// the endpoint that served it, nothing to announce. `assigned`: the
+    /// request carried no usable tag — a session's first request — and
+    /// the response announces one (the Set-Cookie stamp). `repicked`:
+    /// the request named an endpoint it did not get (ejected, drained,
+    /// capped, config-removed, or forged) and the response re-announces;
+    /// a *rate* of these is the interesting signal — endpoints flapping
+    /// under a sticky population.
+    l7_sticky_followed: Value = Value.init(0),
+    l7_sticky_assigned: Value = Value.init(0),
+    l7_sticky_repicked: Value = Value.init(0),
     /// §8 rungs at the L7 request level, answered 503: relay buffers or
     /// upstream slots exhausted when a valid request needed them. Like the
     /// reject counters, the connection was admitted, so these stay out of

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -660,6 +660,37 @@ pub fn headerValue(headers: []const Header, name: []const u8) ?[]const u8 {
     return null;
 }
 
+/// The value of the named cookie in the request's Cookie header, or null
+/// when the request carries none (#178). Reads the first Cookie header
+/// only — RFC 6265 has user agents send exactly one — and scans its
+/// `name=value` crumbs. The *name* compare is byte-exact, unlike
+/// `headerValue`'s: cookie names are case-sensitive, and the only names
+/// asked about are ones this proxy's own config spelled. A crumb's value
+/// runs to the next `;`, so a value may contain `=` (base64 does).
+pub fn cookieValue(headers: []const Header, name: []const u8) ?[]const u8 {
+    assert(name.len >= 1);
+    // A validated pick name is a token, so `=` cannot sit inside it and
+    // split the crumb somewhere other than where this scan splits it.
+    assert(std.mem.indexOfScalar(u8, name, '=') == null);
+    const header = headerValue(headers, "cookie") orelse return null;
+    var crumbs = std.mem.splitScalar(u8, header, ';');
+    // Bounded: the iterator yields at most header.len + 1 pieces.
+    while (crumbs.next()) |raw_crumb| {
+        const crumb = std.mem.trim(u8, raw_crumb, " \t");
+        if (crumb.len <= name.len) {
+            continue;
+        }
+        if (crumb[name.len] != '=') {
+            continue;
+        }
+        if (!std.mem.eql(u8, crumb[0..name.len], name)) {
+            continue;
+        }
+        return crumb[name.len + 1 ..];
+    }
+    return null;
+}
+
 /// True if a comma-separated token list (Connection, TE, ...) contains
 /// `token`, case-insensitively, with optional whitespace around tokens.
 pub fn tokenListHas(value: []const u8, token: []const u8) bool {
@@ -1510,6 +1541,38 @@ test "http parser: header helpers are case-insensitive" {
     try testing.expect(tokenListHas("close", "CLOSE"));
     try testing.expect(!tokenListHas("closed", "close"));
     try testing.expect(!tokenListHas("", "close"));
+}
+
+test "http parser: cookieValue finds its crumb, byte-exactly" {
+    const headers = [_]Header{
+        Header.init("Host", "example"),
+        Header.init("Cookie", "theme=dark; zoxy-srv=0123456789abcdef; b=1"),
+    };
+    try testing.expectEqualStrings(
+        "0123456789abcdef",
+        cookieValue(&headers, "zoxy-srv").?,
+    );
+    try testing.expectEqualStrings("dark", cookieValue(&headers, "theme").?);
+    try testing.expectEqualStrings("1", cookieValue(&headers, "b").?);
+    // Cookie *names* are case-sensitive (the header name is not): a
+    // differently-cased crumb is a different cookie, RFC 6265's rule.
+    try testing.expectEqual(@as(?[]const u8, null), cookieValue(&headers, "ZOXY-SRV"));
+    try testing.expectEqual(@as(?[]const u8, null), cookieValue(&headers, "zoxy"));
+    try testing.expectEqual(@as(?[]const u8, null), cookieValue(&headers, "srv"));
+
+    // A value may contain `=` (base64 padding does); the crumb runs to
+    // the `;`, so only the first `=` after the name splits.
+    const padded = [_]Header{Header.init("cookie", "s=YWJjZA==;t=x")};
+    try testing.expectEqualStrings("YWJjZA==", cookieValue(&padded, "s").?);
+    try testing.expectEqualStrings("x", cookieValue(&padded, "t").?);
+
+    // No Cookie header, an empty value, and a value-less crumb.
+    const bare = [_]Header{Header.init("Host", "example")};
+    try testing.expectEqual(@as(?[]const u8, null), cookieValue(&bare, "zoxy-srv"));
+    const empty = [_]Header{Header.init("Cookie", "zoxy-srv=; other=1")};
+    try testing.expectEqualStrings("", cookieValue(&empty, "zoxy-srv").?);
+    const nameless = [_]Header{Header.init("Cookie", "zoxy-srv")};
+    try testing.expectEqual(@as(?[]const u8, null), cookieValue(&nameless, "zoxy-srv"));
 }
 
 // Chunked-scanner tests drive `feed` through `chunkedOutcome`, the same

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -690,7 +690,15 @@ pub fn Proxy(comptime IoType: type) type {
             // out a parked connection starts a request the origin has to
             // serve, which is the thing being bounded — the saved
             // handshake does not make it free.
-            const pick = pickEndpointOrShed(server, conn, requestKeyFor(server, conn, request)) orelse return;
+            const request_key = requestKeyFor(server, conn, request);
+            // The head bytes are gone by the response render (§7 buffer
+            // rotation), so the render's half of #178 — "did the request
+            // already name the endpoint it got?" — is recorded now.
+            conn.l7.sticky_cookie = switch (request_key) {
+                .endpoint => |identity| identity,
+                else => null,
+            };
+            const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
@@ -1411,6 +1419,109 @@ pub fn Proxy(comptime IoType: type) type {
             }, out);
         }
 
+        /// The #178 verdict for this exchange, decided at the response
+        /// render — the one moment that knows both what the request's
+        /// cookie named (`sticky_cookie`, recorded at routing) and which
+        /// endpoint actually served (a replay may have moved it since
+        /// the pick). `.none` on every cluster that is not cookie-keyed.
+        const StickyVerdict = enum(u2) { none, followed, assigned, repicked };
+
+        fn stickyVerdict(server: *const ServerType, conn: *const ConnType) StickyVerdict {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.cluster_index < server.config.clusters.len);
+            const cluster = &server.config.clusters[conn.cluster_index];
+            switch (cluster.hash_key) {
+                .source_ip, .header => return .none,
+                .cookie => {},
+            }
+            // An exchange rendering a response holds an upstream, so the
+            // endpoint was recorded when its slot was (§8).
+            assert(conn.log.endpoint_index != conn_module.LogState.endpoint_none);
+            const served = server.balancer.endpointIdentity(
+                conn.cluster_index,
+                conn.log.endpoint_index,
+            );
+            const carried = conn.l7.sticky_cookie orelse return .assigned;
+            if (carried == served) {
+                return .followed;
+            }
+            return .repicked;
+        }
+
+        /// The Set-Cookie attributes every #178 stamp carries. `Path=/`
+        /// because the assignment is per *backend*, not per resource;
+        /// `HttpOnly` because no script has business reading a routing
+        /// tag. No `Max-Age`: a session cookie, HAProxy's default for
+        /// the same feature. No `Secure`: this proxy does not terminate
+        /// TLS (#125), so it cannot know the client-facing scheme.
+        const sticky_attributes = "; Path=/; HttpOnly";
+        const sticky_value_bytes_max = constants.pick_name_bytes_max + 1 +
+            Balancer.endpoint_tag_len + sticky_attributes.len;
+
+        /// This render's full edit set: the #175 filter edits, plus —
+        /// when the verdict owes the client an announcement — the #178
+        /// stamp in the one buffer slot reserved past the filter budget.
+        /// The stamp is an `add`, so an origin's own Set-Cookie lines
+        /// ride beside it untouched. The composed value lives in the
+        /// caller's scratch: it must survive exactly until the render
+        /// consumes it, in the same frame.
+        fn responseEditsWithStamp(
+            server: *const ServerType,
+            conn: *const ConnType,
+            response: *const parser.ResponseHead,
+            verdict: StickyVerdict,
+            buffer: *[constants.response_edits_max]filter.AppliedHeaderEdit,
+            scratch: *[sticky_value_bytes_max]u8,
+        ) []const filter.AppliedHeaderEdit {
+            const edits = responseEdits(conn, response, buffer[0..constants.header_edits_max]);
+            assert(edits.len <= constants.header_edits_max);
+            switch (verdict) {
+                .none, .followed => return edits,
+                .assigned, .repicked => {},
+            }
+            const name = switch (server.config.clusters[conn.cluster_index].hash_key) {
+                .cookie => |name| name,
+                // The verdict said cookie cluster; the config cannot
+                // have changed under it (§5 parse-once).
+                .source_ip, .header => unreachable,
+            };
+            assert(name.len >= 1);
+            assert(name.len <= constants.pick_name_bytes_max);
+            var len: u32 = 0;
+            @memcpy(scratch[0..name.len], name);
+            len += @intCast(name.len);
+            scratch[len] = '=';
+            len += 1;
+            // Through the one mint (`formatEndpointTag`), so the tag the
+            // stamp announces is byte-identical to the tag the next
+            // request's parse will match.
+            Balancer.formatEndpointTag(
+                server.balancer.endpointIdentity(conn.cluster_index, conn.log.endpoint_index),
+                scratch[len..][0..Balancer.endpoint_tag_len],
+            );
+            len += Balancer.endpoint_tag_len;
+            @memcpy(scratch[len..][0..sticky_attributes.len], sticky_attributes);
+            len += sticky_attributes.len;
+            // Exactly the four pieces, no gaps: the value the render
+            // emits is the whole composition.
+            assert(len == name.len + 1 + Balancer.endpoint_tag_len + sticky_attributes.len);
+            buffer[edits.len] = .{ .kind = .add, .name = "Set-Cookie", .value = scratch[0..len] };
+            return buffer[0 .. edits.len + 1];
+        }
+
+        /// Count the #178 verdict — only after the render commits, so a
+        /// 502'd or replayed render try cannot double-count, and the
+        /// three counters partition exactly the forwarded responses of
+        /// cookie clusters (their doc's contract).
+        fn creditSticky(server: *ServerType, verdict: StickyVerdict) void {
+            switch (verdict) {
+                .none => {},
+                .followed => server.counters.increment("l7_sticky_followed"),
+                .assigned => server.counters.increment("l7_sticky_assigned"),
+                .repicked => server.counters.increment("l7_sticky_repicked"),
+            }
+        }
+
         fn renderResponse(
             server: *ServerType,
             conn: *ConnType,
@@ -1424,17 +1535,19 @@ pub fn Proxy(comptime IoType: type) type {
             const keep_downstream = downstreamKeepAlive(server, conn, response);
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
-            var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
+            const verdict = stickyVerdict(server, conn);
+            var edit_buffer: [constants.response_edits_max]filter.AppliedHeaderEdit = undefined;
+            var cookie_scratch: [sticky_value_bytes_max]u8 = undefined;
             const rendered = render.renderResponseHead(
                 response,
                 !keep_downstream,
-                responseEdits(conn, response, &edit_buffer),
+                responseEditsWithStamp(server, conn, response, verdict, &edit_buffer, &cookie_scratch),
                 headBytes(server, conn),
             ) catch {
-                // The head no longer fits — after the #175 edits, or
-                // never did: an origin response the proxy cannot
-                // re-render is not the client's fault, so 502, the
-                // same verdict an unparseable origin head earns.
+                // The head no longer fits — after the #175 edits or the
+                // #178 stamp, or never did: an origin response the proxy
+                // cannot re-render is not the client's fault, so 502,
+                // the same verdict an unparseable origin head earns.
                 upstreamFailed(server, conn);
                 return;
             };
@@ -1469,6 +1582,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.response_leg = .sending_head;
             // Committed to answering: no verdict may intervene from here (§7).
             conn.l7.response_started = true;
+            // Credited only here, at the point of no return — the
+            // malformed-excess bail above can still discard a rendered
+            // head, and a discarded try must not count (`l7_redirected`'s
+            // placement rule).
+            creditSticky(server, verdict);
             // What the origin said, so a line can report it even if the
             // exchange never finishes. Whether the client *got* it is a
             // separate fact, and `outcome` stays `aborted` until
@@ -2000,7 +2118,12 @@ pub fn Proxy(comptime IoType: type) type {
             // a cap hit here answers rather than replaying again — and
             // the same request key (#178), re-derived from the re-parse
             // exactly like the framing: same bytes, same key.
-            const pick = pickEndpointOrShed(server, conn, requestKeyFor(server, conn, &request)) orelse return;
+            const request_key = requestKeyFor(server, conn, &request);
+            conn.l7.sticky_cookie = switch (request_key) {
+                .endpoint => |identity| identity,
+                else => null,
+            };
+            const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
             dialUpstream(server, conn, pick);
         }
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -604,16 +604,58 @@ pub fn Proxy(comptime IoType: type) type {
             beginUpstream(server, conn, request, &keys.views);
         }
 
+        /// The request-derived half of this exchange's pick (#178): what
+        /// the routed cluster's hash key reads off the parsed head —
+        /// `.none` for every cluster that keys on nothing or on the
+        /// address. Derived while the head is live: at routing on the
+        /// first try, and from the replay's re-parse on the second, the
+        /// same source-of-truth rule the replay applies to the framing.
+        fn requestKeyFor(
+            server: *const ServerType,
+            conn: *const ConnType,
+            request: *const parser.RequestHead,
+        ) Balancer.RequestKey {
+            assert(conn.cluster_index < server.config.clusters.len);
+            assert(request.head_len >= 1);
+            const cluster = &server.config.clusters[conn.cluster_index];
+            if (cluster.pick != .hash) {
+                return .none;
+            }
+            switch (cluster.hash_key) {
+                .source_ip => return .none,
+                .header => |name| {
+                    const value = parser.headerValue(request.headers, name) orelse
+                        return .absent;
+                    if (value.len == 0) {
+                        return .absent;
+                    }
+                    return .{ .key = Balancer.bytesKey(value) };
+                },
+                .cookie => |name| {
+                    const value = parser.cookieValue(request.headers, name) orelse
+                        return .absent;
+                    const identity = Balancer.parseEndpointTag(value) orelse
+                        return .absent;
+                    return .{ .endpoint = identity };
+                },
+            }
+        }
+
         /// Picks a live endpoint under the §8 per-endpoint inflight cap, or
         /// sheds 503 and returns null when every endpoint of this cluster
         /// is already at it. Shared by the first-try and replay dial paths
         /// so the cap and its shed counter cannot drift between them.
-        fn pickEndpointOrShed(server: *ServerType, conn: *ConnType) ?Balancer.Pick {
+        fn pickEndpointOrShed(
+            server: *ServerType,
+            conn: *ConnType,
+            request_key: Balancer.RequestKey,
+        ) ?Balancer.Pick {
             return server.balancer.pick(
                 conn.cluster_index,
                 &server.endpointLoad(),
                 server.health.healthy,
                 &conn.client_address,
+                request_key,
             ) orelse {
                 // The labeled twin (#179) carries only the cluster: this
                 // fires precisely because no endpoint could be picked —
@@ -648,7 +690,7 @@ pub fn Proxy(comptime IoType: type) type {
             // out a parked connection starts a request the origin has to
             // serve, which is the thing being bounded — the saved
             // handshake does not make it free.
-            const pick = pickEndpointOrShed(server, conn) orelse return;
+            const pick = pickEndpointOrShed(server, conn, requestKeyFor(server, conn, request)) orelse return;
             if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
@@ -1955,8 +1997,10 @@ pub fn Proxy(comptime IoType: type) type {
             //
             // The replay is a fresh try against the same cluster, so it
             // meets the same §8 cap; its budget is already spent (§7), so
-            // a cap hit here answers rather than replaying again.
-            const pick = pickEndpointOrShed(server, conn) orelse return;
+            // a cap hit here answers rather than replaying again — and
+            // the same request key (#178), re-derived from the re-parse
+            // exactly like the framing: same bytes, same key.
+            const pick = pickEndpointOrShed(server, conn, requestKeyFor(server, conn, &request)) orelse return;
             dialUpstream(server, conn, pick);
         }
 

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -149,9 +149,11 @@ pub fn renderRequestHead(
 /// connection after this response (§7). `edits` are the matched
 /// response filters' header edits (#175), applied by the same
 /// suppress-and-append machinery the request render uses — empty when
-/// the listener configured none, which is most listeners. Overflow is
-/// the caller's 502: an origin response that cannot be re-rendered
-/// after edits is not the client's fault.
+/// the listener configured none, which is most listeners; the one slot
+/// past `header_edits_max` is the #178 Set-Cookie stamp, which rides
+/// this same machinery rather than owning a second injection path.
+/// Overflow is the caller's 502: an origin response that cannot be
+/// re-rendered after edits is not the client's fault.
 pub fn renderResponseHead(
     response: *const parser.ResponseHead,
     inject_close: bool,
@@ -160,7 +162,7 @@ pub fn renderResponseHead(
 ) error{Oversize}![]const u8 {
     assert(response.status >= 100);
     assert(response.status <= 599);
-    assert(edits.len <= constants.header_edits_max);
+    assert(edits.len <= constants.response_edits_max);
     assert(buffer.len <= std.math.maxInt(u32));
 
     var staging = Staging{ .buffer = buffer };
@@ -305,7 +307,8 @@ fn appendEndToEndHeaders(
     suppress_forwarded_for: bool,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
-    assert(edits.len <= constants.header_edits_max);
+    // One slot past the filter budget: the #178 Set-Cookie stamp.
+    assert(edits.len <= constants.response_edits_max);
     // Collect the Connection header value(s) once (usually zero or one).
     // Re-finding them inside the per-header hop-by-hop test made the walk
     // O(headers²) — the render's top user-CPU cost under load (§9).
@@ -391,7 +394,8 @@ fn collectNominations(
 /// copies must not be forwarded (`add` never suppresses — it appends).
 fn suppressedByEdit(name: []const u8, edits: []const filter.AppliedHeaderEdit) bool {
     assert(name.len >= 1);
-    assert(edits.len <= constants.header_edits_max);
+    // One slot past the filter budget: the #178 Set-Cookie stamp.
+    assert(edits.len <= constants.response_edits_max);
     for (edits) |edit| {
         switch (edit.kind) {
             .set, .remove => if (std.ascii.eqlIgnoreCase(name, edit.name)) return true,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -8,6 +8,7 @@
 
 const std = @import("std");
 
+const Balancer = @import("balancer.zig").Balancer;
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
 const router = @import("http/router.zig");
@@ -533,6 +534,12 @@ const Http1Bed = struct {
         /// §8 per-endpoint concurrency cap; null leaves the cluster
         /// uncapped, which is what every pre-existing scenario wants.
         max_inflight: ?u32 = null,
+        /// The one cluster's §7 pick policy; p2c, the config default,
+        /// for every pre-existing scenario.
+        pick: config_module.Config.Cluster.Pick = .p2c,
+        /// What a `hash` cluster keys on (#178); `source_ip` is inert
+        /// beside any other policy, matching the loader's contract.
+        hash_key: config_module.Config.Cluster.HashKey = .source_ip,
         /// Probe pacing for `check` scenarios — tight, so fall/rise fit
         /// inside a short virtual run.
         health_interval_ms: u32 = 40,
@@ -558,7 +565,7 @@ const Http1Bed = struct {
             .buffer_group_bytes = options.head_buffer_bytes,
         });
         bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -2263,6 +2270,156 @@ test "l7: an origin head that no longer fits after response edits is 502 (#175)"
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try bed.expectDrained();
+}
+
+/// The #178 tag of the bed's one endpoint, spelled the way the stamp
+/// spells it — through the server's own balancer, so mint and
+/// expectation cannot drift.
+fn bedEndpointTag(bed: *const Http1Bed) [Balancer.endpoint_tag_len]u8 {
+    var tag: [Balancer.endpoint_tag_len]u8 = undefined;
+    Balancer.formatEndpointTag(bed.server.balancer.endpointIdentity(0, 0), &tag);
+    return tag;
+}
+
+test "l7: a cookieless request on a cookie cluster is assigned and stamped (#178)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 31,
+        // The origin sets its own cookie: the stamp is an `add`, so the
+        // application's Set-Cookie must ride through beside it.
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nSet-Cookie: app=1\r\n\r\nhi",
+        .pick = .hash,
+        .hash_key = .{ .cookie = "zoxy-srv" },
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    var expected_buffer: [512]u8 = undefined;
+    const expected = std.fmt.bufPrint(
+        &expected_buffer,
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nSet-Cookie: app=1\r\n" ++
+            "Set-Cookie: zoxy-srv={s}; Path=/; HttpOnly\r\n" ++
+            "Connection: close\r\n\r\nhi",
+        .{&bedEndpointTag(&bed)},
+    ) catch unreachable;
+    try std.testing.expectEqualStrings(expected, bed.client.response());
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_sticky_assigned"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_followed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_repicked"));
+    try bed.expectDrained();
+}
+
+test "l7: a request naming the endpoint it reaches is followed, not re-stamped (#178)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 32,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .pick = .hash,
+        .hash_key = .{ .cookie = "zoxy-srv" },
+    });
+    defer bed.tearDown();
+
+    var request_buffer: [256]u8 = undefined;
+    const request = std.fmt.bufPrint(
+        &request_buffer,
+        "GET / HTTP/1.1\r\nHost: o\r\nCookie: theme=dark; zoxy-srv={s}\r\n" ++
+            "Connection: close\r\n\r\n",
+        .{&bedEndpointTag(&bed)},
+    ) catch unreachable;
+    try bed.exchange(request);
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // Idempotent: the client already holds the right tag, so the
+    // response must not re-speak it — a stamp on every response would
+    // reset session-cookie expiry semantics the operator may layer on.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_sticky_followed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_assigned"));
+    try bed.expectDrained();
+}
+
+test "l7: a well-formed tag naming no endpoint is repicked and re-stamped (#178)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 33,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .pick = .hash,
+        .hash_key = .{ .cookie = "zoxy-srv" },
+    });
+    defer bed.tearDown();
+
+    // Sixteen lowercase hex — the minted grammar — but no endpoint of
+    // this cluster: a config that shrank, or a forgery. Either way the
+    // request is served and the response re-announces.
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\n" ++
+        "Cookie: zoxy-srv=ffffffffffffffff\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    var expected_buffer: [512]u8 = undefined;
+    const expected = std.fmt.bufPrint(
+        &expected_buffer,
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n" ++
+            "Set-Cookie: zoxy-srv={s}; Path=/; HttpOnly\r\n" ++
+            "Connection: close\r\n\r\nhi",
+        .{&bedEndpointTag(&bed)},
+    ) catch unreachable;
+    try std.testing.expectEqualStrings(expected, bed.client.response());
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_sticky_repicked"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_assigned"));
+    try bed.expectDrained();
+}
+
+test "l7: a malformed tag is an absent one — assigned, not repicked (#178)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 34,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .pick = .hash,
+        .hash_key = .{ .cookie = "zoxy-srv" },
+    });
+    defer bed.tearDown();
+
+    // Not the minted grammar (wrong length): it names nothing, so the
+    // request is a first request, not a re-homing — the distinction the
+    // repicked counter exists to keep clean.
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\n" ++
+        "Cookie: zoxy-srv=notatag\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_sticky_assigned"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_repicked"));
+    try bed.expectDrained();
+}
+
+test "l7: a header-keyed cluster stamps nothing (#178)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 35,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .pick = .hash,
+        .hash_key = .{ .header = "x-tenant" },
+    });
+    defer bed.tearDown();
+
+    // The keyed header present and absent: rendezvous and the load
+    // fallback both serve, and neither direction owes the client any
+    // announcement — a header key is the client's own statement.
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nX-Tenant: acme\r\n" ++
+        "Connection: close\r\n\r\n");
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_followed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_assigned"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_repicked"));
     try bed.expectDrained();
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -483,6 +483,16 @@ pub fn Conn(comptime IoType: type) type {
             /// across by hand — a replay is the same request retrying, not
             /// a new one earning a fresh budget.
             request_deadline_ns: u64 = 0,
+            /// The endpoint identity this request's stickiness cookie
+            /// named (#178), or null when the cluster is not
+            /// cookie-keyed or the request carried nothing usable.
+            /// Recorded at routing — the head bytes are gone by the
+            /// response render (§7 buffer rotation), and the render is
+            /// exactly who asks: it compares this against the endpoint
+            /// that actually served, and stamps a Set-Cookie on any
+            /// mismatch. The replay rebuild re-derives it from its
+            /// re-parse, like the framing.
+            sticky_cookie: ?u64 = null,
             /// True once the request head has been forwarded off conn.head
             /// (head sent and any coalesced body excess drained), so the
             /// response head may render into conn.head (§7 buffer rotation).


### PR DESCRIPTION
Closes #178.

`pick` becomes string-or-object: the bare strings stay for the keyless
policies, and `hash` takes only the object form —
`{ "policy": "hash", "key": ..., "name": ... }`. A bare `"hash"` is
rejected at load: keying on `source_ip` by default read as "sticky" and
quietly was not behind NAT, so which identity a cluster is sticky on is
now the operator's sentence to write. The `hash` block dies with the
default (no deployed configs to break).

Three keys. `source_ip` as before. `header` — rendezvous over the named
header's value via a pinned FNV-1a folded through the pinned finalizer
(published-vector-tested, the `mix64` cross-build argument): stickiness
on an identity the client states, which survives NAT. `cookie` — the
issue's feature, and not a hash at all: the named cookie carries an
**endpoint tag** (16 lowercase hex of the endpoint's rendezvous
identity — stable across restarts, processes and config reordering, and
leaking a hash rather than an address). A tag naming a healthy,
under-capacity endpoint is honoured whatever the load says; a request
with no usable tag — or one naming an ejected, drained, capped or
removed endpoint — is placed by load (the p2c draw, shared), and the
response answers `Set-Cookie: <name>=<tag>; Path=/; HttpOnly` as one
`add` edit riding the #175 render machinery in the slot
`response_edits_max` reserves. A request already naming the endpoint it
reached is never re-stamped. The client holding the state is §3's
no-table argument satisfied a second way: every process reads the same
cookie and reaches the same endpoint with nothing shared.

Request-keyed clusters are rejected on `l4` listeners (the
`proxy_protocol_send` reachability rule, other direction). The L7 path
derives the request key while the head is live — at routing, and again
from the replay's re-parse. `l7_sticky_followed` / `assigned` /
`repicked` partition a cookie cluster's forwarded responses, credited
at the render's point of no return so a discarded try counts nothing;
a repick rate is the operational signal (flapping under a sticky
population). Forgery is priced consciously: a tag is unsigned because a
client can only choose which backend serves itself, from the eligible
set only.

Gates: a quarter of sim seeds draw the cookie-keyed cluster, the pinned
tag is re-proved against the running mint at every setup, two scripts
echo and forge tags on every seed, and the client oracle demands the
stamp's exact bytes per response head — census covers all three
counters. The live gate round-trips assignment, echo and forgery
against the shipped binary and holds the counters to exactly one each.
Directed tests pin the stamp bytes, idempotence, malformed-is-absent,
and that header-keyed clusters stamp nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)