### PR TITLE
feat: named response bodies, error pages, and a respond action (#159)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1183,6 +1183,52 @@ origin, not one this proxy can pick for them.
   per-request — and it may do so only because its render runs after
   every read of those bytes: the Location is composed first, into the
   rewrite scratch, so nothing aliases what the render overwrites (§7).
+- **Those responses can carry a body, and bodies are a named table**
+  (#159, settled 2026-08-03). `bodies` maps a name to bytes — a `file`
+  read once at startup or an `inline` string, exactly one, plus the
+  `content_type` nothing infers — and every feature that serves content
+  references one *by name*: `error_pages` maps a status to a body,
+  a `respond` filter action answers with one. The indirection is the
+  design, not ceremony: one body is one read, one charge against the
+  cap, and one rendered buffer per (body, status) however many places
+  serve it, while a dangling name is a load error rather than a
+  silently empty page — the `clusters` idiom, applied to the same kind
+  of thing.
+  Each configured page is rendered **at load** into two complete
+  responses — both persistence variants, status line through body, one
+  contiguous arena buffer each — with the head length recorded so a
+  `HEAD` request sends that same buffer's prefix. Serving one is
+  therefore the comptime path unchanged: one send from immutable
+  memory, nothing acquired. That is the whole reason bodies live in
+  memory rather than being spliced from a file: an admitted `503` is
+  raised *because* a pool ran out, and an error page whose delivery
+  needed a pipe from another bounded pool would fail exactly when it is
+  needed. `body_bytes_max` caps a body and marks the scope boundary —
+  below it memory is the right answer, above it the page cache and a
+  streaming path are, which is a different feature. The cost is per
+  process, so N workers behind `SO_REUSEPORT` hold N copies; the banner
+  prints the page count beside the measured config arena that holds
+  them. A changed file needs a restart, like every other parse-once
+  input (§1).
+  Configuring a status is the **whole opt-in**, sheds included. A `503`
+  does not grow a body by default: the cost is not arena bytes but
+  kernel socket-buffer bytes, which §5 explicitly leaves outside the
+  closed form, multiplied by the shed rate at the moment the proxy is
+  under most pressure. Writing the page down is the operator saying
+  they want that, so a second `send_body_on_shed` switch would only
+  override a decision the config already expresses — the reasoning that
+  makes `forwarded` an absent block rather than a `mode: "off"`.
+  The `respond` action is the same machinery pointed at a different
+  question: a maintenance page, a `robots.txt`, a health target served
+  by the balancer itself. It is terminal like `reject` and `redirect`
+  and stops the request before routing acquires anything, but it is
+  deliberately *not* a body on `reject`: a reject is policy refusing
+  traffic and a respond is this proxy being the origin, so they keep
+  separate counters (`l7_responded`) and separate access-log outcomes
+  (`responded`). Its status set is the error statuses plus `200`, the
+  one status no rung raises. Response filters (#175) cannot carry the
+  action at all — those rules run when an origin response already
+  exists, and replacing it is not an edit.
 - **A shed keeps the connection when it can.** Closing is not free: it
   costs the client a handshake and this proxy an accept, a conn slot and
   an admission — so an always-closing shed is *more* expensive per
@@ -1571,7 +1617,7 @@ src/
     router.zig        // §7 path routing: canonical-path longest-prefix table
     proxy.zig         // L7 state machine over phases
   balancer.zig        // upstream endpoint pick: rr | p2c | hash (§7)
-  shed.zig            // exhaustion ladder: decisions + static responses
+  shed.zig            // exhaustion ladder: decisions + static responses (incl. configured pages, #159)
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
   admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
   access_log.zig      // JSON access log: double-buffered sink, drop rung (§8)

--- a/docs/README.md
+++ b/docs/README.md
@@ -498,8 +498,8 @@ the list but the file you write.
 Match on `method`, `host`, `path_prefix`, header predicates
 (`present` / `equals` / `contains`), and `client` — CIDR ranges the
 connection's address must fall inside. Actions are `reject` with a status,
-`redirect`, `header_set` / `header_add` / `header_remove`, and
-`rewrite_prefix`.
+`redirect`, `respond` (answer from a configured body),
+`header_set` / `header_add` / `header_remove`, and `rewrite_prefix`.
 
 Rules compile into immutable tables at load time and are interpreted with
 bounded loops — no plugins, no scripting, nothing that can allocate or run
@@ -579,8 +579,64 @@ headers zoxy owns (`Content-Length`, `Transfer-Encoding`, `Connection`
 and the hop-by-hop set, `X-Forwarded-For`), and a response head that no
 longer fits after edits is answered `502` — an origin response the proxy
 cannot re-render is not the client's fault. Responses zoxy generates
-itself (`404`, `503`, filter rejects) are not origin responses and carry
-no edits.
+itself (`404`, `503`, filter rejects, a `respond` action's body) are not
+origin responses and carry no edits.
+
+### Response bodies
+
+Every status zoxy sends itself is empty by default. `bodies` names
+content once — from a file read at startup, or inline for one-liners —
+and anything that serves content references it by name:
+
+```json
+"bodies": {
+    "maintenance": { "file": "/etc/zoxy/503.html", "content_type": "text/html; charset=utf-8" },
+    "not-found":   { "file": "/etc/zoxy/404.html", "content_type": "text/html; charset=utf-8" },
+    "robots":      { "inline": "User-agent: *\nDisallow: /private\n",
+                     "content_type": "text/plain" }
+},
+"error_pages": { "404": "not-found", "503": "maintenance" }
+```
+
+Each name is read once and rendered once, however many places serve it —
+so the same maintenance page on `error_pages` and three filter rules is
+one buffer, and a name that does not exist is a startup error rather
+than a silently blank page. `content_type` is required: nothing is
+guessed from a filename. Files are read at startup like the rest of the
+config, so **changing one needs a restart**.
+
+`error_pages` accepts only the statuses zoxy actually sends — `400`,
+`403`, `404`, `414`, `429`, `431`, `501`, `502`, `503`, `504` — and a
+page for anything else is refused at load.
+
+Bodies live in memory, and that is the point rather than a shortcut: a
+`503` is raised *because* something ran out, so an error page whose
+delivery needed a resource would fail exactly when it is needed. The
+cost is bounded and visible — capped per body, counted in the startup
+banner, and paid once per worker process.
+
+**Listing a status is the opt-in, including for sheds.** Leave `503`
+out and overload behaves exactly as it does today; put it in and you
+have said you want the bytes. There is no second switch, because
+writing the page down is the decision.
+
+#### Serving a body directly
+
+```json
+"request_filters": [
+    { "match": { "path_prefix": "/robots.txt" },
+      "actions": [{ "respond": { "status": 200, "body": "robots" } }] },
+    { "match": { "host": "old.example.com" },
+      "actions": [{ "respond": { "status": 503, "body": "maintenance" } }] }
+]
+```
+
+`respond` answers from a body instead of forwarding — a `robots.txt`, a
+maintenance window, a health target the balancer serves itself. It stops
+the request like `reject` and `redirect` do, but counts as
+`zoxy_l7_responded` and logs as `responded`: refusing traffic and serving
+it are different facts, and neither should have to be subtracted from
+the other. Statuses are `200` plus the error set.
 
 ### Timeouts
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -69,7 +69,7 @@ weights_http: [1]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
-request_filters_http: [4]zoxy.http.filter.Rule,
+request_filters_http: [5]zoxy.http.filter.Rule,
 /// The #175 response rules beside them: the always-on stamp the client
 /// oracle requires on every proxied 200, and the 5xx rule whose edit
 /// must never appear (the scripted origin answers no 5xx).
@@ -502,6 +502,13 @@ fn deriveServerConfig(
         // that must reserve nothing and read no clock (§5, §8).
         .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
         .health_interval_ms = health_interval_ms,
+        // #159: a page for `403` on every seed — the one status a
+        // script earns from a filter reject — so the configured-page
+        // arm of the static path runs under the whole schedule fuzz,
+        // and the client can demand its bytes on every 403. `503` is
+        // deliberately left out: the sheds keep their empty bodies,
+        // which is the opt-in rule stated as a property.
+        .error_pages = &error_pages,
     };
 }
 
@@ -693,6 +700,48 @@ fn deriveProxyProtocolSend(random: std.Random) ?zoxy.config.Config.Cluster.Proxy
     };
 }
 
+/// The two #159 pages the sweep serves, rendered here exactly as
+/// `config.zig`'s loader renders one — the simulator builds its
+/// `Config` by hand (no filesystem, no parse), so the shape is spelled
+/// out rather than loaded. The client oracle demands these bodies
+/// byte-for-byte on every seed.
+///
+/// The duplication is deliberate but not free: this spelling and the
+/// loader's could drift, and nothing here would notice, because what
+/// the serving path consumes is the `StaticPage` *fields* — it never
+/// re-reads the head it was handed. What that costs is coverage of the
+/// loader's exact byte layout, which `config.zig`'s own tests pin
+/// instead (`bodies render into complete pages`). Same trade, same
+/// reason, as `src/http_proxy_test.zig`'s hand-spelled page.
+const error_page: zoxy.config.Config.StaticPage = renderSimPage(403, l7.canon.error_page_body);
+const respond_page: zoxy.config.Config.StaticPage = renderSimPage(200, l7.canon.respond_body);
+const error_pages = [_]*const zoxy.config.Config.StaticPage{&error_page};
+
+fn renderSimPage(comptime status: u16, comptime body: []const u8) zoxy.config.Config.StaticPage {
+    // The loader's own preconditions, restated where the loader is
+    // being stood in for: a status a page may carry, and a body the
+    // client oracle can demand.
+    comptime assert(zoxy.shed.isPageStatus(status));
+    comptime assert(body.len >= 1);
+    const head = std.fmt.comptimePrint(
+        "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\n",
+        .{ status, zoxy.shed.reasonPhrase(status), body.len, l7.canon.page_content_type },
+    );
+    const keep = head ++ "\r\n" ++ body;
+    const close = head ++ "Connection: close\r\n\r\n" ++ body;
+    // `renderStaticPage`'s postcondition: the head is a real prefix, so
+    // the HEAD slice the serve path takes is never the whole response.
+    comptime assert(keep.len > body.len);
+    comptime assert(close.len > keep.len);
+    return .{
+        .status = status,
+        .keep = keep,
+        .close = close,
+        .keep_head_len = keep.len - body.len,
+        .close_head_len = close.len - body.len,
+    };
+}
+
 fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
     harness.request_filters_http = .{
         .{
@@ -707,6 +756,14 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .actions = &.{.{ .redirect = .{ .status = 301, .target = .{ .composed = .{
                 .scheme = .https,
             } } } }},
+        },
+        .{
+            // #159: answered from a configured body, before any
+            // post-parse resource is acquired and without reaching an
+            // origin. The page is pre-rendered like the loader's, so
+            // the sweep exercises the static path's body-carrying arm.
+            .match = .{ .path_prefix = "/respond" },
+            .actions = &.{.{ .respond = &respond_page }},
         },
         .{
             .match = .{ .path_prefix = "/edit" },
@@ -1234,6 +1291,7 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_no_route",
         "l7_filtered",
         "l7_redirected",
+        "l7_responded",
         "l7_shed_relay_buffers",
         "l7_shed_upstream_slots",
         "l7_shed_endpoint_inflight",

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -47,6 +47,16 @@ pub const sticky_tag = "b4a7ea22f14bfcac";
 pub const sticky_set_cookie_value =
     sticky_cookie_name ++ "=" ++ sticky_tag ++ "; Path=/; HttpOnly";
 
+/// The #159 configured bodies. `error_page_body` is the harness's page
+/// for `403` — the one status a script earns from a filter reject — so
+/// every 403 in the sweep must carry exactly these bytes; `respond_body`
+/// is what the `/respond` rule answers `200` with. Both are served from
+/// immutable memory by the static path, which is what lets the client
+/// demand them under every schedule the adversary produces.
+pub const error_page_body = "sim-403-page\n";
+pub const respond_body = "sim-respond-body\n";
+pub const page_content_type = "text/plain";
+
 /// A parseable head that cannot survive the render: 8190 bytes fits the
 /// proxy's 8 KiB response buffer, but no Content-Length and no
 /// Transfer-Encoding makes it until-close framing, which forces a

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -409,7 +409,7 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = ClientError.ResponseStatusUnexpected;
                     return walk;
                 }
-                if (responseEditViolation(&response)) |violation| {
+                if (responseEditViolation(script, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
                 }
@@ -428,7 +428,7 @@ pub fn Client(comptime IoType: type) type {
                     }
                 }
                 const body = bytes[walk.offset + response.head_len ..];
-                const verdict = walkBody(response, body) orelse return walk;
+                const verdict = walkBody(response, body, script) orelse return walk;
                 if (verdict.violation) |violation| {
                     walk.violation = violation;
                     return walk;
@@ -456,7 +456,7 @@ pub fn Client(comptime IoType: type) type {
         /// means the class predicate fired on a class the origin never
         /// answers. Distinguishes the two render paths from outside the
         /// process, under every schedule the adversary produces.
-        fn responseEditViolation(response: *const parser.ResponseHead) ?ClientError {
+        fn responseEditViolation(script: Script, response: *const parser.ResponseHead) ?ClientError {
             assert(response.status >= 100);
             assert(response.headers.len <= zoxy.constants.headers_max);
             const stamped = headerEquals(
@@ -464,7 +464,12 @@ pub fn Client(comptime IoType: type) type {
                 canon.response_edit_name,
                 canon.response_edit_value,
             );
-            if (response.status == 200) {
+            // A #159 page is a static however good its status looks: it
+            // is sent from immutable memory and never crosses the
+            // response render, so the stamp on one would mean a
+            // configured body had grown filter edits.
+            const from_memory = pageBodyFor(script, response.status) != null;
+            if (response.status == 200 and !from_memory) {
                 if (!stamped) {
                     return ClientError.ResponseEditMissing;
                 }
@@ -502,7 +507,11 @@ pub fn Client(comptime IoType: type) type {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
-            if (response.status != 200) {
+            // Same rule as the #175 stamp, one mechanism over: a page
+            // reaches no origin and runs no response render, so a
+            // cookie on one would be the stamp path firing for an
+            // exchange that never happened.
+            if (response.status != 200 or pageBodyFor(script, response.status) != null) {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
@@ -560,6 +569,35 @@ pub fn Client(comptime IoType: type) type {
             return std.mem.eql(u8, tail[0..check_len], anchor[0..check_len]);
         }
 
+        /// The #159 body a configured page carries for this (script,
+        /// status), or null when the response is not one. Two pages are
+        /// configured by the harness: `403` — the status a filter
+        /// reject earns, so every 403 in the sweep is one — and the
+        /// `200` the `/respond` rule answers, which reaches no origin.
+        ///
+        /// This doubles as "answered from memory": a page is a static,
+        /// so it bypasses the response render and therefore *both*
+        /// response-side mechanisms — the #175 stamp and the #178
+        /// cookie. The three oracles below all key off this one
+        /// predicate, so the sweep cannot come to disagree with itself
+        /// about which responses were rendered.
+        fn pageBodyFor(script: Script, status: u16) ?[]const u8 {
+            assert(status >= 100);
+            assert(status <= 599);
+            if (status == 403) {
+                // Blanket by status, mirroring the server: a configured
+                // page answers *any* path that raises 403, not only the
+                // `/reject` rule that raises one today.
+                assert(canon.error_page_body.len >= 1);
+                return canon.error_page_body;
+            }
+            if (status == 200 and script == .filter_respond) {
+                assert(canon.respond_body.len >= 1);
+                return canon.respond_body;
+            }
+            return null;
+        }
+
         const BodyVerdict = struct {
             body_len: u32,
             violation: ?ClientError,
@@ -572,9 +610,19 @@ pub fn Client(comptime IoType: type) type {
         /// framing (the proxy relays body wire bytes verbatim), and
         /// every legal non-200 is a static with Content-Length 0 — so a
         /// corrupted length fails even before its body arrives.
-        fn walkBody(response: parser.ResponseHead, body: []const u8) ?BodyVerdict {
+        fn walkBody(response: parser.ResponseHead, body: []const u8, script: Script) ?BodyVerdict {
+            const page_body = pageBodyFor(script, response.status);
             switch (response.framing) {
                 .content_length => |length| {
+                    // A configured page's body, byte-exact (#159): it is
+                    // rendered once at load, so any drift here is the
+                    // static path corrupting immutable memory.
+                    if (page_body) |expected| {
+                        if (length != expected.len) {
+                            return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
+                        }
+                        return prefixVerdict(body, expected, @intCast(length));
+                    }
                     if (response.status == 200) {
                         if (length != canon.sized_body.len) {
                             return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
@@ -586,14 +634,17 @@ pub fn Client(comptime IoType: type) type {
                     }
                     return .{ .body_len = 0, .violation = null };
                 },
+                // A page is always Content-Length framed — the loader
+                // renders it that way — so either streaming framing on
+                // one is the render inventing a shape.
                 .chunked => {
-                    if (response.status != 200) {
+                    if (response.status != 200 or page_body != null) {
                         return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
                     }
                     return prefixVerdict(body, canon.chunked_wire, canon.chunked_wire.len);
                 },
                 .until_close => {
-                    if (response.status != 200) {
+                    if (response.status != 200 or page_body != null) {
                         return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
                     }
                     // The FIN delimits this body, so it is transcript-

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -70,6 +70,14 @@ pub const Script = enum(u8) {
     /// with the one response this proxy renders per request instead of
     /// serving from static memory.
     filter_redirect,
+    /// A GET under `/respond`: a §7 filter answers `200` from a
+    /// configured body (#159) — this proxy as the origin. Timed like
+    /// `filter_reject`: answered before any post-parse resource is
+    /// acquired or origin dialed. The client demands the exact body,
+    /// and — because a configured page is a static — that it carries
+    /// *neither* response-side stamp, which is how the sweep proves
+    /// from outside that a page bypasses the response render.
+    filter_respond,
     /// A GET under `/edit`: a §7 filter adds a header to the forwarded
     /// request. It routes and succeeds (200); the origin's §7 oracle proves
     /// the edited head still forwards canonical.
@@ -373,6 +381,17 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 301,
         .method = .get,
         .allowed_statuses = &.{ 301, 503 },
+    },
+    .filter_respond = .{
+        // `filter_reject`'s timing exactly — the answer precedes every
+        // post-parse resource — so the §5 head ring's 503 is again the
+        // one verdict that can arrive instead.
+        .request = "GET /respond HTTP/1.1\r\nHost: sim\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = &.{ 200, 503 },
     },
     .filter_edit = .{
         // Routes and forwards like a plain GET, so the §8 rungs and a

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -157,6 +157,13 @@ const uncovered = [_]Uncovered{
             "live gate counts it against a real one",
     },
     .{
+        .name = "l7_responded",
+        .why = .unreached,
+        .reason = "the sweep configures no respond action yet (#159 — the " ++
+            "scripts and the body-carrying listener are the next slice); " ++
+            "src/http_proxy_test.zig covers the answer and its counter",
+    },
+    .{
         .name = "admin_served",
         .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -157,13 +157,6 @@ const uncovered = [_]Uncovered{
             "live gate counts it against a real one",
     },
     .{
-        .name = "l7_responded",
-        .why = .unreached,
-        .reason = "the sweep configures no respond action yet (#159 — the " ++
-            "scripts and the body-carrying listener are the next slice); " ++
-            "src/http_proxy_test.zig covers the answer and its counter",
-    },
-    .{
         .name = "admin_served",
         .why = .unreached,
         .reason = "the sweep configures no admin listener; " ++

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -43,6 +43,23 @@ const config_path = work_directory ++ "/zoxy.json";
 const access_log_path = work_directory ++ "/access.log";
 const zoxy_log_path = work_directory ++ "/zoxy.log";
 
+/// The #159 bodies this run configures. `robots_body` goes through the
+/// **file** arm — written here, read by the real binary at startup — so
+/// this tier covers the one path the deterministic gates cannot: an
+/// actual `open`/`read` of an operator's file. `not_found_body` rides
+/// the inline arm beside it, and both are asserted byte-for-byte on the
+/// wire (their lengths are the equality; the exact bytes are pinned by
+/// the sim and the directed tests).
+const robots_path = work_directory ++ "/robots.txt";
+const robots_body = "User-agent: *\nDisallow: /private\n";
+const not_found_body = "no such route";
+
+/// The Host a request must carry to match the main route, and one that
+/// deliberately does not — the run's only way to reach a `404`, since
+/// every other request is routed by design.
+const routed_host_suffix = "127.0.0.1";
+const unrouted_host = "not-this-proxy.invalid";
+
 /// The L7 load: keep-alive connections, each serving the same count. Both
 /// numbers are above one on purpose — the access-log equality this gate
 /// exists for is a per-*request* claim that a per-*connection* bug
@@ -84,11 +101,18 @@ const l4_connections: u8 = 2;
 /// only the `origin` cluster has served.
 const sticky_exchanges: u32 = 3;
 
+/// The #159 leg: two exchanges on one connection — a request no route
+/// matches, answered by the configured `404` page, and one the
+/// `respond` action answers from the file-backed body. Like the sticky
+/// leg it runs after the counter scrapes, so those scrapes keep
+/// describing a run whose every request was routed.
+const body_exchanges: u32 = 2;
+
 const exchanges_per_pass: u32 =
     @as(u32, keep_alive_connections) * requests_per_connection + large_requests;
 const http_exchanges: u32 = load_passes * exchanges_per_pass;
 const access_log_lines_expected: u32 =
-    http_exchanges + sticky_exchanges + l4_connections;
+    http_exchanges + sticky_exchanges + body_exchanges + l4_connections;
 
 /// What the resident set may grow by between the two passes. Measured at
 /// exactly zero, run after run — the tolerance is headroom for page
@@ -110,10 +134,11 @@ const rss_growth_kb_max: u64 = 64;
 /// and the alternative — a floor — is satisfied by a proxy accepting
 /// connections nobody made.
 const sticky_connections: u32 = 1;
+const body_connections: u32 = 1;
 const readiness_probes: u32 = 1;
 const connections_expected: u32 = keep_alive_connections +
     load_passes * large_requests + l4_connections + sticky_connections +
-    readiness_probes;
+    body_connections + readiness_probes;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
@@ -296,6 +321,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // The #178 leg runs after the scrapes above on purpose — see
     // `sticky_exchanges` — and brings its own scrape.
     const sticky_ok = try stickyPassed(arena, io, &ports);
+    const bodies_ok = try bodiesPassed(arena, io, &ports);
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
@@ -303,7 +329,8 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const log_ok = accessLogPassed(&lines);
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
-    const passed = log_ok and counters.passed and sticky_ok and memory_ok and drain_ok;
+    const passed = log_ok and counters.passed and sticky_ok and bodies_ok and
+        memory_ok and drain_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -391,6 +418,11 @@ const LogCounts = struct {
     /// HTTP lines that both completed and carried the origin's status —
     /// the outcome every request in this load is owed.
     http_ok: u32 = 0,
+    /// The #159 leg's lines: one page-wearing `404` and one `respond`
+    /// answer. Neither is `ok` — no origin served them — so they are
+    /// counted apart rather than weakening the ok-equality.
+    http_rejected: u32 = 0,
+    http_responded: u32 = 0,
 };
 
 /// The access-log verdict, printed so a red run explains itself without a
@@ -401,12 +433,13 @@ fn accessLogPassed(lines: *const LogCounts) bool {
     // below its own subset would mean the counter itself is wrong — which
     // no comparison below would otherwise notice.
     assert(lines.http_ok <= lines.http);
-    assert(access_log_lines_expected == http_exchanges + sticky_exchanges + l4_connections);
+    const http_lines_expected = http_exchanges + sticky_exchanges + body_exchanges;
+    assert(access_log_lines_expected == http_lines_expected + l4_connections);
     var passed = true;
-    if (lines.http != http_exchanges + sticky_exchanges) {
+    if (lines.http != http_lines_expected) {
         std.debug.print(
             "FAIL: {d} http access-log lines for {d} requests (#129 is exactly this)\n",
-            .{ lines.http, http_exchanges + sticky_exchanges },
+            .{ lines.http, http_lines_expected },
         );
         passed = false;
     }
@@ -421,10 +454,20 @@ fn accessLogPassed(lines: *const LogCounts) bool {
         std.debug.print("FAIL: {d} access-log lines of no known kind\n", .{lines.other});
         passed = false;
     }
-    if (lines.http_ok != lines.http) {
+    // Every line but the #159 leg's two carries the origin's 200; those
+    // two carry the outcomes only a configured page produces, so the
+    // three counts partition the http lines exactly.
+    if (lines.http_ok + body_exchanges != lines.http) {
         std.debug.print(
             "FAIL: {d} of {d} http lines did not complete with the origin's 200\n",
             .{ lines.http - lines.http_ok, lines.http },
+        );
+        passed = false;
+    }
+    if (lines.http_rejected != 1 or lines.http_responded != 1) {
+        std.debug.print(
+            "FAIL: {d} rejected and {d} responded lines, not 1 each (#159)\n",
+            .{ lines.http_rejected, lines.http_responded },
         );
         passed = false;
     }
@@ -625,13 +668,14 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
         );
         passed = false;
     }
-    // Minus the #178 leg, which deliberately runs after this scrape (see
-    // `sticky_exchanges`); the whole-run equality is asserted on the
-    // sticky verdict's own later scrape.
-    if (accepted != connections_expected - sticky_connections) {
+    // Minus the two legs that deliberately run after this scrape (see
+    // `sticky_exchanges` and `body_exchanges`); the whole-run equality
+    // is asserted on the last of their scrapes.
+    const opened_so_far = connections_expected - sticky_connections - body_connections;
+    if (accepted != opened_so_far) {
         std.debug.print(
             "FAIL: {d} connections accepted, not the {d} opened before this scrape\n",
-            .{ accepted, connections_expected - sticky_connections },
+            .{ accepted, opened_so_far },
         );
         passed = false;
     }
@@ -892,9 +936,59 @@ fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
             passed = false;
         }
     }
-    // The whole-run accept equality, deferred from `identitiesPassed`:
-    // with the sticky connection in, every accepted connection is
-    // accounted for again.
+    // The accept count with this leg in, but still short the #159
+    // leg's connection — the whole-run equality lands there, on the
+    // last scrape of the run.
+    const accepted = counterOf(&scrape, "accepted") orelse return false;
+    if (accepted != connections_expected - body_connections) {
+        std.debug.print(
+            "FAIL: {d} connections accepted, not the {d} opened by here\n",
+            .{ accepted, connections_expected - body_connections },
+        );
+        passed = false;
+    }
+    return passed;
+}
+
+/// The #159 leg against the live binary: a request no route matches,
+/// answered by the configured `404` page, and one the `respond` action
+/// answers from the file-backed body — both on one connection, both
+/// judged on their exact framing, then the counters on a scrape. Runs
+/// after `countersPassed` so those scrapes still describe a run whose
+/// every request routed.
+fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
+    assert(ports.http != 0);
+    assert(ports.admin != 0);
+    var host_buffer: [32]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
+    try single_client.connect(io, ports.http);
+    defer single_client.close();
+
+    // No route for this Host, so the router's 404 — wearing the inline
+    // page rather than the empty static it would have been.
+    const not_found = try single_client.get(unrouted_host, "/", .keep_alive, null);
+    var passed = expectBodyResponse(not_found, 404, not_found_body.len, "error page");
+
+    // The respond action, off the file arm: the body zoxy read at
+    // startup, byte count and all, on a request that never reached an
+    // origin.
+    const robots = try single_client.get(host, "/robots.txt", .close, null);
+    if (!expectBodyResponse(robots, 200, robots_body.len, "respond")) passed = false;
+
+    const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
+    const responded = counterOf(&scrape, "l7_responded") orelse return false;
+    if (responded != 1) {
+        std.debug.print("FAIL: l7_responded reads {d}, not 1\n", .{responded});
+        passed = false;
+    }
+    const no_route = counterOf(&scrape, "l7_no_route") orelse return false;
+    if (no_route != 1) {
+        std.debug.print("FAIL: l7_no_route reads {d}, not 1\n", .{no_route});
+        passed = false;
+    }
+    // The whole-run accept equality, deferred through both late legs:
+    // this is the last scrape, so every connection the run opened is
+    // accounted for here or nowhere.
     const accepted = counterOf(&scrape, "accepted") orelse return false;
     if (accepted != connections_expected) {
         std.debug.print(
@@ -904,6 +998,43 @@ fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         passed = false;
     }
     return passed;
+}
+
+/// One #159 response: the status the config asked for, and a body of
+/// exactly the configured length. The length is the equality this tier
+/// can hold — that the *bytes* are the operator's is pinned by the
+/// simulator's oracle and the directed tests — and it is enough to
+/// catch a page served empty, truncated, or from the wrong body.
+fn expectBodyResponse(
+    response: client_module.Response,
+    status: u16,
+    body_bytes: usize,
+    role: []const u8,
+) bool {
+    assert(role.len >= 1);
+    assert(body_bytes >= 1);
+    if (response.status != status) {
+        std.debug.print(
+            "FAIL: the {s} exchange answered {d}, not {d}\n",
+            .{ role, response.status, status },
+        );
+        return false;
+    }
+    if (response.body_bytes != body_bytes) {
+        std.debug.print(
+            "FAIL: the {s} body was {d} bytes, not the configured {d}\n",
+            .{ role, response.body_bytes, body_bytes },
+        );
+        return false;
+    }
+    // A configured page is a static: it never crosses the response
+    // render, so the listener's #175 stamp must not be on it — the same
+    // boundary the simulator's oracle holds from outside.
+    if (response.edited) {
+        std.debug.print("FAIL: the {s} response carried the response-filter stamp\n", .{role});
+        return false;
+    }
+    return true;
 }
 
 /// One sticky response: the ordinary http-leg checks, then the #178
@@ -1019,6 +1150,16 @@ fn readAccessLog(arena: std.mem.Allocator, io: Io) !LogCounts {
             const completed = std.mem.indexOf(u8, line, "\"outcome\":\"ok\"") != null;
             const answered = std.mem.indexOf(u8, line, "\"status\":200") != null;
             if (completed and answered) counts.http_ok += 1;
+            // The #159 leg's two lines, told apart by the outcomes only
+            // it produces: a page the router's 404 wore, and a body the
+            // proxy answered with itself. Counting them here is what
+            // lets the ok-equality below stay an equality.
+            if (std.mem.indexOf(u8, line, "\"outcome\":\"rejected\"") != null) {
+                counts.http_rejected += 1;
+            }
+            if (std.mem.indexOf(u8, line, "\"outcome\":\"responded\"") != null) {
+                counts.http_responded += 1;
+            }
         } else {
             if (std.mem.indexOf(u8, line, "\"kind\":\"l4\"") != null) {
                 counts.l4 += 1;
@@ -1069,8 +1210,12 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\    "listeners": [
         \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
         \\          "routes": [
-        \\              {{ "prefix": "/", "cluster": "origin" }},
-        \\              {{ "prefix": "/sticky", "cluster": "sticky" }}
+        \\              {{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }},
+        \\              {{ "host": "127.0.0.1", "prefix": "/sticky", "cluster": "sticky" }}
+        \\          ],
+        \\          "request_filters": [
+        \\              {{ "match": {{ "path_prefix": "/robots.txt" }},
+        \\                "actions": [{{ "respond": {{ "status": 200, "body": "robots" }} }}] }}
         \\          ],
         \\          "response_filters": [
         \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
@@ -1087,6 +1232,11 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\            "pick": {{ "policy": "hash", "key": "cookie", "name": "zoxy-smoke-srv" }}
         \\        }}
         \\    }},
+        \\    "bodies": {{
+        \\        "gone": {{ "inline": "{s}", "content_type": "text/plain" }},
+        \\        "robots": {{ "file": "{s}", "content_type": "text/plain" }}
+        \\    }},
+        \\    "error_pages": {{ "404": "gone" }},
         \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
         \\    "access_log": {{ "sink": "file", "path": "{s}" }},
         \\    "timeouts": {{
@@ -1108,6 +1258,8 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         origin_port,
         health_probe_timeout_ms,
         origin_port,
+        not_found_body,
+        robots_path,
         ports.admin,
         access_log_path,
         health_interval_ms,
@@ -1128,6 +1280,10 @@ fn prepareWorkDirectory(io: Io) !void {
         error.FileNotFound => {},
         else => return err,
     };
+    // The #159 file arm's input, written before zoxy starts because it
+    // is read once at startup (parse-once, §1) — the one thing in this
+    // config that comes off the filesystem rather than out of the JSON.
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = robots_path, .data = robots_body });
 }
 
 /// zoxy's own output goes to a file rather than this process's stderr:

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -59,6 +59,11 @@ pub const Outcome = enum(u8) {
     /// traffic must not fish redirects out of it, and one grepping for
     /// redirect volume must not see refusals.
     redirected,
+    /// A filter rule answered the request from a configured body
+    /// (#159). Its own outcome for `redirected`'s reason: an operator
+    /// counting what the origins served must not find these in it, and
+    /// one counting what policy answered must not have to subtract.
+    responded,
     /// zoxy ran out of a resource and answered `503` (§8) — a relay buffer
     /// or an upstream slot the request needed.
     shed,

--- a/src/config.zig
+++ b/src/config.zig
@@ -15,6 +15,7 @@ const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
 const parser = @import("http/parser.zig");
 const render = @import("http/render.zig");
+const shed = @import("shed.zig");
 
 const assert = std.debug.assert;
 
@@ -59,6 +60,14 @@ pub const Config = struct {
     /// or null when no `admin` block is configured — the plane stays off.
     /// A static IP:port literal like every other bind (hostnames rejected).
     admin_bind: ?std.Io.net.IpAddress = null,
+    /// The #159 error pages: complete responses pre-rendered at load,
+    /// one entry per configured status, empty when none are. Serving
+    /// one is byte-for-byte the comptime-static path — one send from
+    /// immutable memory, no acquisition — which is the whole point: an
+    /// error page whose delivery needed a pool would fail exactly when
+    /// it is needed. Configuring a status is also the opt-in for bodies
+    /// on its sheds; absent, shedding costs what it does today.
+    error_pages: []const StaticPage = &.{},
     /// Where access-log lines go (§8), or null when no `access_log` block
     /// is configured — the log stays off and reserves nothing.
     access_log_sink: ?AccessLogSink = null,
@@ -77,6 +86,18 @@ pub const Config = struct {
     pub const AccessLogSink = union(AccessLogSinkKind) {
         stdout,
         file: []const u8,
+    };
+
+    /// One pre-rendered #159 page: both persistence variants of the
+    /// complete response, with each head's length recorded so a HEAD
+    /// request sends the prefix of the same buffer — still one send,
+    /// no third copy.
+    pub const StaticPage = struct {
+        status: u16,
+        keep: []const u8,
+        close: []const u8,
+        keep_head_len: u32,
+        close_head_len: u32,
     };
 
     /// The sink names the config may spell — split from `AccessLogSink`
@@ -391,6 +412,20 @@ pub const ValidationError = error{
     ClusterPickNameInvalid,
     ClusterPickNameTooLong,
     ListenerL4RequestKeyedHash,
+    BodiesOverLimit,
+    BodyNameEmpty,
+    BodyNameTooLong,
+    BodyNameDuplicate,
+    BodySourceMissing,
+    BodySourceAmbiguous,
+    BodyContentTypeInvalid,
+    BodyFileUnreadable,
+    BodyOverLimit,
+    BodyUnknown,
+    ErrorPagesOverLimit,
+    ErrorPageStatusInvalid,
+    ErrorPageStatusUnknown,
+    ErrorPageDuplicate,
     ListenerClusterOrRoutes,
     ListenerL4Routes,
     RoutesEmpty,
@@ -463,7 +498,49 @@ pub const ValidationError = error{
 
 pub const ParseError = std.json.ParseError(std.json.Scanner) || ValidationError;
 
+/// How the loader reads a body's `file` source (#159). A seam rather
+/// than a direct read, so the loader stays pure: `parse` below refuses
+/// every file source (tests, the fuzzer and the simulator need no
+/// filesystem — an `inline` body is theirs), and the binary's entry
+/// point passes the one real reader through `parseWithFiles`, keeping
+/// filesystem access where the config file itself is already read.
+pub const FileSource = struct {
+    context: ?*anyopaque = null,
+    /// Read the whole file, at most `limit` bytes, into the arena.
+    /// A file over the limit reports `FileTooLarge` — the loader turns
+    /// it into the same `BodyOverLimit` an oversized inline body earns.
+    read: *const fn (
+        context: ?*anyopaque,
+        arena: std.mem.Allocator,
+        path: []const u8,
+        limit: u32,
+    ) error{ FileUnreadable, FileTooLarge, OutOfMemory }![]const u8,
+
+    pub const none: FileSource = .{ .read = refuse };
+
+    fn refuse(
+        context: ?*anyopaque,
+        arena: std.mem.Allocator,
+        path: []const u8,
+        limit: u32,
+    ) error{ FileUnreadable, FileTooLarge, OutOfMemory }![]const u8 {
+        _ = context;
+        _ = arena;
+        _ = limit;
+        assert(path.len >= 1); // The caller validated the path shape first.
+        return error.FileUnreadable;
+    }
+};
+
 pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config {
+    return parseWithFiles(arena, json_bytes, .none);
+}
+
+pub fn parseWithFiles(
+    arena: std.mem.Allocator,
+    json_bytes: []const u8,
+    files: FileSource,
+) ParseError!Config {
     const parsed = try std.json.parseFromSliceLeaky(ConfigJson, arena, json_bytes, .{
         .duplicate_field_behavior = .@"error",
         .ignore_unknown_fields = false,
@@ -500,6 +577,8 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
     );
     const listeners = try resolveListeners(arena, parsed.listeners, clusters, limits.head_buffer_bytes);
     const admin_bind = try resolveAdminBind(parsed.admin);
+    const bodies = try resolveBodies(arena, parsed.bodies, files);
+    const error_pages = try resolveErrorPages(arena, parsed.error_pages, bodies);
 
     assert(listeners.len >= 1);
     assert(clusters.len >= 1);
@@ -515,6 +594,212 @@ pub fn parse(arena: std.mem.Allocator, json_bytes: []const u8) ParseError!Config
         .limits = limits,
         .admin_bind = admin_bind,
         .access_log_sink = access_log_sink,
+        .error_pages = error_pages,
+    };
+}
+
+/// A resolved #159 body: load-time only — consumers embed pre-rendered
+/// responses, so nothing at serve time ever walks this table.
+const ResolvedBody = struct {
+    name: []const u8,
+    bytes: []const u8,
+    content_type: []const u8,
+};
+
+/// Resolve the #159 `bodies` map: names bounded and unique, exactly one
+/// source arm per body, bytes under `body_bytes_max` whichever arm they
+/// came through, content type a forwardable header value. Absent means
+/// an empty table, and every reference then fails as `BodyUnknown`.
+fn resolveBodies(
+    arena: std.mem.Allocator,
+    bodies_json: ?BodiesJson,
+    files: FileSource,
+) ParseError![]const ResolvedBody {
+    const parsed = bodies_json orelse return &.{};
+    if (parsed.entries.len > std.math.maxInt(u16)) {
+        return error.BodiesOverLimit;
+    }
+    const bodies = try arena.alloc(ResolvedBody, parsed.entries.len);
+    for (parsed.entries, 0..) |entry, index| {
+        if (entry.name.len == 0) {
+            return error.BodyNameEmpty;
+        }
+        if (entry.name.len > constants.body_name_bytes_max) {
+            return error.BodyNameTooLong;
+        }
+        // Nested rather than sorted (the cluster-names rationale does
+        // not carry): a config lists a handful of bodies, and each is
+        // already paying a file read next to this compare.
+        for (bodies[0..index]) |previous| {
+            if (std.mem.eql(u8, previous.name, entry.name)) {
+                return error.BodyNameDuplicate;
+            }
+        }
+        bodies[index] = .{
+            .name = entry.name,
+            .bytes = try resolveBodyBytes(arena, &entry.body, files),
+            .content_type = try resolveContentType(entry.body.content_type),
+        };
+        assert(bodies[index].name.len >= 1);
+        assert(bodies[index].bytes.len <= constants.body_bytes_max);
+    }
+    assert(bodies.len == parsed.entries.len);
+    return bodies;
+}
+
+/// One body's bytes through its one source arm (#159): `file` XOR
+/// `inline`, the redirect target's exactly-one-fork rule. The cap
+/// applies to both arms identically — where the bytes came from is not
+/// what the memory statement is about.
+fn resolveBodyBytes(
+    arena: std.mem.Allocator,
+    body_json: *const BodyJson,
+    files: FileSource,
+) ParseError![]const u8 {
+    const has_file = body_json.file != null;
+    const has_inline = body_json.@"inline" != null;
+    if (!has_file and !has_inline) {
+        return error.BodySourceMissing;
+    }
+    if (has_file and has_inline) {
+        return error.BodySourceAmbiguous;
+    }
+    if (body_json.file) |path| {
+        if (path.len == 0) {
+            return error.BodyFileUnreadable;
+        }
+        const bytes = files.read(
+            files.context,
+            arena,
+            path,
+            constants.body_bytes_max,
+        ) catch |err| switch (err) {
+            error.FileUnreadable => return error.BodyFileUnreadable,
+            error.FileTooLarge => return error.BodyOverLimit,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        assert(bytes.len <= constants.body_bytes_max);
+        return bytes;
+    }
+    const inline_bytes = body_json.@"inline".?;
+    if (inline_bytes.len > constants.body_bytes_max) {
+        return error.BodyOverLimit;
+    }
+    // The same postcondition the file arm states: where the bytes came
+    // from is not what the memory statement is about.
+    assert(inline_bytes.len <= constants.body_bytes_max);
+    return inline_bytes;
+}
+
+/// A body's Content-Type: non-empty and injection-safe — the same
+/// forwardable-byte rule filter header values keep, since this value
+/// lands on the wire inside a rendered head.
+fn resolveContentType(content_type: []const u8) ParseError![]const u8 {
+    if (content_type.len == 0) {
+        return error.BodyContentTypeInvalid;
+    }
+    validateHeaderValue(content_type) catch return error.BodyContentTypeInvalid;
+    assert(content_type.len >= 1);
+    return content_type;
+}
+
+/// Resolve `error_pages` (#159): each entry a status from the closed
+/// static set, each naming a body, each pre-rendered here — both
+/// persistence variants, head lengths recorded — so serve time is the
+/// comptime-static path unchanged: one send from immutable memory.
+fn resolveErrorPages(
+    arena: std.mem.Allocator,
+    error_pages_json: ?ErrorPagesJson,
+    bodies: []const ResolvedBody,
+) ParseError![]const Config.StaticPage {
+    const parsed = error_pages_json orelse return &.{};
+    // The closed status set bounds what can survive validation, so a
+    // longer map always fails below — on an unknown status or on a
+    // duplicate, and which one is not knowable from the count alone,
+    // which is why this has an error of its own rather than guessing at
+    // either. Ahead of the allocation, so a rejected config's arena
+    // stays bounded by the vocabulary rather than by the file's length
+    // (`BodiesOverLimit`'s reasoning, one resolver up).
+    if (parsed.entries.len > shed.static_statuses.len) {
+        return error.ErrorPagesOverLimit;
+    }
+    const pages = try arena.alloc(Config.StaticPage, parsed.entries.len);
+    for (parsed.entries, 0..) |entry, index| {
+        const status = std.fmt.parseUnsigned(u16, entry.status, 10) catch
+            return error.ErrorPageStatusInvalid;
+        if (!shed.isStaticStatus(status)) {
+            return error.ErrorPageStatusUnknown;
+        }
+        // The closed set is ten wide, so the duplicate scan is bounded
+        // by it whatever the entry count claims.
+        for (pages[0..index]) |previous| {
+            if (previous.status == status) {
+                return error.ErrorPageDuplicate;
+            }
+        }
+        const body = bodyNamed(bodies, entry.body) orelse return error.BodyUnknown;
+        const keep = try renderStaticPage(arena, status, body, .keep);
+        const close = try renderStaticPage(arena, status, body, .close);
+        pages[index] = .{
+            .status = status,
+            .keep = keep.bytes,
+            .close = close.bytes,
+            .keep_head_len = keep.head_len,
+            .close_head_len = close.head_len,
+        };
+        // What the serve path reads back (`configuredPage`): a head
+        // that is a prefix of its own response, on both variants.
+        assert(pages[index].keep_head_len <= pages[index].keep.len);
+        assert(pages[index].close_head_len <= pages[index].close.len);
+    }
+    assert(pages.len == parsed.entries.len);
+    assert(pages.len <= shed.static_statuses.len);
+    return pages;
+}
+
+fn bodyNamed(bodies: []const ResolvedBody, name: []const u8) ?*const ResolvedBody {
+    assert(bodies.len <= std.math.maxInt(u16)); // `BodiesOverLimit`'s bound.
+    for (bodies) |*body| {
+        assert(body.name.len >= 1); // resolveBodies rejected empty names.
+        assert(body.content_type.len >= 1);
+        if (std.mem.eql(u8, body.name, name)) {
+            return body;
+        }
+    }
+    return null;
+}
+
+/// One rendered #159 page: the complete response in one contiguous
+/// arena buffer — status line, framing, content type, the persistence
+/// announcement, then the body — with the head's length recorded so a
+/// HEAD request is a prefix slice of the same buffer.
+fn renderStaticPage(
+    arena: std.mem.Allocator,
+    status: u16,
+    body: *const ResolvedBody,
+    persistence: shed.Persistence,
+) ParseError!struct { bytes: []const u8, head_len: u32 } {
+    assert(shed.isStaticStatus(status));
+    assert(body.content_type.len >= 1);
+    const rendered = try std.fmt.allocPrint(
+        arena,
+        "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\n{s}\r\n{s}",
+        .{
+            status,
+            shed.reasonPhrase(status),
+            body.bytes.len,
+            body.content_type,
+            switch (persistence) {
+                .keep => "",
+                .close => "Connection: close\r\n",
+            },
+            body.bytes,
+        },
+    );
+    assert(rendered.len > body.bytes.len);
+    return .{
+        .bytes = rendered,
+        .head_len = @intCast(rendered.len - body.bytes.len),
     };
 }
 
@@ -752,6 +1037,12 @@ pub const ConfigJson = struct {
     admin: ?AdminJson = null,
     /// Optional access log (§8); absent leaves it off.
     access_log: ?AccessLogJson = null,
+    /// Optional #159 named bodies; absent reserves nothing.
+    bodies: ?BodiesJson = null,
+    /// Optional #159 error pages over the closed static-status set;
+    /// absent means every static stays `Content-Length: 0` — including
+    /// the sheds, whose bodies this block is the deliberate opt-in for.
+    error_pages: ?ErrorPagesJson = null,
 
     pub const schema_doc =
         "Startup config for the zoxy L4/L7 proxy. Encodes structure, enums, " ++
@@ -771,6 +1062,16 @@ pub const ConfigJson = struct {
         .limits = .{ .desc = "Optional pool sizes and the CQ-fill headroom knob; absent fields take the lean defaults." },
         .admin = .{ .desc = "Optional admin/metrics listener; absent leaves it off." },
         .access_log = .{ .desc = "Optional per-request/per-connection JSON access log; absent leaves it off." },
+        .bodies = .{
+            .desc = "Named response bodies (file or inline, read once at " ++
+                "startup), referenced by name from error_pages.",
+        },
+        .error_pages = .{
+            .desc = "Bodies for the statuses zoxy sends itself, keyed by " ++
+                "status literal, each naming a body. Configuring a status " ++
+                "is the opt-in — absent, every static response stays empty, " ++
+                "sheds included.",
+        },
     };
 };
 
@@ -1400,6 +1701,124 @@ pub const PickJson = struct {
     }
 };
 
+/// One named body (#159): the bytes a configured response serves, plus
+/// the content type nothing will guess. Exactly one source arm — a
+/// `file` read once at load (parse-once, §1: a changed file needs a
+/// restart), or the `inline` string for one-liners that deserve no
+/// fixture. The arm structure is the extension point: a future source
+/// is a new arm here, and no consumer of a body ever changes.
+pub const BodyJson = struct {
+    file: ?[]const u8 = null,
+    @"inline": ?[]const u8 = null,
+    content_type: []const u8,
+
+    pub const schema_doc =
+        "One named response body: bytes from a file read at startup, or an " ++
+        "inline string — exactly one of the two — plus the Content-Type it " ++
+        "is served with. Referenced by name from error_pages (and any " ++
+        "future body-serving feature), so one body is one buffer however " ++
+        "many places serve it.";
+    pub const schema_fields = .{
+        .file = .{
+            .desc = "Path to the body's file, read once at startup; a change " ++
+                "needs a restart (parse-once config).",
+        },
+        .@"inline" = .{
+            .desc = "The body's bytes, verbatim, for content small enough to " ++
+                "live in the config.",
+        },
+        .content_type = .{
+            .desc = "The Content-Type header value this body is served with; " ++
+                "nothing is inferred from a filename.",
+            .min_length = 1,
+        },
+    };
+};
+
+/// The #159 `bodies` map: named assets, keyed by name — `ClustersJson`'s
+/// shape, because it is the same idea: a shared resource defined once
+/// and referenced by name, so a dangling reference is a load error and
+/// one body referenced twice is still one buffer.
+pub const BodiesJson = struct {
+    entries: []const Entry,
+
+    const Entry = struct {
+        name: []const u8,
+        body: BodyJson,
+    };
+
+    pub fn jsonParse(
+        allocator: std.mem.Allocator,
+        source: anytype,
+        options: std.json.ParseOptions,
+    ) !@This() {
+        var entries: std.ArrayList(Entry) = .empty;
+        if (try source.next() != .object_begin) {
+            return error.UnexpectedToken;
+        }
+        // Terminated by the object's own `}` or by the input running
+        // out, which the scanner reports as an error — every map here
+        // carries the same bound.
+        while (true) {
+            const token = try source.nextAlloc(allocator, .alloc_if_needed);
+            const name: []const u8 = switch (token) {
+                .object_end => break,
+                .string => |slice| slice,
+                .allocated_string => |slice| slice,
+                else => return error.UnexpectedToken,
+            };
+            try entries.append(allocator, .{
+                .name = name,
+                .body = try std.json.innerParse(BodyJson, allocator, source, options),
+            });
+        }
+        const seen = entries.items.len;
+        const parsed: @This() = .{ .entries = try entries.toOwnedSlice(allocator) };
+        assert(parsed.entries.len == seen);
+        return parsed;
+    }
+};
+
+/// The #159 `error_pages` map: status literal → body name. Small and
+/// closed — the loader rejects a status this proxy never sends — so the
+/// value is a bare name string, not an object waiting for fields.
+pub const ErrorPagesJson = struct {
+    entries: []const Entry,
+
+    const Entry = struct {
+        status: []const u8,
+        body: []const u8,
+    };
+
+    pub fn jsonParse(
+        allocator: std.mem.Allocator,
+        source: anytype,
+        options: std.json.ParseOptions,
+    ) !@This() {
+        var entries: std.ArrayList(Entry) = .empty;
+        if (try source.next() != .object_begin) {
+            return error.UnexpectedToken;
+        }
+        while (true) {
+            const token = try source.nextAlloc(allocator, .alloc_if_needed);
+            const status: []const u8 = switch (token) {
+                .object_end => break,
+                .string => |slice| slice,
+                .allocated_string => |slice| slice,
+                else => return error.UnexpectedToken,
+            };
+            try entries.append(allocator, .{
+                .status = status,
+                .body = try std.json.innerParse([]const u8, allocator, source, options),
+            });
+        }
+        const seen = entries.items.len;
+        const parsed: @This() = .{ .entries = try entries.toOwnedSlice(allocator) };
+        assert(parsed.entries.len == seen);
+        return parsed;
+    }
+};
+
 pub const ClusterProxyProtocolJson = struct {
     send: []const u8,
 
@@ -1660,7 +2079,7 @@ pub const dto_types = .{
     RewriteJson,        ClusterJson,       TimeoutsJson,             LimitsJson,
     AdminJson,          AccessLogJson,     CheckJson,                PickJson,
     ForwardedJson,      ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
-    ResponseFilterJson, ResponseMatchJson, RedirectJson,
+    ResponseFilterJson, ResponseMatchJson, RedirectJson,             BodyJson,
 };
 
 comptime {
@@ -4277,6 +4696,8 @@ const fuzz_seed_json =
     \\ "max_lifetime_ms":300000,"request_ms":30000,"health_interval_ms":2000},
     \\ "limits":{"conn_slots":64,"relay_buffers":32,"upstream_slots":32},
     \\ "access_log":{"sink":"file","path":"/var/log/zoxy.log"},
+    \\ "bodies":{"oops":{"inline":"be right back","content_type":"text/plain"}},
+    \\ "error_pages":{"503":"oops"},
     \\ "admin":{"bind":"127.0.0.1:9901"}}
 ;
 // The `file` arm here, `stdout` in `example_json` beside it: between the
@@ -4297,6 +4718,10 @@ test "config: the fuzz seed carrying every block parses" {
     try std.testing.expectEqual(@as(u32, 10000), parsed.drain_deadline_ms);
     try std.testing.expectEqual(@as(u32, 30000), parsed.request_timeout_ms);
     try std.testing.expectEqualSlices(u16, &.{ 1, 3 }, parsed.clusters[0].weights.?);
+    // The #159 grammar rides the corpus through its `inline` arm — the
+    // fuzzer's `parse` has no filesystem, deliberately.
+    try std.testing.expectEqual(@as(usize, 1), parsed.error_pages.len);
+    try std.testing.expectEqual(@as(u16, 503), parsed.error_pages[0].status);
 }
 
 test "fuzz: parse never panics — parse or reject, no third outcome" {
@@ -4665,6 +5090,222 @@ test "config: a request-keyed hash cluster is unreachable from l4" {
                 cookie_cluster ++ tail,
         );
         try std.testing.expectEqualStrings("zoxy-srv", parsed.clusters[0].hash_key.cookie);
+    }
+}
+
+/// A #159 stub file source: two magic paths for the two read failures,
+/// anything else answers a fixed page.
+const test_file_source: FileSource = .{ .read = testReadBodyFile };
+const test_file_body = "<h1>maintenance</h1>\n";
+
+fn testReadBodyFile(
+    context: ?*anyopaque,
+    arena: std.mem.Allocator,
+    path: []const u8,
+    limit: u32,
+) error{ FileUnreadable, FileTooLarge, OutOfMemory }![]const u8 {
+    _ = context;
+    assert(limit >= 1);
+    if (std.mem.eql(u8, path, "/big")) return error.FileTooLarge;
+    if (std.mem.eql(u8, path, "/gone")) return error.FileUnreadable;
+    return arena.dupe(u8, test_file_body);
+}
+
+const bodies_head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}]," ++
+    "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}},";
+const bodies_tail = "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+test "config: bodies render into complete pages, both variants, HEAD as prefix" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parseWithFiles(
+        arena_state.allocator(),
+        bodies_head ++
+            "\"bodies\":{\"oops\":{\"inline\":\"gone\",\"content_type\":\"text/plain\"}," ++
+            "\"maint\":{\"file\":\"/etc/zoxy/maint.html\",\"content_type\":\"text/html\"}}," ++
+            "\"error_pages\":{\"404\":\"oops\",\"503\":\"maint\"}," ++ bodies_tail,
+        test_file_source,
+    );
+    try std.testing.expectEqual(@as(usize, 2), parsed.error_pages.len);
+
+    const not_found = parsed.error_pages[0];
+    try std.testing.expectEqual(@as(u16, 404), not_found.status);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 4\r\n" ++
+            "Content-Type: text/plain\r\n\r\ngone",
+        not_found.keep,
+    );
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 4\r\n" ++
+            "Content-Type: text/plain\r\nConnection: close\r\n\r\ngone",
+        not_found.close,
+    );
+    // The head lengths are the HEAD contract: the prefix ends exactly at
+    // the blank line, whatever the variant added.
+    try std.testing.expectEqual(not_found.keep.len - 4, not_found.keep_head_len);
+    try std.testing.expectEqual(not_found.close.len - 4, not_found.close_head_len);
+
+    // The file arm reads through the seam, and the page carries exactly
+    // what the file held.
+    const maintenance = parsed.error_pages[1];
+    try std.testing.expectEqual(@as(u16, 503), maintenance.status);
+    try std.testing.expect(std.mem.endsWith(u8, maintenance.keep, test_file_body));
+
+    // Every rendered variant must parse as a complete, correctly framed
+    // response — the same round-trip the comptime statics prove.
+    for (parsed.error_pages) |page| {
+        for ([_][]const u8{ page.keep, page.close }) |bytes| {
+            var storage: parser.HeaderStorage = undefined;
+            const head = try parser.parseResponseHead(bytes, false, &storage, .get);
+            try std.testing.expectEqual(page.status, head.status);
+        }
+    }
+}
+
+test "config: a body names exactly one source, and its grammar is enforced" {
+    // Neither arm, and both arms: the redirect target's exactly-one rule.
+    try expectParseError(
+        error.BodySourceMissing,
+        bodies_head ++ "\"bodies\":{\"x\":{\"content_type\":\"text/plain\"}}," ++ bodies_tail,
+    );
+    try expectParseError(
+        error.BodySourceAmbiguous,
+        bodies_head ++
+            "\"bodies\":{\"x\":{\"inline\":\"a\",\"file\":\"/b\",\"content_type\":\"text/plain\"}}," ++
+            bodies_tail,
+    );
+    // The content type lands on the wire inside a rendered head, so the
+    // injection rule is the filter values' own.
+    try expectParseError(
+        error.BodyContentTypeInvalid,
+        bodies_head ++ "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"\"}}," ++ bodies_tail,
+    );
+    try expectParseError(
+        error.BodyContentTypeInvalid,
+        bodies_head ++
+            "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"text/html\\r\\nX: 1\"}}," ++
+            bodies_tail,
+    );
+    // Names are identifiers: non-empty, bounded, unique.
+    try expectParseError(
+        error.BodyNameEmpty,
+        bodies_head ++ "\"bodies\":{\"\":{\"inline\":\"a\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+    );
+    try expectParseError(
+        error.BodyNameTooLong,
+        bodies_head ++ "\"bodies\":{\"" ++ ("n" ** (constants.body_name_bytes_max + 1)) ++
+            "\":{\"inline\":\"a\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+    );
+    // `parse` without a file source refuses every file arm — the fuzzer
+    // and the simulator never touch a filesystem.
+    try expectParseError(
+        error.BodyFileUnreadable,
+        bodies_head ++ "\"bodies\":{\"x\":{\"file\":\"/any\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+    );
+}
+
+test "config: error pages take only known statuses naming known bodies" {
+    const one_body = "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}},";
+    // The closed static set: a status zoxy never sends as a static is a
+    // config the operator misread — 200 is not an error, 301 is the
+    // redirect action's, 500 is not in the vocabulary.
+    for ([_][]const u8{ "200", "301", "500" }) |status| {
+        var json_buffer: [1024]u8 = undefined;
+        const json = std.fmt.bufPrint(
+            &json_buffer,
+            "{s}{s}\"error_pages\":{{\"{s}\":\"x\"}},{s}",
+            .{ bodies_head, one_body, status, bodies_tail },
+        ) catch unreachable;
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        try std.testing.expectError(
+            error.ErrorPageStatusUnknown,
+            parse(arena_state.allocator(), json),
+        );
+    }
+    try expectParseError(
+        error.ErrorPageStatusInvalid,
+        bodies_head ++ one_body ++ "\"error_pages\":{\"abc\":\"x\"}," ++ bodies_tail,
+    );
+    try expectParseError(
+        error.ErrorPageDuplicate,
+        bodies_head ++ one_body ++
+            "\"error_pages\":{\"404\":\"x\",\"404\":\"x\"}," ++ bodies_tail,
+    );
+    // A dangling name is a load error, never an empty page.
+    try expectParseError(
+        error.BodyUnknown,
+        bodies_head ++ one_body ++ "\"error_pages\":{\"404\":\"y\"}," ++ bodies_tail,
+    );
+    // A map longer than the vocabulary cannot be all-valid, and which
+    // way it fails is not knowable from the count — its own error, and
+    // the allocation is bounded ahead of it.
+    {
+        var json: std.ArrayList(u8) = .empty;
+        defer json.deinit(std.testing.allocator);
+        try json.appendSlice(std.testing.allocator, bodies_head ++ one_body ++ "\"error_pages\":{");
+        for (0..shed.static_statuses.len + 1) |index| {
+            if (index > 0) try json.append(std.testing.allocator, ',');
+            var entry_buffer: [16]u8 = undefined;
+            const entry = std.fmt.bufPrint(
+                &entry_buffer,
+                "\"{d}\":\"x\"",
+                .{600 + index},
+            ) catch unreachable;
+            try json.appendSlice(std.testing.allocator, entry);
+        }
+        try json.appendSlice(std.testing.allocator, "}," ++ bodies_tail);
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        try std.testing.expectError(
+            error.ErrorPagesOverLimit,
+            parse(arena_state.allocator(), json.items),
+        );
+    }
+    try expectParseError(
+        error.BodyNameDuplicate,
+        bodies_head ++
+            "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}," ++
+            "\"x\":{\"inline\":\"b\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+    );
+}
+
+test "config: the body cap holds on both arms, exactly" {
+    // The file arm: the reader reports over-limit, the loader speaks the
+    // same verdict an oversized inline earns.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    try std.testing.expectError(error.BodyOverLimit, parseWithFiles(
+        arena_state.allocator(),
+        bodies_head ++ "\"bodies\":{\"x\":{\"file\":\"/big\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+        test_file_source,
+    ));
+    // The inline arm, at the boundary: the cap itself loads, one past
+    // fails. Built at runtime — a comptime megabyte literal costs every
+    // build what this test costs one run.
+    const gpa = std.testing.allocator;
+    const at_limit = try gpa.alloc(u8, constants.body_bytes_max);
+    defer gpa.free(at_limit);
+    @memset(at_limit, 'x');
+    for ([_]usize{ constants.body_bytes_max, constants.body_bytes_max + 1 }) |body_len| {
+        var json: std.ArrayList(u8) = .empty;
+        defer json.deinit(gpa);
+        try json.appendSlice(gpa, bodies_head ++ "\"bodies\":{\"x\":{\"inline\":\"");
+        try json.appendSlice(gpa, at_limit);
+        if (body_len > constants.body_bytes_max) try json.append(gpa, 'x');
+        try json.appendSlice(gpa, "\",\"content_type\":\"t/p\"}},\"error_pages\":{\"404\":\"x\"}," ++ bodies_tail);
+        var body_arena = std.heap.ArenaAllocator.init(gpa);
+        defer body_arena.deinit();
+        const outcome = parse(body_arena.allocator(), json.items);
+        if (body_len > constants.body_bytes_max) {
+            try std.testing.expectError(error.BodyOverLimit, outcome);
+        } else {
+            const parsed = try outcome;
+            try std.testing.expectEqual(
+                constants.body_bytes_max,
+                @as(u32, @intCast(parsed.error_pages[0].keep.len - parsed.error_pages[0].keep_head_len)),
+            );
+        }
     }
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -67,7 +67,11 @@ pub const Config = struct {
     /// error page whose delivery needed a pool would fail exactly when
     /// it is needed. Configuring a status is also the opt-in for bodies
     /// on its sheds; absent, shedding costs what it does today.
-    error_pages: []const StaticPage = &.{},
+    ///
+    /// By pointer into the load-time render cache: a body serving a
+    /// page here and a `respond` action there is rendered once and
+    /// pointed at twice — #159's one-body-one-buffer contract.
+    error_pages: []const *const StaticPage = &.{},
     /// Where access-log lines go (§8), or null when no `access_log` block
     /// is configured — the log stays off and reserves nothing.
     access_log_sink: ?AccessLogSink = null,
@@ -88,17 +92,10 @@ pub const Config = struct {
         file: []const u8,
     };
 
-    /// One pre-rendered #159 page: both persistence variants of the
-    /// complete response, with each head's length recorded so a HEAD
-    /// request sends the prefix of the same buffer — still one send,
-    /// no third copy.
-    pub const StaticPage = struct {
-        status: u16,
-        keep: []const u8,
-        close: []const u8,
-        keep_head_len: u32,
-        close_head_len: u32,
-    };
+    /// One pre-rendered #159 page, defined beside the static-response
+    /// machinery it joins (`shed.StaticPage`) because the filter table
+    /// carries these too and cannot import this module.
+    pub const StaticPage = shed.StaticPage;
 
     /// The sink names the config may spell — split from `AccessLogSink`
     /// because the schema renders (and the parser matches) bare names,
@@ -422,6 +419,8 @@ pub const ValidationError = error{
     BodyFileUnreadable,
     BodyOverLimit,
     BodyUnknown,
+    FilterRespondStatus,
+    ResponseFilterRespond,
     ErrorPagesOverLimit,
     ErrorPageStatusInvalid,
     ErrorPageStatusUnknown,
@@ -575,9 +574,21 @@ pub fn parseWithFiles(
         http_listeners_count,
         access_log_sink != null,
     );
-    const listeners = try resolveListeners(arena, parsed.listeners, clusters, limits.head_buffer_bytes);
-    const admin_bind = try resolveAdminBind(parsed.admin);
+    // Bodies before listeners (#159): a `respond` action names one, and
+    // both consumers render through the same load-time cache — so the
+    // table has to exist before any rule compiles. A body's own errors
+    // therefore outrank a listener's, which is the honest order anyway:
+    // an unreadable file is a fact about the deployment, where a bad
+    // filter is a fact about a rule that may never have loaded.
     const bodies = try resolveBodies(arena, parsed.bodies, files);
+    const listeners = try resolveListeners(
+        arena,
+        parsed.listeners,
+        clusters,
+        limits.head_buffer_bytes,
+        bodies,
+    );
+    const admin_bind = try resolveAdminBind(parsed.admin);
     const error_pages = try resolveErrorPages(arena, parsed.error_pages, bodies);
 
     assert(listeners.len >= 1);
@@ -598,12 +609,22 @@ pub fn parseWithFiles(
     };
 }
 
-/// A resolved #159 body: load-time only — consumers embed pre-rendered
-/// responses, so nothing at serve time ever walks this table.
+/// A resolved #159 body: load-time only — consumers hold pointers to
+/// pre-rendered responses, so nothing at serve time ever walks this
+/// table.
+///
+/// `rendered` is the one-body-one-buffer contract made real: one slot
+/// per page status, filled on first use, so a body named by an error
+/// page and by three `respond` actions is read once, capped once, and
+/// rendered once per (status, persistence) pair however many places
+/// serve it. Pointers into it stay valid because every page is its own
+/// arena allocation — the cache holds pointers, never inline structs
+/// that a growing table could move.
 const ResolvedBody = struct {
     name: []const u8,
     bytes: []const u8,
     content_type: []const u8,
+    rendered: [shed.page_statuses.len]?*const Config.StaticPage = @splat(null),
 };
 
 /// Resolve the #159 `bodies` map: names bounded and unique, exactly one
@@ -614,7 +635,7 @@ fn resolveBodies(
     arena: std.mem.Allocator,
     bodies_json: ?BodiesJson,
     files: FileSource,
-) ParseError![]const ResolvedBody {
+) ParseError![]ResolvedBody {
     const parsed = bodies_json orelse return &.{};
     if (parsed.entries.len > std.math.maxInt(u16)) {
         return error.BodiesOverLimit;
@@ -710,8 +731,8 @@ fn resolveContentType(content_type: []const u8) ParseError![]const u8 {
 fn resolveErrorPages(
     arena: std.mem.Allocator,
     error_pages_json: ?ErrorPagesJson,
-    bodies: []const ResolvedBody,
-) ParseError![]const Config.StaticPage {
+    bodies: []ResolvedBody,
+) ParseError![]const *const Config.StaticPage {
     const parsed = error_pages_json orelse return &.{};
     // The closed status set bounds what can survive validation, so a
     // longer map always fails below — on an unknown status or on a
@@ -723,10 +744,13 @@ fn resolveErrorPages(
     if (parsed.entries.len > shed.static_statuses.len) {
         return error.ErrorPagesOverLimit;
     }
-    const pages = try arena.alloc(Config.StaticPage, parsed.entries.len);
+    const pages = try arena.alloc(*const Config.StaticPage, parsed.entries.len);
     for (parsed.entries, 0..) |entry, index| {
         const status = std.fmt.parseUnsigned(u16, entry.status, 10) catch
             return error.ErrorPageStatusInvalid;
+        // The error set, not the wider page set: `200` is a `respond`
+        // action's status, and no rung raises it — a page here for one
+        // would never serve.
         if (!shed.isStaticStatus(status)) {
             return error.ErrorPageStatusUnknown;
         }
@@ -737,16 +761,7 @@ fn resolveErrorPages(
                 return error.ErrorPageDuplicate;
             }
         }
-        const body = bodyNamed(bodies, entry.body) orelse return error.BodyUnknown;
-        const keep = try renderStaticPage(arena, status, body, .keep);
-        const close = try renderStaticPage(arena, status, body, .close);
-        pages[index] = .{
-            .status = status,
-            .keep = keep.bytes,
-            .close = close.bytes,
-            .keep_head_len = keep.head_len,
-            .close_head_len = close.head_len,
-        };
+        pages[index] = try pageFor(arena, bodies, entry.body, status);
         // What the serve path reads back (`configuredPage`): a head
         // that is a prefix of its own response, on both variants.
         assert(pages[index].keep_head_len <= pages[index].keep.len);
@@ -757,7 +772,43 @@ fn resolveErrorPages(
     return pages;
 }
 
-fn bodyNamed(bodies: []const ResolvedBody, name: []const u8) ?*const ResolvedBody {
+/// The page for one (body name, status) pair (#159), rendered on first
+/// use and reused after — so a body named by an error page and by any
+/// number of `respond` actions costs one pair of buffers, not one per
+/// reference. Every consumer of a configured body comes through here.
+fn pageFor(
+    arena: std.mem.Allocator,
+    bodies: []ResolvedBody,
+    name: []const u8,
+    status: u16,
+) ParseError!*const Config.StaticPage {
+    assert(shed.isPageStatus(status));
+    const slot = shed.pageStatusIndex(status).?;
+    const body = bodyNamed(bodies, name) orelse return error.BodyUnknown;
+    if (body.rendered[slot]) |cached| {
+        assert(cached.status == status);
+        return cached;
+    }
+    const keep = try renderStaticPage(arena, status, body, .keep);
+    const close = try renderStaticPage(arena, status, body, .close);
+    const page = try arena.create(Config.StaticPage);
+    page.* = .{
+        .status = status,
+        .keep = keep.bytes,
+        .close = close.bytes,
+        .keep_head_len = keep.head_len,
+        .close_head_len = close.head_len,
+    };
+    // What every consumer of a page relies on, stated where every page
+    // is made rather than at one call site: the head is a prefix of its
+    // own response, on both variants (the serve path's HEAD slice).
+    assert(page.keep_head_len <= page.keep.len);
+    assert(page.close_head_len <= page.close.len);
+    body.rendered[slot] = page;
+    return page;
+}
+
+fn bodyNamed(bodies: []ResolvedBody, name: []const u8) ?*ResolvedBody {
     assert(bodies.len <= std.math.maxInt(u16)); // `BodiesOverLimit`'s bound.
     for (bodies) |*body| {
         assert(body.name.len >= 1); // resolveBodies rejected empty names.
@@ -779,7 +830,7 @@ fn renderStaticPage(
     body: *const ResolvedBody,
     persistence: shed.Persistence,
 ) ParseError!struct { bytes: []const u8, head_len: u32 } {
-    assert(shed.isStaticStatus(status));
+    assert(shed.isPageStatus(status));
     assert(body.content_type.len >= 1);
     const rendered = try std.fmt.allocPrint(
         arena,
@@ -1348,6 +1399,7 @@ pub const HeaderMatchJson = struct {
 pub const ActionJson = struct {
     reject: ?u16 = null,
     redirect: ?RedirectJson = null,
+    respond: ?RespondJson = null,
     header_set: ?HeaderEditJson = null,
     header_add: ?HeaderEditJson = null,
     header_remove: ?[]const u8 = null,
@@ -1364,10 +1416,39 @@ pub const ActionJson = struct {
         .redirect = .{
             .desc = "Answer the request with a redirect instead of forwarding it.",
         },
+        .respond = .{
+            .desc = "Answer the request from a configured body instead of " ++
+                "forwarding it — this proxy as the origin.",
+        },
         .header_set = .{ .desc = "Set (replace) a request header." },
         .header_add = .{ .desc = "Append a request header." },
         .header_remove = .{ .desc = "Remove a request header by name." },
         .rewrite_prefix = .{ .desc = "Rewrite the request path prefix before proxying." },
+    };
+};
+
+/// A `respond` action (#159): the proxy answers from a named body
+/// instead of forwarding. The status defaults to `200` — the common
+/// case is serving content, and the error statuses are reachable for a
+/// policy page that wants a body without a matching `error_pages`
+/// entry.
+pub const RespondJson = struct {
+    status: u16 = 200,
+    body: []const u8,
+
+    pub const schema_doc =
+        "Answer the matched request from a configured body, with the status " ++
+        "given — the proxy responding as the origin, from memory.";
+    pub const schema_fields = .{
+        .status = .{
+            .desc = "Status to answer with: 200, or one of the error statuses " ++
+                "this proxy sends.",
+            .int_values = &shed.page_statuses,
+        },
+        .body = .{
+            .desc = "Name of the body to serve, from the top-level `bodies` map.",
+            .min_length = 1,
+        },
     };
 };
 
@@ -2231,6 +2312,7 @@ fn resolveListeners(
     listeners_json: []const ListenerJson,
     clusters: []const Config.Cluster,
     head_buffer_bytes: u32,
+    bodies: []ResolvedBody,
 ) ParseError![]const Config.Listener {
     assert(clusters.len >= 1);
     if (listeners_json.len == 0) {
@@ -2245,23 +2327,14 @@ fn resolveListeners(
     }
 
     const listeners = try arena.alloc(Config.Listener, listeners_json.len);
-    for (listeners_json, 0..) |listener_json, index| {
-        const bind_address = std.Io.net.IpAddress.parseLiteral(listener_json.bind) catch {
-            return error.ListenerBindInvalid;
-        };
-        const protocol = try protocolOf(listener_json.protocol);
-        listeners[index] = .{
-            .bind_address = bind_address,
-            .routes = try resolveRoutes(arena, &listener_json, clusters, protocol, head_buffer_bytes),
-            .request_filters = try resolveRequestFilters(arena, &listener_json, protocol, head_buffer_bytes),
-            .response_filters = try resolveResponseFilters(arena, &listener_json, protocol),
-            .protocol = protocol,
-            .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
-            .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
-        };
-        if (protocol == .http) {
-            try rejectHttpClusterSend(listeners[index].routes, clusters);
-        }
+    for (listeners_json, listeners) |listener_json, *listener| {
+        listener.* = try resolveListener(
+            arena,
+            &listener_json,
+            clusters,
+            head_buffer_bytes,
+            bodies,
+        );
     }
 
     // Duplicate binds in O(n log n), for the reason `resolveClusters`
@@ -2293,6 +2366,46 @@ fn resolveListeners(
     return listeners;
 }
 
+/// One listener's whole resolution — split from `resolveListeners`
+/// when #159 threaded the bodies table through it and the loop body
+/// pushed that function past the length limit. The duplicate-bind pass
+/// stays with the caller: it is a property of the set, not of one
+/// entry.
+fn resolveListener(
+    arena: std.mem.Allocator,
+    listener_json: *const ListenerJson,
+    clusters: []const Config.Cluster,
+    head_buffer_bytes: u32,
+    bodies: []ResolvedBody,
+) ParseError!Config.Listener {
+    assert(clusters.len >= 1);
+    assert(head_buffer_bytes >= 1);
+    const bind_address = std.Io.net.IpAddress.parseLiteral(listener_json.bind) catch {
+        return error.ListenerBindInvalid;
+    };
+    const protocol = try protocolOf(listener_json.protocol);
+    const listener: Config.Listener = .{
+        .bind_address = bind_address,
+        .routes = try resolveRoutes(arena, listener_json, clusters, protocol, head_buffer_bytes),
+        .request_filters = try resolveRequestFilters(
+            arena,
+            listener_json,
+            protocol,
+            head_buffer_bytes,
+            bodies,
+        ),
+        .response_filters = try resolveResponseFilters(arena, listener_json, protocol),
+        .protocol = protocol,
+        .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
+        .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
+    };
+    if (protocol == .http) {
+        try rejectHttpClusterSend(listener.routes, clusters);
+    }
+    assert(listener.routes.len >= 1);
+    return listener;
+}
+
 /// A total order over bind addresses, for the duplicate sort above. Only
 /// the ordering matters, never the value: equal keys are re-checked with
 /// `std.meta.eql`, so a collision costs a comparison rather than a wrong
@@ -2316,6 +2429,7 @@ fn resolveRequestFilters(
     listener_json: *const ListenerJson,
     protocol: Config.Listener.Protocol,
     head_buffer_bytes: u32,
+    bodies: []ResolvedBody,
 ) ParseError![]const filter.Rule {
     const filters_json = listener_json.request_filters orelse return &.{};
     // Any `request_filters` key on an l4 listener is a mistake — l4 relays bytes,
@@ -2332,7 +2446,7 @@ fn resolveRequestFilters(
     for (filters_json, rules) |rule_json, *rule| {
         rule.* = .{
             .match = try resolveMatch(arena, &rule_json.match, head_buffer_bytes),
-            .actions = try resolveActions(arena, rule_json.actions, head_buffer_bytes),
+            .actions = try resolveActions(arena, rule_json.actions, head_buffer_bytes, bodies),
         };
         header_edits += countHeaderEdits(rule.actions);
     }
@@ -2360,7 +2474,7 @@ fn countHeaderEdits(actions: []const filter.Action) u32 {
     for (actions) |action| {
         switch (action) {
             .header_set, .header_add, .header_remove => count += 1,
-            .reject, .redirect, .rewrite_prefix => {},
+            .reject, .redirect, .respond, .rewrite_prefix => {},
         }
     }
     assert(count <= actions.len); // Edits are a subset of the actions.
@@ -2479,6 +2593,13 @@ fn resolveResponseEdit(action_json: *const ActionJson) ParseError!filter.Applied
         // and is sent elsewhere. An origin response already exists by
         // the time these rules run.
         return error.ResponseFilterRedirect;
+    }
+    if (action_json.respond != null) {
+        // Also a request-side answer (#159): a response rule runs when
+        // the origin has already answered, and replacing that answer is
+        // not an *edit* — it is a different feature, and one this table
+        // deliberately does not have.
+        return error.ResponseFilterRespond;
     }
     if (action_json.rewrite_prefix != null) {
         return error.ResponseFilterRewrite;
@@ -2665,6 +2786,7 @@ fn resolveActions(
     arena: std.mem.Allocator,
     actions_json: []const ActionJson,
     head_buffer_bytes: u32,
+    bodies: []ResolvedBody,
 ) ParseError![]const filter.Action {
     if (actions_json.len == 0) {
         return error.FilterActionsEmpty;
@@ -2672,7 +2794,7 @@ fn resolveActions(
     assert(actions_json.len >= 1); // Past the empty guard.
     const actions = try arena.alloc(filter.Action, actions_json.len);
     for (actions_json, actions) |action_json, *action| {
-        action.* = try resolveAction(&action_json, head_buffer_bytes);
+        action.* = try resolveAction(arena, &action_json, head_buffer_bytes, bodies);
     }
     assert(actions.len == actions_json.len);
     return actions;
@@ -2684,18 +2806,24 @@ fn resolveActions(
 fn requireOneActionKind(action_json: *const ActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
         @intFromBool(action_json.redirect != null) +
+        @intFromBool(action_json.respond != null) +
         @intFromBool(action_json.header_set != null) +
         @intFromBool(action_json.header_add != null) +
         @intFromBool(action_json.header_remove != null) +
         @intFromBool(action_json.rewrite_prefix != null);
-    assert(set <= 6); // The action object has six kind fields.
+    assert(set <= 7); // The action object has seven kind fields.
     if (set != 1) {
         return error.FilterActionKind;
     }
     assert(set == 1);
 }
 
-fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseError!filter.Action {
+fn resolveAction(
+    arena: std.mem.Allocator,
+    action_json: *const ActionJson,
+    head_buffer_bytes: u32,
+    bodies: []ResolvedBody,
+) ParseError!filter.Action {
     try requireOneActionKind(action_json);
     if (action_json.reject) |status| {
         if (!filter.isRejectStatus(status)) {
@@ -2705,6 +2833,20 @@ fn resolveAction(action_json: *const ActionJson, head_buffer_bytes: u32) ParseEr
     }
     if (action_json.redirect) |redirect_json| {
         return .{ .redirect = try resolveRedirect(&redirect_json) };
+    }
+    if (action_json.respond) |respond_json| {
+        // The page set, not the reject set: `200` is the point of this
+        // action, and an error status here is a policy page that wants
+        // a body without an `error_pages` entry to match.
+        if (!shed.isPageStatus(respond_json.status)) {
+            return error.FilterRespondStatus;
+        }
+        const page = try pageFor(arena, bodies, respond_json.body, respond_json.status);
+        // The precondition `firstVerdict` asserts on the far side, so
+        // the compiled action and the interpreter agree at load rather
+        // than on the serving path.
+        assert(shed.isPageStatus(page.status));
+        return .{ .respond = page };
     }
     if (action_json.header_set) |edit| {
         return .{ .header_set = try resolveHeaderEdit(&edit) };
@@ -4686,7 +4828,9 @@ var fuzz_arena_buffer: [1 << 20]u8 = undefined;
 /// `drain_deadline_ms` gives it no path to that branch of the parser.
 const fuzz_seed_json =
     \\{"listeners":[{"bind":"127.0.0.1:8080","routes":[{"prefix":"/","cluster":"o"}],
-    \\ "request_filters":[{"match":{"client":["10.0.0.0/8"]},"actions":[{"reject":403}]}],
+    \\ "request_filters":[{"match":{"client":["10.0.0.0/8"]},"actions":[{"reject":403}]},
+    \\ {"match":{"path_prefix":"/old"},"actions":[{"redirect":{"status":301,"scheme":"https"}}]},
+    \\ {"match":{"path_prefix":"/robots.txt"},"actions":[{"respond":{"status":200,"body":"oops"}}]}],
     \\ "protocol":"http"}],
     \\ "clusters":{"o":{"endpoints":["127.0.0.1:9000",
     \\ {"address":"127.0.0.1:9001","weight":3}],
@@ -4703,10 +4847,13 @@ const fuzz_seed_json =
 // The `file` arm here, `stdout` in `example_json` beside it: between the
 // two corpus entries the mutator sees every sink spelling, including the
 // `path` key only one of them may carry — both endpoint spellings
-// (#174), and both pick spellings (#178: the object form with its
-// key/name grammar here, the bare string in the example), so each
+// (#174), both pick spellings (#178: the object form with its key/name
+// grammar here, the bare string in the example), and every terminal
+// filter action (`reject`, `redirect` #176, `respond` #159) — so each
 // grammar is a starting point rather than a shape the mutator must
-// blindly discover.
+// blindly discover. The `inline` body arm is the one it can reach:
+// `parse` refuses `file` sources outright, since the fuzzer has no
+// filesystem.
 
 test "config: the fuzz seed carrying every block parses" {
     // It is a corpus entry, so it has to be a *valid* config — an
@@ -4719,9 +4866,15 @@ test "config: the fuzz seed carrying every block parses" {
     try std.testing.expectEqual(@as(u32, 30000), parsed.request_timeout_ms);
     try std.testing.expectEqualSlices(u16, &.{ 1, 3 }, parsed.clusters[0].weights.?);
     // The #159 grammar rides the corpus through its `inline` arm — the
-    // fuzzer's `parse` has no filesystem, deliberately.
+    // fuzzer's `parse` has no filesystem, deliberately — and every
+    // terminal action is in the seed's rule table.
     try std.testing.expectEqual(@as(usize, 1), parsed.error_pages.len);
     try std.testing.expectEqual(@as(u16, 503), parsed.error_pages[0].status);
+    const rules = parsed.listeners[0].request_filters;
+    try std.testing.expectEqual(@as(usize, 3), rules.len);
+    try std.testing.expectEqual(@as(u16, 403), rules[0].actions[0].reject);
+    try std.testing.expectEqual(@as(u16, 301), rules[1].actions[0].redirect.status);
+    try std.testing.expectEqual(@as(u16, 200), rules[2].actions[0].respond.status);
 }
 
 test "fuzz: parse never panics — parse or reject, no third outcome" {
@@ -5267,6 +5420,96 @@ test "config: error pages take only known statuses naming known bodies" {
         bodies_head ++
             "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}," ++
             "\"x\":{\"inline\":\"b\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
+    );
+}
+
+test "config: a respond action compiles to a page, sharing one buffer (#159)" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const parsed = try parse(arena_state.allocator(),
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http",
+        \\ "request_filters":[
+        \\   {"match":{"path_prefix":"/robots.txt"},
+        \\    "actions":[{"respond":{"status":200,"body":"robots"}}]},
+        \\   {"match":{"path_prefix":"/down"},
+        \\    "actions":[{"respond":{"status":503,"body":"maint"}}]},
+        \\   {"match":{"path_prefix":"/also-down"},
+        \\    "actions":[{"respond":{"status":503,"body":"maint"}}]}]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "bodies":{"robots":{"inline":"User-agent: *\n","content_type":"text/plain"},
+        \\   "maint":{"inline":"back soon","content_type":"text/plain"}},
+        \\ "error_pages":{"503":"maint"},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const rules = parsed.listeners[0].request_filters;
+    try std.testing.expectEqual(@as(usize, 3), rules.len);
+
+    // The 200 page: the action's own status, the body's content type,
+    // and the complete response rendered once.
+    const robots = rules[0].actions[0].respond;
+    try std.testing.expectEqual(@as(u16, 200), robots.status);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
+            "Content-Type: text/plain\r\n\r\nUser-agent: *\n",
+        robots.keep,
+    );
+
+    // One body, one buffer: two actions and an error page naming the
+    // same (body, status) all point at the *same* rendered page — the
+    // load-time cache, not three copies of "back soon".
+    const first_maint = rules[1].actions[0].respond;
+    const second_maint = rules[2].actions[0].respond;
+    try std.testing.expectEqual(first_maint, second_maint);
+    try std.testing.expectEqual(first_maint, parsed.error_pages[0]);
+    // A different status off the same body is a different page, and
+    // shares nothing but the bytes it embeds.
+    try std.testing.expect(robots != first_maint);
+}
+
+test "config: the respond action's vocabulary is closed, and request-side only" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"," ++
+        "\"request_filters\":[{\"match\":{},\"actions\":[";
+    const mid = "]}]}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}},";
+    const tail = "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // 200 and the error statuses load; a status this proxy has no
+    // reason phrase for does not.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ "{\"respond\":{\"status\":404,\"body\":\"x\"}}" ++ mid ++ tail,
+        );
+        try std.testing.expectEqual(
+            @as(u16, 404),
+            parsed.listeners[0].request_filters[0].actions[0].respond.status,
+        );
+    }
+    try expectParseError(
+        error.FilterRespondStatus,
+        head ++ "{\"respond\":{\"status\":418,\"body\":\"x\"}}" ++ mid ++ tail,
+    );
+    // A dangling body name fails the same way an error page's does.
+    try expectParseError(
+        error.BodyUnknown,
+        head ++ "{\"respond\":{\"status\":200,\"body\":\"nope\"}}" ++ mid ++ tail,
+    );
+    // Still exactly one action kind, with the new arm counted.
+    try expectParseError(
+        error.FilterActionKind,
+        head ++ "{\"respond\":{\"body\":\"x\"},\"reject\":403}" ++ mid ++ tail,
+    );
+    // And it is a request-side answer: a response rule runs when the
+    // origin has already answered, so replacing that answer is not an
+    // edit this table has.
+    try expectParseError(
+        error.ResponseFilterRespond,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"," ++
+            "\"response_filters\":[{\"actions\":[{\"respond\":{\"body\":\"x\"}}]}]}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}}," ++ tail,
     );
 }
 

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -116,8 +116,17 @@ fn writeFieldSchema(
             if (Base == config.PickJson) {
                 try writePickField(out);
             } else {
-                // Nested object; its description is the field's, written above.
-                try writeObjectBody(out, Base, false);
+                if (Base == config.BodiesJson) {
+                    try writeNamedMap(out, config.BodyJson);
+                } else {
+                    if (Base == config.ErrorPagesJson) {
+                        try writeNamedMap(out, null);
+                    } else {
+                        // Nested object; its description is the field's,
+                        // written above.
+                        try writeObjectBody(out, Base, false);
+                    }
+                }
             }
         },
         else => try writeShape(out, Base, meta),
@@ -352,6 +361,29 @@ fn writeClustersMap(out: *Stringify) Writer.Error!void {
     try out.beginObject();
     try writeObjectBody(out, config.ClusterJson, true);
     try out.endObject();
+}
+
+/// A #159 map field: string keys to either a nested object schema
+/// (`bodies`, whose values are `BodyJson`) or bare strings
+/// (`error_pages`, whose values are body names). Like `ClustersJson`,
+/// the maps carry custom `jsonParse`s the reflection cannot see, so
+/// their shapes are emitted by hand.
+fn writeNamedMap(out: *Stringify, comptime Value: ?type) Writer.Error!void {
+    try out.objectField("type");
+    try out.write("object");
+    try out.objectField("additionalProperties");
+    if (Value) |ValueType| {
+        try out.beginObject();
+        try writeObjectBody(out, ValueType, true);
+        try out.endObject();
+    } else {
+        try out.beginObject();
+        try out.objectField("type");
+        try out.write("string");
+        try out.objectField("description");
+        try out.write("Name of a configured body.");
+        try out.endObject();
+    }
 }
 
 /// The non-optional element type of `T`, or `T` itself if it is not an

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -381,6 +381,22 @@ pub const pick_name_bytes_max: u16 = 64;
 /// reserved slot cannot drift out of any of them.
 pub const response_edits_max: u16 = header_edits_max + 1;
 
+/// Upper bound on one configured body's bytes (#159) — file or inline,
+/// rejected at load. The bound is the scope boundary, not a tuning
+/// knob: below it, holding the bytes in the startup arena is the cheap
+/// answer (an error page whose delivery needed a pool would fail when
+/// it is needed most); above it you want the kernel page cache and a
+/// streaming mechanism, which is a different feature. It is also why
+/// the cost statement stays honest — scale-out is N processes behind
+/// SO_REUSEPORT, each holding its own copy, so 1 MiB here is N MiB on
+/// the box, printed per process in the banner's config-arena term.
+pub const body_bytes_max: u32 = 1024 * 1024;
+
+/// Upper bound on a configured body's *name* (#159) — an identifier an
+/// operator writes and error messages echo, bounded like
+/// `cluster_name_bytes_max` and for the same reason.
+pub const body_name_bytes_max: u16 = 64;
+
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
@@ -784,6 +800,11 @@ comptime {
     assert(endpoint_inflight_max >= upstream_slots_max);
     assert(header_edits_max >= 1);
     assert(response_edits_max == header_edits_max + 1);
+    assert(body_bytes_max >= 1);
+    // A body must fit the u32 lengths the render and the channel carry.
+    assert(body_bytes_max <= std.math.maxInt(u32) / 2);
+    assert(body_name_bytes_max >= 1);
+    assert(body_name_bytes_max == cluster_name_bytes_max); // one identifier rule
     assert(pick_name_bytes_max >= 1);
     // A pick name is a header-adjacent identifier; keeping it under the
     // host bound is the sanity relation "this is a name, not a payload".

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -84,6 +84,15 @@ pub const Counters = struct {
     /// on a dashboard, and a redirect storm is a different diagnosis
     /// from a reject storm.
     l7_redirected: Value = Value.init(0),
+    /// A §7 filter rule answered the request from a configured body
+    /// (#159) — this proxy serving as the origin rather than refusing
+    /// or relocating. `l7_filtered`'s sibling like `l7_redirected`, and
+    /// outside `reconcile`'s shed sum for the same reason: the request
+    /// was admitted and answered. Kept apart from `l7_filtered` even
+    /// where the status matches one a reject could carry, because
+    /// "policy refused this" and "policy served this" are opposite
+    /// facts about the same traffic.
+    l7_responded: Value = Value.init(0),
     /// #178 cookie stickiness, counted once per forwarded response on a
     /// cookie-keyed cluster — at the response render, so a replayed try
     /// counts once and a torn-down exchange not at all. The three

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -14,6 +14,7 @@ const std = @import("std");
 const constants = @import("../constants.zig");
 const parser = @import("parser.zig");
 const router = @import("router.zig");
+const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
 
@@ -180,6 +181,12 @@ pub const Action = union(enum) {
     /// Answer a redirect and stop (#176): rendered per request, since
     /// its `Location` may carry the request's own path.
     redirect: Redirect,
+    /// Answer a configured body and stop (#159): this proxy responding
+    /// as the origin — a maintenance page, a `robots.txt`, a health
+    /// target. The page is pre-rendered at load and shared with every
+    /// other reference to the same body and status, so the action
+    /// carries a pointer, and serving it is the static path's one send.
+    respond: *const shed.StaticPage,
     /// Set (replacing any existing), add (append), or remove a header on
     /// the forwarded request, applied during the head render.
     header_set: HeaderEdit,
@@ -350,6 +357,11 @@ pub const RequestView = struct {
 pub const Verdict = union(enum) {
     reject: u16,
     redirect: *const Redirect,
+    /// A configured body answers (#159). Distinct from `reject` even
+    /// where the status is one a reject could carry: a reject is policy
+    /// refusing traffic, a respond is this proxy *being* the origin,
+    /// and the counters and access-log outcomes stay separable for it.
+    respond: *const shed.StaticPage,
 };
 
 /// The verdict of the first matching rule that carries a terminal
@@ -375,6 +387,10 @@ pub fn firstVerdict(rules: []const Rule, view: RequestView) ?Verdict {
                 .redirect => |*redirect| {
                     assert(isRedirectStatus(redirect.status));
                     return .{ .redirect = redirect };
+                },
+                .respond => |page| {
+                    assert(shed.isPageStatus(page.status));
+                    return .{ .respond = page };
                 },
                 // Edits apply at the render, only when the request
                 // forwards; a terminal anywhere in a matched rule stops it.
@@ -436,7 +452,7 @@ pub fn collectForward(
                     rewrite = candidate;
                 }
             },
-            .reject, .redirect => {},
+            .reject, .redirect, .respond => {},
         };
     }
     assert(count <= out.len);
@@ -450,7 +466,7 @@ fn appliedEdit(action: Action) AppliedHeaderEdit {
         .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
         .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
         .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
-        .reject, .redirect, .rewrite_prefix => unreachable,
+        .reject, .redirect, .respond, .rewrite_prefix => unreachable,
     };
 }
 
@@ -1004,9 +1020,9 @@ test "filter: response rules match on status, class and headers" {
     try std.testing.expectEqualStrings("Server", ok[0].name);
 
     // A 503 gathers the unconditional and the class rule, in rule order.
-    const shed = collectResponseEdits(&rules, .{ .status = 503, .headers = &.{} }, &out);
-    try std.testing.expectEqual(@as(usize, 2), shed.len);
-    try std.testing.expectEqualStrings("Retry-After", shed[1].name);
+    const shed_edits = collectResponseEdits(&rules, .{ .status = 503, .headers = &.{} }, &out);
+    try std.testing.expectEqual(@as(usize, 2), shed_edits.len);
+    try std.testing.expectEqualStrings("Retry-After", shed_edits[1].name);
     // The class boundaries are the RFC's: 499 is not a 5xx, 599 is.
     try std.testing.expectEqual(
         @as(usize, 1),

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -35,6 +35,7 @@ const std = @import("std");
 
 const access_log = @import("../access_log.zig");
 const Balancer = @import("../balancer.zig").Balancer;
+const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
 const pump = @import("../net/pump.zig");
@@ -2298,17 +2299,75 @@ pub fn Proxy(comptime IoType: type) type {
                 !server.draining and
                 !server.keepAliveSuppressed();
             conn.state = .l7_responding;
-            // Straight from static memory (§8): the channel carries the slice
-            // and never copies it, so a shed still costs one send. Both
-            // spellings are comptime byte arrays; only the choice is runtime,
-            // and it must match what happens after the send — an announced
-            // close that kept serving, or a kept connection the client was
-            // told to stop using, are both §7 violations.
+            armStaticAnswer(server, conn, status, keep);
+        }
+
+        /// Send one static answer: the #159 configured page for this
+        /// status when the config carries one, the comptime-rendered
+        /// default otherwise — both straight from immutable memory (§8):
+        /// the channel carries the slice and never copies it, so a shed
+        /// still costs one send. The persistence choice is the caller's
+        /// and must match what happens after the send — an announced
+        /// close that kept serving, or a kept connection the client was
+        /// told to stop using, are both §7 violations. A HEAD request
+        /// gets a configured page's head-only prefix (same buffer, same
+        /// framing headers, RFC 9110's HEAD rule); the defaults carry
+        /// `Content-Length: 0`, where whole and prefix are one slice.
+        ///
+        /// The method is only *known* where a head parsed. On the rungs
+        /// that answer without one — the head-buffer shed (nothing was
+        /// ever read), a malformed head, an oversize URI — the method
+        /// reads as the reset default and an actual `HEAD` would be sent
+        /// a body it must not read. That cannot desync anything, and the
+        /// assert below is why: an unparsed head leaves
+        /// `request_head_len` at zero, `staticResponseResyncable`
+        /// refuses to keep on that, and a closing connection has no next
+        /// response for stray bytes to be mistaken for — the client
+        /// discards them with the FIN.
+        fn armStaticAnswer(
+            server: *ServerType,
+            conn: *ConnType,
+            comptime status: u16,
+            keep: bool,
+        ) void {
+            assert(conn.state == .l7_responding);
+            assert(!conn.l7.response_started);
+            // Keeping implies the head parsed (§7 resync), which is what
+            // makes the HEAD decision below sound wherever it matters.
+            if (keep) {
+                assert(conn.l7.request_head_len >= 1);
+            }
+            if (configuredPage(server, status)) |page| {
+                const head_only = conn.l7.request_method == .head;
+                const bytes = if (keep)
+                    (if (head_only) page.keep[0..page.keep_head_len] else page.keep)
+                else
+                    (if (head_only) page.close[0..page.close_head_len] else page.close);
+                const then: conn_module.ClientWrite.Then =
+                    if (keep) .next_request else .lingering_close;
+                armClientWrite(server, conn, bytes, then);
+                return;
+            }
             if (keep) {
                 armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
             } else {
                 armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
             }
+        }
+
+        /// The #159 page configured for `status`, or null for the
+        /// comptime default. A linear scan: the table is bounded by the
+        /// closed static-status set (ten), and this runs only on the
+        /// verdict paths — never per proxied byte.
+        fn configuredPage(server: *const ServerType, status: u16) ?*const config_module.Config.StaticPage {
+            for (server.config.error_pages) |*page| {
+                assert(page.keep_head_len <= page.keep.len);
+                assert(page.close_head_len <= page.close.len);
+                if (page.status == status) {
+                    return page;
+                }
+            }
+            return null;
         }
 
         /// The #176 Location for a redirect verdict. A literal target is

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -593,6 +593,7 @@ pub fn Proxy(comptime IoType: type) type {
                     .redirect => |redirect| {
                         return respondRedirect(server, conn, redirect, keys.host, keys.views.forward);
                     },
+                    .respond => |page| return respondWithPage(server, conn, page),
                 }
             }
             conn.cluster_index = router.route(conn.routes, keys.host, keys.views.match) orelse {
@@ -2338,15 +2339,7 @@ pub fn Proxy(comptime IoType: type) type {
                 assert(conn.l7.request_head_len >= 1);
             }
             if (configuredPage(server, status)) |page| {
-                const head_only = conn.l7.request_method == .head;
-                const bytes = if (keep)
-                    (if (head_only) page.keep[0..page.keep_head_len] else page.keep)
-                else
-                    (if (head_only) page.close[0..page.close_head_len] else page.close);
-                const then: conn_module.ClientWrite.Then =
-                    if (keep) .next_request else .lingering_close;
-                armClientWrite(server, conn, bytes, then);
-                return;
+                return armPageWrite(server, conn, page, keep);
             }
             if (keep) {
                 armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
@@ -2355,12 +2348,81 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
+        /// Send one pre-rendered #159 page: the persistence variant the
+        /// caller decided, whole for a GET and head-only for a HEAD —
+        /// the prefix of that same buffer, so the framing headers still
+        /// describe what a GET would have carried (RFC 9110) and the
+        /// send count is unchanged. Shared by the configured statics
+        /// and the `respond` action, so the two cannot drift on the
+        /// HEAD rule or on the continuation.
+        fn armPageWrite(
+            server: *ServerType,
+            conn: *ConnType,
+            page: *const config_module.Config.StaticPage,
+            keep: bool,
+        ) void {
+            assert(conn.state == .l7_responding);
+            assert(page.keep_head_len <= page.keep.len);
+            assert(page.close_head_len <= page.close.len);
+            const head_only = conn.l7.request_method == .head;
+            const bytes = if (keep)
+                (if (head_only) page.keep[0..page.keep_head_len] else page.keep)
+            else
+                (if (head_only) page.close[0..page.close_head_len] else page.close);
+            assert(bytes.len >= 1);
+            const then: conn_module.ClientWrite.Then =
+                if (keep) .next_request else .lingering_close;
+            armClientWrite(server, conn, bytes, then);
+        }
+
+        /// Answer a matched `respond` action from its configured body
+        /// (#159): this proxy as the origin, not a refusal. Reached
+        /// from routing like the other terminal verdicts, so nothing is
+        /// acquired yet and the answer is the static path's one send.
+        fn respondWithPage(
+            server: *ServerType,
+            conn: *ConnType,
+            page: *const config_module.Config.StaticPage,
+        ) void {
+            assert(conn.state == .l7_reading_head);
+            // `respond`'s own contract: both data ops free, so the send
+            // and any lingering drain have their completions.
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.l7.response_started);
+            // A terminal verdict runs before routing acquires anything,
+            // which is what keeps it clear of every rung past the head
+            // ring (the redirect's precondition, same phase).
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            // The page is immutable arena memory, never the connection's
+            // head buffer — so this answer releases before the send like
+            // every other static one, rather than holding through it the
+            // way the #176 redirect must (it renders into that buffer).
+            // The continuations below are the plain static pair for the
+            // same reason, and they assert the buffer is already gone.
+            releaseForStaticResponse(server, conn);
+            ServerType.clearRequestDeadline(conn);
+            server.storeDeadline(conn, server.idleTimeoutMs());
+            server.counters.increment("l7_responded");
+            conn.log.status = page.status;
+            conn.log.outcome = .responded;
+            // The same three brakes every static answer honors (§7, §8):
+            // the client's own ask, the drain, and relay pressure.
+            const keep = staticResponseResyncable(conn) and
+                conn.l7.client_keep_alive and
+                !server.draining and
+                !server.keepAliveSuppressed();
+            conn.state = .l7_responding;
+            armPageWrite(server, conn, page, keep);
+        }
+
         /// The #159 page configured for `status`, or null for the
         /// comptime default. A linear scan: the table is bounded by the
         /// closed static-status set (ten), and this runs only on the
         /// verdict paths — never per proxied byte.
         fn configuredPage(server: *const ServerType, status: u16) ?*const config_module.Config.StaticPage {
-            for (server.config.error_pages) |*page| {
+            for (server.config.error_pages) |page| {
                 assert(page.keep_head_len <= page.keep.len);
                 assert(page.close_head_len <= page.close.len);
                 if (page.status == status) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -536,7 +536,7 @@ const Http1Bed = struct {
         max_inflight: ?u32 = null,
         /// The #159 pre-rendered error pages; empty for every
         /// pre-existing scenario, so the comptime statics keep serving.
-        error_pages: []const config_module.Config.StaticPage = &.{},
+        error_pages: []const *const config_module.Config.StaticPage = &.{},
         /// The one cluster's §7 pick policy; p2c, the config default,
         /// for every pre-existing scenario.
         pick: config_module.Config.Cluster.Pick = .p2c,
@@ -2450,7 +2450,7 @@ test "l7: a configured 404 page serves where the empty static did (#159)" {
         .seed = 41,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{test_not_found_page},
+        .error_pages = &.{&test_not_found_page},
     });
     defer bed.tearDown();
 
@@ -2471,7 +2471,7 @@ test "l7: a keep-alive reject serves the page and keeps serving (#159)" {
         .seed = 42,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{test_not_found_page},
+        .error_pages = &.{&test_not_found_page},
     });
     defer bed.tearDown();
 
@@ -2500,7 +2500,7 @@ test "l7: a HEAD request gets a page's head and none of its body (#159)" {
         .seed = 43,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{test_not_found_page},
+        .error_pages = &.{&test_not_found_page},
     });
     defer bed.tearDown();
 
@@ -2542,7 +2542,7 @@ test "l7: a filter reject wears its configured page too (#159)" {
         .seed = 44,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .request_filters = &rules,
-        .error_pages = &.{page},
+        .error_pages = &.{&page},
     });
     defer bed.tearDown();
 
@@ -2551,6 +2551,56 @@ test "l7: a filter reject wears its configured page too (#159)" {
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(page.close, bed.client.response());
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+    try bed.expectDrained();
+}
+
+test "l7: a respond action answers from memory and never dials (#159)" {
+    const robots_body = "User-agent: *\n";
+    const robots_keep = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
+        "Content-Type: text/plain\r\n\r\n" ++ robots_body;
+    const robots_close = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
+        "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ robots_body;
+    const robots_page = config_module.Config.StaticPage{
+        .status = 200,
+        .keep = robots_keep,
+        .close = robots_close,
+        .keep_head_len = robots_keep.len - robots_body.len,
+        .close_head_len = robots_close.len - robots_body.len,
+    };
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/robots.txt" },
+        .actions = &.{.{ .respond = &robots_page }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 45,
+        // The origin listens and would answer, so a dial that happened
+        // would show up as this body instead of the configured one.
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .request_filters = &rules,
+    });
+    defer bed.tearDown();
+
+    // Two requests on one connection: the first is answered from the
+    // page and the connection keeps serving, the second proves the
+    // origin was reachable all along — so the first not reaching it was
+    // the verdict, not a broken upstream.
+    bed.client.second_request = "GET /api HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /robots.txt HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    var expected_buffer: [512]u8 = undefined;
+    const expected = std.fmt.bufPrint(
+        &expected_buffer,
+        "{s}HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
+        .{robots_keep},
+    ) catch unreachable;
+    try std.testing.expectEqualStrings(expected, bed.client.response());
+    // Answered as the origin, counted apart from refusals — and only
+    // the second request ever reached an upstream.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responded"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_filtered"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
     try bed.expectDrained();
 }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -534,6 +534,9 @@ const Http1Bed = struct {
         /// §8 per-endpoint concurrency cap; null leaves the cluster
         /// uncapped, which is what every pre-existing scenario wants.
         max_inflight: ?u32 = null,
+        /// The #159 pre-rendered error pages; empty for every
+        /// pre-existing scenario, so the comptime statics keep serving.
+        error_pages: []const config_module.Config.StaticPage = &.{},
         /// The one cluster's §7 pick policy; p2c, the config default,
         /// for every pre-existing scenario.
         pick: config_module.Config.Cluster.Pick = .p2c,
@@ -585,6 +588,7 @@ const Http1Bed = struct {
             .request_timeout_ms = options.request_timeout_ms,
             .access_log_sink = if (options.access_log) .stdout else null,
             .health_interval_ms = options.health_interval_ms,
+            .error_pages = options.error_pages,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -2420,6 +2424,133 @@ test "l7: a header-keyed cluster stamps nothing (#178)" {
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_followed"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_assigned"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_sticky_repicked"));
+    try bed.expectDrained();
+}
+
+/// A hand-rendered #159 page for the directed tests: exactly what the
+/// loader's `renderStaticPage` produces for a 5-byte text body, so the
+/// serve path's output can be pinned byte-for-byte here without a
+/// loader round trip.
+const test_page_body = "gone\n";
+const test_not_found_keep = "HTTP/1.1 404 Not Found\r\nContent-Length: 5\r\n" ++
+    "Content-Type: text/plain\r\n\r\n" ++ test_page_body;
+const test_not_found_close = "HTTP/1.1 404 Not Found\r\nContent-Length: 5\r\n" ++
+    "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ test_page_body;
+const test_not_found_page = config_module.Config.StaticPage{
+    .status = 404,
+    .keep = test_not_found_keep,
+    .close = test_not_found_close,
+    .keep_head_len = test_not_found_keep.len - test_page_body.len,
+    .close_head_len = test_not_found_close.len - test_page_body.len,
+};
+
+test "l7: a configured 404 page serves where the empty static did (#159)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 41,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .route_prefix = "/api",
+        .error_pages = &.{test_not_found_page},
+    });
+    defer bed.tearDown();
+
+    // No route for /nope: the 404 rides the ordinary keep rule — the
+    // head parsed cleanly and announced close, so the close variant
+    // answers, body and all, from immutable memory.
+    try bed.exchange("GET /nope HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(test_not_found_page.close, bed.client.response());
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
+    try bed.expectDrained();
+}
+
+test "l7: a keep-alive reject serves the page and keeps serving (#159)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 42,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .route_prefix = "/api",
+        .error_pages = &.{test_not_found_page},
+    });
+    defer bed.tearDown();
+
+    // First request misses the route and earns the keep-variant page;
+    // the connection stays synchronized, so the second — sent only after
+    // the first response completes, sequential keep-alive rather than
+    // pipelining — is served by the origin: the page rode the same
+    // keep-or-close rules the empty static keeps.
+    bed.client.second_request = "GET /api HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /nope HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    var expected_buffer: [512]u8 = undefined;
+    const expected = std.fmt.bufPrint(
+        &expected_buffer,
+        "{s}HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
+        .{test_not_found_page.keep},
+    ) catch unreachable;
+    try std.testing.expectEqualStrings(expected, bed.client.response());
+    try bed.expectDrained();
+}
+
+test "l7: a HEAD request gets a page's head and none of its body (#159)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 43,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .route_prefix = "/api",
+        .error_pages = &.{test_not_found_page},
+    });
+    defer bed.tearDown();
+
+    // RFC 9110's HEAD rule on the configured page: the framing headers
+    // say what a GET would have carried, and no body follows — the
+    // prefix slice of the same rendered buffer.
+    try bed.exchange("HEAD /nope HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        test_not_found_page.close[0..test_not_found_page.close_head_len],
+        bed.client.response(),
+    );
+    try bed.expectDrained();
+}
+
+test "l7: a filter reject wears its configured page too (#159)" {
+    // `respondFilter` routes through the same `respond`, so a 403 page
+    // fires for policy rejects without any per-feature wiring — the
+    // point of pages living behind the one static path.
+    const forbidden_body = "no\n";
+    const forbidden_keep = "HTTP/1.1 403 Forbidden\r\nContent-Length: 3\r\n" ++
+        "Content-Type: text/plain\r\n\r\n" ++ forbidden_body;
+    const forbidden_close = "HTTP/1.1 403 Forbidden\r\nContent-Length: 3\r\n" ++
+        "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ forbidden_body;
+    const page = config_module.Config.StaticPage{
+        .status = 403,
+        .keep = forbidden_keep,
+        .close = forbidden_close,
+        .keep_head_len = forbidden_keep.len - forbidden_body.len,
+        .close_head_len = forbidden_close.len - forbidden_body.len,
+    };
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/private" },
+        .actions = &.{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 44,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .request_filters = &rules,
+        .error_pages = &.{page},
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /private HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(page.close, bed.client.response());
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
     try bed.expectDrained();
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -210,9 +210,49 @@ fn readConfig(
         std.debug.print("zoxy: cannot read config '{s}': {t}\n", .{ config_path, err });
         return err;
     };
-    return zoxy.config.parse(arena, config_bytes) catch |err| {
+    // Body files (#159) are read through the loader's seam by the same
+    // startup-time reader the config file itself used — the one moment
+    // this process touches the filesystem for content (parse-once, §1).
+    var file_context: BodyFileContext = .{ .io = io };
+    return zoxy.config.parseWithFiles(arena, config_bytes, .{
+        .context = &file_context,
+        .read = readBodyFile,
+    }) catch |err| {
         std.debug.print("zoxy: invalid config '{s}': {t}\n", .{ config_path, err });
         return err;
+    };
+}
+
+const BodyFileContext = struct {
+    io: std.Io,
+};
+
+/// The loader's `FileSource.read` against the real filesystem: whole
+/// file into the arena, refused past `limit` — the loader turns that
+/// into the same verdict an oversized inline body earns.
+fn readBodyFile(
+    context: ?*anyopaque,
+    arena: std.mem.Allocator,
+    path: []const u8,
+    limit: u32,
+) error{ FileUnreadable, FileTooLarge, OutOfMemory }![]const u8 {
+    assert(path.len >= 1);
+    assert(limit >= 1);
+    const body_context: *BodyFileContext = @ptrCast(@alignCast(context.?));
+    return std.Io.Dir.cwd().readFileAlloc(
+        body_context.io,
+        path,
+        arena,
+        .limited(limit),
+    ) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        error.StreamTooLong => error.FileTooLarge,
+        else => blk: {
+            // Which file and why, here where both are known: the
+            // loader's error names the verdict, not the path.
+            std.debug.print("zoxy: cannot read body file '{s}': {t}\n", .{ path, err });
+            break :blk error.FileUnreadable;
+        },
     };
 }
 
@@ -402,7 +442,7 @@ fn printBudgets(
     std.debug.print(
         \\  fds     {d} required (asserted against RLIMIT_NOFILE)
         \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
-        \\  config  {d} listener(s), {d} cluster(s), access log {s}
+        \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}
         \\
     , .{
         fds_required,
@@ -411,6 +451,10 @@ fn printBudgets(
         in_flight,
         config.listeners.len,
         config.clusters.len,
+        // Their rendered bytes live in the config arena term above —
+        // read and pre-rendered at load (#159), so the measured number
+        // already covers them; this count is what says why it grew.
+        config.error_pages.len,
         if (config.access_log_sink) |sink| @tagName(sink) else "off",
     });
 }

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -38,11 +38,32 @@ pub fn staticResponse(comptime status: u16, comptime persistence: Persistence) [
     return bytes;
 }
 
-/// Reason phrases for the closed set of statuses the ladder (§8) and the
-/// L7 state machine (§7) send.
-fn reasonPhrase(comptime status: u16) []const u8 {
-    comptime assert(status >= 400);
-    comptime assert(status <= 599);
+/// The closed set of statuses the ladder (§8) and the L7 state machine
+/// (§7) send as static responses — the statuses `error_pages` may
+/// configure a body for (#159): a page for a status this proxy never
+/// sends is a config the operator misread, refused at load.
+pub const static_statuses = [_]u16{ 400, 403, 404, 414, 429, 431, 501, 502, 503, 504 };
+
+/// Whether `error_pages` may carry this status (#159) — membership in
+/// the closed set above, the loader's half of the contract
+/// `reasonPhrase` enforces at comptime for the built-in statics.
+pub fn isStaticStatus(status: u16) bool {
+    for (static_statuses) |candidate| {
+        assert(candidate >= 400); // The set is error statuses only.
+        assert(candidate <= 599);
+        if (status == candidate) return true;
+    }
+    return false;
+}
+
+/// Reason phrases for the closed static-status set. Callable at runtime
+/// (#159: a configured page's status is the config's, rendered at load)
+/// and in comptime context by `staticResponse`, where an unlisted
+/// status is still a compile error via the `unreachable`; at runtime
+/// the loader's `isStaticStatus` gate is what keeps it unreachable.
+pub fn reasonPhrase(status: u16) []const u8 {
+    assert(status >= 400);
+    assert(status <= 599);
     return switch (status) {
         400 => "Bad Request",
         403 => "Forbidden",
@@ -54,7 +75,7 @@ fn reasonPhrase(comptime status: u16) []const u8 {
         502 => "Bad Gateway",
         503 => "Service Unavailable",
         504 => "Gateway Timeout",
-        else => @compileError("unlisted static-response status"),
+        else => unreachable,
     };
 }
 
@@ -84,12 +105,25 @@ test "shed: static responses are exact bytes with close announced" {
     );
 }
 
+test "shed: the status set is one set, comptime and runtime" {
+    // `static_statuses` is what the loader accepts a page for and
+    // `staticResponse` compiles a default for; a member the phrase
+    // switch does not list would make one half of the contract silent.
+    for (static_statuses) |status| {
+        try std.testing.expect(isStaticStatus(status));
+        try std.testing.expect(reasonPhrase(status).len >= 1);
+    }
+    try std.testing.expect(!isStaticStatus(200));
+    try std.testing.expect(!isStaticStatus(301));
+    try std.testing.expect(!isStaticStatus(500));
+}
+
 test "shed: every static response parses as a valid bodiless head" {
     // Round-trip through zoxy's own parser: each response must be a
     // complete, correctly framed head whose persistence matches the
     // requested one — the same verdict a strict client would reach.
     const parser = @import("http/parser.zig");
-    inline for ([_]u16{ 400, 403, 404, 414, 429, 431, 501, 502, 503, 504 }) |status| {
+    inline for (static_statuses) |status| {
         inline for ([_]Persistence{ .keep, .close }) |persistence| {
             const bytes = staticResponse(status, persistence);
             var storage: parser.HeaderStorage = undefined;

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -44,6 +44,32 @@ pub fn staticResponse(comptime status: u16, comptime persistence: Persistence) [
 /// sends is a config the operator misread, refused at load.
 pub const static_statuses = [_]u16{ 400, 403, 404, 414, 429, 431, 501, 502, 503, 504 };
 
+/// Every status a configured page may carry (#159): the error set
+/// above, plus `200` — which no rung raises, but a `respond` filter
+/// action does, this proxy answering as the origin for a `robots.txt`
+/// or a health target. Closed and small on purpose: growing a closed
+/// vocabulary is cheap, shrinking a documented one is not.
+pub const page_statuses = [_]u16{200} ++ static_statuses;
+
+/// One pre-rendered page (#159): both persistence variants of a
+/// complete response — status line, framing, content type, body — each
+/// in one contiguous arena buffer, with the head's length recorded so a
+/// HEAD request sends the prefix of that same buffer. Rendered at load
+/// and immutable after, so serving one is the comptime-static path
+/// unchanged: one send, no assembly, no acquisition.
+///
+/// It lives here rather than in `config.zig` because both sides of the
+/// serving path need to name the type and neither may import the
+/// other: the config builds these, and `http/filter.zig` carries one
+/// per `respond` action.
+pub const StaticPage = struct {
+    status: u16,
+    keep: []const u8,
+    close: []const u8,
+    keep_head_len: u32,
+    close_head_len: u32,
+};
+
 /// Whether `error_pages` may carry this status (#159) — membership in
 /// the closed set above, the loader's half of the contract
 /// `reasonPhrase` enforces at comptime for the built-in statics.
@@ -56,15 +82,35 @@ pub fn isStaticStatus(status: u16) bool {
     return false;
 }
 
+/// Whether a configured page may carry this status (#159) —
+/// `isStaticStatus` widened by the statuses only a `respond` action
+/// reaches. The index into `page_statuses` doubles as a body's
+/// render-cache slot at load, which is why membership and position are
+/// one question, answered by `pageStatusIndex` below.
+pub fn isPageStatus(status: u16) bool {
+    return pageStatusIndex(status) != null;
+}
+
+/// Where `status` sits in `page_statuses`, or null when it is not one.
+pub fn pageStatusIndex(status: u16) ?u8 {
+    assert(page_statuses.len <= std.math.maxInt(u8));
+    for (page_statuses, 0..) |candidate, index| {
+        assert(candidate >= 100);
+        if (status == candidate) return @intCast(index);
+    }
+    return null;
+}
+
 /// Reason phrases for the closed static-status set. Callable at runtime
 /// (#159: a configured page's status is the config's, rendered at load)
 /// and in comptime context by `staticResponse`, where an unlisted
 /// status is still a compile error via the `unreachable`; at runtime
 /// the loader's `isStaticStatus` gate is what keeps it unreachable.
 pub fn reasonPhrase(status: u16) []const u8 {
-    assert(status >= 400);
+    assert(status >= 100);
     assert(status <= 599);
     return switch (status) {
+        200 => "OK",
         400 => "Bad Request",
         403 => "Forbidden",
         404 => "Not Found",
@@ -111,11 +157,26 @@ test "shed: the status set is one set, comptime and runtime" {
     // switch does not list would make one half of the contract silent.
     for (static_statuses) |status| {
         try std.testing.expect(isStaticStatus(status));
+        try std.testing.expect(isPageStatus(status)); // the wider set contains it
         try std.testing.expect(reasonPhrase(status).len >= 1);
     }
     try std.testing.expect(!isStaticStatus(200));
     try std.testing.expect(!isStaticStatus(301));
     try std.testing.expect(!isStaticStatus(500));
+
+    // 200 is the one status a page may carry that no rung raises: an
+    // `error_pages` entry for it is refused, a `respond` action's is
+    // exactly the point (#159).
+    try std.testing.expect(isPageStatus(200));
+    try std.testing.expectEqualStrings("OK", reasonPhrase(200));
+    try std.testing.expect(!isPageStatus(301));
+    try std.testing.expectEqual(@as(usize, static_statuses.len + 1), page_statuses.len);
+    // Position is identity for the load-time render cache: every page
+    // status must have one slot, and no two may share it.
+    for (page_statuses, 0..) |status, index| {
+        try std.testing.expectEqual(@as(?u8, @intCast(index)), pageStatusIndex(status));
+    }
+    try std.testing.expectEqual(@as(?u8, null), pageStatusIndex(301));
 }
 
 test "shed: every static response parses as a valid bodiless head" {


### PR DESCRIPTION
Closes #159.

Every status zoxy sends itself was `Content-Length: 0`. Now it can
carry a body — and the mechanism is deliberately generic rather than a
field bolted onto error pages.

**Bodies are a named table.** `bodies` maps a name to content — a
`file` read once at startup or an `inline` string, exactly one, plus
the `content_type` nothing infers — and every feature that serves
content references one *by name*: `error_pages` maps a status to a
body, and the new `respond` filter action answers with one. The
indirection is the design, the `clusters` idiom applied to the same
kind of thing: one body is one read, one charge against the cap, and
**one rendered buffer per (body, status)** however many places serve
it — a load-time render cache makes that literal, and a test pins the
pointer identity. A dangling name is a load error, never a silently
blank page. Every future source is a new arm in one object that no
consumer sees.

**Pages are rendered at load, served like the comptime statics.** Each
becomes both persistence variants of a complete response in one
contiguous arena buffer, with the head length recorded so a `HEAD`
request sends that same buffer's prefix. Serving one is therefore one
send from immutable memory with nothing acquired — which is the whole
reason the bytes live in memory rather than being spliced: an admitted
`503` is raised *because* a pool ran out, and an error page whose
delivery needed a pipe from another bounded pool would fail exactly
when it is needed. `body_bytes_max` caps a body and marks the scope
boundary; above it you want the page cache and a streaming path, which
is a different feature. Configuring a status is the whole opt-in,
sheds included.

**`respond` is the same machinery pointed elsewhere**: a
`robots.txt`, a maintenance window, a health target the balancer
serves itself. Terminal like reject and redirect, but not a body on
`reject` — refusing traffic and serving it are opposite facts, so it
keeps its own counter (`l7_responded`) and outcome (`responded`).
Response filters refuse the arm by name: those rules run when an origin
answer already exists, and replacing it is not an edit.

File reads go through a loader seam, so `parse` stays
filesystem-free for the fuzzer, the unit tests and the simulator; only
the binary's entry point wires the real reader.

Gates: the sweep configures a page for `403` and a `/respond` rule,
and one predicate in the client oracle demands the exact page body
while forbidding *both* response-side marks — the #175 stamp and the
#178 cookie — which is how it proves from outside that a static
bypasses the response render. `503` keeps no page on purpose, so the
opt-out is a property the sweep holds. The live gate covers what no
deterministic gate can: a real file, written to the work directory and
read by the shipped binary at startup, served beside an inline page
that a foreign Host earns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)