### PR TITLE
feat: access-log lines can carry headers the operator names (#140)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1345,6 +1345,52 @@ origin, not one this proxy can pick for them.
   reached the client" and is earned only when the last byte does. An exchange cut off mid-response logs its origin's status
   with outcome `aborted`; exactly one `ok` line per `zoxy_l7_responses`
   is what the §9 oracle asserts.
+  **A line can also carry headers the operator names** (#140, settled
+  2026-08-03), and that is what joins this log to the origin's. Nothing
+  here mints an identifier: zoxy is usually not the outermost hop, a
+  CDN or ingress in front almost always sets `X-Request-ID` or
+  `traceparent`, and that header passes through untouched and reaches
+  the backend — so logging it at both ends builds the join with nothing
+  added to the wire. Minting one is postponed rather than dropped, and
+  the reason it is a separate question is concrete: generating an ID
+  needs entropy, this proxy has no randomness source in production, and
+  obtaining one is a §4 seam decision with a §9 determinism constraint
+  attached. It is also the more general feature — `User-Agent`, a
+  tenant header, a CDN's ray ID, the origin's `X-Cache` — none of which
+  is a correlation ID.
+  `access_log.request_headers` and `response_headers` name them, absent
+  lists leaving the line byte-identical to what it was. The values are
+  **copied** at capture, not borrowed: the head buffer's zero-copy
+  slices do not survive the awaits before the line is written (§7
+  rotation), so they land in a per-connection table under
+  `access_log_header_bytes_max`, truncated with a trailing `...` on
+  `path`'s terms. That table is addressed by connection *slot*, so it
+  is cleared when a slot is acquired as well as on each keep-alive
+  turnaround — a head that never parses reaches no capture, and its
+  line would otherwise report the slot's previous occupant's header,
+  which is one client's correlation ID on another client's request.
+  Four decisions worth stating. The fields are **nested** objects, one
+  per direction: flattening would let a header called `status` shadow
+  the real one, and the nesting keeps "what the client sent" visibly
+  apart from "what zoxy observed". A configured header that did not
+  arrive is **omitted** rather than emitted as null, so the object says
+  what was there. Names are matched case-insensitively and logged
+  **lowercased**, one spelling a downstream query need not guess at.
+  And a repeated header logs its **first** value, because
+  `parser.headerValue`'s does — what the line reports is then the value
+  zoxy itself read, which is the property worth having when the two
+  disagree.
+  The structural consequence is that `access_log_line_bytes_max` stops
+  being a comptime sum over a fixed field set: the named headers are
+  the operator's list, so a line's maximum length is theirs too. It
+  becomes `accessLogLineBytes(count)` — with the compiled ceiling kept
+  for the budget asserts, the header-free bound kept as the staging
+  floor, and the loader refusing a staging buffer that could not hold
+  *this* config's line, since that drop would mean arithmetic rather
+  than backpressure. That move is #179's, already argued and already
+  landed: the metrics exposition's render buffer became a config-derived
+  banner term for exactly this reason when labels arrived, and the
+  capture table is priced in the banner the same way.
   **The unit is an admitted connection**, which is what draws the line
   between the two kinds of shed in the table above. A request-level shed
   — a `503` for relay buffers or upstream slots — belongs to a connection
@@ -1620,7 +1666,7 @@ src/
   shed.zig            // exhaustion ladder: decisions + static responses (incl. configured pages, #159)
   counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
   admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
-  access_log.zig      // JSON access log: double-buffered sink, drop rung (§8)
+  access_log.zig      // JSON access log: double-buffered sink, drop rung, named headers (§8)
 sim/                  // simulator harness + invariants
 smoke/                // the live gate (Tier 0.5): origin + client + verdicts, §9
 bench/                // micro benches (poop) + loopback harness (zrk), §9

--- a/docs/README.md
+++ b/docs/README.md
@@ -778,6 +778,46 @@ events. It reads `ok`, `rejected`, `shed`, `timed_out`, `upstream_failed`,
 Logging never blocks the event loop, so a sink that stalls costs dropped
 lines rather than latency; `zoxy_access_log_dropped` counts them exactly.
 
+#### Joining this log to your origin's
+
+By default a zoxy line and your backend's line for the same request share
+no key, so a slow request cannot be attributed to a hop. Naming headers
+fixes that without changing a byte on the wire:
+
+```json
+"access_log": {
+    "sink": "stdout",
+    "request_headers": ["X-Request-ID", "User-Agent"],
+    "response_headers": ["X-Cache"]
+}
+```
+
+```json
+{"...":"...","status":200,"upstream_reused":true,"upstream_replayed":false,"request_headers":{"x-request-id":"7f3c…","user-agent":"curl/8.6.0"},"response_headers":{"x-cache":"HIT"},"duration_us":1873}
+```
+
+zoxy does not mint an identifier. It usually is not your outermost hop —
+a CDN, cloud LB or ingress in front almost always sets `X-Request-ID` or
+`traceparent`, and that header reaches your origin untouched — so logging
+it at both ends is the whole join. The same mechanism is why the feature
+is not trace-specific: `User-Agent` for traffic analysis, a tenant header
+for multi-tenant routing, the origin's `X-Cache` on the way out.
+
+Names are matched case-insensitively and logged lowercased, so a query
+does not have to guess the spelling. A header that did not arrive is
+omitted rather than logged as null. A repeated header logs its first
+value — the one zoxy itself read. Values are truncated at 256 bytes with
+a trailing `...`, and up to 8 headers may be named across both lists;
+`response_headers` is ignored for L4 lines, which have no response to
+read. Absent lists leave the line exactly as it was.
+
+The values are held per connection for the life of a request, so naming
+headers costs memory proportional to `conn_slots` — the startup banner
+prints it beside everything else. Naming a lot of headers on a large
+`conn_slots` is real memory, and a wider line also needs a staging
+buffer that can hold one: zoxy refuses to start rather than dropping
+every line that carries them.
+
 `sink` is either `stdout` — the process's own standard output, inherited
 rather than opened, so it costs no file descriptor and carries no rotation
 story of its own — or `file` with a `path`:

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -501,6 +501,14 @@ fn deriveServerConfig(
         // schedule fuzz; the fourth leaves it off, which is the shape
         // that must reserve nothing and read no clock (§5, §8).
         .access_log_sink = if (random.uintLessThan(u8, 4) == 0) null else .stdout,
+        // #140, on every seed: two scripts send the request header and
+        // the sized origin answers with the response one, so both
+        // captures run under the whole schedule fuzz. What the sweep
+        // proves is shape and value — the objects on exactly the http
+        // lines, and never a value the scripts did not send; staleness
+        // needs distinguishable values and is the directed tests'.
+        .access_log_request_headers = &log_request_headers,
+        .access_log_response_headers = &log_response_headers,
         .health_interval_ms = health_interval_ms,
         // #159: a page for `403` on every seed — the one status a
         // script earns from a filter reject — so the configured-page
@@ -717,6 +725,12 @@ const error_page: zoxy.config.Config.StaticPage = renderSimPage(403, l7.canon.er
 const respond_page: zoxy.config.Config.StaticPage = renderSimPage(200, l7.canon.respond_body);
 const error_pages = [_]*const zoxy.config.Config.StaticPage{&error_page};
 
+/// The #140 names every seed's config logs, already lowercased the way
+/// the loader would leave them (the simulator builds its `Config` by
+/// hand, so it owes that spelling itself).
+const log_request_headers = [_][]const u8{l7.canon.log_request_header};
+const log_response_headers = [_][]const u8{l7.canon.log_response_header};
+
 fn renderSimPage(comptime status: u16, comptime body: []const u8) zoxy.config.Config.StaticPage {
     // The loader's own preconditions, restated where the loader is
     // being stood in for: a status a page may carry, and a body the
@@ -812,26 +826,45 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
     };
 }
 
+/// The staging size this seed runs with (§8, §9). Adversarial seeds sit
+/// at the floor — one worst-case line each — so the buffer swap runs
+/// constantly and every line meets a nearly-full buffer, against the
+/// default's hundred-line headroom where the swap fires once a
+/// scenario. The *drop* rung itself stays out of reach here: a scenario
+/// emits a handful of lines and filling even the floor takes dozens, so
+/// it is pinned by a directed test (`access_log_test.zig`) rather than
+/// left to a seed that cannot generate the volume.
+///
+/// The floor is one line of *this* config, not the static minimum:
+/// #140's named headers widen a line, and the loader holds a real
+/// config to the wider bound — a hand-built one owes itself the same,
+/// or the drop rung would fire on arithmetic rather than on the
+/// backpressure it is there to force.
+fn deriveAccessLogBuffer(harness: *const Harness) u32 {
+    if (harness.config.access_log_sink == null) {
+        return 0;
+    }
+    if (harness.clean) {
+        return zoxy.constants.access_log_buffer_bytes_default;
+    }
+    const floor = @max(
+        zoxy.constants.access_log_buffer_bytes_min,
+        zoxy.constants.accessLogLineBytes(
+            log_request_headers.len + log_response_headers.len,
+        ),
+    );
+    assert(floor >= zoxy.constants.access_log_buffer_bytes_min);
+    assert(floor <= zoxy.constants.access_log_buffer_bytes_max);
+    return floor;
+}
+
 fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: std.Random) !void {
     // A quarter of adversarial seeds shrink the pools to force the
     // §8 rungs; clean seeds keep ample pools so golden outcomes
     // never meet a shed. Decided in `setUp` (see `force_exhaustion`)
     // because the ring size had to precede `io.init`.
     const force_exhaustion = harness.force_exhaustion;
-    // Adversarial seeds size the staging buffers at the floor — one
-    // worst-case line each — so the buffer swap runs constantly and every
-    // line meets a nearly-full buffer, against the default's hundred-line
-    // headroom where the swap fires once a scenario. The *drop* rung
-    // itself stays out of reach here: a scenario emits a handful of lines
-    // and filling even the floor takes dozens, so it is pinned by a
-    // directed test (`access_log_test.zig`) rather than left to a seed
-    // that cannot generate the volume.
-    const access_log_buffer_bytes: u32 = if (harness.config.access_log_sink == null)
-        0
-    else if (harness.clean)
-        zoxy.constants.access_log_buffer_bytes_default
-    else
-        zoxy.constants.access_log_buffer_bytes_min;
+    const access_log_buffer_bytes = harness.deriveAccessLogBuffer();
     const options: ServerSim.InitOptions = if (force_exhaustion)
         .{
             // head_buffers ≤ conn_slots is a Server.init precondition, so
@@ -1337,6 +1370,52 @@ fn verifyAccessLogLine(line: []const u8) !void {
     const is_http = std.mem.indexOf(u8, line, "\"kind\":\"http\"") != null;
     const has_status = std.mem.indexOf(u8, line, "\"status\":") != null;
     if (is_http != has_status) return error.AccessLogLineWrongShape;
+    try verifyLoggedHeaders(line, is_http);
+}
+
+/// The #140 objects (§9). Every seed names one header each way, so an
+/// http line must carry both objects and an l4 line neither — a
+/// connection has no head to have read one from. Within them, the only
+/// value that may ever appear is the one the scripts and the origin
+/// send: a capture that truncated or corrupted fails here under every
+/// schedule. A capture that went *stale* does not, since every sender
+/// shares one value — the directed tests own that one.
+fn verifyLoggedHeaders(line: []const u8, is_http: bool) !void {
+    const request_key = "\"request_headers\":";
+    const response_key = "\"response_headers\":";
+    const has_request = std.mem.indexOf(u8, line, request_key) != null;
+    const has_response = std.mem.indexOf(u8, line, response_key) != null;
+    if (has_request != is_http) return error.AccessLogHeadersWrongShape;
+    if (has_response != is_http) return error.AccessLogHeadersWrongShape;
+    if (!is_http) return;
+    try verifyLoggedValue(line, l7.canon.log_request_header, l7.canon.log_request_value);
+    try verifyLoggedValue(line, l7.canon.log_response_header, l7.canon.log_response_value);
+}
+
+/// One logged name carries the canonical value or does not appear.
+fn verifyLoggedValue(line: []const u8, name: []const u8, value: []const u8) !void {
+    assert(name.len >= 1);
+    assert(name.len <= zoxy.constants.access_log_header_name_bytes_max);
+    assert(value.len >= 1);
+    assert(value.len <= zoxy.constants.access_log_header_bytes_max);
+    // Sized from the caps the loader enforces, so this helper stays
+    // sound for any name and value a config could legally hold — the
+    // `catch unreachable`s below are what rest on that.
+    var needle_buffer: [zoxy.constants.access_log_header_name_bytes_max + 4]u8 = undefined;
+    const needle = std.fmt.bufPrint(&needle_buffer, "\"{s}\":", .{name}) catch unreachable;
+    const at = std.mem.indexOf(u8, line, needle) orelse return;
+    var expected_buffer: [
+        zoxy.constants.access_log_header_name_bytes_max +
+            zoxy.constants.access_log_header_bytes_max + 8
+    ]u8 = undefined;
+    const expected = std.fmt.bufPrint(
+        &expected_buffer,
+        "\"{s}\":\"{s}\"",
+        .{ name, value },
+    ) catch unreachable;
+    if (!std.mem.startsWith(u8, line[at..], expected)) {
+        return error.AccessLogHeaderValueWrong;
+    }
 }
 
 /// Both clients' ended hook: type-erased because the client files cannot

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -8,8 +8,20 @@ const std = @import("std");
 
 const assert = std.debug.assert;
 
+/// The #140 logged headers: a request header two scripts send and a
+/// response header the sized origin answers with, plus the one value
+/// each may ever carry. The access-log verifier demands that any value
+/// appearing under either name is exactly this one — a truncated,
+/// corrupted, or stale-from-another-request capture is then a failure
+/// under every schedule the adversary produces.
+pub const log_request_header = "x-sim-trace";
+pub const log_request_value = "sim-trace-1";
+pub const log_response_header = "x-sim-origin";
+pub const log_response_value = "sized";
+
 pub const sized_body = "canonical-sized-response-body-00";
-pub const sized_head = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n\r\n";
+pub const sized_head = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n" ++
+    log_response_header ++ ": " ++ log_response_value ++ "\r\n\r\n";
 pub const sized_response = sized_head ++ sized_body;
 pub const chunked_wire = "10\r\nchunked-body-16b\r\n0\r\n\r\n";
 pub const chunked_head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -147,7 +147,17 @@ pub const Spec = struct {
 };
 
 const post_body = "request-body-24-bytes-ab";
-pub const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n\r\n";
+/// The #140 trace header, on the two scripts that carry one: enough for
+/// the access-log verifier to see captured values under every schedule
+/// the adversary produces. The scripts that omit it are not an
+/// absent-case oracle — one canonical value is shared by every sender,
+/// so a stale capture bleeding it into a line that should carry none is
+/// indistinguishable from a fresh one here. That regression is the
+/// directed tests' (`http_proxy_test.zig` chains two connections
+/// through one pool slot); what the sweep adds is that no *other* value
+/// can ever appear.
+const trace_line = canon.log_request_header ++ ": " ++ canon.log_request_value ++ "\r\n";
+pub const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++ "\r\n";
 /// Deterministic 6000-byte body for `post_big`, cycled so the
 /// origin-side §7 oracle can spot any reordering.
 const big_body = blk: {
@@ -234,7 +244,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .allowed_statuses = statuses_routed,
     },
     .post_sized = .{
-        .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+        .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++
             "Content-Length: 24\r\n\r\n" ++ post_body,
         .expected_responses = 1,
         .transcript_cap = 1,

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -46,6 +46,13 @@ pub const Response = struct {
     sticky_tag: ?[16]u8,
 };
 
+/// The #140 correlation header every request carries, and the one value
+/// it ever holds — spelled here rather than imported, like the counter
+/// names: the gate reads what the binary *wrote*, so a drift must fail
+/// loudly rather than agree with itself.
+pub const request_id_header = "X-Request-ID";
+pub const request_id_value = "smoke-req-1";
+
 /// What a request says about its connection's future. HTTP/1.1's default
 /// is keep-alive, so that arm sends nothing; the other says so.
 pub const Persistence = enum {
@@ -121,15 +128,21 @@ pub const Client = struct {
         assert(client.connected);
         assert(target.len >= 1);
         assert(target[0] == '/');
+        // The #140 request header rides every request: the gate names it
+        // in the config and then finds this exact value in the written
+        // log, which is the join an operator would make between this log
+        // and the origin's.
         if (cookie) |crumb| {
             assert(crumb.len >= 1);
             try client.writer.interface.print(
-                "GET {s} HTTP/1.1\r\nHost: {s}\r\nCookie: {s}\r\n{s}\r\n",
+                "GET {s} HTTP/1.1\r\nHost: {s}\r\nCookie: {s}\r\n" ++
+                    request_id_header ++ ": " ++ request_id_value ++ "\r\n{s}\r\n",
                 .{ target, host, crumb, persistence.header() },
             );
         } else {
             try client.writer.interface.print(
-                "GET {s} HTTP/1.1\r\nHost: {s}\r\n{s}\r\n",
+                "GET {s} HTTP/1.1\r\nHost: {s}\r\n" ++
+                    request_id_header ++ ": " ++ request_id_value ++ "\r\n{s}\r\n",
                 .{ target, host, persistence.header() },
             );
         }

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -54,6 +54,29 @@ const robots_path = work_directory ++ "/robots.txt";
 const robots_body = "User-agent: *\nDisallow: /private\n";
 const not_found_body = "no such route";
 
+/// The #140 fields as they must appear in a written line: the client's
+/// header lowercased under `request_headers`, the origin's under
+/// `response_headers`. Built from the same constants the two ends send,
+/// so a rename cannot leave this gate agreeing with itself.
+const logged_request_id = "\"request_headers\":{\"" ++
+    lowerAscii(client_module.request_id_header) ++ "\":\"" ++
+    client_module.request_id_value ++ "\"}";
+const logged_origin_tag = "\"response_headers\":{\"" ++
+    lowerAscii(origin_module.tag_header) ++ "\":\"" ++
+    origin_module.tag_value ++ "\"}";
+
+/// Lowercase a comptime header name — the spelling zoxy logs a named
+/// header under, whatever the config wrote.
+fn lowerAscii(comptime name: []const u8) *const [name.len]u8 {
+    comptime {
+        assert(name.len >= 1);
+        var lowered: [name.len]u8 = undefined;
+        for (name, &lowered) |byte, *slot| slot.* = std.ascii.toLower(byte);
+        const frozen = lowered;
+        return &frozen;
+    }
+}
+
 /// The Host a request must carry to match the main route, and one that
 /// deliberately does not — the run's only way to reach a `404`, since
 /// every other request is routed by design.
@@ -423,6 +446,9 @@ const LogCounts = struct {
     /// counted apart rather than weakening the ok-equality.
     http_rejected: u32 = 0,
     http_responded: u32 = 0,
+    /// The #140 headers as the log actually spelled them.
+    http_with_request_id: u32 = 0,
+    http_with_origin_tag: u32 = 0,
 };
 
 /// The access-log verdict, printed so a red run explains itself without a
@@ -468,6 +494,29 @@ fn accessLogPassed(lines: *const LogCounts) bool {
         std.debug.print(
             "FAIL: {d} rejected and {d} responded lines, not 1 each (#159)\n",
             .{ lines.http_rejected, lines.http_responded },
+        );
+        passed = false;
+    }
+    // Every http request this gate sends carries the correlation
+    // header, so every http line must report it — including the two
+    // the proxy answered itself, which is exactly when a join matters.
+    if (lines.http_with_request_id != lines.http) {
+        std.debug.print(
+            "FAIL: {d} of {d} http lines carried the logged X-Request-ID (#140)\n",
+            .{ lines.http_with_request_id, lines.http },
+        );
+        passed = false;
+    }
+    // The origin's tag rides only the lines whose exchange reached it —
+    // never the page or the respond answer, which no origin served.
+    // Asserted rather than assumed: a near-empty log would otherwise
+    // underflow this subtraction into a panic, where the whole point of
+    // this function is to print a verdict.
+    assert(lines.http >= body_exchanges);
+    if (lines.http_with_origin_tag != lines.http - body_exchanges) {
+        std.debug.print(
+            "FAIL: {d} of {d} origin-served lines carried the logged X-Origin-Tag (#140)\n",
+            .{ lines.http_with_origin_tag, lines.http - body_exchanges },
         );
         passed = false;
     }
@@ -1160,6 +1209,18 @@ fn readAccessLog(arena: std.mem.Allocator, io: Io) !LogCounts {
             if (std.mem.indexOf(u8, line, "\"outcome\":\"responded\"") != null) {
                 counts.http_responded += 1;
             }
+            // The #140 join, on the real wire: every http line must
+            // carry the client's correlation header, and every line
+            // whose exchange reached the origin must carry the origin's
+            // tag. Spelled out rather than counted loosely — a value
+            // that truncated or came from another request is the one
+            // failure a correlation field must never have.
+            if (std.mem.indexOf(u8, line, logged_request_id) != null) {
+                counts.http_with_request_id += 1;
+            }
+            if (std.mem.indexOf(u8, line, logged_origin_tag) != null) {
+                counts.http_with_origin_tag += 1;
+            }
         } else {
             if (std.mem.indexOf(u8, line, "\"kind\":\"l4\"") != null) {
                 counts.l4 += 1;
@@ -1238,7 +1299,8 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\    }},
         \\    "error_pages": {{ "404": "gone" }},
         \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
-        \\    "access_log": {{ "sink": "file", "path": "{s}" }},
+        \\    "access_log": {{ "sink": "file", "path": "{s}",
+        \\        "request_headers": ["X-Request-ID"], "response_headers": ["X-Origin-Tag"] }},
         \\    "timeouts": {{
         \\        "connect_ms": 2000,
         \\        "idle_ms": 30000,

--- a/smoke/origin.zig
+++ b/smoke/origin.zig
@@ -78,10 +78,18 @@ const large_body: [large_body_bytes]u8 = blk: {
     break :blk bytes;
 };
 
+/// The header this origin tags every response with, so the live gate
+/// can name it in `access_log.response_headers` and then find its value
+/// in the written log (#140) — the response half of the join, from an
+/// origin that is not the proxy.
+pub const tag_header = "X-Origin-Tag";
+pub const tag_value = "smoke-origin";
+
 fn renderResponse(comptime payload: []const u8) []const u8 {
     return "HTTP/1.1 200 OK\r\n" ++
         std.fmt.comptimePrint("Content-Length: {d}\r\n", .{payload.len}) ++
         "Content-Type: application/octet-stream\r\n" ++
+        tag_header ++ ": " ++ tag_value ++ "\r\n" ++
         "\r\n" ++
         payload;
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -22,6 +22,7 @@ const conn_module = @import("net/Conn.zig");
 const health_module = @import("net/health.zig");
 const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
+const parser = @import("http/parser.zig");
 const proxy = @import("http/proxy.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
@@ -124,6 +125,25 @@ pub fn Server(comptime IoType: type) type {
         /// Empty on an L4-only config, which never canonicalizes.
         target_scratch: []u8,
         rewrite_scratch: []u8,
+        /// The #140 capture table: one value slot per connection slot per
+        /// named header, and the length of each. A logged value is copied
+        /// out of the head buffer while it is still live (the response
+        /// render writes over it, §7 rotation) and read back when the
+        /// line is written, so it needs storage that survives the awaits
+        /// between — per connection, because that is the unit an
+        /// in-flight request belongs to.
+        ///
+        /// A side table rather than fields on `Conn`, and the reason is
+        /// the #179 precedent: sized by the config, so a deployment that
+        /// names no headers allocates nothing and every `Conn` stays the
+        /// width it was. Addressed by `conns.indexOf`, which is stable
+        /// across reuse.
+        log_header_values: []u8,
+        log_header_lens: []u16,
+        /// Named headers per connection — the config's two lists summed,
+        /// zero when it named none. Stored because every index into the
+        /// tables above is a multiple of it.
+        log_headers_per_conn: u32,
         /// Highest armed-op count any one connection has reached (§8):
         /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
         /// under runtime safety only (never in the shipped ReleaseFast
@@ -368,6 +388,31 @@ pub fn Server(comptime IoType: type) type {
             server.rewrite_scratch = try arena.alloc(u8, scratch_bytes);
             assert(server.target_scratch.len + server.rewrite_scratch.len +
                 options.head_buffer_bytes == headScratchBytes(options.*));
+            try server.initLogHeaders(arena, options);
+        }
+
+        /// The #140 capture table, sized by the config's named headers
+        /// times the connection slots that can each hold one request's
+        /// worth. Both allocations are empty when no header is named,
+        /// which is what makes the feature free to a deployment that
+        /// does not use it.
+        fn initLogHeaders(
+            server: *Self,
+            arena: std.mem.Allocator,
+            options: *const InitOptions,
+        ) error{OutOfMemory}!void {
+            const per_conn = logHeadersPerConn(server.config);
+            server.log_headers_per_conn = per_conn;
+            const slots: usize = @as(usize, options.conn_slots) * per_conn;
+            server.log_header_values = try arena.alloc(
+                u8,
+                slots * constants.access_log_header_bytes_max,
+            );
+            server.log_header_lens = try arena.alloc(u16, slots);
+            @memset(server.log_header_lens, 0);
+            assert(server.log_header_values.len ==
+                logHeaderBytes(server.config, options.conn_slots) -
+                    server.log_header_lens.len * @sizeOf(u16));
         }
 
         /// The metrics state (§8, #179): the process totals, the labeled
@@ -918,6 +963,13 @@ pub fn Server(comptime IoType: type) type {
             conn.request_filters = listener.request_filters;
             conn.response_filters = listener.response_filters;
             conn.forwarded = listener.forwarded;
+            // The #140 captures live in a side table addressed by pool
+            // slot, so a slot's bytes outlive the connection that wrote
+            // them. Clearing on acquire is what keeps them from being
+            // read as this client's: a head that never parses reaches no
+            // capture at all, and its line would otherwise report
+            // whatever the slot's *previous* occupant sent.
+            server.resetLogHeaders(conn);
             assert(conn.routes.len >= 1);
             server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));
             server.armDeadline(conn);
@@ -974,6 +1026,185 @@ pub fn Server(comptime IoType: type) type {
         pub fn headScratchBytes(options: InitOptions) u64 {
             const serving: u64 = if (options.head_buffers >= 1) 2 else 0;
             return (serving + 1) * options.head_buffer_bytes;
+        }
+
+        /// Named headers one connection can be holding values for (#140):
+        /// both configured lists, since a single exchange captures from
+        /// the request on the way in and the response on the way out.
+        pub fn logHeadersPerConn(config: *const config_module.Config) u32 {
+            const total = config.access_log_request_headers.len +
+                config.access_log_response_headers.len;
+            // The loader's shared cap, restated where every table sized
+            // by it is about to be allocated (§9: a hand-built config —
+            // a test, the simulator — never reaches the loader).
+            assert(total <= constants.access_log_headers_max);
+            return @intCast(total);
+        }
+
+        /// The #140 capture table's closed form — values plus their
+        /// lengths — for the banner and for `initLogHeaders` to assert
+        /// against. Zero for a config that names no headers.
+        pub fn logHeaderBytes(config: *const config_module.Config, conn_slots: u32) u64 {
+            const slots: u64 = @as(u64, conn_slots) * logHeadersPerConn(config);
+            return slots * constants.access_log_header_bytes_max + slots * @sizeOf(u16);
+        }
+
+        /// One connection's slice of the capture table: `per_conn` value
+        /// slots, addressed by the pool index — stable across reuse, and
+        /// the same index for the whole life of the connection holding
+        /// it. Split from the capture and the read so both speak one
+        /// piece of arithmetic.
+        fn logHeaderSlot(server: *Self, conn: *const ConnType, index: u32) []u8 {
+            assert(index < server.log_headers_per_conn);
+            const conn_index = server.conns.indexOf(conn);
+            const slot = conn_index * server.log_headers_per_conn + index;
+            assert(slot < server.log_header_lens.len);
+            const bytes = constants.access_log_header_bytes_max;
+            return server.log_header_values[slot * bytes ..][0..bytes];
+        }
+
+        fn logHeaderLen(server: *Self, conn: *const ConnType, index: u32) *u16 {
+            assert(index < server.log_headers_per_conn);
+            const conn_index = server.conns.indexOf(conn);
+            const slot = conn_index * server.log_headers_per_conn + index;
+            assert(slot < server.log_header_lens.len);
+            return &server.log_header_lens[slot];
+        }
+
+        /// Capture one direction's named headers out of a parsed head
+        /// (#140), while its zero-copy slices are still live. Values are
+        /// truncated to `access_log_header_bytes_max` on the same terms
+        /// as `path` — the prefix is what identifies a value — and an
+        /// absent header records nothing, which the render reads as
+        /// "omit this key".
+        ///
+        /// First occurrence wins, because `parser.headerValue`'s does:
+        /// what the line reports is then the same value zoxy itself read,
+        /// which is the property that makes a logged header worth
+        /// anything when the two disagree.
+        fn captureLogHeaders(
+            server: *Self,
+            conn: *ConnType,
+            headers: []const parser.Header,
+            names: []const []const u8,
+            first_index: u32,
+        ) void {
+            assert(first_index + names.len <= server.log_headers_per_conn);
+            for (names, 0..) |name, offset| {
+                const index = first_index + @as(u32, @intCast(offset));
+                const slot = server.logHeaderSlot(conn, index);
+                const value = parser.headerValue(headers, name) orelse {
+                    server.logHeaderLen(conn, index).* = 0;
+                    continue;
+                };
+                const captured = access_log_module.captureTruncated(slot, value);
+                server.logHeaderLen(conn, index).* = @intCast(captured.len);
+            }
+        }
+
+        /// One direction's captured values, paired with the names they
+        /// were captured for — what a `Record` carries. The values alias
+        /// the capture table, which the caller reads out before the next
+        /// request touches it (the `Record` contract).
+        fn loggedHeaders(
+            server: *Self,
+            conn: *const ConnType,
+            names: []const []const u8,
+            first_index: u32,
+            out: *[constants.access_log_headers_max][]const u8,
+        ) access_log_module.NamedHeaders {
+            assert(first_index + names.len <= server.log_headers_per_conn);
+            for (names, 0..) |_, offset| {
+                const index = first_index + @as(u32, @intCast(offset));
+                const len = server.logHeaderLen(conn, index).*;
+                assert(len <= constants.access_log_header_bytes_max);
+                out[offset] = server.logHeaderSlot(conn, index)[0..len];
+            }
+            return .{ .names = names, .values = out[0..names.len] };
+        }
+
+        /// The #140 request capture, called where the parsed head is
+        /// still live (§7 rotation writes over it). A no-op for a config
+        /// that names none, which is every config that did not ask.
+        pub fn captureRequestLogHeaders(
+            server: *Self,
+            conn: *ConnType,
+            headers: []const parser.Header,
+        ) void {
+            assert(conn.protocol == .http); // Only a parsed head has headers.
+            assert(headers.len <= constants.headers_max);
+            if (server.config.access_log_request_headers.len == 0) return;
+            server.captureLogHeaders(
+                conn,
+                headers,
+                server.config.access_log_request_headers,
+                0,
+            );
+        }
+
+        /// The response half, from the origin's parsed head — same
+        /// liveness rule, one direction over.
+        pub fn captureResponseLogHeaders(
+            server: *Self,
+            conn: *ConnType,
+            headers: []const parser.Header,
+        ) void {
+            assert(conn.protocol == .http); // An l4 relay parses no response.
+            assert(headers.len <= constants.headers_max);
+            if (server.config.access_log_response_headers.len == 0) return;
+            server.captureLogHeaders(
+                conn,
+                headers,
+                server.config.access_log_response_headers,
+                @intCast(server.config.access_log_request_headers.len),
+            );
+        }
+
+        /// A line's worth of #140 value slices, one array per direction
+        /// — the storage `loggedHeaderPair` fills and the `Record`
+        /// borrows for exactly as long as the render runs.
+        const LoggedHeaderValues = struct {
+            request: [constants.access_log_headers_max][]const u8,
+            response: [constants.access_log_headers_max][]const u8,
+        };
+
+        /// Both directions' logged headers for one line. L4 lines carry
+        /// none: they have no head to have read one from, and the
+        /// config's lists say nothing about relayed bytes.
+        fn loggedHeaderPair(
+            server: *Self,
+            conn: *const ConnType,
+            values: *LoggedHeaderValues,
+        ) struct {
+            request: access_log_module.NamedHeaders,
+            response: access_log_module.NamedHeaders,
+        } {
+            if (conn.protocol != .http) {
+                return .{ .request = .{}, .response = .{} };
+            }
+            const request_names = server.config.access_log_request_headers;
+            return .{
+                .request = server.loggedHeaders(conn, request_names, 0, &values.request),
+                .response = server.loggedHeaders(
+                    conn,
+                    server.config.access_log_response_headers,
+                    @intCast(request_names.len),
+                    &values.response,
+                ),
+            };
+        }
+
+        /// Forget this connection's captured values, so a kept-alive
+        /// turnaround cannot report the previous request's headers on
+        /// the next one's line — `LogState.reset`'s rule for the fields
+        /// that live in the side table instead of on the conn.
+        pub fn resetLogHeaders(server: *Self, conn: *const ConnType) void {
+            assert(server.log_header_lens.len ==
+                @as(usize, server.conns.capacity()) * server.log_headers_per_conn);
+            var index: u32 = 0;
+            while (index < server.log_headers_per_conn) : (index += 1) {
+                server.logHeaderLen(conn, index).* = 0;
+            }
         }
 
         /// The same pair for conn slots, with `admitConn` as its acquire
@@ -1378,6 +1609,8 @@ pub fn Server(comptime IoType: type) type {
             if (conn.log.endpoint_index != conn_module.LogState.endpoint_none) {
                 assert(conn.log.endpoint_index < cluster.endpoints.len);
             }
+            var values: LoggedHeaderValues = undefined;
+            const logged = server.loggedHeaderPair(conn, &values);
             const entry: access_log_module.Record = .{
                 .kind = switch (conn.protocol) {
                     .l4 => .l4,
@@ -1403,6 +1636,8 @@ pub fn Server(comptime IoType: type) type {
                 .status = conn.log.status,
                 .upstream_reused = conn.l7.upstream_was_reused,
                 .upstream_replayed = conn.l7.replay_used,
+                .request_headers = logged.request,
+                .response_headers = logged.response,
             };
             // A duration is never negative once saturated, and a line
             // always names a start: both are what `renderLine` prints

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -134,6 +134,32 @@ pub const Record = struct {
     /// first.
     upstream_reused: bool = false,
     upstream_replayed: bool = false,
+    /// The operator-named headers this line reports (#140), paired with
+    /// the values captured for them — the request's on the way in, the
+    /// response's on the way out. Empty on an L4 line and on any config
+    /// that names none, which is what keeps the line byte-identical to
+    /// what it was for a deployment that did not ask.
+    request_headers: NamedHeaders = .{},
+    response_headers: NamedHeaders = .{},
+};
+
+/// One direction's logged headers: the configured names and the values
+/// captured for them, parallel and equal-length. A value is empty when
+/// the request or response carried no such header, and the render omits
+/// those keys rather than emitting nulls — a line says what was there.
+///
+/// The two slices come from different places on purpose: the names are
+/// the config's arena and live forever, the values are the connection's
+/// capture table and live until the next request. Pairing them here
+/// keeps the render from having to know either.
+pub const NamedHeaders = struct {
+    names: []const []const u8 = &.{},
+    values: []const []const u8 = &.{},
+
+    pub fn len(headers: NamedHeaders) usize {
+        assert(headers.names.len == headers.values.len);
+        return headers.names.len;
+    }
 };
 
 /// Render `record` as one JSON object plus its newline into `buffer`,
@@ -217,6 +243,51 @@ fn renderHttpFields(record: *const Record, writer: *std.Io.Writer) std.Io.Writer
         record.upstream_reused,
         record.upstream_replayed,
     });
+    try writeNamedHeaders(writer, "request_headers", &record.request_headers);
+    try writeNamedHeaders(writer, "response_headers", &record.response_headers);
+}
+
+/// One direction's #140 headers as a nested object, omitted entirely
+/// when the config named none. Nested rather than flattened so a header
+/// called `status` cannot shadow the real field — and so "what the
+/// client sent" stays visibly apart from "what zoxy observed".
+///
+/// A configured-but-absent header is omitted rather than emitted as
+/// null: the object then says what arrived, and a consumer asking
+/// whether a header was present gets the same answer from the line as
+/// from the wire. Values ride the same escaper `path` and `host` use —
+/// these are client-controlled bytes, and the log is often the one
+/// component parsing untrusted text.
+fn writeNamedHeaders(
+    writer: *std.Io.Writer,
+    key: []const u8,
+    headers: *const NamedHeaders,
+) std.Io.Writer.Error!void {
+    assert(key.len >= 1);
+    if (headers.len() == 0) {
+        return;
+    }
+    assert(headers.len() <= constants.access_log_headers_max);
+    try writer.print(",\"{s}\":{{", .{key});
+    var written: u32 = 0;
+    for (headers.names, headers.values) |name, value| {
+        // Both bounds are load-bearing for `accessLogLineBytes`, so both
+        // are stated where the bytes are actually written.
+        assert(name.len >= 1);
+        assert(name.len <= constants.access_log_header_name_bytes_max);
+        assert(value.len <= constants.access_log_header_bytes_max);
+        if (value.len == 0) {
+            continue;
+        }
+        if (written >= 1) {
+            try writer.writeAll(",");
+        }
+        try std.json.Stringify.encodeJsonString(name, .{}, writer);
+        try writer.writeAll(":");
+        try std.json.Stringify.encodeJsonString(value, .{}, writer);
+        written += 1;
+    }
+    try writer.writeAll("}");
 }
 
 /// RFC 3339 UTC to the millisecond, the spelling every log pipeline reads
@@ -375,7 +446,15 @@ pub fn AccessLog(comptime IoType: type) type {
                 log.server.counters.increment("access_log_dropped");
                 return;
             };
-            assert(line.len <= constants.access_log_line_bytes_max);
+            // The config's own bound, not the compiled ceiling (#140):
+            // the loader sized this buffer to hold one line of exactly
+            // this shape, so a line past it would mean the two
+            // arithmetics disagree — the drop below would then be
+            // arithmetic wearing backpressure's name.
+            assert(line.len <= constants.accessLogLineBytes(
+                @intCast(log.server.config.access_log_request_headers.len +
+                    log.server.config.access_log_response_headers.len),
+            ));
             log.staging_len += @intCast(line.len);
             assert(log.staging_len <= buffer.len);
             log.server.counters.increment("access_log_lines");
@@ -569,6 +648,124 @@ test "access log: an L4 line omits the request fields and names no status" {
     // `kind` must not find a `status` on an L4 line at all.
     try testing.expect(std.mem.indexOf(u8, line, "status") == null);
     try testing.expect(std.mem.indexOf(u8, line, "method") == null);
+}
+
+test "access log: named headers ride nested objects, absent ones omitted (#140)" {
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    var entry = testRecord();
+    const request_names = [_][]const u8{ "x-request-id", "user-agent" };
+    // The second header was not on the request: an empty value is how a
+    // capture says "absent", and the key must not appear at all.
+    const request_values = [_][]const u8{ "abc-123", "" };
+    const response_names = [_][]const u8{"x-cache"};
+    const response_values = [_][]const u8{"HIT"};
+    entry.request_headers = .{ .names = &request_names, .values = &request_values };
+    entry.response_headers = .{ .names = &response_names, .values = &response_values };
+    const line = try renderLine(&entry, &buffer);
+
+    try testing.expectEqualStrings(
+        "{\"time\":\"2026-07-31T09:14:22.481Z\",\"kind\":\"http\",\"outcome\":\"ok\"," ++
+            "\"client\":\"10.1.2.3:52344\",\"method\":\"GET\",\"host\":\"api.example.com\"," ++
+            "\"path\":\"/v1/items\",\"status\":200,\"upstream_reused\":true," ++
+            "\"upstream_replayed\":false,\"request_headers\":{\"x-request-id\":\"abc-123\"}," ++
+            "\"response_headers\":{\"x-cache\":\"HIT\"},\"duration_us\":1873," ++
+            "\"bytes_in\":142,\"bytes_out\":4096,\"cluster\":\"api\"," ++
+            "\"upstream\":\"10.0.0.7:8080\"}\n",
+        line,
+    );
+    // Nesting is what keeps a header from shadowing a real field: a
+    // header literally called `status` lands inside the object, and the
+    // line's own `status` is still the one zoxy answered with.
+    const shadow_names = [_][]const u8{"status"};
+    const shadow_values = [_][]const u8{"not-a-status"};
+    entry.request_headers = .{ .names = &shadow_names, .values = &shadow_values };
+    entry.response_headers = .{};
+    const shadowed = try renderLine(&entry, &buffer);
+    try testing.expect(std.mem.indexOf(u8, shadowed, "\"status\":200") != null);
+    try testing.expect(
+        std.mem.indexOf(u8, shadowed, "{\"status\":\"not-a-status\"}") != null,
+    );
+    // A direction whose every configured header was absent renders an
+    // empty object, not a missing one: the config said to report it.
+    const absent_values = [_][]const u8{""};
+    entry.request_headers = .{ .names = &shadow_names, .values = &absent_values };
+    const empty = try renderLine(&entry, &buffer);
+    try testing.expect(std.mem.indexOf(u8, empty, "\"request_headers\":{}") != null);
+    try testing.expect(std.mem.indexOf(u8, empty, "response_headers") == null);
+}
+
+test "access log: a logged header value is escaped like every other text (#140)" {
+    // These are client-controlled bytes — the one field on the line an
+    // attacker writes directly — so a quote or a newline must land as
+    // an escape rather than as a forged second line.
+    var buffer: [constants.access_log_line_bytes_max]u8 = undefined;
+    var entry = testRecord();
+    const names = [_][]const u8{"x-evil"};
+    const values = [_][]const u8{"a\"b\n{\"kind\":\"http\"}"};
+    entry.request_headers = .{ .names = &names, .values = &values };
+    const line = try renderLine(&entry, &buffer);
+
+    // Exactly one line, and the injected object is inert text inside a
+    // JSON string.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, line, "\n"));
+    try testing.expect(std.mem.indexOf(u8, line, "a\\\"b\\n") != null);
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        line,
+        .{},
+    );
+    defer parsed.deinit();
+    const logged = parsed.value.object.get("request_headers").?.object.get("x-evil").?;
+    try testing.expectEqualStrings("a\"b\n{\"kind\":\"http\"}", logged.string);
+}
+
+test "access log: a line at every cap still fits the bound (#140)" {
+    // The bound is derived, so the worst case has to actually be
+    // measured against it: every field at its cap, every named header
+    // present and at its own — the shape the loader sized the staging
+    // buffer for.
+    const gpa = testing.allocator;
+    const value = try gpa.alloc(u8, constants.access_log_header_bytes_max);
+    defer gpa.free(value);
+    // Control bytes: JSON's 6x worst case, which is what the per-header
+    // term budgets for.
+    @memset(value, 0x01);
+    const name = "x" ** constants.access_log_header_name_bytes_max;
+
+    var names: [constants.access_log_headers_max][]const u8 = undefined;
+    var values: [constants.access_log_headers_max][]const u8 = undefined;
+    for (&names, &values) |*name_slot, *value_slot| {
+        name_slot.* = name;
+        value_slot.* = value;
+    }
+    const path = try gpa.alloc(u8, constants.access_log_path_bytes_max);
+    defer gpa.free(path);
+    @memset(path, 0x01);
+    const host = try gpa.alloc(u8, constants.host_bytes_max);
+    defer gpa.free(host);
+    @memset(host, 0x01);
+
+    var entry = testRecord();
+    entry.path = path;
+    entry.host = host;
+    entry.method = "M" ** constants.access_log_method_bytes_max;
+    entry.cluster = "c" ** constants.cluster_name_bytes_max;
+    entry.client = try std.Io.net.IpAddress.parseLiteral("[2001:db8::1]:65535");
+    entry.upstream = try std.Io.net.IpAddress.parseLiteral("[2001:db8::2]:65535");
+    entry.duration_ns = std.math.maxInt(u64);
+    entry.bytes_in = std.math.maxInt(u64);
+    entry.bytes_out = std.math.maxInt(u64);
+    // Split across the directions the way a config's two lists are, so
+    // the wrapper objects are both paid for.
+    const split = constants.access_log_headers_max / 2;
+    entry.request_headers = .{ .names = names[0..split], .values = values[0..split] };
+    entry.response_headers = .{ .names = names[split..], .values = values[split..] };
+
+    const buffer = try gpa.alloc(u8, constants.access_log_line_bytes_max);
+    defer gpa.free(buffer);
+    const line = try renderLine(&entry, buffer);
+    try testing.expect(line.len <= constants.access_log_line_bytes_max);
 }
 
 test "access log: every line is valid JSON, including hostile paths" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -72,6 +72,14 @@ pub const Config = struct {
     /// page here and a `respond` action there is rendered once and
     /// pointed at twice — #159's one-body-one-buffer contract.
     error_pages: []const *const StaticPage = &.{},
+    /// The headers each access-log line records (#140), lowercased and
+    /// deduplicated at load, empty when none are named. Read on the
+    /// capture paths, so the request list is what an http line's
+    /// `request_headers` object carries and the response list its
+    /// `response_headers` — and their summed length is what widens the
+    /// line bound this config's staging buffer was checked against.
+    access_log_request_headers: []const []const u8 = &.{},
+    access_log_response_headers: []const []const u8 = &.{},
     /// Where access-log lines go (§8), or null when no `access_log` block
     /// is configured — the log stays off and reserves nothing.
     access_log_sink: ?AccessLogSink = null,
@@ -419,6 +427,11 @@ pub const ValidationError = error{
     BodyFileUnreadable,
     BodyOverLimit,
     BodyUnknown,
+    AccessLogHeadersOverLimit,
+    AccessLogHeaderNameInvalid,
+    AccessLogHeaderNameTooLong,
+    AccessLogHeaderDuplicate,
+    LimitAccessLogBufferUnderLine,
     FilterRespondStatus,
     ResponseFilterRespond,
     ErrorPagesOverLimit,
@@ -568,11 +581,15 @@ pub fn parseWithFiles(
         if (try protocolOf(listener_json.protocol) == .http) http_listeners_count += 1;
     }
     const access_log_sink = try resolveAccessLogSink(parsed.access_log);
+    // Before the limits, because the named headers widen the line the
+    // staging buffer has to be able to hold (#140).
+    const log_headers = try resolveLogHeaders(arena, parsed.access_log);
     const limits = try resolveLimits(
         &parsed.limits,
         @intCast(parsed.listeners.len),
         http_listeners_count,
         access_log_sink != null,
+        log_headers.count(),
     );
     // Bodies before listeners (#159): a `respond` action names one, and
     // both consumers render through the same load-time cache — so the
@@ -605,8 +622,80 @@ pub fn parseWithFiles(
         .limits = limits,
         .admin_bind = admin_bind,
         .access_log_sink = access_log_sink,
+        .access_log_request_headers = log_headers.request,
+        .access_log_response_headers = log_headers.response,
         .error_pages = error_pages,
     };
+}
+
+/// The #140 header lists, resolved: lowercased so the logged key is one
+/// stable spelling a query need not guess at, deduplicated so a name
+/// written twice renders one field, and bounded together — the two
+/// lists share `access_log_headers_max`, because what the cap protects
+/// (the line bound, the per-connection capture table) is the total.
+const ResolvedLogHeaders = struct {
+    request: []const []const u8,
+    response: []const []const u8,
+
+    fn count(headers: *const ResolvedLogHeaders) u32 {
+        return @intCast(headers.request.len + headers.response.len);
+    }
+};
+
+fn resolveLogHeaders(
+    arena: std.mem.Allocator,
+    access_log_json: ?AccessLogJson,
+) ParseError!ResolvedLogHeaders {
+    const access_log = access_log_json orelse return .{ .request = &.{}, .response = &.{} };
+    const request_json = access_log.request_headers orelse &.{};
+    const response_json = access_log.response_headers orelse &.{};
+    if (request_json.len + response_json.len > constants.access_log_headers_max) {
+        return error.AccessLogHeadersOverLimit;
+    }
+    const request = try resolveLogHeaderNames(arena, request_json);
+    const response = try resolveLogHeaderNames(arena, response_json);
+    // Deduplicated per direction, not across: the same name on both
+    // sides is two different facts — what the client sent and what the
+    // origin answered — and they land in different objects.
+    assert(request.len == request_json.len);
+    assert(response.len == response_json.len);
+    return .{ .request = request, .response = response };
+}
+
+fn resolveLogHeaderNames(
+    arena: std.mem.Allocator,
+    names_json: []const []const u8,
+) ParseError![]const []const u8 {
+    if (names_json.len == 0) {
+        return &.{};
+    }
+    const names = try arena.alloc([]const u8, names_json.len);
+    for (names_json, 0..) |raw, index| {
+        if (raw.len == 0) {
+            return error.AccessLogHeaderNameInvalid;
+        }
+        if (raw.len > constants.access_log_header_name_bytes_max) {
+            return error.AccessLogHeaderNameTooLong;
+        }
+        // An RFC 9110 token, like every other header name this config
+        // spells — a name with a space or a colon could never match a
+        // parsed header, and would render a key nothing produces.
+        for (raw) |byte| {
+            if (!isTokenByte(byte)) {
+                return error.AccessLogHeaderNameInvalid;
+            }
+        }
+        const lowered = try arena.alloc(u8, raw.len);
+        for (raw, lowered) |byte, *slot| slot.* = std.ascii.toLower(byte);
+        for (names[0..index]) |previous| {
+            if (std.mem.eql(u8, previous, lowered)) {
+                return error.AccessLogHeaderDuplicate;
+            }
+        }
+        names[index] = lowered;
+    }
+    assert(names.len == names_json.len);
+    return names;
 }
 
 /// A resolved #159 body: load-time only — consumers hold pointers to
@@ -904,6 +993,7 @@ fn resolveLimits(
     listeners_count: u32,
     http_listeners_count: u32,
     access_log_on: bool,
+    log_header_count: u32,
 ) ValidationError!Config.Limits {
     assert(listeners_count >= 1);
     assert(http_listeners_count <= listeners_count);
@@ -958,6 +1048,7 @@ fn resolveLimits(
     const access_log_buffer_bytes = try resolveAccessLogBuffer(
         limits_json.access_log_buffer_bytes,
         access_log_on,
+        log_header_count,
     );
     assert(relay_buffers <= conn_slots);
     assert(head_buffers <= conn_slots);
@@ -1044,6 +1135,7 @@ fn resolveHeadBufferBytes(requested: ?u32) ValidationError!u32 {
 fn resolveAccessLogBuffer(
     requested: ?u32,
     access_log_on: bool,
+    log_header_count: u32,
 ) ValidationError!u32 {
     if (!access_log_on) {
         if (requested != null) return error.LimitAccessLogBufferWithoutSink;
@@ -1055,6 +1147,16 @@ fn resolveAccessLogBuffer(
     {
         return error.LimitAccessLogBufferOutOfRange;
     }
+    // The static floor covers a line with no named headers; this config's
+    // own line may be wider (#140), and a buffer that cannot hold one
+    // would drop every line carrying its headers — a drop that means
+    // arithmetic rather than backpressure, which is the one thing the
+    // counter must never mean.
+    const line_bytes = constants.accessLogLineBytes(log_header_count);
+    if (bytes < line_bytes) {
+        return error.LimitAccessLogBufferUnderLine;
+    }
+    assert(bytes >= line_bytes);
     return bytes;
 }
 
@@ -1129,6 +1231,11 @@ pub const ConfigJson = struct {
 pub const AccessLogJson = struct {
     sink: []const u8,
     path: ?[]const u8 = null,
+    /// Headers to log (#140), absent meaning none — so a deployment
+    /// that does not ask pays nothing, the same shape as `access_log`
+    /// itself being absent.
+    request_headers: ?[]const []const u8 = null,
+    response_headers: ?[]const []const u8 = null,
 
     pub const schema_doc =
         "Optional access log. When present, zoxy writes one JSON object per " ++
@@ -1146,6 +1253,20 @@ pub const AccessLogJson = struct {
                 "append-only at startup (one extra fd), never truncated — so a " ++
                 "copy-truncate rotation is safe. Required by `sink:\"file\"`, " ++
                 "rejected beside `stdout`, which cannot use it.",
+        },
+        .request_headers = .{
+            .desc = "Request headers to record under `request_headers` on each " ++
+                "http line — an upstream's X-Request-ID or traceparent is what " ++
+                "joins this log to the origin's. Names are matched " ++
+                "case-insensitively and logged lowercased; absent headers are " ++
+                "omitted from the line.",
+            .max_items = constants.access_log_headers_max,
+        },
+        .response_headers = .{
+            .desc = "Response headers to record under `response_headers`, on the " ++
+                "same terms — the origin's X-Cache, say. Ignored for l4 lines, " ++
+                "which have no response to read.",
+            .max_items = constants.access_log_headers_max,
         },
     };
 };
@@ -5421,6 +5542,115 @@ test "config: error pages take only known statuses naming known bodies" {
             "\"bodies\":{\"x\":{\"inline\":\"a\",\"content_type\":\"t/p\"}," ++
             "\"x\":{\"inline\":\"b\",\"content_type\":\"t/p\"}}," ++ bodies_tail,
     );
+}
+
+test "config: logged header names are lowercased, deduped and bounded (#140)" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}]," ++
+        "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}},\"access_log\":{\"sink\":\"stdout\"";
+    const tail = "},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // The logged key is one stable spelling whatever the config wrote,
+    // so a query does not have to guess at the casing.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ ",\"request_headers\":[\"X-Request-ID\",\"User-Agent\"]," ++
+                "\"response_headers\":[\"X-Cache\"]" ++ tail,
+        );
+        try std.testing.expectEqual(@as(usize, 2), parsed.access_log_request_headers.len);
+        try std.testing.expectEqualStrings("x-request-id", parsed.access_log_request_headers[0]);
+        try std.testing.expectEqualStrings("user-agent", parsed.access_log_request_headers[1]);
+        try std.testing.expectEqualStrings("x-cache", parsed.access_log_response_headers[0]);
+    }
+    // Absent lists leave the line exactly as it was.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(arena_state.allocator(), head ++ tail);
+        try std.testing.expectEqual(@as(usize, 0), parsed.access_log_request_headers.len);
+        try std.testing.expectEqual(@as(usize, 0), parsed.access_log_response_headers.len);
+    }
+    // The same name twice renders one field, so the config saying it
+    // twice is a mistake worth reporting — case-insensitively, since
+    // the two spellings are the same header.
+    try expectParseError(
+        error.AccessLogHeaderDuplicate,
+        head ++ ",\"request_headers\":[\"X-Request-ID\",\"x-request-id\"]" ++ tail,
+    );
+    // The same name on both sides is *not* a duplicate: they are two
+    // different facts, and they land in different objects.
+    {
+        var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena_state.deinit();
+        const parsed = try parse(
+            arena_state.allocator(),
+            head ++ ",\"request_headers\":[\"x-trace\"],\"response_headers\":[\"x-trace\"]" ++ tail,
+        );
+        try std.testing.expectEqualStrings("x-trace", parsed.access_log_request_headers[0]);
+        try std.testing.expectEqualStrings("x-trace", parsed.access_log_response_headers[0]);
+    }
+    // A name that is not a token could never match a parsed header.
+    try expectParseError(
+        error.AccessLogHeaderNameInvalid,
+        head ++ ",\"request_headers\":[\"bad name\"]" ++ tail,
+    );
+    try expectParseError(
+        error.AccessLogHeaderNameInvalid,
+        head ++ ",\"request_headers\":[\"\"]" ++ tail,
+    );
+    try expectParseError(
+        error.AccessLogHeaderNameTooLong,
+        head ++ ",\"request_headers\":[\"" ++
+            ("x" ** (constants.access_log_header_name_bytes_max + 1)) ++ "\"]" ++ tail,
+    );
+}
+
+test "config: the two header lists share one cap, and widen the line (#140)" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"cluster\":\"a\",\"protocol\":\"http\"}]," ++
+        "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}},\"access_log\":{\"sink\":\"stdout\"";
+    const tail = "},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // The cap is the total, because what it protects — the line bound
+    // and the capture table — is the total. At the cap it loads; one
+    // past it does not, whichever list carries the extra.
+    const gpa = std.testing.allocator;
+    for ([_]u8{ constants.access_log_headers_max, constants.access_log_headers_max + 1 }) |count| {
+        var json: std.ArrayList(u8) = .empty;
+        defer json.deinit(gpa);
+        try json.appendSlice(gpa, head ++ ",\"request_headers\":[");
+        for (0..count) |index| {
+            if (index > 0) try json.append(gpa, ',');
+            var name_buffer: [16]u8 = undefined;
+            const name = std.fmt.bufPrint(&name_buffer, "\"x-h{d}\"", .{index}) catch unreachable;
+            try json.appendSlice(gpa, name);
+        }
+        try json.appendSlice(gpa, "]" ++ tail);
+        var arena_state = std.heap.ArenaAllocator.init(gpa);
+        defer arena_state.deinit();
+        const outcome = parse(arena_state.allocator(), json.items);
+        if (count > constants.access_log_headers_max) {
+            try std.testing.expectError(error.AccessLogHeadersOverLimit, outcome);
+        } else {
+            const parsed = try outcome;
+            try std.testing.expectEqual(@as(usize, count), parsed.access_log_request_headers.len);
+        }
+    }
+
+    // A staging buffer that clears the static floor but not this
+    // config's own line is refused: it would drop every line carrying
+    // the headers, which is a drop that means arithmetic.
+    const narrow = constants.access_log_buffer_bytes_min;
+    try std.testing.expect(narrow < constants.accessLogLineBytes(1));
+    var buffer_json: [512]u8 = undefined;
+    const with_narrow_buffer = std.fmt.bufPrint(
+        &buffer_json,
+        "{s},\"request_headers\":[\"x-request-id\"]}},\"limits\":{{\"access_log_buffer_bytes\":{d}}}," ++
+            "\"timeouts\":{{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}}}",
+        .{ head, narrow },
+    ) catch unreachable;
+    try expectParseError(error.LimitAccessLogBufferUnderLine, with_narrow_buffer);
 }
 
 test "config: a respond action compiles to a page, sharing one buffer (#159)" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -471,7 +471,13 @@ pub const access_log_buffer_bytes_default: u32 = 32 * 1024;
 /// thing the drop counter must never mean. The simulator sizes down to it
 /// to force the drop rung, the same way it sizes the pools down to force
 /// theirs (§9).
-pub const access_log_buffer_bytes_min: u32 = access_log_line_bytes_max;
+///
+/// One line *of a config that names no headers* (#140). A config that
+/// names some has a wider line, and the loader holds its buffer to that
+/// wider bound (`LimitAccessLogBufferUnderLine`) — so the floor stays
+/// the price of the feature nobody asked for, and the rest is charged
+/// where it is chosen.
+pub const access_log_buffer_bytes_min: u32 = accessLogLineBytes(0);
 pub const access_log_buffer_bytes_max: u32 = 1024 * 1024;
 pub const access_log_buffers: u32 = 2;
 
@@ -495,14 +501,40 @@ pub const access_log_path_bytes_max: u16 = 256;
 /// without letting one widen a log line without limit.
 pub const access_log_method_bytes_max: u8 = 24;
 
+/// Raw bytes of one operator-named header value kept for its log line
+/// (#140). The value lives in a head buffer the render writes over (§7
+/// rotation), so it is copied out under this cap while it is still
+/// there — `access_log_path_bytes_max`'s rule, one field over —
+/// truncated with a trailing `...` rather than dropped.
+pub const access_log_header_bytes_max: u16 = 256;
+
+/// How many headers one `access_log` block may name, request and
+/// response lists summed (#140). The cap is what keeps the per-line
+/// bound and the per-connection capture table closed-form: both are
+/// this times a per-header term. Eight covers the correlation header
+/// plus the handful an operator routinely wants beside it.
+pub const access_log_headers_max: u8 = 8;
+
+/// Raw bytes of a named header's *name* — the key the line renders.
+/// Bounded because the key is config text that lands in every line.
+pub const access_log_header_name_bytes_max: u8 = 64;
+
 /// Upper bound on one rendered access-log line, including its newline
 /// (§5: the caller sizes a fixed buffer to it, so a line never has to be
 /// dropped for want of room in an *empty* buffer). Derived from the field
 /// caps rather than chosen, so raising one of them cannot silently make
-/// the bound a lie. The `6 *` on the two text fields is JSON's worst case:
+/// the bound a lie. The `6 *` on the text fields is JSON's worst case:
 /// a control byte escapes to `\u00XX`, and a percent-decoded path may
 /// legitimately contain one.
-pub const access_log_line_bytes_max: u32 = blk: {
+///
+/// A function of the config since #140: the named headers a line carries
+/// are the operator's list, so its maximum length is theirs too. The
+/// precedent is #179's metrics exposition, whose render buffer became a
+/// config-derived banner term for the same reason when labels arrived.
+/// `access_log_line_bytes_max` below is the compiled ceiling — the value
+/// at the header cap — and is what the comptime budget asserts speak.
+pub fn accessLogLineBytes(header_count: u32) u32 {
+    assert(header_count <= access_log_headers_max);
     // Every key, brace, comma, quote, and the trailing newline, with slack
     // for a field or two more before the bound has to be re-derived.
     const scaffolding = 320;
@@ -512,10 +544,21 @@ pub const access_log_line_bytes_max: u32 = blk: {
     const number = 20; // a u64 at its widest
     const addresses = 2; // client and upstream
     const numbers = 4; // duration, bytes in, bytes out, status
-    break :blk scaffolding + timestamp + addresses * address + numbers * number +
+    const fixed = scaffolding + timestamp + addresses * address + numbers * number +
         @as(u32, access_log_method_bytes_max) + @as(u32, cluster_name_bytes_max) +
         6 * @as(u32, host_bytes_max) + 6 * @as(u32, access_log_path_bytes_max);
-};
+    // Per named header: the quoted key, the escaped value at JSON's
+    // worst case, and the `"":,` punctuation between them — plus the two
+    // wrapper objects' own keys and braces, charged once per header so
+    // the term stays a single multiplication.
+    const per_header = @as(u32, access_log_header_name_bytes_max) +
+        6 * @as(u32, access_log_header_bytes_max) + 48;
+    return fixed + header_count * per_header;
+}
+
+/// The compiled ceiling: a line at the header cap. Every budget assert
+/// and every test buffer speaks this, so they cover any config.
+pub const access_log_line_bytes_max: u32 = accessLogLineBytes(access_log_headers_max);
 
 /// Worst-case in-flight ring ops (§8: the ring is pre-budgeted, not shed):
 /// every connection slot at its op peak (L7 slots hold armed ops with or
@@ -870,7 +913,15 @@ comptime {
     // lines it had room for — the bound exists precisely so a drop always
     // means backpressure, never arithmetic. The floor is that bound, so
     // no config can name a buffer that breaks it.
-    assert(access_log_buffer_bytes_min >= access_log_line_bytes_max);
+    // An empty staging buffer must always fit one line of a config that
+    // names no headers; the loader carries the same guarantee up to the
+    // wider bound a config with headers earns (#140).
+    assert(access_log_buffer_bytes_min >= accessLogLineBytes(0));
+    assert(access_log_line_bytes_max >= access_log_buffer_bytes_min);
+    assert(access_log_buffer_bytes_max >= access_log_line_bytes_max);
+    assert(access_log_headers_max >= 1);
+    assert(access_log_header_bytes_max >= 16);
+    assert(access_log_header_name_bytes_max >= 16);
     assert(access_log_buffer_bytes_default >= access_log_buffer_bytes_min);
     assert(access_log_buffer_bytes_default <= access_log_buffer_bytes_max);
     // Two buffers exactly: the swap is what lets appends continue during
@@ -944,6 +995,13 @@ pub const PoolSizes = struct {
     /// holds for its life, and §5's promise is that the printed total
     /// covers all of that. `accessLogBytes` is the closed form.
     access_log_bytes: u64,
+    /// The #140 per-connection capture table: the operator-named header
+    /// values a line reports, held from the head they were read out of
+    /// until the line is written. Zero when the config names none —
+    /// which is what keeps the feature free to a deployment that did
+    /// not ask for it. Config-derived like `metrics_bytes` beside it,
+    /// and priced the same way: next to everything else you pay for.
+    log_header_bytes: u64 = 0,
     /// The endpoint-keyed tables (§7) — the pool's idle heads and lease
     /// counts, the balancer's endpoint hashes, rotation state and pick
     /// scratch, the server's L4 charges, and the health checker's mask
@@ -1030,8 +1088,8 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
-        sizes.access_log_bytes + sizes.endpoint_table_bytes +
-        sizes.metrics_bytes +
+        sizes.access_log_bytes + sizes.log_header_bytes +
+        sizes.endpoint_table_bytes + sizes.metrics_bytes +
         @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
         bufferGroupDescriptorBytes(sizes.head_buffers) +
         @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes +

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -488,7 +488,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// A malformed or oversize head never reaches here, so it never
         /// sets these: `request_head_len` staying 0 is exactly what marks a
         /// stream whose message boundary the parser could not find.
-        fn recordRequestFacts(conn: *ConnType, request: *const parser.RequestHead) void {
+        fn recordRequestFacts(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len >= 1);
             // Once per request: `resetForNextRequest` and
@@ -503,6 +503,10 @@ pub fn Proxy(comptime IoType: type) type {
             // read later: the response head renders over it (§7 buffer
             // rotation), and by the exchange's settle these bytes are gone.
             conn.log.captureMethod(request.method_token);
+            // The #140 named headers, on the same terms and for the same
+            // reason — and here rather than deeper, so every line that
+            // reports a parsed request carries them, rejects included.
+            server.captureRequestLogHeaders(conn, request.headers);
         }
 
         /// Start this exchange's §8 deadline, if the deployment set one.
@@ -553,7 +557,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len <= conn.head_len);
-            recordRequestFacts(conn, request);
+            recordRequestFacts(server, conn, request);
             armRequestDeadline(server, conn);
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");
@@ -1594,6 +1598,10 @@ pub fn Proxy(comptime IoType: type) type {
             // separate fact, and `outcome` stays `aborted` until
             // `finishExchange` earns `ok` (§8).
             conn.log.status = response.status;
+            // The #140 response headers, captured here for the same
+            // reason and at the same moment: the origin's head is live
+            // now, and this render is what writes over it.
+            server.captureResponseLogHeaders(conn, response.headers);
             armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .response_excess);
         }
 
@@ -1965,6 +1973,10 @@ pub fn Proxy(comptime IoType: type) type {
             conn.head_len = 0;
             conn.l7 = .{};
             conn.log.reset();
+            // The #140 captures live in the server's side table, not on
+            // `log`, so they need clearing beside it — or the next
+            // request's line would report this one's headers.
+            server.resetLogHeaders(conn);
             conn.directions = .{ .{}, .{} };
             conn.state = .l7_reading_head;
             server.storeDeadline(conn, server.idleTimeoutMs());

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -528,6 +528,12 @@ const Http1Bed = struct {
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
         access_log: bool = false,
+        /// The #140 headers each line records; empty for every
+        /// pre-existing scenario, so their lines stay byte-identical.
+        /// Names must already be lowercase — the loader lowercases, and
+        /// a bed builds its `Config` directly.
+        access_log_request_headers: []const []const u8 = &.{},
+        access_log_response_headers: []const []const u8 = &.{},
         /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
         check: ?config_module.Config.Cluster.Check = null,
@@ -589,6 +595,8 @@ const Http1Bed = struct {
             .access_log_sink = if (options.access_log) .stdout else null,
             .health_interval_ms = options.health_interval_ms,
             .error_pages = options.error_pages,
+            .access_log_request_headers = options.access_log_request_headers,
+            .access_log_response_headers = options.access_log_response_headers,
         };
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -3442,6 +3450,167 @@ fn accessLogLineFor(bed: *const Http1Bed, needle: []const u8) ![]const u8 {
         found = line;
     }
     return found orelse error.NoSuchAccessLogLine;
+}
+
+test "l7: a line reports the named headers from both directions (#140)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 46,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nX-Cache: HIT\r\n\r\nhi",
+        .access_log = true,
+        .access_log_request_headers = &.{ "x-request-id", "user-agent" },
+        .access_log_response_headers = &.{"x-cache"},
+    });
+    defer bed.tearDown();
+
+    // The request carries the correlation header but no User-Agent: the
+    // join exists with nothing added to the wire, and the header that
+    // did not arrive is simply absent from the line.
+    try bed.exchange("GET /path HTTP/1.1\r\nHost: o\r\nX-Request-Id: abc-123\r\n" ++
+        "Connection: close\r\n\r\n");
+    try bed.expectDrained();
+
+    const line = try onlyAccessLogLine(&bed);
+    try std.testing.expect(
+        std.mem.indexOf(u8, line, "\"request_headers\":{\"x-request-id\":\"abc-123\"}") != null,
+    );
+    try std.testing.expect(
+        std.mem.indexOf(u8, line, "\"response_headers\":{\"x-cache\":\"HIT\"}") != null,
+    );
+    // Matched case-insensitively (the request wrote `X-Request-Id`) and
+    // logged under the one spelling the config resolved to.
+    try std.testing.expect(std.mem.indexOf(u8, line, "user-agent") == null);
+}
+
+test "l7: a keep-alive turnaround does not carry the last request's headers (#140)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 47,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .access_log = true,
+        .access_log_request_headers = &.{"x-request-id"},
+    });
+    defer bed.tearDown();
+
+    // The first request names an ID, the second does not. The capture
+    // lives in a side table the turnaround has to clear, so a stale
+    // value would show up as the second line reporting the first's ID —
+    // the worst possible failure for a correlation field.
+    bed.client.second_request = "GET /two HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\nX-Request-Id: first\r\n\r\n");
+    try bed.expectDrained();
+
+    const first = try accessLogLineFor(&bed, "\"path\":\"/one\"");
+    const second = try accessLogLineFor(&bed, "\"path\":\"/two\"");
+    try std.testing.expect(
+        std.mem.indexOf(u8, first, "\"request_headers\":{\"x-request-id\":\"first\"}") != null,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, second, "\"request_headers\":{}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, second, "first") == null);
+}
+
+test "l7: a rejected request still reports its named headers (#140)" {
+    // The correlation header earns its keep exactly when something went
+    // wrong, so a line that reports a verdict must carry it too — which
+    // is why the capture sits with the other request facts, ahead of
+    // every rung, rather than on the path that reaches an origin.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 48,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .route_prefix = "/api",
+        .access_log = true,
+        .access_log_request_headers = &.{"x-request-id"},
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /nope HTTP/1.1\r\nHost: o\r\nX-Request-Id: traced\r\n" ++
+        "Connection: close\r\n\r\n");
+    try bed.expectDrained();
+
+    const line = try onlyAccessLogLine(&bed);
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"outcome\":\"rejected\"") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, line, "\"request_headers\":{\"x-request-id\":\"traced\"}") != null,
+    );
+    // No response reached this request, so its response object is the
+    // empty one the config asked for — never the previous exchange's.
+    try std.testing.expect(std.mem.indexOf(u8, line, "response_headers") == null);
+}
+
+test "l7: a reused conn slot reports no previous connection's headers (#140)" {
+    // The capture table is addressed by pool slot, so its bytes outlive
+    // the connection that wrote them. This is the shape that makes that
+    // dangerous: one connection logs a header, its slot is reused, and
+    // the next connection's head never parses — so nothing overwrites
+    // the slot and the reject's line would attribute one client's
+    // correlation ID to a different client's request.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 50,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .conn_slots = 1,
+        .relay_buffers = 1,
+        .access_log = true,
+        .access_log_request_headers = &.{"x-request-id"},
+    });
+    defer bed.tearDown();
+
+    // Chained, not concurrent: with one slot the second must arrive
+    // after the first released it, or it would be shed rather than
+    // reuse the slot. Its head is a bare-LF smuggling shape, so it is
+    // rejected 400 before any capture runs and nothing this client sent
+    // overwrites what the slot already held.
+    bed.client.drain_on_finish = false;
+    bed.client2.request = "GET /two HTTP/1.1\nHost: o\r\n\r\n";
+    bed.client.next = &bed.client2;
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\nX-Request-Id: leaked\r\n" ++
+        "Connection: close\r\n\r\n");
+    try bed.expectDrained();
+
+    const rejected = try accessLogLineFor(&bed, "\"outcome\":\"rejected\"");
+    try std.testing.expect(std.mem.indexOf(u8, rejected, "leaked") == null);
+    try std.testing.expect(std.mem.indexOf(u8, rejected, "\"request_headers\":{}") != null);
+    // The first connection's own line still carries what it sent, so
+    // the fix is a clear-on-acquire and not a disabled feature.
+    const served = try accessLogLineFor(&bed, "\"path\":\"/one\"");
+    try std.testing.expect(
+        std.mem.indexOf(u8, served, "\"request_headers\":{\"x-request-id\":\"leaked\"}") != null,
+    );
+}
+
+test "l7: an oversize header value is truncated, not dropped (#140)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 49,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
+        .access_log = true,
+        .access_log_request_headers = &.{"x-request-id"},
+    });
+    defer bed.tearDown();
+
+    var request_buffer: [2048]u8 = undefined;
+    var value_buffer: [constants.access_log_header_bytes_max + 64]u8 = undefined;
+    @memset(&value_buffer, 'v');
+    const request = std.fmt.bufPrint(
+        &request_buffer,
+        "GET / HTTP/1.1\r\nHost: o\r\nX-Request-Id: {s}\r\nConnection: close\r\n\r\n",
+        .{value_buffer},
+    ) catch unreachable;
+    try bed.exchange(request);
+    try bed.expectDrained();
+
+    // The prefix identifies the value, and the ellipsis says the rest
+    // was there — `path`'s rule, one field over.
+    const line = try onlyAccessLogLine(&bed);
+    const marker = "\"x-request-id\":\"";
+    const start = std.mem.indexOf(u8, line, marker).? + marker.len;
+    const end = std.mem.indexOfScalarPos(u8, line, start, '"').?;
+    try std.testing.expectEqual(
+        @as(usize, constants.access_log_header_bytes_max),
+        end - start,
+    );
+    try std.testing.expect(std.mem.endsWith(u8, line[start..end], "..."));
 }
 
 test "l7: a proxied GET writes one access-log line naming the origin's status" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -388,6 +388,7 @@ fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
         .upstream_slots = limits.upstream_slots,
         .upstream_bytes = @sizeOf(UpstreamType),
         .access_log_bytes = zoxy.constants.accessLogBytes(limits.access_log_buffer_bytes),
+        .log_header_bytes = ServerXev.logHeaderBytes(config, limits.conn_slots),
         .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
         .metrics_bytes = ServerXev.metricsBytes(config),
         .head_buffers = limits.head_buffers,
@@ -480,7 +481,7 @@ fn printMemoryBanner(
         \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
         \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
         \\          + upstream head buffers {d} x {d} B + head scratch {d} B
-        \\          + access log {d} KiB
+        \\          + access log {d} KiB (+ logged headers {d} B)
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + labeled metrics {d} B (tables, labels and render buffers)
         \\          + config arena {d} KiB (measured, not closed-form)
@@ -504,6 +505,7 @@ fn printMemoryBanner(
         sizes.upstream_head_buffer_bytes,
         sizes.head_scratch_bytes,
         access_log_bytes / 1024,
+        sizes.log_header_bytes,
         ServerXev.endpointTableBytes(config),
         config.clusters.len,
         ServerXev.endpointKeysFor(config).stride,


### PR DESCRIPTION
Closes #140.

A zoxy line and the origin's line for the same request shared no key, so
a slow request could not be attributed to a hop. The cheap half of
fixing that is not to mint an identifier but to log one that already
exists: zoxy is usually not the outermost hop, a CDN or ingress in front
almost always sets `X-Request-ID` or `traceparent`, and that header
passes through untouched and reaches the backend — **so logging it at
both ends builds the join with nothing added to the wire.** It is also
strictly more general than a trace ID: `User-Agent`, a tenant header,
a CDN's ray ID, the origin's `X-Cache` on the way out.

Minting an identifier stays postponed rather than dropped, for a stated
reason: it needs entropy, this proxy has no randomness source in
production, and obtaining one is a §4 seam decision with a §9
determinism constraint attached. Logging a header that already exists
needs none of that.

`access_log.request_headers` and `response_headers` name them, and
absent lists leave the line byte-identical to what it was. Four
decisions worth naming: the fields are **nested** objects, one per
direction, so a header called `status` cannot shadow the real one and
"what the client sent" stays visibly apart from "what zoxy observed";
a configured header that did not arrive is **omitted**, so the object
says what was there; names are matched case-insensitively and logged
**lowercased**, one spelling a query need not guess at; and a repeated
header logs its **first** value, matching `headerValue`, so the line
reports the value zoxy itself read. Values ride the same escaper
`path` does — they are client-controlled bytes, and the log is often
the one component parsing untrusted text.

**The bound is the structural part.** `access_log_line_bytes_max` was
a comptime sum over a fixed field set; named headers make a line's
maximum length the config's, so it becomes `accessLogLineBytes(count)`
— the compiled ceiling kept for the budget asserts, the header-free
bound kept as the staging floor, and the loader refusing a buffer that
could not hold *this* config's line (that drop would mean arithmetic,
not backpressure). #179's move for the metrics exposition, same reason.
The capture table is per connection slot and config-sized, so it costs
nothing unnamed and is priced in the banner beside everything else.

**One bug found in review, and it is the interesting one.** That table
is addressed by pool slot, which outlives the connection that wrote it.
Clearing only on the keep-alive turnaround left a freshly-admitted
connection inheriting the previous occupant's values — and a head that
never parses reaches no capture to overwrite them, so its line would
report one client's correlation ID on another client's request. Fixed
by clearing on acquire as well; a directed test chains two connections
through a single slot and fails without it.

Gates: every sweep seed names one header each way, two scripts send the
request one and the sized origin answers with the response one, and the
verifier holds each line to shape and value. It deliberately does not
claim to catch staleness — one canonical value is shared by every
sender, which makes a bled value indistinguishable there, and the
comments say so. Live, every request carries an `X-Request-ID` and the
origin tags every response: the log check demands the ID on every http
line and the origin's tag on exactly the lines an origin served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)