### PR TITLE
fix: the census can bound a rare event, and a census failure reports as one

### DIFF
--- a/.github/workflows/nightly-sim.yml
+++ b/.github/workflows/nightly-sim.yml
@@ -212,13 +212,31 @@ jobs:
           # for the verdict.
           seeds_failed=$(grep -oE '^sim: [0-9]+ seed\(s\) failed: .*' "sweep-${SHARD}.log" \
             | sed 's/^.*failed: //' | head -1 || true)
+          # A shard can fail with every seed passing: the §9 census is a
+          # verdict about the whole range, not about one schedule, so it
+          # names no seed. Its line is the only thing that says what
+          # broke, and without carrying it the report can do no better
+          # than "something failed, go read the log" — which is what it
+          # used to say. Anchored like the lines above.
+          census_reason=$(grep -oE '^sim census: .*' "sweep-${SHARD}.log" | head -1 || true)
           swept_last=$(grep -oE '^sim: swept [0-9]+\.\.[0-9]+' "sweep-${SHARD}.log" \
             | grep -oE '[0-9]+$' | head -1 || true)
+          # A census failure sweeps its whole slice and *then* fails on
+          # the aggregate, so it prints neither of the lines above — it
+          # names its range on its own line. Without reading it the
+          # branch below would take a shard where every seed held for a
+          # shard that crashed, and credit it zero verified seeds.
+          census_last=$(grep -oE '^sim: [0-9]+ seed\(s\) ran, [0-9]+\.\.[0-9]+, census FAILED' \
+            "sweep-${SHARD}.log" | sed -E 's/.*\.\.([0-9]+), census FAILED$/\1/' | head -1 || true)
           extent=exact
           if [ -z "$swept_last" ]; then
             if [ "$status" -eq 0 ]; then
               # A clean pass prints no `swept` line; the whole slice is done.
               swept_last="$shard_last"
+            elif [ -n "$census_last" ]; then
+              # Every seed in the slice held; what failed was the census
+              # over their totals. The coverage is real and exact.
+              swept_last="$census_last"
             else
               # Neither summary line: the sim panicked rather than
               # returning, so `keep-going` never ran and how far this
@@ -249,9 +267,10 @@ jobs:
             --arg kind "$kind" \
             --arg extent "$extent" \
             --arg seeds "$seeds_failed" \
+            --arg reason "$census_reason" \
             '{shard: $shard, start: $start, last: $last, swept_last: $swept_last,
               status: $status, elapsed: $elapsed, capped: $capped, kind: $kind,
-              extent: $extent,
+              extent: $extent, reason: $reason,
               failed: ($seeds | split(" ") | map(select(length > 0) | tonumber))}' \
             > "result-${SHARD}.json"
           cat "result-${SHARD}.json"
@@ -307,6 +326,12 @@ jobs:
           capped=$(echo "$records" | jq '[.[] | select(.capped)] | length')
           seeds=$(echo "$records" | jq -r '[.[] | .failed[]] | sort | .[0:20] | join(" ")')
           total_seeds=$(echo "$records" | jq '[.[] | .failed | length] | add // 0')
+          # The census verdicts, deduplicated: shards sweep disjoint
+          # slices, so two hitting the same rung is one finding stated
+          # twice. `// ""` because a record written before this field
+          # existed is still a valid record.
+          reasons=$(echo "$records" \
+            | jq -r '[.[] | select((.reason // "") != "") | .reason] | unique | .[0:3] | join("\n")')
           missing=$(( SHARDS - reported ))
           unknown=$(echo "$records" | jq '[.[] | select(.extent == "unknown")] | length')
           elapsed=$(echo "$records" | jq '[.[] | .elapsed] | max // 0')
@@ -331,8 +356,16 @@ jobs:
             if [ "$total_seeds" -gt 0 ]; then
               detail=$(printf '%s of %s shards failed, naming %s seed(s)%s. Replay any of them exactly:\n```\nzig build sim -- <seed> 1\n```\nSeeds: `%s`' \
                 "$failing" "$SHARDS" "$total_seeds" "$shown" "$seeds")
+            elif [ -n "$reasons" ]; then
+              # Every seed held and the sweep still failed: a §9 census
+              # verdict, which is about the range rather than any one
+              # schedule. There is no seed to replay, so the reason is
+              # the whole finding — print it rather than sending someone
+              # to the log for a line we already have.
+              detail=$(printf '%s of %s shards failed with every seed holding — a §9 census verdict, so there is no seed to replay:\n```\n%s\n```' \
+                "$failing" "$SHARDS" "$reasons")
             else
-              detail=$(printf '%s of %s shards failed without naming a seed — see the run log.' \
+              detail=$(printf '%s of %s shards failed without naming a seed or a census verdict — see the run log.' \
                 "$failing" "$SHARDS")
             fi
             if [ "$capped" -gt 0 ]; then

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -433,6 +433,42 @@ protected was available more cheaply. Reversed deliberately, no knob:
 - SimIo keeps zeroing its slab — that was never residency, it is seed
   determinism (a replayed schedule must see identical bytes).
 
+## The simulator runs fastest in Debug — why, not just that (2026-08-03)
+
+That Debug beats ReleaseSafe here was measured on 2026-07-28 and
+recorded where the decision lives, in `nightly-sim.yml`'s build step
+(20k seeds: Debug 25 s, ReleaseSafe 88 s, ReleaseFast 3 s). Re-measured
+2026-08-03 when the question came up again — 20k seeds, raw binaries,
+no build overhead — it reproduces, and `perf` now says *why*, which the
+original note could not:
+
+| build | wall | instructions | cache misses |
+|---|---|---|---|
+| Debug (self-hosted backend) | 21.0 s | 7.73e9 | 1.88e8 |
+| ReleaseSafe (LLVM) | 65.8 s | 6.84e10 | 1.68e8 |
+
+Nearly nine times the instructions for identical work, with *fewer*
+cache misses — so it is not memory traffic, which rules out the first
+hypothesis (the `undefined` 0xaa fill over the harness's large
+structs). The optimized build simply emits far more work per
+operation; the likely cause is the safety checks LLVM materializes that
+the self-hosted Debug backend does not, amplified by inlining. Not
+chased past that: the verdict does not depend on the mechanism, and the
+instruction ratio is the part worth knowing — it says the gap is code
+generation, not the machine or the workload.
+
+ReleaseFast is not the fallback, for the reason the workflow already
+gives: it compiles `assert` out entirely, and a sweep with no
+assertions checks the oracles and nothing else — §9's density is most
+of what a seed is for.
+
+So Debug is not a leftover, it is the fast mode, and the sweep's cost
+is what it is: ~4.8 s for `ci`'s 4096 seeds, ~115 s for 100 000, and
+~800-1060 seeds/s on the nightly's shared runners (measured across the
+four shards of run 30789778589). Do not re-propose an optimize-mode
+change without re-measuring this table; if the self-hosted backend's
+safety coverage ever changes, that is the thing to re-check first.
+
 ## Pre-block spin — rejected (2026-07-12)
 
 Spinning before the loop blocks: p50 +15–25 µs *worse* and CPU ×2. The

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -59,7 +59,7 @@ const failures_max: u8 = 16;
 /// not move — but that is what re-measuring them was for.
 const census_iterations_min: u64 = 1024;
 
-/// A counter the sweep expects to stay at zero, and why.
+/// A counter the sweep expects to stay at (or under) zero, and why.
 const Uncovered = struct {
     name: []const u8,
     why: Why,
@@ -67,20 +67,54 @@ const Uncovered = struct {
     /// non-zero reading would mean. Printed when the entry's claim stops
     /// holding, so it has to read as an argument rather than a label.
     reason: []const u8,
+    /// How often this may fire and still hold. Almost every entry says
+    /// `.never`, and that is the whole table's usual claim.
+    ///
+    /// The exception is an alarm for a regression that would fire
+    /// *constantly*, guarding an event that is legal and vanishingly
+    /// rare. There the honest claim is a rate, not zero: "never" was
+    /// only ever true at the sweep sizes we had run, and a nightly soak
+    /// large enough to see the rare event would fail on the legal case
+    /// while the regression it guards against is orders of magnitude
+    /// louder. Scaling the allowance with the sweep is what keeps the
+    /// two apart at every size.
+    allowance: Allowance = .never,
 
     /// The two reasons an entry is here. They look identical to the gate
-    /// — both must read zero — and want opposite things from whoever the
-    /// gate wakes, so the remedy is printed from this rather than assumed.
+    /// — both are bounded by their allowance — and want opposite things
+    /// from whoever the gate wakes, so the remedy is printed from this
+    /// rather than assumed.
     const Why = enum {
         /// No scenario reaches it. A non-zero reading is good news: some
         /// scenario grew, and the entry has outlived its argument.
         unreached,
-        /// It can be reached and must not be. A non-zero reading is a bug
-        /// report, and deleting the entry would be deleting the alarm.
+        /// It can be reached and must not be, past its allowance. A
+        /// reading over that is a bug report, and deleting the entry
+        /// would be deleting the alarm.
         must_stay_zero,
     };
 
-    /// What to tell the reader when this entry's counter fires.
+    const Allowance = union(enum) {
+        never,
+        /// At most one per this many seeds, plus one — so a small sweep
+        /// tolerates a single occurrence of a rare legal event and a
+        /// large one scales with its own size, rather than the gate
+        /// becoming stricter the longer it runs.
+        at_most_one_per: u64,
+
+        fn limit(allowance: Allowance, iterations: u64) u64 {
+            return switch (allowance) {
+                .never => 0,
+                .at_most_one_per => |per| blk: {
+                    assert(per >= 1);
+                    break :blk 1 + iterations / per;
+                },
+            };
+        }
+    };
+
+    /// What to tell the reader when this entry's counter fires past its
+    /// allowance.
     fn remedy(entry: *const Uncovered) []const u8 {
         return switch (entry.why) {
             .unreached => "a scenario now reaches it, so delete this entry",
@@ -111,11 +145,19 @@ const uncovered = [_]Uncovered{
     .{
         .name = "health_probe_deadline_raced",
         .why = .must_stay_zero,
+        // Legal and vanishingly rare, so the claim is a rate: the
+        // nightly soak saw it once in a million seeds (run
+        // 30789778589), where "never" had held for every 4096-seed
+        // sweep before it. One per 100k leaves ten times the observed
+        // rate as headroom and still sits five orders of magnitude
+        // under the regression, which fires more than once per seed.
+        .allowance = .{ .at_most_one_per = 100_000 },
         .reason = "the §4 race it counts — a probe deadline firing after its " ++
-            "own cancel was issued — is legal but has never occurred in a " ++
-            "sweep, while a prober that stopped cancelling at all reports " ++
-            "every verdict correctly and moves only this. That is #130 " ++
-            "exactly. Measured: 0 with the fix, 4760 with it reverted",
+            "own cancel was issued — is legal and vanishingly rare (once in " ++
+            "a million seeds), while a prober that stopped cancelling at all " ++
+            "reports every verdict correctly and moves only this. That is " ++
+            "#130 exactly. Measured: 1 per million with the fix, 4760 per " ++
+            "4096 seeds with it reverted",
     },
     .{
         .name = "l7_headers_too_large",
@@ -336,9 +378,14 @@ const Census = struct {
     /// sentence twice: a silent rung wants a scenario that reaches it, and
     /// a fired entry wants either its deletion or a bug fixed, depending
     /// on which kind of entry it was (`Uncovered.remedy`).
-    fn verify(census: *const Census) bool {
+    fn verify(census: *const Census, iterations: u64) bool {
+        assert(iterations >= census_iterations_min);
         var held = true;
         var fired: usize = 0;
+        // Exempt entries that fired *within* their allowance — the rare
+        // legal ones. Counted so the partition below stays exact
+        // instead of being loosened to an inequality.
+        var allowed_fired: usize = 0;
         for (Counters.names, census.totals) |name, total| {
             if (total != 0) fired += 1;
             const entry = entryFor(name);
@@ -351,21 +398,29 @@ const Census = struct {
                 held = false;
             }
             if (entry) |exempt| {
-                if (total != 0) {
+                const limit = exempt.allowance.limit(iterations);
+                if (total > limit) {
                     std.debug.print(
-                        "sim census: {s} fired {d} time(s), and should not have.\n" ++
-                            "  why: {s}\n  do: {s}\n",
-                        .{ name, total, exempt.reason, exempt.remedy() },
+                        "sim census: {s} fired {d} time(s) against an allowance " ++
+                            "of {d}, and should not have.\n  why: {s}\n  do: {s}\n",
+                        .{ name, total, limit, exempt.reason, exempt.remedy() },
                     );
                     held = false;
+                }
+                if (total != 0 and total <= limit) {
+                    allowed_fired += 1;
                 }
             }
         }
         assert(fired <= Counters.names.len);
+        assert(allowed_fired <= uncovered.len);
         // The verdict restated as a partition: holding means the set that
-        // fired is exactly the complement of the exemption table — not
-        // merely that no single name was caught on the wrong side.
-        if (held) assert(fired == Counters.names.len - uncovered.len);
+        // fired is exactly the complement of the exemption table — plus
+        // whichever exempt entries fired inside their allowance, which
+        // is the one way a name can honestly be on both sides.
+        if (held) {
+            assert(fired == Counters.names.len - uncovered.len + allowed_fired);
+        }
         return census.verifyOps() and held;
     }
 
@@ -541,7 +596,7 @@ fn checkCensus(options: *const Sweep, census: *const Census) bool {
         });
         return true;
     }
-    if (!census.verify()) return false;
+    if (!census.verify(options.iterations)) return false;
     std.debug.print("sim: census ok, {d} counter(s) fired, {d} exempt; {d} seam op(s), {d} exempt\n", .{
         Counters.names.len - uncovered.len,
         uncovered.len,


### PR DESCRIPTION
The nightly failed on a shard where every one of its million seeds held
([run 30789778589](https://github.com/zoxy-io/zoxy/actions/runs/30789778589)).
Three problems behind one symptom.

**The census claim was empirical and got falsified.** The entry for
`health_probe_deadline_raced` said the event had never occurred in a
sweep — true of every 4096-seed sweep, and false the moment a sweep was
big enough to see it. The event is legal: a probe deadline whose
completion the ring had already queued when its cancel was issued, which
`onProbeDeadline` treats as accounting and nothing else — no verdict
changes. What the counter actually guards is #130, a prober that never
cancels and burns every probe's whole budget: more than one per *seed*,
against the one per *million* measured here. Six orders of magnitude
apart, so the discriminator was always a rate and zero was a proxy that
only held at small sizes. An entry can now carry an allowance that
scales with the sweep, and the failing range replays clean:
`1000000 seed(s) ok, 13000001..14000000`.

**"Failed without naming a seed" was true and useless.** A census
verdict is about the whole range rather than any one schedule, so there
is no seed to name — but there is a reason, and it was already in the
log. It now travels in the shard record, and the report prints it
instead of sending the reader to the run log for a line we had.

**The same shard was reported as having crashed.** The sim prints three
different summary lines and the workflow parsed two; a census failure
names its range on a line matching neither, so it fell into the panic
branch — recorded as `start - 1`, crediting zero of its million swept
seeds and telling the reader it never returned a verdict. Parsed now, so
the coverage it really achieved is counted and the claim matches what
happened.

Also records the Debug-beats-ReleaseSafe measurement in
IMPLEMENTATION_NOTES with the instruction counts that explain it (6.84e10
vs 7.73e9 for identical work, with fewer cache misses) — the verdict was
already in `nightly-sim.yml`'s build step from 2026-07-28; this adds the
mechanism so the next person to propose optimizing the sweep finds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)