### PR TITLE
build: ship ReleaseSafe instead of ReleaseFast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             # recognises and omits — a release says `zoxy 0.0.7` and
             # nothing else, whatever the checkout depth happens to be.
             devenv shell -- zig build \
-              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseFast \
+              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseSafe \
               -Dbuild-id="${{ steps.ver.outputs.tag }}" --prefix "out/$label"
             tar czf "dist/zoxy-$version-$label.tar.gz" -C "out/$label/bin" zoxy
             echo "::endgroup::"

--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -7,9 +7,10 @@
 //! zrk load threads, the inherited nginx) is pinned off that core so the load
 //! generator never steals it.
 //!
-//! Run via `zig build profile`, which builds a ReleaseFast zoxy and passes its
-//! path as the first argument; perf, flamegraph and nginx come from the dev
-//! shell. Tooling stays in Zig, not bash (TIGER_STYLE): the perf orchestration
+//! Run via `zig build profile`, which builds a ReleaseSafe zoxy (matching the
+//! shipped binary) and passes its path as the first argument; perf,
+//! flamegraph and nginx come from the dev shell. Tooling stays in Zig, not
+//! bash (TIGER_STYLE): the perf orchestration
 //! and the perf-script -> stackcollapse -> flamegraph pipeline run as
 //! file-redirected child processes here rather than a shell pipe.
 

--- a/build.zig
+++ b/build.zig
@@ -59,7 +59,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     // src/main.zig reads its version from this module (also added to the
-    // ReleaseFast `release_zoxy` below, the other build of that same source).
+    // ReleaseSafe `release_zoxy` below, the other build of that same source).
     exe.root_module.addOptions("build_options", build_options);
     b.installArtifact(exe);
 
@@ -133,7 +133,7 @@ pub fn build(b: *std.Build) void {
 
     // §9 Tier 0.5: the live gate — the shipped binary, on a real kernel,
     // against a real origin, on every change. It drives the *default*
-    // build (the one `zig build` installs) rather than the ReleaseFast
+    // build (the one `zig build` installs) rather than the ReleaseSafe
     // one the bench uses: its verdicts are correctness equalities on real
     // output, so what a Debug build's extra checks add is worth more here
     // than the shipped binary's code generation, which Tier 1 is the gate
@@ -156,12 +156,10 @@ pub fn build(b: *std.Build) void {
     const smoke_step = b.step("smoke", "Tier-0.5 live gate: the real binary against a live origin");
     smoke_step.dependOn(&smoke_run.step);
 
-    // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash),
-    // and the zoxy under test is a ReleaseFast build — matching the
-    // shipped binary — whatever -Doptimize says. ReleaseFast selects the
-    // LLVM backend (Zig 0.16's default for release modes), so hparse's
-    // SIMD paths are emitted; a Debug/self-hosted zoxy scalarizes them
-    // and would benchmark the wrong code.
+    // §9 Tier 1: the loopback band harness embeds zrk (pinned by hash) as
+    // its load generator — that role stays ReleaseFast regardless of what
+    // zoxy itself ships as; it isn't the thing under test, it just needs
+    // to generate load fast enough not to be the bottleneck.
     const zrk_dependency = b.dependency("zrk", .{
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseFast,
@@ -173,16 +171,22 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseFast,
     });
-    // The ReleaseFast zoxy shared by the bench and the profiler, with its
-    // own ReleaseFast hparse instance (SIMD, not scalarized).
+    // The zoxy under test is ReleaseSafe — matching the shipped binary
+    // (release.yml) — whatever -Doptimize says for the default install.
+    // ReleaseSafe still selects the LLVM backend (Zig 0.16's default for
+    // every release mode, not just ReleaseFast), so hparse's SIMD paths
+    // are emitted; only a Debug/self-hosted zoxy scalarizes them and
+    // would benchmark the wrong code. hparse_fast_dependency keeps its
+    // name (distinguishing it from the module-tests' Debug hparse) even
+    // though it's no longer the *fastest* build mode.
     const hparse_fast_dependency = b.dependency("hparse", .{
         .target = target,
-        .optimize = std.builtin.OptimizeMode.ReleaseFast,
+        .optimize = std.builtin.OptimizeMode.ReleaseSafe,
     });
     const zoxy_fast_module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
-        .optimize = .ReleaseFast,
+        .optimize = .ReleaseSafe,
         .imports = &.{
             .{ .name = "xev", .module = xev_module },
             .{ .name = "hparse", .module = hparse_fast_dependency.module("hparse") },
@@ -193,13 +197,15 @@ pub fn build(b: *std.Build) void {
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .target = target,
-            .optimize = .ReleaseFast,
+            .optimize = .ReleaseSafe,
             .imports = &.{
                 .{ .name = "zoxy", .module = zoxy_fast_module },
             },
         }),
     });
     release_zoxy.root_module.addOptions("build_options", build_options);
+    // The harness itself (drives zrk against release_zoxy over the wire)
+    // stays ReleaseFast for the same reason zrk/zio do above.
     const bench_exe = b.addExecutable(.{
         .name = "zoxy-bench",
         .root_module = b.createModule(.{
@@ -213,7 +219,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     const bench_run = b.addRunArtifact(bench_exe);
-    // Drive the ReleaseFast zoxy, not the default-optimize install
+    // Drive the ReleaseSafe zoxy, not the default-optimize install
     // artifact — a Debug zoxy scalarizes hparse and benchmarks the wrong
     // binary (§9). bench/run.zig takes it via --zoxy.
     bench_run.addArg("--zoxy");
@@ -229,8 +235,8 @@ pub fn build(b: *std.Build) void {
 
     // §9 Tier 0: micro binaries for manual poop A/B; installed, never run
     // in CI (counter deltas on shared runners are noise). They reuse the
-    // ReleaseFast `zoxy_fast_module` defined above so the SIMD parser is
-    // what gets measured.
+    // ReleaseSafe `zoxy_fast_module` defined above so what gets measured
+    // (SIMD parser included) matches the shipped binary, checks and all.
     const micro_step = b.step("bench-micro", "Build Tier-0 micro binaries for poop A/B");
     for ([_][]const u8{ "pool_acquire_release", "relay_chunking", "l7_head_pipeline", "conn_touch_scaling" }) |micro_name| {
         const micro_exe = b.addExecutable(.{
@@ -238,7 +244,7 @@ pub fn build(b: *std.Build) void {
             .root_module = b.createModule(.{
                 .root_source_file = b.path(b.fmt("bench/micro/{s}.zig", .{micro_name})),
                 .target = target,
-                .optimize = .ReleaseFast,
+                .optimize = .ReleaseSafe,
                 .imports = &.{
                     .{ .name = "zoxy", .module = zoxy_fast_module },
                 },
@@ -247,12 +253,14 @@ pub fn build(b: *std.Build) void {
         micro_step.dependOn(&b.addInstallArtifact(micro_exe, .{}).step);
     }
 
-    // §9 Tier 0: pinned perf + flamegraph of zoxy under load. Two ReleaseFast
-    // binaries — the zoxy under test (shipped-binary fidelity) and the harness
-    // (bench/profile.zig) that spawns nginx + zoxy, pins zoxy to one core so
-    // the PMU and LBR call-graph stay on a single core type, drives zrk load,
-    // and folds perf into a flamegraph. Linux-only — perf/flamegraph/nginx
-    // live in the dev shell. Tooling in Zig, not bash (TIGER_STYLE §Tooling).
+    // §9 Tier 0: pinned perf + flamegraph of zoxy under load. The zoxy
+    // under test is ReleaseSafe (shipped-binary fidelity); the harness
+    // (bench/profile.zig) — which spawns nginx + zoxy, pins zoxy to one
+    // core so the PMU and LBR call-graph stay on a single core type,
+    // drives zrk load, and folds perf into a flamegraph — stays
+    // ReleaseFast, same reasoning as bench_exe above. Linux-only —
+    // perf/flamegraph/nginx live in the dev shell. Tooling in Zig, not
+    // bash (TIGER_STYLE §Tooling).
     const profile_harness = b.addExecutable(.{
         .name = "zoxy-profile-harness",
         .root_module = b.createModule(.{

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1246,9 +1246,11 @@ Measured while sizing the nightly soak, 20k seeds on the dev box:
 **Debug 25 s, ReleaseSafe 88 s, ReleaseFast 3 s.** ReleaseSafe being
 3.5× *slower than unoptimized* is the surprise; it is unexplained and
 worth its own look if anything ever wants to ship ReleaseSafe. Nothing
-does today — release.yml builds `-Doptimize=ReleaseFast` — so this is a
-simulator-workload finding, not a production one, and the ~90 k req/s
-bench bands are unaffected.
+did at the time — release.yml built `-Doptimize=ReleaseFast` then — so
+this was a simulator-workload finding, not a production one, and the
+~90 k req/s bench bands were unaffected. (release.yml now ships
+ReleaseSafe — see "Shipping ReleaseSafe" below — but the sim gate itself
+stays on Debug regardless; that verdict doesn't change.)
 
 The actionable half is the build mode the sim gates run under. ReleaseFast
 is 8× faster than Debug and is exactly the wrong choice: it compiles
@@ -1259,6 +1261,50 @@ a performance argument as a disguise. ReleaseSafe keeps the assertions
 but loses to Debug on speed, so Debug is both the strictest and the
 fastest option available and there is no trade to make. Recorded so the
 soak's runtime is never "optimized" by changing its build mode.
+
+The 3.5× anomaly stayed unexplained — but it's a `sim/main.zig` seed-loop
+finding, not evidence about the proxy's own request-handling code; see
+"Shipping ReleaseSafe" below for what the production hot path actually
+does under it.
+
+## Shipping ReleaseSafe (2026-08-04)
+
+`release.yml` and every build.zig target that compiles zoxy's own code
+for measurement (`release_zoxy`, the Tier-0 micro binaries) moved from
+ReleaseFast to ReleaseSafe. Motivation: a security review found that
+`std.debug.assert` — which several bounds/invariant guards rely on as
+their *only* enforcement (`mem/Pool.zig`'s double-release guard,
+`net/Conn.zig`'s stale-completion generation check) — is UB-on-violation
+in ReleaseFast, not a panic, contradicting TIGER_STYLE.md's "assertions
+are always on" policy. No live trigger for either guard was found after
+tracing every call site, so this is a hardening move, not a hotfix.
+zrk/zio and the bench/profile harness binaries stayed ReleaseFast — they
+generate load, they aren't the thing under test.
+
+Given the sim finding above, the change shipped only after measuring the
+actual proxy, not by assuming the sim's 3.5× applied here. Procedure:
+`git worktree add` at the pre-change commit (ReleaseFast baseline),
+`zig build bench -- --rate 20000 --connections 32 --seconds 5` alternated
+3 rounds each between that worktree and the ReleaseSafe tree (§9 band
+procedure). Steady-state (20k req/s, ~100k requests/run, the
+high-volume/low-noise scenario): hop p50 zoxy L4 baseline [24,25]µs vs
+ReleaseSafe [24,27]µs, zoxy L7 baseline [18,24]µs vs ReleaseSafe
+[22,25]µs — bands overlap, no separation. Overload/churn band (256 conns
+vs 64 slots): completed throughput baseline {5017,5009,5007} vs
+ReleaseSafe {5007,5030,5007} req/s — indistinguishable. The large-body
+scenario (400 req/s, 100 MiB/s, only 2000 requests/run — noisiest band)
+looked separated after 2 rounds (baseline max 314µs vs ReleaseSafe min
+362µs) and collapsed to full overlap by round 3 (baseline max 360µs,
+ReleaseSafe min 362µs) — a clean in-session demonstration of why one or
+two runs isn't enough, matching the "run-to-run variance" note below.
+Confirms the prior CPU profiling (zoxy is syscall-bound, 98.6% of cycles
+in `io_uring_enter`, user code 1.26%): ReleaseSafe's added checks land in
+that thin user-code slice and don't move the wall-clock number. One real,
+minor difference: RSS under the overload scenario sat ~1440 KiB higher
+under ReleaseSafe (2128-2132 KiB baseline vs 3600-3604 KiB ReleaseSafe,
+each stable across its own 3 runs) — larger static code/metadata from the
+safety instrumentation, not a per-connection or growth-under-load cost
+(both stayed flat across their own churn window).
 
 ## The deadline rebase cancel reaches the expiry path (#65)
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -146,10 +146,11 @@ pub fn Server(comptime IoType: type) type {
         log_headers_per_conn: u32,
         /// Highest armed-op count any one connection has reached (§8):
         /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
-        /// under runtime safety only (never in the shipped ReleaseFast
-        /// build), records the peak here, so a test can claim a race
-        /// co-armed exactly the budgeted worst case, not merely stayed
-        /// under it.
+        /// under runtime safety only (Debug and ReleaseSafe — the shipped
+        /// build is ReleaseSafe, see docs/IMPLEMENTATION_NOTES.md
+        /// "Shipping ReleaseSafe"), records the peak here, so a test can
+        /// claim a race co-armed exactly the budgeted worst case, not
+        /// merely stayed under it.
         armed_ops_peak: u8,
         /// The raw errno of the most recent kernel-pressure failure, or 0
         /// (§8). Reported as a gauge rather than a counter because it is a

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -664,10 +664,11 @@ pub fn Conn(comptime IoType: type) type {
             op.generation_at_submit = conn.generation;
             @field(conn.armed, bit) = true;
             assert(conn.armedCount() <= constants.conn_ops_max);
-            // Test-only watermark: tracked wherever the budget assert
-            // above is live (Debug, ReleaseSafe), never in the shipped
-            // ReleaseFast build, so the hot path pays nothing in
-            // production for what only a test reads.
+            // Test-only *reader*, not test-only *cost*: tracked wherever
+            // the budget assert above is live (Debug, ReleaseSafe) — the
+            // shipped build is ReleaseSafe, so this compare-and-max runs
+            // in production now, same cost class as the assert next to
+            // it; only the counter's only reader is a test.
             if (std.debug.runtime_safety) {
                 conn.server.armed_ops_peak =
                     @max(conn.server.armed_ops_peak, conn.armedCount());


### PR DESCRIPTION
## Summary
- A security review of the Zig sources found the shipped `ReleaseFast` build silently disables `std.debug.assert` (UB-on-violation, not a panic) along with bounds/overflow checks — contradicting `docs/TIGER_STYLE.md`'s stated "assertions are always on" policy. A couple of bounds/invariant guards (`mem/Pool.zig` double-release, `net/Conn.zig` stale-completion generation check) rely on `assert` alone with no other enforcement in production.
- `release.yml` and every `build.zig` target that compiles zoxy's own code for measurement (`release_zoxy`, the Tier-0 micro binaries) now build `ReleaseSafe`. The load-generator/tooling binaries (`zrk`, `zio`, `bench_exe`, `profile_harness`) stay `ReleaseFast` since they aren't the thing under test.
- Two comments in `src/Server.zig`/`src/net/Conn.zig` claiming an `armed_ops_peak` watermark "never runs in the shipped ReleaseFast build" were stale given the switch and corrected.
- `docs/IMPLEMENTATION_NOTES.md` gained a dated entry recording the bench validation, and a correction to the existing "ReleaseSafe is a trap" note (that 3.5x sim-workload anomaly doesn't apply to the proxy's own request path).

## Test plan
- [x] `zig fmt --check src scripts smoke build.zig build.zig.zon`
- [x] `zig build ci` (test + lint + sim + smoke) — passing
- [x] `zig build bench-micro` compiles under the new ReleaseSafe `zoxy_fast_module`
- [x] 3-round alternating `zig build bench` A/B (scratch `git worktree` at the pre-change commit vs. this branch): steady-state hop p50 and overload/churn throughput bands fully overlap between ReleaseFast and ReleaseSafe — no measurable regression. Full numbers in the `IMPLEMENTATION_NOTES.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)