### PR TITLE
docs: name the metrics example's fence language

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -738,7 +738,7 @@ a wall is *hit*, while `zoxy_conn_slots_in_use` against
 
 The scrape also says **which backend**, per cluster and endpoint:
 
-```
+```text
 zoxy_endpoint_responses{cluster="api",endpoint="10.0.0.1:8080"} 4182
 zoxy_endpoint_connect_failed{cluster="api",endpoint="10.0.0.2:8080"} 17
 zoxy_endpoint_health_down{cluster="api",endpoint="10.0.0.2:8080"} 2


### PR DESCRIPTION
## Summary
- The new "which backend" Prometheus example in the Metrics section (v0.1.0) is fenced with a bare ` ``` ` — GitHub renders that fine, but zoxy-io/site's docs reader requires every fence to name a language, so `/docs`'s v0.1.0 sync build fails on it.
- Tags it `text` (it's Prometheus exposition format, not a language the site highlights).

## Test plan
- [x] Verified against the site's actual parser: `ZOXY_DOCS_LOCAL=<this file> npm run refresh-docs && npm run build` in zoxy-io now succeeds end-to-end for the full v0.1.0 manual.