### PR TITLE
test: the live gate terminates real TLS — and finds two bugs no other tier could (#125)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -185,6 +185,18 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    // The TLS fixture, handed in rather than embedded: `@embedFile` cannot
+    // escape its module root and the harness is its own module. The
+    // `example_config` import above is the same shape. It stays a
+    // *config* input — the harness writes both files into its work
+    // directory and points the proxy at them, exactly as an operator
+    // would — so nothing here links ztls or libcrypto (§4, §9).
+    smoke_exe.root_module.addAnonymousImport("tls_cert_pem", .{
+        .root_source_file = b.path("src/tls/testdata/cert.pem"),
+    });
+    smoke_exe.root_module.addAnonymousImport("tls_key_pem", .{
+        .root_source_file = b.path("src/tls/testdata/key.pem"),
+    });
     const smoke_run = b.addRunArtifact(smoke_exe);
     smoke_run.addArg("--zoxy");
     smoke_run.addArtifactArg(exe);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1598,6 +1598,19 @@ equalities a shared runner's noise cannot move.
    rendered head that did not *grow* fits its excess exactly. The
    proxy's resident set must not move across two identical load passes,
    §5's promise witnessed from outside the process.
+   One listener terminates TLS (§4), driven by `std.crypto.tls.Client` —
+   an implementation sharing no code with the one zoxy terminates on,
+   which is the only kind whose agreement is evidence. It handshakes,
+   holds a keep-alive session across several requests, and ends it with a
+   `close_notify`; its requests join the same line and accept equalities
+   as every other, because a terminated request is an ordinary request by
+   the time it is logged. It earned its place immediately: it found that
+   every terminating process segfaulted at exit — after a clean drain and
+   a correct exit code — in a libcrypto atexit handler freeing through a
+   heap the arena had already taken, which needs a real *process* to see;
+   and a phantom access-log line per terminated keep-alive connection,
+   the same defect as #129 one layer down, where the log clock started on
+   the ciphertext delivery rather than the first decrypted byte.
    The one exception to "equalities" is the health-probe *rate*, and it
    is the exception that proves the rule: #130 was a bug no equality
    could see, because every verdict the prober reached was correct and

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1619,6 +1619,38 @@ can only be the proxy's fault. The band now prints the refused/timed-out
 split every run: a threshold whose margin is invisible until it trips is
 how this one sat mis-specified for a week.
 
+## Open: the https leg wedged once on macOS (2026-08-11, #125)
+
+The first CI run carrying the Tier-0.5 https leg wedged on the macOS
+runner — the whole 30 s budget, against a run that takes about a second.
+Every run since has passed there, on the same commit and on later ones,
+so this is **intermittent and unexplained**, not a platform that cannot
+terminate TLS. Recorded rather than waved off: an intermittently red gate
+is worse than a red one, because the first instinct on seeing it green
+again is to stop looking.
+
+What is known. Linux has never reproduced it, over dozens of local runs
+and every CI run. The commit before — the same TLS listener, configured
+and started, but with no client connecting to it — passed macOS, so the
+listener, the certificate load and the libcrypto heap install are not it;
+the first macOS execution of the *handshake and exchange* path is also
+its only failure. The proxy was alive and quiet, not crashed: no panic
+reached its log.
+
+What is *not* the explanation, checked: the delayed-ACK stall documented
+above is bounded by a timer in the tens of milliseconds and cannot
+produce a thirty-second wait; and the extra admin scrape the leg adds is
+the fourth of its kind in a run whose first three already pass there.
+
+The instrumentation to catch it next time is in: the watchdog names the
+wait it died in (and, for the requests, which one), and it now SIGTERMs
+the proxy and lets it drain before killing it, so the report carries the
+proxy's own counters. The first wedge had neither — it said only that
+thirty seconds had passed, which is what made it un-diagnosable. The
+standing suspicion to test first is a lost wakeup in the kqueue path,
+since the TLS legs are the one place a data op is armed outside the
+provided-buffer ring, and a race there would present exactly this way.
+
 ## The live gate's measured numbers (2026-08-02, #144)
 
 Tier 0.5 (`zig build smoke`, DESIGN.md §9) landed with these readings on a

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -55,20 +55,39 @@ Remaining, in the order the work wants:
    wired, so no ticket is ever sent. That is both §4's resumption and the
    ~45 ms stall below, and the emission has to land *after* the client
    Finished is processed, not alongside the server flight.
-2. **The Tier-0.5 smoke gate.** Feasible as planned and with no new
-   dependency: `std.crypto.tls.Client` in the pinned toolchain offers
-   `ca: .self_signed` and `host: .no_verification`, which is exactly the
-   checked-in fixture's shape. Worth doing with std rather than
-   `TestClient` precisely because it is an *independent* implementation —
-   ztls talking to ztls proves interoperability with nobody.
-3. **The Tier-1 bands**, whose acceptance is the close-mode rate gate PR
+2. **The Tier-1 bands**, whose acceptance is the close-mode rate gate PR
    #84 could not pass; (1) is what is expected to move it.
 
 Two smaller things the reviews left open: `ResponseBodyPolicy.afterSend`
 credits ciphertext to `bytes_out` where the client-write channel credits
 plaintext, so a streamed TLS response over-counts; and the sim's TLS
-http client sends `Connection: close` and a GET, leaving the keep-alive
-turnaround and the request-body leg reachable by directed tests only.
+http client sends `Connection: close` and a GET, leaving the request-body
+leg reachable by directed tests only.
+
+### What the live gate found
+
+Tier 0.5 terminates real TLS from `std.crypto.tls.Client` — an
+implementation sharing no code with ztls, which is the only kind whose
+agreement means anything. It landed two defects that every other tier had
+been green on, and both are worth recording because neither was reachable
+from where the other tiers stand.
+
+- **Every terminating process crashed at exit.** The fixed libcrypto heap
+  was arena-backed; `OPENSSL_cleanup` runs from an atexit handler, after
+  `main` returned and took the arena with it. Needs a *process* that
+  installs the heap and then exits — which unit tests never do, the
+  simulator has no process for, and the heap proof already avoids by
+  installing into a static. Storage is static now.
+- **A phantom access-log line per terminated keep-alive connection.** The
+  log clock started on the ciphertext *delivery* rather than on the first
+  decrypted byte, so the `close_notify` that ends an idle connection
+  opened an entry for a request nobody made, which teardown then wrote out
+  as an `aborted` exchange with no method and no bytes. Now pinned by a
+  directed test, but the sim did not have it: its TLS clients close in
+  protocol only after a `Connection: close` request, so no idle keep-alive
+  connection was ever alerted. The reachable-counter census cannot see
+  this class at all — the phantom line increments `access_log_lines`, a
+  counter every run already fires.
 
 Earlier candidates, recorded so they are not re-chased: a hardened fork
 of [tls.zig](https://github.com/ianic/tls.zig) (pinned `5452baf`) was the

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1243,6 +1243,19 @@ fn startTlsClients(harness: *Harness) void {
             // second request and a POST are what cover both, and each
             // needs the client to end on something other than the peer's
             // EOF.
+            //
+            // The first gap has since cost a real defect: a close_notify
+            // on a connection idle *between* requests started an access
+            // log entry for a request nobody made (see the directed test
+            // `l7: close_notify between requests writes no access-log
+            // line`, and the Tier-0.5 leg that found it). It is covered
+            // now, but by two hand-picked cases rather than the sweep.
+            // Flipping this option on for `.http` is not the fix — the
+            // paragraph above is the reason, and it is a hang, not a
+            // failure: the option would wait for a response as long as
+            // the request. Closing it properly means teaching the client
+            // to end on a *complete response* rather than a byte count,
+            // which is a change to `TestClient`, not to this call.
             .close_after_echo = harness.tls_protocol == .l4,
             .x25519_seed = seeds[0],
             .p256_seed = seeds[1],

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -27,6 +27,17 @@ const response_head_bytes_max: u32 = 8192;
 /// vocabulary, not for one request, so the cap needs no per-call thought.
 pub const response_body_bytes_max: u32 = 256 * 1024;
 
+/// The TLS session's own buffers (§4). `std.crypto.tls` asserts at
+/// least `min_buffer_len` — one max ciphertext record — on each, so this
+/// is that floor stated where the arrays are declared rather than
+/// discovered as a panic on the first handshake.
+const tls_buffer_bytes: u32 = std.crypto.tls.Client.min_buffer_len;
+
+/// What the socket's own reader and writer hold — the larger of a
+/// response head and one ciphertext record, since the same connection
+/// type serves both.
+const socket_buffer_bytes: u32 = @max(response_head_bytes_max, tls_buffer_bytes);
+
 /// Header lines one response head may spend, on the same terms as the
 /// origin's request cap: a bound so the parse loop cannot run forever.
 const response_headers_max: u32 = 64;
@@ -45,6 +56,10 @@ pub const Response = struct {
     /// instead of passing as either presence or absence.
     sticky_tag: ?[16]u8,
 };
+
+/// How much entropy `std.crypto.tls` wants to seed one handshake — the
+/// two keyshares and the client random together.
+const entropy_len: u32 = std.crypto.tls.Client.Options.entropy_len;
 
 /// The #140 correlation header every request carries, and the one value
 /// it ever holds — spelled here rather than imported, like the counter
@@ -72,8 +87,12 @@ pub const Client = struct {
     stream: Io.net.Stream = undefined,
     reader: Io.net.Stream.Reader = undefined,
     writer: Io.net.Stream.Writer = undefined,
-    read_buffer: [response_head_bytes_max]u8 = undefined,
-    write_buffer: [response_head_bytes_max]u8 = undefined,
+    /// The socket's own buffers. Wide enough for both roles they serve:
+    /// a plaintext connection reads a response head through them, and a
+    /// terminated one carries *ciphertext*, which `std.crypto.tls`
+    /// requires be able to hold a whole record at once.
+    read_buffer: [socket_buffer_bytes]u8 = undefined,
+    write_buffer: [socket_buffer_bytes]u8 = undefined,
     /// Requests issued on this connection, so a caller can assert its own
     /// keep-alive arithmetic against what actually went out.
     requests: u32 = 0,
@@ -81,6 +100,19 @@ pub const Client = struct {
     /// one: a static slot starts closed, so `connect` can refuse to
     /// overwrite a live connection instead of leaking its socket.
     connected: bool = false,
+    /// The TLS session, when this connection was opened with `connectTls`
+    /// (§4). `std.crypto.tls.Client` deliberately, not the ztls TestClient
+    /// the other gates share: this tier is the one that runs the shipped
+    /// binary against a real kernel, and an *independent* implementation
+    /// is the only one whose agreement means anything — ztls talking to
+    /// ztls proves interoperability with nobody. It also keeps libcrypto
+    /// out of the smoke binary entirely.
+    tls: ?std.crypto.tls.Client = null,
+    /// The session's own two buffers, beside the socket's rather than
+    /// shared with them: the socket pair carries ciphertext and these
+    /// carry the plaintext it decrypts to, so both are live at once.
+    tls_read_buffer: [tls_buffer_bytes]u8 = undefined,
+    tls_write_buffer: [tls_buffer_bytes]u8 = undefined,
 
     /// Open a connection to a loopback port. In-place through an
     /// out-pointer: both `Reader` and `Writer` hold pointers into the
@@ -96,11 +128,89 @@ pub const Client = struct {
         client.writer = client.stream.writer(io, &client.write_buffer);
         client.requests = 0;
         client.connected = true;
-        assert(client.reader.interface.buffer.len == response_head_bytes_max);
+        assert(client.reader.interface.buffer.len == socket_buffer_bytes);
+    }
+
+    /// The same, terminating TLS (§4). The stream's own reader and writer
+    /// become the *ciphertext* transport and the session hands back
+    /// plaintext ones, so everything after this — `get`, the response
+    /// parse — is the plaintext path unchanged. That is the point: what
+    /// this gate proves is that the same equalities hold through a real
+    /// handshake, not that TLS has its own client.
+    ///
+    /// Verification is `.self_signed` against no host: the fixture is a
+    /// throwaway self-signed certificate (`src/tls/testdata`), so a CA
+    /// bundle would have nothing to check it against. The gate's subject
+    /// is the proxy's record layer, not this client's trust decisions.
+    pub fn connectTls(client: *Client, io: Io, port: u16) !void {
+        try client.connect(io, port);
+        errdefer client.close();
+        // The client's own handshake randomness, from the OS: this is the
+        // one thing in the run that must *not* be reproducible, and
+        // nothing here replays, so it comes straight off `io` rather than
+        // through zoxy's seeded seam.
+        var entropy: [entropy_len]u8 = undefined;
+        io.random(&entropy);
+        client.tls = try .init(&client.reader.interface, &client.writer.interface, .{
+            .host = .no_verification,
+            .ca = .self_signed,
+            .read_buffer = &client.tls_read_buffer,
+            .write_buffer = &client.tls_write_buffer,
+            .entropy = &entropy,
+            // The real clock, not epoch zero: `.self_signed` still checks
+            // the certificate's validity window, and the fixture is dated
+            // from when it was generated. A fixed timestamp here would
+            // pass until the fixture is regenerated and then fail for a
+            // reason having nothing to do with the proxy.
+            .realtime_now = .now(io, .real),
+        });
+        // The postcondition `connect` states for its own reader, restated
+        // for what this adds: every request after this rides the session,
+        // and `plaintext()` picks by exactly this field being set.
+        assert(client.tls != null);
+    }
+
+    /// Where this connection's bytes are read and written: the session's
+    /// plaintext interfaces when one exists, the socket's otherwise.
+    /// Named so `get` states which it is once rather than branching twice.
+    fn plaintext(client: *Client) struct { in: *Io.Reader, out: *Io.Writer } {
+        if (client.tls) |*session| {
+            return .{ .in = &session.reader, .out = &session.writer };
+        }
+        return .{ .in = &client.reader.interface, .out = &client.writer.interface };
+    }
+
+    /// Push everything written so far all the way to the kernel.
+    ///
+    /// A terminated connection has *two* buffers stacked, and flushing the
+    /// session only moves plaintext across the first: `Client.flush`
+    /// encrypts into the socket writer's buffer and returns, leaving the
+    /// ciphertext in this process. Flushing only the session therefore
+    /// wedges — the request never goes out, and the read that follows
+    /// waits for a response to bytes the server never saw. Both layers,
+    /// outermost last, is what `std.http.Client` does at its own send.
+    fn flushAll(client: *Client) !void {
+        if (client.tls) |*session| {
+            try session.writer.flush();
+        }
+        try client.writer.interface.flush();
+    }
+
+    /// End the session the way TLS says to: a `close_notify` alert, then
+    /// the socket. The alert is the point — a bare FIN is indistinguishable
+    /// from a truncation attack, so zoxy has a separate in-band path for
+    /// this (§6's transform seam treats the alert as the EOF), and only a
+    /// client that actually sends one walks it.
+    pub fn endTls(client: *Client) !void {
+        assert(client.connected);
+        assert(client.tls != null);
+        try client.tls.?.end();
+        try client.writer.interface.flush();
     }
 
     pub fn close(client: *Client) void {
         assert(client.connected);
+        client.tls = null;
         client.stream.close(client.io);
         client.connected = false;
     }
@@ -132,23 +242,24 @@ pub const Client = struct {
         // in the config and then finds this exact value in the written
         // log, which is the join an operator would make between this log
         // and the origin's.
+        const wire = client.plaintext();
         if (cookie) |crumb| {
             assert(crumb.len >= 1);
-            try client.writer.interface.print(
+            try wire.out.print(
                 "GET {s} HTTP/1.1\r\nHost: {s}\r\nCookie: {s}\r\n" ++
                     request_id_header ++ ": " ++ request_id_value ++ "\r\n{s}\r\n",
                 .{ target, host, crumb, persistence.header() },
             );
         } else {
-            try client.writer.interface.print(
+            try wire.out.print(
                 "GET {s} HTTP/1.1\r\nHost: {s}\r\n" ++
                     request_id_header ++ ": " ++ request_id_value ++ "\r\n{s}\r\n",
                 .{ target, host, persistence.header() },
             );
         }
-        try client.writer.interface.flush();
+        try client.flushAll();
         client.requests += 1;
-        const response = try readResponse(&client.reader.interface);
+        const response = try readResponse(wire.in);
         assert(client.requests >= 1);
         return response;
     }

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -315,6 +315,64 @@ var single_client: client_module.Client = .{};
 /// Zero until then — the watchdog can outlive the spawn failing.
 var watchdog_child_pid = std.atomic.Value(i32).init(0);
 
+/// What the run is doing, for the watchdog to name if it fires.
+///
+/// A wedge reports from the *other* thread, so it cannot ask the wedged
+/// one where it stopped — this is the only thing that can say. Worth its
+/// weight the first time a gate wedges on a platform the author cannot
+/// run: "exceeded its budget" says a run hung, which is what the exit
+/// code already said; "wedged in: https handshake" says which of a dozen
+/// waits it was, and on which side.
+///
+/// Ordered as the run performs them, so the *last* one reached is also a
+/// statement about everything before it having finished.
+const Stage = enum {
+    starting,
+    awaiting_listener,
+    load,
+    counter_scrape,
+    sticky_leg,
+    bodies_leg,
+    https_handshake,
+    https_request,
+    https_close_notify,
+    https_scrape,
+    drain,
+    verdicts,
+
+    fn label(stage: Stage) []const u8 {
+        return switch (stage) {
+            .starting => "starting the proxy",
+            .awaiting_listener => "waiting for the listener",
+            .load => "the http and l4 load",
+            .counter_scrape => "the counter scrapes",
+            .sticky_leg => "the sticky leg (#178)",
+            .bodies_leg => "the bodies leg (#159)",
+            .https_handshake => "the https handshake",
+            .https_request => "an https request",
+            .https_close_notify => "the https close_notify",
+            .https_scrape => "the https leg's scrape",
+            .drain => "the drain",
+            .verdicts => "reading back the verdicts",
+        };
+    }
+};
+
+var current_stage = std.atomic.Value(u8).init(@intFromEnum(Stage.starting));
+
+/// Which https request is in flight, 1-based, for the stage that repeats.
+/// The distinction it draws is the one worth having: the first request on
+/// a session and the ones after it are different code (the turnaround),
+/// and a wedge that cannot tell them apart leaves both suspect.
+var current_https_request = std.atomic.Value(u32).init(0);
+
+/// Publish what the run is about to wait on. Release-ordered against the
+/// watchdog's acquire load: the label must be readable by the time the
+/// wait it describes can hang.
+fn enterStage(stage: Stage) void {
+    current_stage.store(@intFromEnum(stage), .release);
+}
+
 const Flags = struct {
     zoxy_path: []const u8 = "zig-out/bin/zoxy",
 };
@@ -369,21 +427,28 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     var running = true;
     defer if (running) child.kill(io);
 
+    enterStage(.awaiting_listener);
     try awaitListening(io, ports.http);
+    enterStage(.load);
     const memory = try runLoad(arena, io, &ports, child.id);
 
     // Scraped before the drain: the admin listener closes with every
     // other one when SIGTERM lands (§8).
+    enterStage(.counter_scrape);
     const counters = try countersPassed(arena, io, ports.admin, origin.port);
     // The #178 leg runs after the scrapes above on purpose — see
     // `sticky_exchanges` — and brings its own scrape.
+    enterStage(.sticky_leg);
     const sticky_ok = try stickyPassed(arena, io, &ports);
+    enterStage(.bodies_leg);
     const bodies_ok = try bodiesPassed(arena, io, &ports);
     // Last, so its scrape sees the whole run — and so a wedged handshake
     // cannot cost the legs above their verdicts.
     const tls_ok = try tlsPassed(arena, io, &ports);
 
+    enterStage(.drain);
     const drained_cleanly = try drain(io, &child, &running);
+    enterStage(.verdicts);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
     // both, not stop at the first.
@@ -456,10 +521,19 @@ fn watchdogTask(io: Io) void {
         assert(err == error.Canceled);
         return;
     };
-    std.debug.print(
-        "FAIL: smoke run exceeded its {d}s budget — something is wedged, not slow\n",
-        .{watchdog_budget_ns / std.time.ns_per_s},
-    );
+    const stage: Stage = @enumFromInt(current_stage.load(.acquire));
+    const seconds = watchdog_budget_ns / std.time.ns_per_s;
+    if (stage == .https_request) {
+        std.debug.print(
+            "FAIL: smoke run exceeded its {d}s budget — wedged in: {s} ({d} of {d})\n",
+            .{ seconds, stage.label(), current_https_request.load(.acquire), tls_requests },
+        );
+    } else {
+        std.debug.print(
+            "FAIL: smoke run exceeded its {d}s budget — wedged in: {s}\n",
+            .{ seconds, stage.label() },
+        );
+    }
     const pid = watchdog_child_pid.load(.acquire);
     if (pid != 0) {
         std.posix.kill(pid, .KILL) catch {};
@@ -1162,12 +1236,15 @@ fn tlsPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
     assert(ports.admin != 0);
     var host_buffer: [32]u8 = undefined;
     const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.tls});
+    enterStage(.https_handshake);
     try single_client.connectTls(io, ports.tls);
     defer single_client.close();
 
     var passed = true;
     var request: u32 = 0;
+    enterStage(.https_request);
     while (request < tls_requests) : (request += 1) {
+        current_https_request.store(request + 1, .release);
         // Keep-alive throughout: the turnaround is what is being tested,
         // and it is also what leaves the connection for `close_notify`
         // to end rather than a response the proxy closed on.
@@ -1175,8 +1252,10 @@ fn tlsPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         if (!expectTlsResponse(response, request)) passed = false;
     }
     assert(request == tls_requests);
+    enterStage(.https_close_notify);
     try single_client.endTls();
 
+    enterStage(.https_scrape);
     const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
     const verdicts = [_]struct { name: []const u8, expected: u64 }{
         // One session, completed: the handshake ran once and finished.

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -66,6 +66,10 @@ const tls_key_pem = @embedFile("tls_key_pem");
 /// L7 state a directed test with a single `Connection: close` client
 /// cannot reach and where a real defect already lived once.
 const tls_requests: u32 = 3;
+/// And the one connection they ride, named for the run-wide accept
+/// equality: a leg that opened a second connection without saying so here
+/// would be caught as an off-by-one rather than pass quietly.
+const tls_connections: u32 = 1;
 const not_found_body = "no such route";
 
 /// The #140 fields as they must appear in a written line: the client's
@@ -149,7 +153,7 @@ const exchanges_per_pass: u32 =
     @as(u32, keep_alive_connections) * requests_per_connection + large_requests;
 const http_exchanges: u32 = load_passes * exchanges_per_pass;
 const access_log_lines_expected: u32 =
-    http_exchanges + sticky_exchanges + body_exchanges + l4_connections;
+    http_exchanges + sticky_exchanges + body_exchanges + tls_requests + l4_connections;
 
 /// What the resident set may grow by between the two passes. Measured at
 /// exactly zero, run after run — the tolerance is headroom for page
@@ -175,7 +179,7 @@ const body_connections: u32 = 1;
 const readiness_probes: u32 = 1;
 const connections_expected: u32 = keep_alive_connections +
     load_passes * large_requests + l4_connections + sticky_connections +
-    body_connections + readiness_probes;
+    body_connections + tls_connections + readiness_probes;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
@@ -198,7 +202,18 @@ const drain_deadline_ms: u32 = 300;
 /// scenario — the load is a handful of connections — so the smallest
 /// config that serves it starts fastest and keeps the process's resident
 /// set a number a human can read at a glance.
-const zoxy_limits = .{ .conn_slots = 32, .relay_buffers = 16, .upstream_slots = 16 };
+///
+/// `tls_engines` is set rather than left to default, and it is the one
+/// term here that is not merely thrift: an engine costs two orders of
+/// magnitude more than a conn slot, so the default (one per slot) would
+/// price 32 sessions for a leg that opens one, and the §5 banner this
+/// gate prints would stop being a number a reader can sanity-check.
+const zoxy_limits = .{
+    .conn_slots = 32,
+    .relay_buffers = 16,
+    .upstream_slots = 16,
+    .tls_engines = 2,
+};
 
 /// The head buffer zoxy binds for this run — `limits.head_buffer_bytes`
 /// is not set, so this is `constants.head_buffer_bytes_default`, spelled
@@ -234,6 +249,10 @@ comptime {
     // shed, or `accepted == connections_expected` would be measuring the
     // conn wall instead of the load.
     assert(zoxy_limits.conn_slots >= connections_expected);
+    // Same rule for the engine pool, which is its own admission rung
+    // (§8): the https leg must be admitted rather than shed, or its
+    // counter verdicts would be measuring the wall.
+    assert(zoxy_limits.tls_engines >= tls_connections);
 }
 
 /// The health-check shape this run configures, and the window it is
@@ -360,6 +379,9 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // `sticky_exchanges` — and brings its own scrape.
     const sticky_ok = try stickyPassed(arena, io, &ports);
     const bodies_ok = try bodiesPassed(arena, io, &ports);
+    // Last, so its scrape sees the whole run — and so a wedged handshake
+    // cannot cost the legs above their verdicts.
+    const tls_ok = try tlsPassed(arena, io, &ports);
 
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
@@ -369,7 +391,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
     const passed = log_ok and counters.passed and sticky_ok and bodies_ok and
-        memory_ok and drain_ok;
+        tls_ok and memory_ok and drain_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -475,7 +497,11 @@ fn accessLogPassed(lines: *const LogCounts) bool {
     // below its own subset would mean the counter itself is wrong — which
     // no comparison below would otherwise notice.
     assert(lines.http_ok <= lines.http);
-    const http_lines_expected = http_exchanges + sticky_exchanges + body_exchanges;
+    // The https leg's requests land here with every other L7 one: a
+    // terminated request is an ordinary request by the time it is logged,
+    // and a log that told them apart would be the defect.
+    const http_lines_expected =
+        http_exchanges + sticky_exchanges + body_exchanges + tls_requests;
     assert(access_log_lines_expected == http_lines_expected + l4_connections);
     var passed = true;
     if (lines.http != http_lines_expected) {
@@ -513,6 +539,19 @@ fn accessLogPassed(lines: *const LogCounts) bool {
         );
         passed = false;
     }
+    return loggedHeadersPassed(lines) and passed;
+}
+
+/// The #140 half of the log verdict, split out of `accessLogPassed` on
+/// the same terms `loadShapePassed` was split from `identitiesPassed`:
+/// the https leg's term pushed that one past the length limit, and these
+/// two clauses are the pair that reads as its own claim — not "the log
+/// holds the right lines" but "each line carries the headers the config
+/// named".
+fn loggedHeadersPassed(lines: *const LogCounts) bool {
+    assert(lines.http_with_request_id <= lines.http);
+    assert(lines.http_with_origin_tag <= lines.http);
+    var passed = true;
     // Every http request this gate sends carries the correlation
     // header, so every http line must report it — including the two
     // the proxy answered itself, which is exactly when a join matters.
@@ -733,10 +772,11 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
         );
         passed = false;
     }
-    // Minus the two legs that deliberately run after this scrape (see
-    // `sticky_exchanges` and `body_exchanges`); the whole-run equality
-    // is asserted on the last of their scrapes.
-    const opened_so_far = connections_expected - sticky_connections - body_connections;
+    // Minus the three legs that deliberately run after this scrape (see
+    // `sticky_exchanges`, `body_exchanges` and `tls_requests`); the
+    // whole-run equality is asserted on the last of their scrapes.
+    const opened_so_far = connections_expected -
+        sticky_connections - body_connections - tls_connections;
     if (accepted != opened_so_far) {
         std.debug.print(
             "FAIL: {d} connections accepted, not the {d} opened before this scrape\n",
@@ -1002,14 +1042,15 @@ fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
             passed = false;
         }
     }
-    // The accept count with this leg in, but still short the #159
-    // leg's connection — the whole-run equality lands there, on the
-    // last scrape of the run.
+    // The accept count with this leg in, but still short the connections
+    // the #159 and TLS legs open after it — the whole-run equality lands
+    // on the last scrape of the run.
+    const opened_by_here = connections_expected - body_connections - tls_connections;
     const accepted = counterOf(&scrape, "accepted") orelse return false;
-    if (accepted != connections_expected - body_connections) {
+    if (accepted != opened_by_here) {
         std.debug.print(
             "FAIL: {d} connections accepted, not the {d} opened by here\n",
-            .{ accepted, connections_expected - body_connections },
+            .{ accepted, opened_by_here },
         );
         passed = false;
     }
@@ -1051,14 +1092,14 @@ fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         std.debug.print("FAIL: l7_no_route reads {d}, not 1\n", .{no_route});
         passed = false;
     }
-    // The whole-run accept equality, deferred through both late legs:
-    // this is the last scrape, so every connection the run opened is
-    // accounted for here or nowhere.
+    // Short only the TLS leg's connection, which opens after this scrape
+    // and carries the whole-run equality.
+    const opened_by_here = connections_expected - tls_connections;
     const accepted = counterOf(&scrape, "accepted") orelse return false;
-    if (accepted != connections_expected) {
+    if (accepted != opened_by_here) {
         std.debug.print(
-            "FAIL: {d} connections accepted, not the {d} this run opened\n",
-            .{ accepted, connections_expected },
+            "FAIL: {d} connections accepted, not the {d} opened by here\n",
+            .{ accepted, opened_by_here },
         );
         passed = false;
     }
@@ -1097,6 +1138,117 @@ fn expectBodyResponse(
     // boundary the simulator's oracle holds from outside.
     if (response.edited) {
         std.debug.print("FAIL: the {s} response carried the response-filter stamp\n", .{role});
+        return false;
+    }
+    return true;
+}
+
+/// The #125 leg: a real TLS 1.3 handshake against the terminating
+/// listener, `tls_requests` exchanges over the session it opens, and a
+/// `close_notify` to end it — then the counters on the run's last scrape.
+///
+/// The client is `std.crypto.tls`, an implementation that shares no code
+/// with the one zoxy terminates on. That is the whole point of running
+/// this here: ztls agreeing with ztls proves interoperability with
+/// nobody, and the two things this tier can prove that no directed test
+/// can are that an outside implementation completes the handshake, and
+/// that the session survives a keep-alive turnaround — the L7 state where
+/// a defect already lived once during this work.
+///
+/// Runs last, after both late legs, so it carries the whole-run accept
+/// equality.
+fn tlsPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
+    assert(ports.tls != 0);
+    assert(ports.admin != 0);
+    var host_buffer: [32]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.tls});
+    try single_client.connectTls(io, ports.tls);
+    defer single_client.close();
+
+    var passed = true;
+    var request: u32 = 0;
+    while (request < tls_requests) : (request += 1) {
+        // Keep-alive throughout: the turnaround is what is being tested,
+        // and it is also what leaves the connection for `close_notify`
+        // to end rather than a response the proxy closed on.
+        const response = try single_client.get(host, "/", .keep_alive, null);
+        if (!expectTlsResponse(response, request)) passed = false;
+    }
+    assert(request == tls_requests);
+    try single_client.endTls();
+
+    const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
+    const verdicts = [_]struct { name: []const u8, expected: u64 }{
+        // One session, completed: the handshake ran once and finished.
+        .{ .name = "tls_handshakes_completed", .expected = 1 },
+        // And nothing on the failure side. Stated as equalities against
+        // zero rather than left unread, because every one of these is a
+        // rung a working run must never reach — a session that failed and
+        // silently retried would otherwise pass on the count above.
+        .{ .name = "tls_handshake_failed", .expected = 0 },
+        .{ .name = "tls_relay_failed", .expected = 0 },
+        .{ .name = "shed_tls_engines", .expected = 0 },
+        .{ .name = "shed_tls_crypto", .expected = 0 },
+    };
+    for (verdicts) |verdict| {
+        const value = counterOf(&scrape, verdict.name) orelse {
+            passed = false;
+            continue;
+        };
+        if (value != verdict.expected) {
+            std.debug.print(
+                "FAIL: {s} reads {d}, not {d}, after the https leg\n",
+                .{ verdict.name, value, verdict.expected },
+            );
+            passed = false;
+        }
+    }
+    // The whole-run accept equality, deferred through all three late
+    // legs: this is the last scrape, so every connection the run opened
+    // is accounted for here or nowhere.
+    const accepted = counterOf(&scrape, "accepted") orelse return false;
+    if (accepted != connections_expected) {
+        std.debug.print(
+            "FAIL: {d} connections accepted, not the {d} this run opened\n",
+            .{ accepted, connections_expected },
+        );
+        passed = false;
+    }
+    return passed;
+}
+
+/// One response off the terminated listener. The same framing the
+/// plaintext legs demand — a decrypted head that reframed the body would
+/// fail here exactly as a cleartext one does — plus the absence of the
+/// #175 stamp, which is this leg's witness that it reached the *third*
+/// listener: the stamp is configured on the plaintext one only, so a
+/// response carrying it came from the wrong port.
+fn expectTlsResponse(response: client_module.Response, request: u32) bool {
+    // The reader's own bounds, restated before the comparisons switch on
+    // them: a status or a length outside these did not come off a parse
+    // that succeeded, so comparing it would report the wrong failure.
+    assert(response.status >= 100);
+    assert(response.body_bytes <= client_module.response_body_bytes_max);
+    assert(request < tls_requests);
+    if (response.status != 200) {
+        std.debug.print(
+            "FAIL: https request {d} answered {d}, not 200\n",
+            .{ request, response.status },
+        );
+        return false;
+    }
+    if (response.body_bytes != origin_module.body.len) {
+        std.debug.print(
+            "FAIL: https request {d} carried {d} body bytes, not the origin's {d}\n",
+            .{ request, response.body_bytes, origin_module.body.len },
+        );
+        return false;
+    }
+    if (response.edited) {
+        std.debug.print(
+            "FAIL: https request {d} carried the plaintext listener's stamp\n",
+            .{request},
+        );
         return false;
     }
     return true;
@@ -1287,58 +1439,8 @@ fn reservePorts(io: Io) !Ports {
 /// nobody drains is a drop rung (§8) waiting to make the count a lie.
 fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_port: u16) !void {
     assert(origin_port != 0);
-    const config_json = try std.fmt.allocPrint(arena,
-        \\{{
-        \\    "listeners": [
-        \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
-        \\          "routes": [
-        \\              {{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }},
-        \\              {{ "host": "127.0.0.1", "prefix": "/sticky", "cluster": "sticky" }}
-        \\          ],
-        \\          "request_filters": [
-        \\              {{ "match": {{ "path_prefix": "/robots.txt" }},
-        \\                "actions": [{{ "respond": {{ "status": 200, "body": "robots" }} }}] }}
-        \\          ],
-        \\          "response_filters": [
-        \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
-        \\          ] }},
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
-        \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
-        \\          "routes": [{{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }}],
-        \\          "tls": {{ "cert": "{s}", "key": "{s}" }} }}
-        \\    ],
-        \\    "clusters": {{
-        \\        "origin": {{
-        \\            "endpoints": ["127.0.0.1:{d}"],
-        \\            "check": {{ "type": "http", "path": "/health", "timeout_ms": {d} }}
-        \\        }},
-        \\        "sticky": {{
-        \\            "endpoints": ["127.0.0.1:{d}"],
-        \\            "pick": {{ "policy": "hash", "key": "cookie", "name": "zoxy-smoke-srv" }}
-        \\        }}
-        \\    }},
-        \\    "bodies": {{
-        \\        "gone": {{ "inline": "{s}", "content_type": "text/plain" }},
-        \\        "robots": {{ "file": "{s}", "content_type": "text/plain" }}
-        \\    }},
-        \\    "error_pages": {{ "404": "gone" }},
-        \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
-        \\    "access_log": {{ "sink": "file", "path": "{s}",
-        \\        "request_headers": ["X-Request-ID"], "response_headers": ["X-Origin-Tag"] }},
-        \\    "timeouts": {{
-        \\        "connect_ms": 2000,
-        \\        "idle_ms": 30000,
-        \\        "health_interval_ms": {d},
-        \\        "drain_deadline_ms": {d}
-        \\    }},
-        \\    "limits": {{
-        \\        "conn_slots": {d},
-        \\        "relay_buffers": {d},
-        \\        "upstream_slots": {d}
-        \\    }}
-        \\}}
-        \\
-    , .{
+    assert(ports.http != 0);
+    const config_json = try std.fmt.allocPrint(arena, config_template, .{
         ports.http,
         ports.l4,
         ports.tls,
@@ -1356,9 +1458,69 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         zoxy_limits.conn_slots,
         zoxy_limits.relay_buffers,
         zoxy_limits.upstream_slots,
+        zoxy_limits.tls_engines,
     });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 }
+
+/// The config `writeConfig` fills in. A module-level constant rather than
+/// a literal inside it: the template is most of the function's length,
+/// and it is not logic — separating them keeps the function a readable
+/// list of what each hole is, and keeps that list under the length limit
+/// as listeners are added.
+const config_template =
+    \\{{
+    \\    "listeners": [
+    \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
+    \\          "routes": [
+    \\              {{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }},
+    \\              {{ "host": "127.0.0.1", "prefix": "/sticky", "cluster": "sticky" }}
+    \\          ],
+    \\          "request_filters": [
+    \\              {{ "match": {{ "path_prefix": "/robots.txt" }},
+    \\                "actions": [{{ "respond": {{ "status": 200, "body": "robots" }} }}] }}
+    \\          ],
+    \\          "response_filters": [
+    \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
+    \\          ] }},
+    \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
+    \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
+    \\          "routes": [{{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }}],
+    \\          "tls": {{ "cert": "{s}", "key": "{s}" }} }}
+    \\    ],
+    \\    "clusters": {{
+    \\        "origin": {{
+    \\            "endpoints": ["127.0.0.1:{d}"],
+    \\            "check": {{ "type": "http", "path": "/health", "timeout_ms": {d} }}
+    \\        }},
+    \\        "sticky": {{
+    \\            "endpoints": ["127.0.0.1:{d}"],
+    \\            "pick": {{ "policy": "hash", "key": "cookie", "name": "zoxy-smoke-srv" }}
+    \\        }}
+    \\    }},
+    \\    "bodies": {{
+    \\        "gone": {{ "inline": "{s}", "content_type": "text/plain" }},
+    \\        "robots": {{ "file": "{s}", "content_type": "text/plain" }}
+    \\    }},
+    \\    "error_pages": {{ "404": "gone" }},
+    \\    "admin": {{ "bind": "127.0.0.1:{d}" }},
+    \\    "access_log": {{ "sink": "file", "path": "{s}",
+    \\        "request_headers": ["X-Request-ID"], "response_headers": ["X-Origin-Tag"] }},
+    \\    "timeouts": {{
+    \\        "connect_ms": 2000,
+    \\        "idle_ms": 30000,
+    \\        "health_interval_ms": {d},
+    \\        "drain_deadline_ms": {d}
+    \\    }},
+    \\    "limits": {{
+    \\        "conn_slots": {d},
+    \\        "relay_buffers": {d},
+    \\        "upstream_slots": {d},
+    \\        "tls_engines": {d}
+    \\    }}
+    \\}}
+    \\
+;
 
 /// A fresh work directory every run: the file sink is append-only by
 /// design (§8, so an external rotation is safe), which makes a stale log

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -52,6 +52,20 @@ const zoxy_log_path = work_directory ++ "/zoxy.log";
 /// the sim and the directed tests).
 const robots_path = work_directory ++ "/robots.txt";
 const robots_body = "User-agent: *\nDisallow: /private\n";
+
+/// The §4 fixture the terminating listener serves. Handed in by the build
+/// rather than embedded here (`@embedFile` cannot escape a module root),
+/// and written to the work directory so the proxy reads it off disk the
+/// way a deployment's certificate arrives.
+const tls_cert_path = work_directory ++ "/cert.pem";
+const tls_key_path = work_directory ++ "/key.pem";
+const tls_cert_pem = @embedFile("tls_cert_pem");
+const tls_key_pem = @embedFile("tls_key_pem");
+/// Requests the HTTPS leg issues on one terminated connection. More than
+/// one on purpose: the second is a keep-alive turnaround, which is the
+/// L7 state a directed test with a single `Connection: close` client
+/// cannot reach and where a real defect already lived once.
+const tls_requests: u32 = 3;
 const not_found_body = "no such route";
 
 /// The #140 fields as they must appear in a written line: the client's
@@ -293,6 +307,7 @@ const Ports = struct {
     http: u16,
     l4: u16,
     admin: u16,
+    tls: u16,
 };
 
 pub fn main(init: std.process.Init) !u8 {
@@ -345,6 +360,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // `sticky_exchanges` — and brings its own scrape.
     const sticky_ok = try stickyPassed(arena, io, &ports);
     const bodies_ok = try bodiesPassed(arena, io, &ports);
+
     const drained_cleanly = try drain(io, &child, &running);
     const lines = try readAccessLog(arena, io);
     // Every check runs and prints; a run that fails two ways should say
@@ -792,6 +808,7 @@ fn runLoad(
 ) !Memory {
     assert(ports.http != 0);
     assert(ports.l4 != 0);
+    assert(ports.tls != 0);
     var host_buffer: [32]u8 = undefined;
     const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
     for (&clients) |*client| {
@@ -1004,7 +1021,6 @@ fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
 /// answers from the file-backed body — both on one connection, both
 /// judged on their exact framing, then the counters on a scrape. Runs
 /// after `countersPassed` so those scrapes still describe a run whose
-/// every request routed.
 fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
     assert(ports.http != 0);
     assert(ports.admin != 0);
@@ -1242,18 +1258,23 @@ fn reservePorts(io: Io) !Ports {
     var http_listener = try http_address.listen(io, .{ .mode = .stream });
     var l4_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
     var l4_listener = try l4_address.listen(io, .{ .mode = .stream });
+    var tls_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var tls_listener = try tls_address.listen(io, .{ .mode = .stream });
     var admin_address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
     var admin_listener = try admin_address.listen(io, .{ .mode = .stream });
     const ports: Ports = .{
         .http = http_listener.socket.address.getPort(),
         .l4 = l4_listener.socket.address.getPort(),
+        .tls = tls_listener.socket.address.getPort(),
         .admin = admin_listener.socket.address.getPort(),
     };
     http_listener.deinit(io);
     l4_listener.deinit(io);
+    tls_listener.deinit(io);
     admin_listener.deinit(io);
     assert(ports.http != 0);
     assert(ports.l4 != 0);
+    assert(ports.tls != 0);
     assert(ports.admin != 0);
     assert(ports.http != ports.l4);
     assert(ports.http != ports.admin);
@@ -1281,7 +1302,10 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         \\          "response_filters": [
         \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}
         \\          ] }},
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }}
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "protocol": "http",
+        \\          "routes": [{{ "host": "127.0.0.1", "prefix": "/", "cluster": "origin" }}],
+        \\          "tls": {{ "cert": "{s}", "key": "{s}" }} }}
         \\    ],
         \\    "clusters": {{
         \\        "origin": {{
@@ -1317,6 +1341,9 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
     , .{
         ports.http,
         ports.l4,
+        ports.tls,
+        tls_cert_path,
+        tls_key_path,
         origin_port,
         health_probe_timeout_ms,
         origin_port,
@@ -1346,6 +1373,13 @@ fn prepareWorkDirectory(io: Io) !void {
     // is read once at startup (parse-once, §1) — the one thing in this
     // config that comes off the filesystem rather than out of the JSON.
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = robots_path, .data = robots_body });
+    // The TLS fixture, written where the config points and read by the
+    // proxy at startup like any operator's certificate (§4). Throwaway
+    // and self-signed — `src/tls/testdata/README.md` says why the key is
+    // committed — so the gate's subject is the record layer, not a trust
+    // decision.
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = tls_cert_path, .data = tls_cert_pem });
+    try Io.Dir.cwd().writeFile(io, .{ .sub_path = tls_key_path, .data = tls_key_pem });
 }
 
 /// zoxy's own output goes to a file rather than this process's stderr:

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -534,12 +534,39 @@ fn watchdogTask(io: Io) void {
             .{ seconds, stage.label() },
         );
     }
-    const pid = watchdog_child_pid.load(.acquire);
-    if (pid != 0) {
-        std.posix.kill(pid, .KILL) catch {};
-    }
+    endWedgedProxy(io);
     printZoxyLog(io);
     std.process.exit(3);
+}
+
+/// How long the watchdog lets the proxy drain before killing it. Longer
+/// than the drain deadline the run configures, so a proxy that is *able*
+/// to drain has finished doing so by the time this expires.
+const wedge_drain_grace_ns: u64 = 4 * @as(u64, drain_deadline_ms) * std.time.ns_per_ms;
+
+/// End the proxy, asking before insisting.
+///
+/// SIGTERM first, because a drain makes the proxy dump its counters (§8)
+/// — and on a wedge those counters are the best evidence there is: they
+/// say how many connections it accepted, how many handshakes completed,
+/// and which rung anything was shed on, which together separate "the
+/// proxy never saw the request" from "it answered and the harness missed
+/// it". A SIGKILL throws all of that away, which is what the first
+/// macOS wedge did: the log ended at the startup banner and said nothing
+/// about the run.
+///
+/// Then SIGKILL regardless, since the case being diagnosed is a proxy
+/// that may not answer at all. Killing it is what keeps a timed-out run
+/// from leaving an orphan on the ports the next run will ask for.
+fn endWedgedProxy(io: Io) void {
+    const pid = watchdog_child_pid.load(.acquire);
+    if (pid == 0) return;
+    std.posix.kill(pid, .TERM) catch {
+        // Already gone: nothing to drain and nothing to kill.
+        return;
+    };
+    io.sleep(Io.Duration.fromNanoseconds(wedge_drain_grace_ns), .awake) catch {};
+    std.posix.kill(pid, .KILL) catch {};
 }
 
 /// What one run of the access log said, as counts rather than text: the

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -165,10 +165,6 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(received >= 1);
-            // A request begins with its first byte, on the plaintext
-            // path's own rule: before the decrypt, because a slowloris
-            // dribbling records must report the time it spent (§8).
-            server.beginLogRequest(conn);
             var head: HeadPlaintext = .{ .server = server, .conn = conn };
             const sink = head.sink();
             conn.tls.?.received(received, &sink) catch {
@@ -177,6 +173,15 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             if (head.appended >= 1) {
+                // A request begins with its first *plaintext* byte, on the
+                // plaintext path's own rule (§8) — not with the delivery
+                // that carried it. A record can decrypt to no application
+                // data at all: a KeyUpdate, an alert, or the close_notify
+                // that ends an idle keep-alive connection. Starting the
+                // clock on the delivery opens a log entry for a request
+                // nobody made, which teardown then writes out as an
+                // aborted exchange with no method and no bytes.
+                server.beginLogRequest(conn);
                 conn.log.bytes_in += head.appended;
             }
             if (conn.tls.?.peerClosed()) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -4217,6 +4217,47 @@ const TlsWindDown = struct {
     }
 };
 
+test "l7: close_notify between requests writes no access-log line" {
+    // A terminated keep-alive connection ends the way TLS says to: the
+    // client answers its last response with a close_notify, and the alert
+    // arrives on a connection that is idle between requests.
+    //
+    // The plaintext path has an EOF here too, and writes nothing for it —
+    // an access-log line is a claim that a request was *made*, and nobody
+    // made one. Getting this wrong is invisible from inside: the phantom
+    // line is well-formed, it is merely about nothing, so it shows up as
+    // an `aborted` exchange with no method, no path and no bytes. The
+    // arithmetic below is the only thing that sees it.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 52,
+        .tls = true,
+        .access_log = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    var client: TlsClient = undefined;
+    try client.start(&bed.sim_io, Http1Bed.bindAddress(), .{
+        .host_name = fixture_host_name,
+        // No `Connection: close`: the connection has to still be *open*
+        // and waiting for a next request when the alert lands, which is
+        // the whole state under test.
+        .app_data = "GET /x HTTP/1.1\r\nHost: o\r\n\r\n",
+        .close_after_echo = true,
+    });
+    var wind_down: TlsWindDown = .{ .bed = &bed };
+    wind_down.attach(&client);
+    try bed.sim_io.run();
+
+    // One request was made, so one line is owed — and exactly one.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("access_log_lines"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("access_log_dropped"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tls_relay_failed"));
+    try bed.expectDrained();
+}
+
 test "l7: a terminated head that fits with a body that does not is 413, not 431" {
     // The one L7 state only termination can reach. A plaintext read
     // cannot deliver more than the head buffer holds, but one TLS record

--- a/src/main.zig
+++ b/src/main.zig
@@ -235,6 +235,20 @@ const BodyFileContext = struct {
     io: std.Io,
 };
 
+/// The fixed libcrypto heap's storage (§4). Static rather than carved
+/// from the startup arena, and that is not a style choice: libcrypto
+/// registers an atexit handler, and `OPENSSL_cleanup` frees through our
+/// hooks *after* `main` has returned and the arena with it. An
+/// arena-backed heap therefore segfaults every terminating process on the
+/// way out — clean drain, correct exit code, crash after. Found by the
+/// Tier-0.5 gate the first time it ran the real binary with TLS
+/// configured, which is the only place it could have been found.
+///
+/// BSS, so the pages a plaintext deployment never touches never become
+/// resident; the §5 banner prices this only when a listener terminates,
+/// which is when it is actually used.
+var libcrypto_heap_storage: [zoxy.constants.libcrypto_heap_bytes]u8 align(16) = undefined;
+
 /// Turn each listener's configured certificate paths into loaded
 /// credentials (§4), one slot per listener and null where the listener is
 /// plaintext. Startup-only: the arena owns the decoded chains for the
@@ -260,12 +274,7 @@ fn loadTlsCredentials(
     // and the allocator swap is refused once anything has allocated. If
     // it fails the zero-allocation promise (§5) is unbacked, and a proxy
     // that cannot keep its own invariants should not start.
-    const heap_buffer = try arena.alignedAlloc(
-        u8,
-        .of(u128),
-        zoxy.constants.libcrypto_heap_bytes,
-    );
-    if (!zoxy.tls.libcrypto_heap.install(heap_buffer)) {
+    if (!zoxy.tls.libcrypto_heap.install(&libcrypto_heap_storage)) {
         std.debug.print(
             "zoxy: libcrypto refused the fixed-heap install; " ++
                 "the zero-allocation budget (DESIGN.md §5) cannot be kept\n",


### PR DESCRIPTION
Completes the Tier-0.5 gate for inbound TLS termination. One listener in the smoke config now terminates, driven by `std.crypto.tls.Client` — an implementation sharing no code with the one zoxy terminates on, which is the only kind whose agreement is evidence. It handshakes, holds a keep-alive session across three requests, and ends it with a `close_notify`.

It found two real defects, neither reachable from any other tier.

## 1. Every terminating process crashed at exit

A proxy with any `tls` listener drained cleanly, exited `0`, and **then segfaulted**:

```
Segmentation fault at address 0x757709766048
  init_thread_stop.part.0 (libcrypto.so.3)
  OPENSSL_thread_stop     (libcrypto.so.3)
  OPENSSL_cleanup         (libcrypto.so.3)
  __run_exit_handlers     (libc.so.6)
```

The fixed libcrypto heap was carved from the startup arena. libcrypto registers an atexit handler, and `OPENSSL_cleanup` frees through our hooks *after* `main` returned and took the arena with it. Static BSS now — where memory the C runtime outlives has to live, and where pages a plaintext deployment never touches stay non-resident.

Needs a *process* that installs the heap and then exits: unit tests never exit one, the simulator has no process, and the heap proof installs into a static already. Reverting the fix with the TLS listener present reproduces it, which is what makes this gate's `clean drain` mean something.

## 2. A phantom access-log line per terminated keep-alive connection

The log clock started when the ciphertext *delivery* arrived rather than when the decrypt produced its first plaintext byte. A record can decrypt to no application data at all — a KeyUpdate, an alert, the `close_notify` that ends an idle connection — so the alert opened a log entry for a request nobody made, which teardown then wrote out as:

```json
{"kind":"http","outcome":"aborted","method":"","host":"","path":"","status":0,"bytes_in":0,"bytes_out":0}
```

This is **#129 one layer down** — and #129 is one of the two bugs §9 names as the reason this tier exists.

Nothing cheaper could have caught it. The sweep's TLS clients close in protocol only after a `Connection: close` request, so no idle keep-alive session is ever alerted — a gap `deriveTlsClients` had already predicted in a comment, now annotated with what it cost and why the obvious fix is a *hang* rather than a fix (`close_after_echo` waits for a response as long as the request; closing it properly is a `TestClient` change). And the census cannot see this class at all: the phantom line increments `access_log_lines`, a counter every run already fires.

Pinned by a directed test as well as by the gate — verified to fail with `expected 1, found 2` when the fix is reverted.

## Harness notes

`std.crypto.tls.Client` stacks two buffers, and its `flush` encrypts into the socket writer's buffer without flushing *that* — flushing only the session leaves the request in userspace and wedges the read that follows. Both layers, outermost last, is what `std.http.Client` does at its own send.

`tls_engines` is set rather than defaulted: an engine costs two orders of magnitude more than a conn slot, so one per slot priced 32 sessions for a leg that opens one. Resident set 23.4 → 17.5 MiB.

## Gates

467 tests, 4096 sim seeds, census ok, smoke, heap proof, lint, format — all green. The smoke leg ran 5 consecutive times with identical counts and zero RSS growth each time.

Remaining on #125 after this: session tickets / NST wiring (the diagnosed ~45 ms stall), and the Tier-1 bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)