### PR TITLE
feat(tls): session resumption — issue and accept tickets (#125)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -505,6 +505,18 @@ process-wide reservation: the fixed heap libcrypto allocates from, 4 MiB,
 which is what makes zero-allocation-after-startup provable with a C
 library underneath (§4).
 
+Session resumption adds nothing to either. A resumption ticket has to
+carry its session's PSK back to us, and the obvious shape — a table keyed
+by ticket id — is memory that grows with traffic and a lookup on the
+handshake path, both of which this budget would have to cover. So the
+ticket *is* the state: the PSK is sealed into the bytes handed to the
+client, and the server keeps only the two rotating keys that seal them.
+Sixty-four bytes, whatever the traffic. That trade puts the security
+question on the sealing key rather than on a table, which is why a key
+stops sealing before it stops opening and why none of them ever reaches
+disk — a restart costs every returning client one full handshake, and
+makes a stolen disk worthless.
+
 The access log (§8) adds one fixed reservation beside the pools — two
 staging buffers, 64 KiB together by default — and nothing at all when it
 is off. It is in the printed total, because §5's promise is that the

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -47,22 +47,38 @@ available. The fork carries four commits, each re-audited in
   stall, identified" below. The ticket must be emitted **after**
   processing that `Finished`, not alongside the server flight.
 
-Remaining, in the order the work wants:
+Session tickets are wired now, both halves: every completed handshake
+issues `tls_tickets_per_handshake` of them, and an offered ticket comes
+back through ztls's `psk_lookup` to `Tickets.open`. The emission lands
+where the stall analysis says it must — after the client's `Finished` is
+processed, staged inside the outbound pump's own loop so it rides the
+same send path as the server flight.
 
-1. **Session tickets.** The fork can issue them (`sendNewSessionTicket`,
-   `resumptionPsk`) and accept them (`Config.psk_lookup`, upstream), and
-   `src/tls/Tickets.zig` has the stateless seal/open — but nothing is
-   wired, so no ticket is ever sent. That is both §4's resumption and the
-   ~45 ms stall below, and the emission has to land *after* the client
-   Finished is processed, not alongside the server flight.
-2. **The Tier-1 bands**, whose acceptance is the close-mode rate gate PR
-   #84 could not pass; (1) is what is expected to move it.
+Wiring it moved a counter, which is worth recording because the sweep is
+what noticed. The ticket flight goes out while the connection is still
+`tls_handshaking`, so a peer that leaves during it was being counted as
+`tls_handshake_failed` — a handshake that had in fact *succeeded*. The
+census caught it as a counter firing against an allowance of zero.
+`tls_handshakes_completed` and `tls_resumed` are now counted where the
+session comes up rather than at the hand-over, behind a `tls_session_up`
+latch on the conn, and the send-error arm blames the handshake only while
+that latch is unset.
 
-Two smaller things the reviews left open: `ResponseBodyPolicy.afterSend`
+Remaining:
+
+1. **The Tier-1 bands**, whose acceptance is the close-mode rate gate PR
+   #84 could not pass. The tickets above are what is expected to move it,
+   and the bands are what say whether they did — nothing measured yet.
+
+Three smaller things the reviews left open: `ResponseBodyPolicy.afterSend`
 credits ciphertext to `bytes_out` where the client-write channel credits
-plaintext, so a streamed TLS response over-counts; and the sim's TLS
-http client sends `Connection: close` and a GET, leaving the request-body
-leg reachable by directed tests only.
+plaintext, so a streamed TLS response over-counts; the sim's TLS http
+client sends `Connection: close` and a GET, leaving the request-body leg
+reachable by directed tests only; and the sealing key is drawn once at
+`start` and never rotated, so the two-slot rotation `Tickets` is built
+for runs with one slot live for the process. Rotation wants a timer and
+the interval is a policy question (it bounds how long a stolen key is
+worth having), so it is deliberately not guessed at here.
 
 ### What the live gate found
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -206,19 +206,30 @@ How many TLS sessions may be in flight at once is `limits.tls_engines`,
 and it is the largest single line in the startup banner's memory budget;
 see [Limits](#limits).
 
-> [!WARNING]
-> **Session resumption is not implemented yet, so every connection pays a
-> full handshake.** On steady keep-alive traffic that costs nothing
-> measurable — a terminated hop benchmarks at parity with HAProxy. On
-> handshake-heavy traffic it is expensive twice over: ~260 µs of signing
-> per connection, and a ~45 ms stall per handshake from a delayed-ACK
-> interaction that resumption's post-handshake ticket is what resolves.
-> A `Connection: close` workload measured 664 of 2000 requests per second
-> offered against HAProxy's 831.
->
-> Terminate TLS behind a client population that reuses connections. If
-> yours reconnects constantly — many short-lived clients, no keep-alive —
-> wait for resumption before putting this in that path.
+Session resumption is on, with nothing to configure. Every completed
+handshake hands the client two session tickets; a client that offers one
+back resumes instead of running a full handshake, which skips the
+signature entirely. The tickets are stateless — each carries its own
+session sealed under a key zoxy keeps in memory — so resumption costs no
+per-session memory and no lookup table, and the startup banner's budget
+does not move.
+
+Two consequences worth knowing. A restart invalidates every outstanding
+ticket, because the sealing keys are never written anywhere: returning
+clients pay one full handshake each and then resume again. And tickets
+are not shared between processes, so during a `SO_REUSEPORT` handoff a
+client may land on the process that did not issue its ticket and do a
+full handshake.
+
+> [!NOTE]
+> Resumption's other job is latency, and it is the larger one on
+> handshake-heavy traffic. Without a post-handshake flight, a client that
+> writes its `Finished` and then its request has the second write held by
+> its own Nagle, waiting for an ACK zoxy has no reason to send — a ~45 ms
+> stall per connection. The ticket flight is what carries that ACK. The
+> Tier-1 bands that measure this have not been re-run since resumption
+> landed; the last reading, without it, was 664 of 2000 requests per
+> second offered on a `Connection: close` workload against HAProxy's 831.
 
 ### Routing
 

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -211,6 +211,19 @@ const uncovered = [_]Uncovered{
             "either, which is the honest gap",
     },
     .{
+        .name = "tls_resumed",
+        .why = .unreached,
+        .reason = "resumption needs a client that keeps a ticket from one " ++
+            "connection and offers it on the next, and this population's " ++
+            "clients are single-connection by construction — each ends on " ++
+            "its peer's EOF or its own close_notify and never opens a " ++
+            "second. src/http_proxy_test.zig drives the whole round trip " ++
+            "(issue, capture, offer, open) across two connections and " ++
+            "asserts the counter; what the sweep would add on top is the " ++
+            "adversary's schedules against a resumed handshake, which is " ++
+            "the honest gap and wants a two-connection client to close",
+    },
+    .{
         .name = "l7_no_route",
         .why = .unreached,
         .reason = "the sim's route table is a single \"/\" prefix, which no " ++

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -168,9 +168,10 @@ const uncovered = [_]Uncovered{
     // The §4 counters (#125) the sweep still cannot move. Seeds do
     // terminate TLS now — a quarter of them bind a terminating listener,
     // l4 or http, and run real handshakes under the adversary — so what
-    // is left here is not "no scenario configures one" but three specific
-    // events a seeded, non-corrupting schedule cannot produce. Each names
-    // what reaches it instead.
+    // is left here is not "no scenario configures one" but a handful of
+    // specific events a seeded, non-corrupting schedule of
+    // single-connection clients cannot produce. Each names what reaches
+    // it instead.
     .{
         .name = "tls_handshake_failed",
         .why = .unreached,

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -70,6 +70,11 @@ const tls_requests: u32 = 3;
 /// equality: a leg that opened a second connection without saying so here
 /// would be caught as an off-by-one rather than pass quietly.
 const tls_connections: u32 = 1;
+/// Tickets a completed handshake is expected to issue — `constants
+/// .tls_tickets_per_handshake`, spelled here rather than imported like
+/// the counter names: the gate reads what the binary *wrote*, so a drift
+/// must fail loudly rather than agree with itself.
+const tls_tickets_per_handshake: u64 = 2;
 const not_found_body = "no such route";
 
 /// The #140 fields as they must appear in a written line: the client's
@@ -1292,6 +1297,15 @@ fn tlsPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         // rung a working run must never reach — a session that failed and
         // silently retried would otherwise pass on the count above.
         .{ .name = "tls_handshake_failed", .expected = 0 },
+        // The post-handshake flight, witnessed on the shipped binary
+        // rather than only in a simulator: it is what carries the ACK
+        // that keeps a client's first request out of its own Nagle queue,
+        // so a deployment issuing none has the ~45 ms stall back.
+        .{ .name = "tls_tickets_issued", .expected = tls_tickets_per_handshake },
+        // And nothing resumed: this client is offered tickets and never
+        // returns one, so a count here would mean the counter fires on
+        // something other than resumption.
+        .{ .name = "tls_resumed", .expected = 0 },
         .{ .name = "tls_relay_failed", .expected = 0 },
         .{ .name = "shed_tls_engines", .expected = 0 },
         .{ .name = "shed_tls_crypto", .expected = 0 },

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1220,7 +1220,7 @@ pub fn Server(comptime IoType: type) type {
                 // would offer resumption it could not honour, and every
                 // ticket it opened would be one it never sealed.
                 .tickets = if (server.tls_tickets.ready()) &server.tls_tickets else null,
-                .now_unix = server.io.nowWallNs() / std.time.ns_per_s,
+                .now_unix = @divFloor(server.io.nowWallNs(), std.time.ns_per_s),
             }) catch {
                 // Deriving the ephemeral keypair is the one fallible step,
                 // and under the OpenSSL backend it *allocates*
@@ -1726,6 +1726,29 @@ pub fn Server(comptime IoType: type) type {
         fn pumpTlsOutbound(server: *Self, conn: *ConnType) void {
             assert(conn.state == .tls_handshaking);
             const engine = conn.tls.?;
+            // A drained outbox on a connected session is exactly once per
+            // handshake, and exactly the moment the post-handshake flight
+            // is owed (§4). Staging it here rather than in
+            // `finishTlsHandshake` keeps it inside this pump: the tickets
+            // go out through the same send path as the server flight,
+            // partial writes included, and the hand-over below happens on
+            // a later pass once they have drained too.
+            //
+            // Before the send rather than after it, so this stays one
+            // pass over the outbox: whatever is staged leaves through the
+            // single send below, whether it is the server flight or the
+            // tickets that follow it.
+            if (engine.outbound().len == 0 and engine.isConnected() and !conn.tls_session_up) {
+                conn.tls_session_up = true;
+                // Counted *here*, not at the hand-over: the client's
+                // Finished has been processed, so this handshake has
+                // succeeded whatever becomes of the flight that follows
+                // it. A peer that leaves while the tickets are going out
+                // is a session that ended, not one that never happened.
+                server.counters.increment("tls_handshakes_completed");
+                if (engine.isResumed()) server.counters.increment("tls_resumed");
+                _ = server.stageTlsTickets(conn);
+            }
             const staged = engine.outbound();
             if (staged.len >= 1) {
                 conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
@@ -1739,30 +1762,8 @@ pub fn Server(comptime IoType: type) type {
                 );
                 return;
             }
+            assert(conn.tls_session_up or !engine.isConnected());
             if (engine.isConnected()) {
-                // The session is up and the outbox is empty, which is
-                // exactly once per handshake and exactly the moment the
-                // post-handshake flight is owed (§4). Staging here rather
-                // than in `finishTlsHandshake` keeps it inside the pump's
-                // own loop: the tickets go out through the same send path
-                // as the server flight, partial writes included, and the
-                // hand-over happens on the next pass when the outbox has
-                // drained again.
-                if (!conn.tls_session_up) {
-                    conn.tls_session_up = true;
-                    // Counted *here*, not at the hand-over below: the
-                    // client's Finished has been processed, so this
-                    // handshake has succeeded whatever becomes of the
-                    // flight that follows it. A peer that leaves while
-                    // the tickets are going out is a session that ended,
-                    // not one that never happened.
-                    server.counters.increment("tls_handshakes_completed");
-                    if (engine.isResumed()) server.counters.increment("tls_resumed");
-                    if (server.stageTlsTickets(conn)) {
-                        server.pumpTlsOutbound(conn);
-                        return;
-                    }
-                }
                 server.finishTlsHandshake(conn);
             } else {
                 server.armTlsRecv(conn);
@@ -1783,9 +1784,12 @@ pub fn Server(comptime IoType: type) type {
             assert(engine.outbound().len == 0);
             if (engine.tickets == null) return false;
 
-            var staged: u8 = 0;
-            var index: u8 = 0;
-            while (index < constants.tls_tickets_per_handshake) : (index += 1) {
+            // One counter, not two: `break` leaves before the index
+            // advances, so "how many were staged" and "how far the loop
+            // got" are the same number and keeping both would be two
+            // names for one fact.
+            var issued: u8 = 0;
+            while (issued < constants.tls_tickets_per_handshake) {
                 // Per-ticket randomness, drawn through the seam so a
                 // seeded run replays the tickets it issued (§9). The
                 // sealing nonce must never repeat under one key, so it is
@@ -1795,16 +1799,16 @@ pub fn Server(comptime IoType: type) type {
                 // RFC 8446 §4.6.1 wants the nonce unique per ticket
                 // within a connection; the index is that, and being one
                 // byte it keeps the message small.
-                const ticket_nonce = [_]u8{index};
+                const ticket_nonce = [_]u8{issued};
                 engine.sendSessionTicket(
                     &ticket_nonce,
                     std.mem.readInt(u32, material[Tickets.nonce_bytes..][0..4], .big),
                     material[0..Tickets.nonce_bytes].*,
                 ) catch break;
-                staged += 1;
+                issued += 1;
                 server.counters.increment("tls_tickets_issued");
             }
-            if (staged == 0) return false;
+            if (issued == 0) return false;
             assert(engine.outbound().len >= 1);
             return true;
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -30,6 +30,7 @@ const proxy_protocol = @import("net/proxy_protocol.zig");
 const relay = @import("net/relay.zig");
 const shed = @import("shed.zig");
 const Credentials = @import("tls/Credentials.zig");
+const Tickets = @import("tls/Tickets.zig");
 const TlsEngine = @import("tls/Engine.zig");
 const upstream_module = @import("net/upstream.zig");
 
@@ -82,6 +83,16 @@ pub fn Server(comptime IoType: type) type {
         /// against a conn slot's ~1.7: a deployment pays for the TLS it
         /// serves concurrently, not for every slot it could admit (§5).
         tls_engines: Pool(TlsEngine),
+        /// The §4 session-ticket sealing keys — two slots, rotated, and
+        /// process-lifetime by design: a ticket is a bearer credential
+        /// for a resumed session, so the key that opens one never reaches
+        /// disk. A restart therefore costs every returning client one
+        /// full handshake, which is the price of that.
+        ///
+        /// Sized by nothing: unlike the engine pool this is fixed state
+        /// (two keys), which is what makes stateless tickets free of a
+        /// per-session table (§5).
+        tls_tickets: Tickets,
         /// The load-balancing policy: resolves a cluster to the endpoint to
         /// dial. Owns its own per-cluster state so the serving path never
         /// hardcodes how an endpoint is chosen (§7).
@@ -374,6 +385,10 @@ pub fn Server(comptime IoType: type) type {
             // Empty until `setTlsCredentials`, which is before `start` when
             // there is anything to hand over and never otherwise.
             server.tls_credentials = &.{};
+            // Dead until `start` draws a key: `init` runs in tests that
+            // never start a loop, and a sealing key drawn here would be
+            // one the Io seam had not been asked for.
+            server.tls_tickets.init();
             try server.balancer.init(arena, config, keys);
             try server.initMetrics(arena, config, keys);
             server.resetRuntimeState(&options);
@@ -564,9 +579,25 @@ pub fn Server(comptime IoType: type) type {
             return null;
         }
 
+        /// Draw a sealing key, which is what turns resumption on (§4).
+        ///
+        /// At `start` rather than `init` for the same reason the engine
+        /// seeds are drawn where they are: the key has to come through the
+        /// Io seam, so that a seeded run's tickets are part of what it
+        /// replays (§9). Nothing here decides *whether* to draw — a
+        /// deployment with no terminating listener simply never asks an
+        /// engine for one, and two unused keys are 64 bytes.
+        fn installTicketKey(server: *Self) void {
+            var key: [Tickets.key_bytes]u8 = undefined;
+            server.io.fillRandom(&key);
+            server.tls_tickets.rotate(key);
+            assert(server.tls_tickets.ready());
+        }
+
         pub fn start(server: *Self) Io.ListenError!void {
             assert(!server.draining);
             assert(server.listeners_count >= 1);
+            server.installTicketKey();
             for (server.config.listeners, 0..) |listener_config, index| {
                 const state = &server.listeners[index];
                 state.* = .{
@@ -1185,6 +1216,11 @@ pub fn Server(comptime IoType: type) type {
                 .x25519_seed = seeds[0..32].*,
                 .random = seeds[32..64].*,
                 .credentials = credentials,
+                // Only once a key is installed: before that the engine
+                // would offer resumption it could not honour, and every
+                // ticket it opened would be one it never sealed.
+                .tickets = if (server.tls_tickets.ready()) &server.tls_tickets else null,
+                .now_unix = server.io.nowWallNs() / std.time.ns_per_s,
             }) catch {
                 // Deriving the ephemeral keypair is the one fallible step,
                 // and under the OpenSSL backend it *allocates*
@@ -1704,10 +1740,73 @@ pub fn Server(comptime IoType: type) type {
                 return;
             }
             if (engine.isConnected()) {
+                // The session is up and the outbox is empty, which is
+                // exactly once per handshake and exactly the moment the
+                // post-handshake flight is owed (§4). Staging here rather
+                // than in `finishTlsHandshake` keeps it inside the pump's
+                // own loop: the tickets go out through the same send path
+                // as the server flight, partial writes included, and the
+                // hand-over happens on the next pass when the outbox has
+                // drained again.
+                if (!conn.tls_session_up) {
+                    conn.tls_session_up = true;
+                    // Counted *here*, not at the hand-over below: the
+                    // client's Finished has been processed, so this
+                    // handshake has succeeded whatever becomes of the
+                    // flight that follows it. A peer that leaves while
+                    // the tickets are going out is a session that ended,
+                    // not one that never happened.
+                    server.counters.increment("tls_handshakes_completed");
+                    if (engine.isResumed()) server.counters.increment("tls_resumed");
+                    if (server.stageTlsTickets(conn)) {
+                        server.pumpTlsOutbound(conn);
+                        return;
+                    }
+                }
                 server.finishTlsHandshake(conn);
             } else {
                 server.armTlsRecv(conn);
             }
+        }
+
+        /// Issue this session's NewSessionTickets, returning whether any
+        /// were staged.
+        ///
+        /// Best-effort on purpose: a deployment with no sealing key, or a
+        /// suite whose resumption secret ztls will not hand over, gets a
+        /// working session without resumption rather than a failed
+        /// handshake. Resumption is an optimisation, and a client that is
+        /// offered no ticket simply does a full handshake next time.
+        fn stageTlsTickets(server: *Self, conn: *ConnType) bool {
+            const engine = conn.tls.?;
+            assert(engine.isConnected());
+            assert(engine.outbound().len == 0);
+            if (engine.tickets == null) return false;
+
+            var staged: u8 = 0;
+            var index: u8 = 0;
+            while (index < constants.tls_tickets_per_handshake) : (index += 1) {
+                // Per-ticket randomness, drawn through the seam so a
+                // seeded run replays the tickets it issued (§9). The
+                // sealing nonce must never repeat under one key, so it is
+                // drawn fresh for each rather than derived from anything.
+                var material: [Tickets.nonce_bytes + 4]u8 = undefined;
+                server.io.fillRandom(&material);
+                // RFC 8446 §4.6.1 wants the nonce unique per ticket
+                // within a connection; the index is that, and being one
+                // byte it keeps the message small.
+                const ticket_nonce = [_]u8{index};
+                engine.sendSessionTicket(
+                    &ticket_nonce,
+                    std.mem.readInt(u32, material[Tickets.nonce_bytes..][0..4], .big),
+                    material[0..Tickets.nonce_bytes].*,
+                ) catch break;
+                staged += 1;
+                server.counters.increment("tls_tickets_issued");
+            }
+            if (staged == 0) return false;
+            assert(engine.outbound().len >= 1);
+            return true;
         }
 
         fn onTlsSent(conn: *ConnType, result: Io.SendError!u32) void {
@@ -1719,8 +1818,15 @@ pub fn Server(comptime IoType: type) type {
             }
             assert(conn.state == .tls_handshaking);
             const sent = result catch |err| {
+                // Only while the session is still being built. Past that
+                // this send is the post-handshake ticket flight, and a
+                // peer that leaves during it has not failed a handshake —
+                // it completed one and then went away, which teardown
+                // already accounts for.
                 if (err == error.Reset) {
-                    server.counters.increment("tls_handshake_failed");
+                    if (!conn.tls_session_up) {
+                        server.counters.increment("tls_handshake_failed");
+                    }
                 } else {
                     server.witnessKernelPressure(.send, err);
                 }
@@ -1741,7 +1847,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.state == .tls_handshaking);
             assert(conn.tls.?.isConnected());
             assert(conn.tls.?.outbound().len == 0);
-            server.counters.increment("tls_handshakes_completed");
+            assert(conn.tls_session_up); // The pump counted it on the way here.
             // An L4 connection relays for its whole life and must hold a
             // buffer before the dial (§6); an L7 one takes its per-leg.
             // Admission already settled that, so nothing is acquired here.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -275,8 +275,10 @@ pub const tls_tickets_per_handshake: u8 = 2;
 /// bound: a ticket is a bearer credential for a resumed session, and the
 /// sealing key that opens it lives only in memory, so the real question is
 /// how long a stolen ticket is worth carrying. An hour keeps a busy
-/// client's reconnects free while making yesterday's capture useless, and
-/// it is comfortably inside the two-key rotation window.
+/// client's reconnects free while making yesterday's capture useless.
+/// It would also sit comfortably inside a two-key rotation window, once
+/// rotation is wired — see `tls/Tickets.zig`, which today installs one
+/// key at startup and never replaces it.
 pub const tls_ticket_lifetime_s: u32 = 60 * 60;
 
 comptime {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -260,6 +260,32 @@ pub const tls_engines_max: u32 = 1024;
 /// deliberately, having seen the number in the startup banner.
 pub const tls_engines_default: u32 = @min(tls_engines_max, conn_slots_default);
 
+/// How many NewSessionTickets one completed handshake issues (§4).
+///
+/// Two, which is what haproxy and OpenSSL send and what browsers expect:
+/// a client that opens several connections at once wants more than one
+/// ticket to spend, and a single ticket would have all but the first of
+/// them fall back to a full handshake. More than two buys nothing — the
+/// resumed sessions issue their own.
+pub const tls_tickets_per_handshake: u8 = 2;
+
+/// How long a ticket stays valid, in seconds.
+///
+/// RFC 8446 §4.6.1 caps this at 7 days and the cap is not the interesting
+/// bound: a ticket is a bearer credential for a resumed session, and the
+/// sealing key that opens it lives only in memory, so the real question is
+/// how long a stolen ticket is worth carrying. An hour keeps a busy
+/// client's reconnects free while making yesterday's capture useless, and
+/// it is comfortably inside the two-key rotation window.
+pub const tls_ticket_lifetime_s: u32 = 60 * 60;
+
+comptime {
+    assert(tls_tickets_per_handshake >= 1);
+    // RFC 8446 §4.6.1: "Servers MUST NOT use any value greater than
+    // 604800 seconds (7 days)."
+    assert(tls_ticket_lifetime_s <= 7 * 24 * 60 * 60);
+}
+
 /// The fixed heap libcrypto allocates from (§4, `tls/libcrypto_heap.zig`),
 /// reserved at startup exactly when some listener terminates TLS. Sized
 /// against the measured plateau — ~1 MiB for one handshake's distinct

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -355,6 +355,20 @@ pub const Counters = struct {
     /// count here is a peer misbehaving mid-stream or a far side too slow
     /// to drain, neither of which a handshake counter would attribute.
     tls_relay_failed: Value = Value.init(0),
+    /// NewSessionTickets issued (§4), `tls_tickets_per_handshake` per
+    /// completed handshake that had a sealing key. Read against
+    /// `tls_handshakes_completed` it says whether resumption is being
+    /// *offered* — a deployment whose ratio is zero has tickets
+    /// configured and never sends one, which is invisible from the
+    /// handshake counters alone.
+    tls_tickets_issued: Value = Value.init(0),
+    /// Handshakes that resumed a previous session rather than running a
+    /// full one — a ticket this server sealed, offered back and accepted.
+    /// The other half of the pair above: issuing tickets nobody redeems
+    /// and redeeming none are different failures, and only two counters
+    /// tell them apart. Also the one that moves the handshake CPU: a
+    /// resumed handshake skips the signature entirely.
+    tls_resumed: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -4217,6 +4217,139 @@ const TlsWindDown = struct {
     }
 };
 
+test "l7: a completed handshake issues its session tickets" {
+    // The post-handshake flight, and the reason it exists: the ~45 ms
+    // stall (IMPLEMENTATION_NOTES) is a client's second small write held
+    // by its own Nagle, waiting for an ACK zoxy has no reason to send.
+    // Tickets are what give it one — and they are only worth anything if
+    // they go out *after* the client's Finished, which is what makes
+    // "issued once the session is up" the assertion rather than "issued".
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 53,
+        .tls = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    var client: TlsClient = undefined;
+    try client.start(&bed.sim_io, Http1Bed.bindAddress(), .{
+        .host_name = fixture_host_name,
+        .app_data = "GET /x HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n",
+    });
+    var wind_down: TlsWindDown = .{ .bed = &bed };
+    wind_down.attach(&client);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("tls_handshakes_completed"),
+    );
+    try std.testing.expectEqual(
+        @as(u64, constants.tls_tickets_per_handshake),
+        bed.server.counters.get("tls_tickets_issued"),
+    );
+    // Nothing resumed: this client offered no ticket, so a count here
+    // would mean the counter fires on something other than resumption.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tls_resumed"));
+    // And the flight cost the exchange nothing — the request still got
+    // its answer, which is what says the tickets went out *around* the
+    // hand-over rather than in place of it.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        client.app_received[0..client.app_received_len],
+    );
+    try bed.expectDrained();
+}
+
+/// Starts a second, resuming connection when the first one ends, and
+/// winds the scenario down when *that* one does. Two connections have to
+/// share a loop run — see the test — and this is the seam that lets the
+/// second begin only once the first has a ticket to hand it.
+const TlsResumeAfter = struct {
+    bed: *Http1Bed,
+    first: *TlsClient,
+    second: *TlsClient,
+    wind_down: *TlsWindDown,
+
+    const request = "GET /x HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+
+    fn onFirstEnd(context: ?*anyopaque) void {
+        const self: *TlsResumeAfter = @ptrCast(@alignCast(context.?));
+        self.second.start(&self.bed.sim_io, Http1Bed.bindAddress(), .{
+            .host_name = fixture_host_name,
+            .app_data = request,
+            // Different seeds: a resumed handshake still runs its own
+            // ephemeral key exchange (psk_dhe_ke), so reusing the first
+            // session's would prove less than it appears to.
+            .x25519_seed = @splat(0x71),
+            .p256_seed = @splat(0x72),
+            .random = @splat(0x73),
+            .resume_with = &self.first.ticket,
+        }) catch unreachable; // Seeded keypairs; the inputs are ours.
+        self.wind_down.attach(self.second);
+    }
+
+    fn attach(self: *TlsResumeAfter, client: *TlsClient) void {
+        client.on_end = onFirstEnd;
+        client.on_end_context = self;
+    }
+};
+
+test "l7: a ticket issued by one session resumes the next" {
+    // The round trip the whole feature is: a ticket zoxy sealed, handed
+    // to a client, offered back on a fresh connection, and opened by the
+    // key that sealed it. Nothing short of two handshakes proves it —
+    // the seal and open are unit-tested against each other, but only
+    // this says the ticket survives the wire, the client's storage, and
+    // ztls's pre_shared_key extension in between.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 54,
+        .tls = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    var first: TlsClient = undefined;
+    var second: TlsClient = undefined;
+    var wind_down: TlsWindDown = .{ .bed = &bed };
+    // Both connections in one loop run: the server reaches idle between
+    // them with its accepts armed and nothing inbound, which the
+    // simulator calls a deadlock — correctly, since from inside the loop
+    // it is one. So the second connection is started by the first one
+    // ending, the same seam the wind-down uses.
+    var resumer: TlsResumeAfter = .{
+        .bed = &bed,
+        .first = &first,
+        .second = &second,
+        .wind_down = &wind_down,
+    };
+    try first.start(&bed.sim_io, Http1Bed.bindAddress(), .{
+        .host_name = fixture_host_name,
+        .app_data = TlsResumeAfter.request,
+    });
+    resumer.attach(&first);
+    try bed.sim_io.run();
+
+    try std.testing.expect(first.ticket_captured);
+
+    // Two sessions, the second resumed — and the response still correct,
+    // because a resumption that broke the stream would be worse than no
+    // resumption at all.
+    try std.testing.expectEqual(
+        @as(u64, 2),
+        bed.server.counters.get("tls_handshakes_completed"),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("tls_resumed"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tls_handshake_failed"));
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        second.app_received[0..second.app_received_len],
+    );
+    try bed.expectDrained();
+}
+
 test "l7: close_notify between requests writes no access-log line" {
     // A terminated keep-alive connection ends the way TLS says to: the
     // client answers its last response with a close_notify, and the alert

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -324,6 +324,19 @@ pub fn Conn(comptime IoType: type) type {
         /// segment, and a protocol that only ever armed a fresh read
         /// would wait for bytes already in hand.
         tls_pending_len: u32,
+        /// Whether this session's handshake has completed (§4) — the
+        /// client's Finished processed and the session usable.
+        ///
+        /// Set once, and it has to be a latch rather than a question
+        /// asked of the engine, for two reasons. The pump reaches
+        /// "connected with an empty outbox" a second time once the
+        /// post-handshake ticket flight has gone out, and without a latch
+        /// it would issue a fresh pair every time and never hand over to
+        /// the protocol. And it is what separates a handshake that failed
+        /// from a session that came up and then lost its peer while those
+        /// tickets were still going out — the same send error, two
+        /// different things to count.
+        tls_session_up: bool,
         /// The client-directed write in flight, if any (§7, §8) — see
         /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
         client_write: ClientWrite,
@@ -655,6 +668,7 @@ pub fn Conn(comptime IoType: type) type {
             // connection.
             conn.tls = engine;
             conn.tls_pending_len = 0;
+            conn.tls_session_up = false;
             conn.client_write = .{};
             conn.cluster_index = cluster_index;
             // Placeholders until the admission tail installs the

--- a/src/root.zig
+++ b/src/root.zig
@@ -33,6 +33,7 @@ pub const tls = struct {
     pub const Credentials = @import("tls/Credentials.zig");
     pub const Engine = @import("tls/Engine.zig");
     pub const libcrypto_heap = @import("tls/libcrypto_heap.zig");
+    pub const Tickets = @import("tls/Tickets.zig");
     pub const TestClient = @import("tls/TestClient.zig").TestClient;
     /// The throwaway self-signed fixtures (`tls/testdata/README.md`),
     /// re-exported because `@embedFile` cannot escape its module root and
@@ -71,6 +72,7 @@ test {
     _ = shed;
     _ = tls.Credentials;
     _ = tls.Engine;
+    _ = tls.Tickets;
     _ = @import("tls/engine_test.zig");
     _ = tls.TestClient;
     _ = @import("tls/spike_test.zig");

--- a/src/tls/Engine.zig
+++ b/src/tls/Engine.zig
@@ -32,6 +32,7 @@ const constants = @import("../constants.zig");
 const ztls = @import("ztls");
 
 const Credentials = @import("Credentials.zig");
+const Tickets = @import("Tickets.zig");
 
 const assert = std.debug.assert;
 
@@ -59,6 +60,21 @@ reassembly: ztls.ServerHandshake.Storage,
 outbox: [outbox_bytes]u8,
 outbox_len: u32,
 outbox_sent: u32,
+/// Resumption's two halves, both engine-owned because ztls asks this
+/// session's own state for them mid-handshake (§4).
+///
+/// `tickets` is the listener's sealing keys, borrowed and shared — null
+/// when the deployment has none, which is what turns resumption off. The
+/// PSK a ticket opens to lands in `psk_storage` and is handed back to
+/// ztls as a *borrowed* slice, so it has to outlive the lookup call: per
+/// session is the only lifetime that works, since the handshake reads it
+/// after the callback returns.
+tickets: ?*const Tickets,
+psk_storage: [Tickets.psk_bytes_max]u8,
+/// Wall-clock seconds at this session's start, for sealing and for
+/// ageing an offered ticket out. Injected rather than read: the engine
+/// has no clock, and the simulator's must be the one that answers (§9).
+now_unix: u64,
 /// Where decrypted bytes land: the caller's destination for everything
 /// this session ever receives in plaintext. Assigned once at pool init
 /// from a startup slab, never reassigned — runtime-sized because L7's
@@ -212,6 +228,14 @@ pub const Config = struct {
     /// This listener's cert chain and signing key. Borrowed, not owned:
     /// shared across the listener's engines, and must outlive them.
     credentials: *const Credentials,
+    /// The sealing keys resumption runs on, or null to offer none. Same
+    /// borrowing rule as `credentials`: the server owns them for the
+    /// process, an engine only reads them.
+    tickets: ?*const Tickets = null,
+    /// Wall-clock seconds now. Only meaningful when `tickets` is set —
+    /// it is the stamp a sealed ticket carries and the clock an offered
+    /// one is aged against.
+    now_unix: u64 = 0,
 };
 
 /// What one slot's plaintext buffer must be, given the head size the
@@ -264,10 +288,20 @@ pub fn init(engine: *Engine, config: *const Config) !void {
         .init(config.x25519_seed),
     );
     engine.reassembly = .empty;
+    engine.tickets = config.tickets;
+    engine.now_unix = config.now_unix;
     engine.hs = .init(.{
         .keypairs = .init(keypair),
         .random = .init(config.random),
         .reassembly = &engine.reassembly.buffer,
+        // Offered only when this deployment can actually open one. A
+        // lookup that always answers null would work too, but saying so
+        // in the config keeps "resumption is off" a single readable fact
+        // rather than a callback that turns out to never succeed.
+        .psk_lookup = if (config.tickets != null) .{
+            .context = engine,
+            .lookup = openOfferedTicket,
+        } else null,
     });
     engine.hs.setCredentials(config.credentials.chain, config.credentials.signer());
     engine.record_storage = .empty;
@@ -394,6 +428,108 @@ pub fn sendApp(engine: *Engine, bytes: []const u8) !void {
     assert(wire.len > bytes.len); // Record header + AEAD tag overhead.
     engine.stage(wire);
     engine.hs.completeWrite();
+}
+
+/// What one NewSessionTicket costs the outbox: the encoded message plus
+/// a handshake record's header and AEAD tag. The message is dominated by
+/// the ticket itself, which is fixed-size, so this is a closed form and
+/// not an estimate.
+/// The 128 covers the NewSessionTicket fields around the ticket
+/// (lifetime, age add, nonce, extensions) and the 256 the record header
+/// and AEAD tag, on `control_record_bytes_max`'s own reasoning.
+const session_ticket_record_bytes_max: usize = Tickets.ticket_bytes + 128 + 256;
+
+comptime {
+    // Both tickets are staged into an outbox the transport has not begun
+    // draining, so they must fit beside each other or the second would
+    // trip `stage`'s invariant rather than shed.
+    assert(outbox_bytes >= constants.tls_tickets_per_handshake *
+        session_ticket_record_bytes_max);
+}
+
+/// Stage one NewSessionTicket: derive this session's resumption PSK,
+/// seal it into a ticket only this server can open, and encrypt the
+/// message onto the application stream (RFC 8446 §4.6.1).
+///
+/// **When this is called is the point of it.** The flight must go out
+/// *after* the client's Finished is processed, not alongside the server
+/// flight — TLS 1.3 permits either, but only the later one carries an
+/// ACK covering that Finished. Without it the client's next small write
+/// sits in its own Nagle queue waiting for an ACK zoxy has no reason to
+/// send, which is the ~45 ms stall (IMPLEMENTATION_NOTES).
+///
+/// The randomness is passed in rather than drawn: the engine has no I/O,
+/// and a seeded simulator must be able to replay a ticket byte for byte
+/// (§9). `seal_nonce` must never repeat under one sealing key — it is a
+/// GCM nonce, and a repeat there is not a weak ticket but a broken one.
+pub fn sendSessionTicket(
+    engine: *Engine,
+    ticket_nonce: []const u8,
+    age_add: u32,
+    seal_nonce: [Tickets.nonce_bytes]u8,
+) !void {
+    assert(engine.hs.isConnected());
+    assert(ticket_nonce.len >= 1);
+    assert(engine.outboundRoom() >= session_ticket_record_bytes_max);
+    const tickets = engine.tickets orelse return error.NoTicketKeys;
+
+    var psk_buffer: [Tickets.psk_bytes_max]u8 = undefined;
+    const psk = try engine.hs.resumptionPsk(ticket_nonce, &psk_buffer);
+    var ticket: [Tickets.ticket_bytes]u8 = undefined;
+    const sealed = try tickets.seal(
+        &ticket,
+        psk,
+        engine.hs.cipherSuite(),
+        engine.now_unix,
+        seal_nonce,
+    );
+    const wire = try engine.hs.sendNewSessionTicket(
+        &engine.out.buffer,
+        constants.tls_ticket_lifetime_s,
+        age_add,
+        ticket_nonce,
+        sealed,
+    );
+    assert(wire.len > 0);
+    engine.stage(wire);
+    engine.hs.completeWrite();
+}
+
+/// True when this handshake resumed a previous session rather than
+/// running a full one — an offered ticket that opened, and that ztls then
+/// selected. The counter this feeds is the only way to tell resumption
+/// *working* from resumption merely *configured*.
+pub fn isResumed(engine: *const Engine) bool {
+    return engine.hs.selected_psk != null;
+}
+
+/// ztls asking whether an offered ticket is one of ours. Called during
+/// the handshake, synchronously, with the identity the client sent.
+///
+/// Null for every failure — not ours, not intact, expired — because the
+/// answer a peer is entitled to is only that resumption did not happen.
+/// A full handshake follows either way, so nothing is lost but a round
+/// trip's worth of work.
+fn openOfferedTicket(context: *anyopaque, identity: []const u8) ?ztls.ServerHandshake.PskEntry {
+    const engine: *Engine = @ptrCast(@alignCast(context));
+    const tickets = engine.tickets orelse return null;
+    const opened = tickets.open(
+        identity,
+        &engine.psk_storage,
+        engine.now_unix,
+        constants.tls_ticket_lifetime_s,
+    ) orelse return null;
+    // Borrowed from the engine, which outlives the handshake that is
+    // asking — the reason `psk_storage` is a field and not a local.
+    assert(opened.psk.ptr == &engine.psk_storage);
+    return .{
+        .psk = opened.psk,
+        .cipher_suite = opened.suite,
+        // 0-RTT is not offered (§4): a replayed ticket buys a resumed
+        // handshake and nothing else, which is what lets these tickets be
+        // multi-use without the replay table that would defeat the point.
+        .max_early_data_size = null,
+    };
 }
 
 /// Stage an orderly TLS close (close_notify) for the transport.

--- a/src/tls/TestClient.zig
+++ b/src/tls/TestClient.zig
@@ -68,6 +68,17 @@ pub fn TestClient(comptime IoType: type) type {
         coalesced_len: u32,
         app_received: [65536]u8,
         app_received_len: u32,
+        /// The first NewSessionTicket this session was issued, kept so a
+        /// second session can offer it back — which is the only way to
+        /// test that the server's `psk_lookup` opens what it sealed.
+        /// Meaningless until `ticket_captured`; a server that issues none
+        /// leaves it so, and that is itself an assertable fact.
+        ticket: ztls.ClientHandshake.SessionTicket,
+        ticket_captured: bool,
+        /// A ticket to offer at the *next* handshake, from `Options`.
+        /// Borrowed from whoever captured it — normally an earlier
+        /// client whose storage outlives this one.
+        resume_with: ?*const ztls.ClientHandshake.SessionTicket,
         /// Runs once the client is done — how a scenario learns to wind
         /// down (drain the server, stop the origin).
         on_end: ?*const fn (ctx: ?*anyopaque) void = null,
@@ -120,6 +131,10 @@ pub fn TestClient(comptime IoType: type) type {
             /// runs its sinks synchronously inside `feed`, so the session
             /// can end underneath the step that is still driving it.
             close_in_handshake: bool = false,
+            /// Offer this ticket in the ClientHello, resuming the session
+            /// that issued it instead of running a full handshake. The
+            /// storage is the caller's and must outlive the client.
+            resume_with: ?*const ztls.ClientHandshake.SessionTicket = null,
             /// Seeds for the two keyshares and the client random.
             x25519_seed: [32]u8 = @splat(0x61),
             p256_seed: [32]u8 = @splat(0x62),
@@ -179,6 +194,9 @@ pub fn TestClient(comptime IoType: type) type {
             client.close_in_handshake = options.close_in_handshake;
             client.coalesced_len = 0;
             client.app_received_len = 0;
+            client.ticket = .{};
+            client.ticket_captured = false;
+            client.resume_with = options.resume_with;
             io.connect(address, &client.connect_completion, Self, client, onConnect);
         }
 
@@ -190,10 +208,21 @@ pub fn TestClient(comptime IoType: type) type {
                 return;
             };
             client.connected = true;
-            client.pending_send = client.hs.start(&client.out.buffer) catch {
-                client.finish();
-                return;
-            };
+            // A ticket in hand means offer it: the ClientHello carries a
+            // pre_shared_key extension and the server either opens it
+            // (resumed) or ignores it (full handshake). Both are legal
+            // outcomes of the same call, which is why the test asserts on
+            // the server's counters rather than on this succeeding.
+            client.pending_send = if (client.resume_with) |ticket|
+                client.hs.startWithPsk(ticket, &client.out.buffer, false) catch {
+                    client.finish();
+                    return;
+                }
+            else
+                client.hs.start(&client.out.buffer) catch {
+                    client.finish();
+                    return;
+                };
             client.hs.completeWrite();
             client.armSend();
         }
@@ -411,7 +440,19 @@ pub fn TestClient(comptime IoType: type) type {
                             );
                             client.app_received_len += @intCast(bytes.len);
                         },
-                        .key_update, .new_session_ticket, .none => {},
+                        .new_session_ticket => |nst| {
+                            // Keep the *first* only. A server issues
+                            // several and they are interchangeable, so
+                            // storing one keeps this a fixed-size client
+                            // and makes "the ticket" unambiguous in the
+                            // test that offers it back.
+                            if (!client.ticket_captured) {
+                                client.ticket = client.hs.deriveSessionTicket(nst) catch
+                                    continue;
+                                client.ticket_captured = true;
+                            }
+                        },
+                        .key_update, .none => {},
                     }
                 }
                 if (client.hs.isConnected()) client.handshake_done = true;

--- a/src/tls/Tickets.zig
+++ b/src/tls/Tickets.zig
@@ -1,0 +1,328 @@
+//! Stateless TLS 1.3 session tickets (DESIGN.md §4, PLANS.md 3a).
+//!
+//! A resumption ticket has to carry the session's PSK back to us. The
+//! obvious shape is a server-side table keyed by ticket id — and that is
+//! exactly what zoxy cannot have: a table sized for concurrent sessions
+//! is memory that grows with traffic, and looking one up on the handshake
+//! path is state the §5 budget would have to cover. So the ticket *is*
+//! the state: the PSK is sealed into the bytes handed to the client, and
+//! the server keeps only the key that seals them.
+//!
+//! That trade is what makes resumption free of per-session memory, and it
+//! moves the security question onto the sealing key: anyone holding it
+//! can recover every PSK it ever sealed. Hence two slots and rotation —
+//! a key stops sealing before it stops opening, so tickets stay valid
+//! across a rotation while the window in which any one key matters stays
+//! bounded. Keys live in memory only: a restart invalidates every
+//! outstanding ticket, which costs one full handshake per returning
+//! client and keeps a stolen disk worthless.
+//!
+//! 0-RTT is deliberately not offered (`max_early_data_size` is never
+//! set), so a replayed ticket buys an attacker a resumed handshake and
+//! nothing else — no replayed application data. That is why these
+//! tickets are multi-use: single-use would need the very table this
+//! design exists to avoid.
+
+const std = @import("std");
+
+const ztls = @import("ztls");
+
+const assert = std.debug.assert;
+
+const Tickets = @This();
+
+/// AES-256-GCM: a 32-byte key, 12-byte nonce, 16-byte tag. Chosen over
+/// ChaCha20-Poly1305 because every target that runs zoxy in production
+/// has AES-NI, and this is on the handshake path.
+const Aead = std.crypto.aead.aes_gcm.Aes256Gcm;
+const key_bytes = Aead.key_length;
+const nonce_bytes = Aead.nonce_length;
+const tag_bytes = Aead.tag_length;
+
+/// The largest PSK any supported suite derives (SHA-384).
+pub const psk_bytes_max = 48;
+
+/// Sealed plaintext: the PSK and what is needed to use it again.
+const payload_bytes = 1 + psk_bytes_max + 2 + 8;
+
+/// A sealed ticket on the wire: which key sealed it, the nonce, the
+/// ciphertext, and the tag. Fixed size — the PSK length rides *inside*
+/// the sealed payload rather than shortening the ticket, so a ticket's
+/// length leaks nothing about the suite negotiated.
+pub const ticket_bytes = 1 + nonce_bytes + payload_bytes + tag_bytes;
+
+comptime {
+    // The wire format caps an identity at 2^16-1, and ztls's client-side
+    // `SessionTicket.identity` at 256. Neither is close, but a future
+    // payload change should fail here rather than at runtime.
+    assert(ticket_bytes <= 256);
+}
+
+/// One sealing key and the generation that names it. `id` is carried in
+/// the clear so opening picks a key instead of trying both.
+const Slot = struct {
+    id: u8,
+    key: [key_bytes]u8,
+    /// False before the first `rotate`, so a ticket cannot be opened by
+    /// an uninitialised slot.
+    live: bool,
+};
+
+/// Two slots: the one sealing now, and the one it replaced. Anything
+/// older cannot be opened, which is what bounds a key's exposure.
+slots: [2]Slot,
+current: u1,
+/// Monotonic generation counter, so a wrapped `id` never lets a stale
+/// ticket match a fresh key.
+next_id: u8,
+
+/// Seeded, never drawn from entropy here: the caller supplies key
+/// material so the simulator is deterministic and production reads it
+/// from the kernel (§9). Both slots start dead; `rotate` installs the
+/// first key.
+pub fn init(tickets: *Tickets) void {
+    tickets.slots = @splat(.{ .id = 0, .key = @splat(0), .live = false });
+    tickets.current = 0;
+    tickets.next_id = 1;
+}
+
+/// Install `key` as the sealing key, demoting the previous one to
+/// opening-only. Called at startup and on every rotation interval.
+pub fn rotate(tickets: *Tickets, key: [key_bytes]u8) void {
+    const next: u1 = if (tickets.current == 0) 1 else 0;
+    tickets.slots[next] = .{ .id = tickets.next_id, .key = key, .live = true };
+    tickets.current = next;
+    // Skip 0 on wrap: it is the id of a dead slot.
+    tickets.next_id = if (tickets.next_id == 255) 1 else tickets.next_id + 1;
+    assert(tickets.slots[tickets.current].live);
+}
+
+/// True once a key has been installed; false means resumption is off.
+pub fn ready(tickets: *const Tickets) bool {
+    return tickets.slots[tickets.current].live;
+}
+
+pub const SealError = error{ NoKey, PskTooLong };
+
+/// Seal `psk` and its suite into `out`, returning the ticket. `now_unix`
+/// is stamped in so `open` can age it out.
+pub fn seal(
+    tickets: *const Tickets,
+    out: *[ticket_bytes]u8,
+    psk: []const u8,
+    suite: ztls.CipherSuite,
+    now_unix: u64,
+    nonce: [nonce_bytes]u8,
+) SealError![]const u8 {
+    if (!tickets.ready()) return error.NoKey;
+    if (psk.len > psk_bytes_max) return error.PskTooLong;
+    assert(psk.len >= 1);
+
+    var payload: [payload_bytes]u8 = @splat(0);
+    payload[0] = @intCast(psk.len);
+    @memcpy(payload[1..][0..psk.len], psk);
+    std.mem.writeInt(u16, payload[1 + psk_bytes_max ..][0..2], @intFromEnum(suite), .big);
+    std.mem.writeInt(u64, payload[1 + psk_bytes_max + 2 ..][0..8], now_unix, .big);
+
+    const slot = &tickets.slots[tickets.current];
+    out[0] = slot.id;
+    @memcpy(out[1..][0..nonce_bytes], &nonce);
+    var tag: [tag_bytes]u8 = undefined;
+    Aead.encrypt(
+        out[1 + nonce_bytes ..][0..payload_bytes],
+        &tag,
+        &payload,
+        // The key id is authenticated, so a ticket cannot be replayed
+        // against a different generation by editing one byte.
+        out[0..1],
+        nonce,
+        slot.key,
+    );
+    @memcpy(out[1 + nonce_bytes + payload_bytes ..][0..tag_bytes], &tag);
+    return out[0..];
+}
+
+/// What a ticket yields when it opens: the PSK (borrowed from the
+/// caller's storage) and the suite it belongs to.
+pub const Opened = struct {
+    psk: []const u8,
+    suite: ztls.CipherSuite,
+};
+
+/// Recover a ticket's contents, or null if it is not ours, not intact,
+/// or too old. Every failure is null on purpose: a peer learns only that
+/// resumption did not happen, never why, and the caller falls back to a
+/// full handshake either way.
+pub fn open(
+    tickets: *const Tickets,
+    ticket: []const u8,
+    psk_out: *[psk_bytes_max]u8,
+    now_unix: u64,
+    lifetime_s: u32,
+) ?Opened {
+    if (ticket.len != ticket_bytes) return null;
+    const key_id = ticket[0];
+    const slot = tickets.slotFor(key_id) orelse return null;
+
+    var nonce: [nonce_bytes]u8 = undefined;
+    @memcpy(&nonce, ticket[1..][0..nonce_bytes]);
+    var tag: [tag_bytes]u8 = undefined;
+    @memcpy(&tag, ticket[1 + nonce_bytes + payload_bytes ..][0..tag_bytes]);
+
+    var payload: [payload_bytes]u8 = undefined;
+    Aead.decrypt(
+        &payload,
+        ticket[1 + nonce_bytes ..][0..payload_bytes],
+        tag,
+        ticket[0..1],
+        nonce,
+        slot.key,
+    ) catch return null;
+
+    const psk_len = payload[0];
+    if (psk_len == 0 or psk_len > psk_bytes_max) return null;
+    const suite_wire = std.mem.readInt(u16, payload[1 + psk_bytes_max ..][0..2], .big);
+    const suite = ztls.CipherSuite.fromWire(suite_wire) orelse return null;
+    const issued = std.mem.readInt(u64, payload[1 + psk_bytes_max + 2 ..][0..8], .big);
+
+    // Expired, or issued in the future — a clock that went backwards is
+    // not a reason to honour a ticket indefinitely.
+    if (now_unix < issued) return null;
+    if (now_unix - issued > lifetime_s) return null;
+
+    @memcpy(psk_out[0..psk_len], payload[1..][0..psk_len]);
+    return .{ .psk = psk_out[0..psk_len], .suite = suite };
+}
+
+fn slotFor(tickets: *const Tickets, id: u8) ?*const Slot {
+    for (&tickets.slots) |*slot| {
+        if (slot.live and slot.id == id) return slot;
+    }
+    return null;
+}
+
+const testing = std.testing;
+
+fn testKey(fill: u8) [key_bytes]u8 {
+    return @splat(fill);
+}
+
+test "tickets: a sealed ticket opens to what went into it" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x11));
+
+    const psk = [_]u8{0xab} ** 32;
+    var buf: [ticket_bytes]u8 = undefined;
+    const ticket = try tickets.seal(&buf, &psk, .aes_128_gcm_sha256, 1000, @splat(7));
+
+    var psk_out: [psk_bytes_max]u8 = undefined;
+    const opened = tickets.open(ticket, &psk_out, 1000, 3600) orelse
+        return error.TestExpectedOpen;
+    try testing.expectEqualSlices(u8, &psk, opened.psk);
+    try testing.expectEqual(ztls.CipherSuite.aes_128_gcm_sha256, opened.suite);
+}
+
+test "tickets: sealing needs a key" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    var buf: [ticket_bytes]u8 = undefined;
+    try testing.expectError(
+        error.NoKey,
+        tickets.seal(&buf, &[_]u8{0x01} ** 32, .aes_128_gcm_sha256, 0, @splat(0)),
+    );
+}
+
+test "tickets: a ticket outlives one rotation and not two" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x11));
+
+    const psk = [_]u8{0xcd} ** 32;
+    var buf: [ticket_bytes]u8 = undefined;
+    const sealed = try tickets.seal(&buf, &psk, .aes_128_gcm_sha256, 100, @splat(1));
+    var ticket: [ticket_bytes]u8 = undefined;
+    @memcpy(&ticket, sealed);
+
+    var psk_out: [psk_bytes_max]u8 = undefined;
+    // One rotation: the sealing key becomes the previous key, still able
+    // to open. This is the point of two slots — a client holding a
+    // ticket issued a moment ago does not lose it to a rotation tick.
+    tickets.rotate(testKey(0x22));
+    try testing.expect(tickets.open(&ticket, &psk_out, 100, 3600) != null);
+
+    // Two rotations: the key is gone and so is the ticket.
+    tickets.rotate(testKey(0x33));
+    try testing.expect(tickets.open(&ticket, &psk_out, 100, 3600) == null);
+}
+
+test "tickets: an expired ticket does not open" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x44));
+
+    var buf: [ticket_bytes]u8 = undefined;
+    const ticket = try tickets.seal(&buf, &[_]u8{0x01} ** 32, .aes_128_gcm_sha256, 100, @splat(2));
+
+    var psk_out: [psk_bytes_max]u8 = undefined;
+    try testing.expect(tickets.open(ticket, &psk_out, 100 + 3600, 3600) != null);
+    try testing.expect(tickets.open(ticket, &psk_out, 100 + 3601, 3600) == null);
+    // A clock that ran backwards is not a licence to honour it forever.
+    try testing.expect(tickets.open(ticket, &psk_out, 99, 3600) == null);
+}
+
+test "tickets: a tampered ticket does not open" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x55));
+
+    var buf: [ticket_bytes]u8 = undefined;
+    const sealed = try tickets.seal(&buf, &[_]u8{0x02} ** 32, .aes_128_gcm_sha256, 0, @splat(3));
+    var psk_out: [psk_bytes_max]u8 = undefined;
+
+    // Every byte matters: the key id is authenticated data, the rest is
+    // ciphertext or tag.
+    for (0..ticket_bytes) |index| {
+        var ticket: [ticket_bytes]u8 = undefined;
+        @memcpy(&ticket, sealed);
+        ticket[index] ^= 0xff;
+        try testing.expect(tickets.open(&ticket, &psk_out, 0, 3600) == null);
+    }
+}
+
+test "tickets: a ticket from another server does not open" {
+    var mine: Tickets = undefined;
+    mine.init();
+    mine.rotate(testKey(0x66));
+    var theirs: Tickets = undefined;
+    theirs.init();
+    theirs.rotate(testKey(0x77));
+
+    var buf: [ticket_bytes]u8 = undefined;
+    const ticket = try theirs.seal(&buf, &[_]u8{0x03} ** 32, .aes_128_gcm_sha256, 0, @splat(4));
+
+    var psk_out: [psk_bytes_max]u8 = undefined;
+    try testing.expect(mine.open(ticket, &psk_out, 0, 3600) == null);
+}
+
+test "tickets: a wrong-sized identity is not a ticket" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x88));
+    var psk_out: [psk_bytes_max]u8 = undefined;
+    try testing.expect(tickets.open(&.{}, &psk_out, 0, 3600) == null);
+    try testing.expect(tickets.open(&[_]u8{0} ** 8, &psk_out, 0, 3600) == null);
+    try testing.expect(tickets.open(&[_]u8{0} ** 512, &psk_out, 0, 3600) == null);
+}
+
+test "tickets: a ticket's length says nothing about the suite" {
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x99));
+
+    var short_buf: [ticket_bytes]u8 = undefined;
+    var long_buf: [ticket_bytes]u8 = undefined;
+    const short = try tickets.seal(&short_buf, &[_]u8{1} ** 32, .aes_128_gcm_sha256, 0, @splat(5));
+    const long = try tickets.seal(&long_buf, &[_]u8{2} ** 48, .aes_256_gcm_sha384, 0, @splat(6));
+    try testing.expectEqual(short.len, long.len);
+}

--- a/src/tls/Tickets.zig
+++ b/src/tls/Tickets.zig
@@ -17,6 +17,13 @@
 //! outstanding ticket, which costs one full handshake per returning
 //! client and keeps a stolen disk worthless.
 //!
+//! **The rotation half of that is not wired yet.** The server installs
+//! one key at startup and never calls `rotate` again, so both slots hold
+//! the same generation for the process's life and the bounded-exposure
+//! property above is a property of this module rather than of the running
+//! proxy. What it waits on is a policy decision — the interval *is* the
+//! bound — recorded in IMPLEMENTATION_NOTES under "TLS termination".
+//!
 //! 0-RTT is deliberately not offered (`max_early_data_size` is never
 //! set), so a replayed ticket buys an attacker a resumed handshake and
 //! nothing else — no replayed application data. That is why these
@@ -84,10 +91,14 @@ pub fn init(tickets: *Tickets) void {
     tickets.slots = @splat(.{ .id = 0, .key = @splat(0), .live = false });
     tickets.current = 0;
     tickets.next_id = 1;
+    // The property `ready` exists to report, pinned where it is
+    // established: an uninitialised slot must never seal or open.
+    assert(!tickets.ready());
 }
 
 /// Install `key` as the sealing key, demoting the previous one to
-/// opening-only. Called at startup and on every rotation interval.
+/// opening-only. Called at startup — and, once rotation is wired, on
+/// every interval; today the startup call is the only one.
 pub fn rotate(tickets: *Tickets, key: [key_bytes]u8) void {
     const next: u1 = if (tickets.current == 0) 1 else 0;
     tickets.slots[next] = .{ .id = tickets.next_id, .key = key, .live = true };

--- a/src/tls/Tickets.zig
+++ b/src/tls/Tickets.zig
@@ -35,8 +35,8 @@ const Tickets = @This();
 /// ChaCha20-Poly1305 because every target that runs zoxy in production
 /// has AES-NI, and this is on the handshake path.
 const Aead = std.crypto.aead.aes_gcm.Aes256Gcm;
-const key_bytes = Aead.key_length;
-const nonce_bytes = Aead.nonce_length;
+pub const key_bytes = Aead.key_length;
+pub const nonce_bytes = Aead.nonce_length;
 const tag_bytes = Aead.tag_length;
 
 /// The largest PSK any supported suite derives (SHA-384).


### PR DESCRIPTION
Both halves of TLS 1.3 session resumption, and with them the fix for the diagnosed ~45 ms stall.

## Why the placement is the feature

A TLS client writes its `Finished`, then its request — two small writes. Nagle holds the second until the first is acknowledged, and zoxy, having nothing to send, gives it no ACK to ride on. The client waits out its delayed-ACK timer. That is the ~45 ms stall in IMPLEMENTATION_NOTES, and it is why the post-handshake flight has to land **after** the client's `Finished` rather than alongside the server flight: only the later one carries that ACK.

So the tickets are staged the moment the session comes up and the outbox is empty — once per handshake — from inside the outbound pump, which means they ride the same send path as the server flight, partial writes included.

## Stateless, so §5 does not move

A ticket has to carry its session's PSK back to us. The obvious shape — a table keyed by ticket id — is memory that grows with traffic plus a lookup on the handshake path, both of which the budget would have to cover. So the ticket *is* the state: the PSK is sealed (AES-256-GCM) into the bytes handed to the client, and the server keeps only the keys. **64 bytes, whatever the traffic.**

## The sim census caught a regression I introduced

The ticket flight goes out while the connection is still `tls_handshaking`, so a peer that left during it was counted as a **failed handshake** — one that had in fact succeeded. The census flagged it as a counter firing against an allowance of zero.

`tls_handshakes_completed` and `tls_resumed` now count where the session comes up rather than at the hand-over, behind a `tls_session_up` latch, and the send-error arm blames the handshake only while that latch is unset.

## Coverage

- **Emission** — asserts the flight is issued and costs the exchange nothing. Verified to fail when disabled.
- **Round trip** — two connections: issue, capture, offer, open, and assert the server resumed. Verified to fail with `expected 1, found 0` when `psk_lookup` is unwired.
- **Live gate** — the Tier-0.5 leg now asserts the flight on the shipped binary, which is the tier that matters for something whose whole purpose is a TCP interaction.
- `tls_resumed` is census-exempt naming the round-trip test: the sweep's clients are single-connection by construction and cannot offer a ticket back.

While wiring this I found `Tickets.zig` compiled without its eight tests ever running — it needed registering in the runner's reachability block (476 tests, up from 468).

## Not in this PR

- **Key rotation.** `rotate` is called once at startup, so the two slots hold one generation for the process's life. The interval *is* the security bound, which makes it a policy question I did not want to guess at. Comments that read as though rotation were live have been corrected rather than left flattering.
- **The measurement.** The Tier-1 bands that would confirm the stall is gone have not been re-run; the last reading, without resumption, was 664 of 2000 req/s offered against HAProxy's 831. That is the next slice.

Gates: 478 tests, 4096 sim seeds, census ok, smoke, heap proof, lint, format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)