### PR TITLE
bench: TLS bands, and the nightly's rare handshake failure (#125)

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -36,9 +36,11 @@ const assert = std.debug.assert;
 
 const zoxy_port: u16 = 18180;
 const zoxy_http_port: u16 = 18181;
+const zoxy_https_port: u16 = 18182;
 const origin_port: u16 = 19180;
 const haproxy_port: u16 = 17180;
 const haproxy_http_port: u16 = 17181;
+const haproxy_https_port: u16 = 17182;
 const overload_http_port: u16 = 18291;
 const work_directory = ".zig-cache/zoxy-bench";
 
@@ -104,15 +106,23 @@ const rate_floor_percent: u64 = 90;
 
 const Flags = struct {
     rate: u64 = 20_000,
-    // Connection: close is one TCP handshake per request, so on loopback
-    // it is connect-bound: at this rate the TIME_WAIT population
-    // (rate x 60 s) already exceeds the ~28k ephemeral-port pool, so the
-    // run leans on net.ipv4.tcp_tw_reuse (on by default on modern Linux
-    // and in the dev shell) to reclaim source ports. Without it, lower
-    // --close-rate toward ~400/s or the socket-error gate will trip on
-    // port exhaustion, not a proxy fault. This is a latency band (the
-    // per-request hop cost), never a throughput number.
-    close_rate: u64 = 2_000,
+    // Connection: close is one TCP handshake per request — and, on the
+    // terminating paths, one *TLS* handshake too. That is what sets this
+    // rate: an ECDSA signature plus a key exchange per connection tops
+    // out near 840/s on a single pinned core, measured, and measured the
+    // same for haproxy (843 vs 830 — IMPLEMENTATION_NOTES). Offering
+    // past that makes every path's latency a queueing artefact rather
+    // than a hop cost, which is the opposite of what this band is for:
+    // it is a latency band (the per-request hop cost), never a
+    // throughput number.
+    //
+    // So the offer is one every path can actually hold, which keeps all
+    // seven directly comparable — the whole point of a band. It also
+    // eases what the previous rate had to lean on: at 2000/s the
+    // TIME_WAIT population (rate x 60 s) exceeded the ~28k ephemeral-port
+    // pool and the run depended on net.ipv4.tcp_tw_reuse to reclaim
+    // source ports.
+    close_rate: u64 = 500,
     /// Requests per second for the large-body bands. At
     /// `large_body_bytes` each, 400/s offers ~100 MiB/s through the hop —
     /// enough that per-byte cost dominates, and well inside what loopback
@@ -160,6 +170,8 @@ pub fn main(init: std.process.Init) !u8 {
     // that manifested as a SEGV in this ReleaseFast harness.
     defer if (origin_child) |*child| child.kill(io);
 
+    // Before either proxy: both configs name these paths.
+    try writeCertificates(arena, io);
     var zoxy_child = try spawnZoxy(arena, io, flags.zoxy_path, origin_address);
     var zoxy_running = true;
     defer if (zoxy_running) zoxy_child.kill(io);
@@ -320,13 +332,13 @@ fn runOverload(
     if (proxy_cpu) |cpu| {
         affinity.pinChildTo(child.id.?, cpu);
     }
-    _ = try awaitResponsive(arena, io, overload_http_port, "zoxy overload");
+    _ = try awaitResponsive(arena, io, overload_http_port, "zoxy overload", false);
 
     // The same saturate-then-measure discipline as the primary (§9): the
     // shrunken pools are lazily resident too, and an overload burst is
     // its own saturation — the walls this scenario exists to hit fault
     // everything a longer run can touch.
-    var config = benchConfig(overload_http_port, overload_connections, flags.rate, "/");
+    var config = benchConfig(overload_http_port, overload_connections, flags.rate, "/", false);
     config.duration_ns = saturate_duration_s * std.time.ns_per_s;
     _ = try zrk.runner.run(arena, io, &config, 0, null, null, null);
 
@@ -568,17 +580,26 @@ fn saturate(arena: std.mem.Allocator, io: Io, flags: *const Flags, head_buffers:
     const ring_seconds: u64 = (3 * head_buffers) / flags.rate + 1;
     warm_flags.duration_s = @max(saturate_duration_s, ring_seconds);
     std.debug.print(
-        "bench: saturating warmup — {d}s keep-alive + {d}s close + {d}s large-body, both zoxy ports\n",
+        "bench: saturating warmup — {d}s keep-alive + {d}s close + {d}s large-body, every zoxy port\n",
         .{ warm_flags.duration_s, saturate_duration_s, saturate_duration_s },
     );
-    const zoxy_ports = [_]u16{ zoxy_port, zoxy_http_port };
-    for (zoxy_ports) |port| {
-        _ = try loadTest(arena, io, port, &warm_flags, .keep_alive);
+    // The terminating port is here for the ceiling gate's sake, not for
+    // symmetry: engine slots and the libcrypto heap are the largest
+    // lazily-resident pools §5 prints, and a warmup that never handshakes
+    // leaves them unfaulted — which would make the RSS ceiling pass by
+    // measuring memory the run never touched.
+    const zoxy_ports = [_]struct { port: u16, tls: bool }{
+        .{ .port = zoxy_port, .tls = false },
+        .{ .port = zoxy_http_port, .tls = false },
+        .{ .port = zoxy_https_port, .tls = true },
+    };
+    for (zoxy_ports) |target| {
+        _ = try loadTest(arena, io, target.port, &warm_flags, .keep_alive, target.tls);
     }
     warm_flags.duration_s = saturate_duration_s;
-    for (zoxy_ports) |port| {
-        _ = try loadTest(arena, io, port, &warm_flags, .close);
-        _ = try loadTest(arena, io, port, &warm_flags, .large_body);
+    for (zoxy_ports) |target| {
+        _ = try loadTest(arena, io, target.port, &warm_flags, .close, target.tls);
+        _ = try loadTest(arena, io, target.port, &warm_flags, .large_body, target.tls);
     }
 }
 
@@ -587,11 +608,13 @@ fn saturate(arena: std.mem.Allocator, io: Io, flags: *const Flags, head_buffers:
 /// before any numbers are printed.
 fn warmUp(arena: std.mem.Allocator, io: Io, direct_port: u16) !void {
     assert(direct_port != 0);
-    _ = try awaitResponsive(arena, io, direct_port, "origin");
-    _ = try awaitResponsive(arena, io, zoxy_port, "zoxy L4");
-    _ = try awaitResponsive(arena, io, zoxy_http_port, "zoxy L7");
-    _ = try awaitResponsive(arena, io, haproxy_port, "haproxy tcp");
-    _ = try awaitResponsive(arena, io, haproxy_http_port, "haproxy http");
+    _ = try awaitResponsive(arena, io, direct_port, "origin", false);
+    _ = try awaitResponsive(arena, io, zoxy_port, "zoxy L4", false);
+    _ = try awaitResponsive(arena, io, zoxy_http_port, "zoxy L7", false);
+    _ = try awaitResponsive(arena, io, haproxy_port, "haproxy tcp", false);
+    _ = try awaitResponsive(arena, io, haproxy_http_port, "haproxy http", false);
+    _ = try awaitResponsive(arena, io, zoxy_https_port, "zoxy L7 TLS", true);
+    _ = try awaitResponsive(arena, io, haproxy_https_port, "haproxy https", true);
 }
 
 /// One scenario's bands plus what they were asked to do, so the gates can
@@ -799,7 +822,9 @@ fn spawnZoxy(
         \\{{
         \\    "listeners": [
         \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "l4" }},
-        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }}
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http" }},
+        \\        {{ "bind": "127.0.0.1:{d}", "cluster": "origin", "protocol": "http",
+        \\          "tls": {{ "cert": "{s}", "key": "{s}" }} }}
         \\    ],
         \\    "clusters": {{
         \\        "origin": {{ "endpoints": ["{s}"] }}
@@ -811,7 +836,14 @@ fn spawnZoxy(
         \\    }}
         \\}}
         \\
-    , .{ zoxy_port, zoxy_http_port, origin_address });
+    , .{
+        zoxy_port,
+        zoxy_http_port,
+        zoxy_https_port,
+        work_directory ++ "/cert.pem",
+        work_directory ++ "/key.pem",
+        origin_address,
+    });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = config_json });
 
     // stderr is piped so `readBanner` can gate on the §5 total (the
@@ -837,6 +869,40 @@ fn spawnZoxy(
 /// origin, same load, `mode tcp` to match zoxy's L4 relay and
 /// `nbthread 1` to match zoxy's single event-loop thread. Timeouts mirror
 /// the generated zoxy config so neither proxy wins by timing out earlier.
+/// The throwaway self-signed fixtures the TLS gates use
+/// (`src/tls/testdata/README.md`), read from the tree rather than
+/// embedded — the bench is its own module, so `@embedFile` cannot reach
+/// across the package boundary, and the harness already assumes a
+/// repo-root cwd (`zig-out/bin/zoxy`, `.zig-cache/…`). Benchmarking the
+/// same certificate the tests use keeps the bands honest about what they
+/// measure.
+const cert_source = "src/tls/testdata/cert.pem";
+const key_source = "src/tls/testdata/key.pem";
+
+/// zoxy reads cert and key as separate files; haproxy wants them
+/// concatenated into one. Written once, before either proxy starts —
+/// both configs name these paths, so a missing file has to fail here,
+/// where the error can say which source it came from, rather than as a
+/// proxy that will not start.
+fn writeCertificates(arena: std.mem.Allocator, io: Io) !void {
+    const dir = Io.Dir.cwd();
+    const cert = dir.readFileAlloc(io, cert_source, arena, .unlimited) catch |err| {
+        std.debug.print(
+            "bench: could not read {s} ({t}); run from the repository root\n",
+            .{ cert_source, err },
+        );
+        return err;
+    };
+    const key = try dir.readFileAlloc(io, key_source, arena, .unlimited);
+    assert(cert.len > 0);
+    assert(key.len > 0);
+    try dir.writeFile(io, .{ .sub_path = work_directory ++ "/cert.pem", .data = cert });
+    try dir.writeFile(io, .{ .sub_path = work_directory ++ "/key.pem", .data = key });
+    const combined = try std.mem.concat(arena, u8, &.{ cert, key });
+    try dir.writeFile(io, .{ .sub_path = work_directory ++ "/haproxy.pem", .data = combined });
+    assert(combined.len == cert.len + key.len);
+}
+
 fn spawnHaproxy(
     arena: std.mem.Allocator,
     io: Io,
@@ -864,7 +930,20 @@ fn spawnHaproxy(
         \\    bind 127.0.0.1:{d}
         \\    server origin {s}
         \\
-    , .{ haproxy_port, origin_address, haproxy_http_port, origin_address });
+        \\listen bench_https
+        \\    mode http
+        \\    bind 127.0.0.1:{d} ssl crt {s}
+        \\    server origin {s}
+        \\
+    , .{
+        haproxy_port,
+        origin_address,
+        haproxy_http_port,
+        origin_address,
+        haproxy_https_port,
+        work_directory ++ "/haproxy.pem",
+        origin_address,
+    });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = conf_path, .data = conf });
 
     // -db keeps haproxy in the foreground so kill() reaches the process
@@ -885,7 +964,13 @@ fn spawnHaproxy(
 
 /// Short probing runs double as warmup; a target that never answers is a
 /// setup failure, reported before any numbers are printed.
-fn awaitResponsive(arena: std.mem.Allocator, io: Io, port: u16, label: []const u8) !void {
+fn awaitResponsive(
+    arena: std.mem.Allocator,
+    io: Io,
+    port: u16,
+    label: []const u8,
+    tls: bool,
+) !void {
     assert(port != 0);
     assert(label.len > 0);
     const probe_attempts_max: u8 = 10;
@@ -894,7 +979,7 @@ fn awaitResponsive(arena: std.mem.Allocator, io: Io, port: u16, label: []const u
     const retry_sleep = Io.Duration.fromNanoseconds(200 * std.time.ns_per_ms);
     var attempt: u8 = 0;
     while (attempt < probe_attempts_max) : (attempt += 1) {
-        var config = benchConfig(port, 4, 100, "/");
+        var config = benchConfig(port, 4, 100, "/", tls);
         config.duration_ns = std.time.ns_per_s / 2;
         const report = zrk.runner.run(arena, io, &config, 0, null, null, null) catch |err| {
             if (attempt == probe_attempts_max - 1) return err;
@@ -950,6 +1035,7 @@ fn loadTest(
     port: u16,
     flags: *const Flags,
     scenario: Scenario,
+    tls: bool,
 ) !zrk.runner.Report {
     assert(port != 0);
     assert(flags.duration_s >= 1);
@@ -958,6 +1044,7 @@ fn loadTest(
         flags.connections,
         scenario.rate(flags),
         scenario.target(),
+        tls,
     );
     config.duration_ns = flags.duration_s * std.time.ns_per_s;
     if (scenario == .close) {
@@ -977,8 +1064,10 @@ const Runs = struct {
     direct: zrk.runner.Report,
     l4: zrk.runner.Report,
     l7: zrk.runner.Report,
+    l7_tls: zrk.runner.Report,
     tcp: zrk.runner.Report,
     http: zrk.runner.Report,
+    https: zrk.runner.Report,
 };
 
 /// One full band matrix for a scenario. The paths are identical across
@@ -992,21 +1081,37 @@ fn runMode(
 ) !Runs {
     assert(direct_port != 0);
     return .{
-        .direct = try loadTest(arena, io, direct_port, flags, scenario),
-        .l4 = try loadTest(arena, io, zoxy_port, flags, scenario),
-        .l7 = try loadTest(arena, io, zoxy_http_port, flags, scenario),
-        .tcp = try loadTest(arena, io, haproxy_port, flags, scenario),
-        .http = try loadTest(arena, io, haproxy_http_port, flags, scenario),
+        .direct = try loadTest(arena, io, direct_port, flags, scenario, false),
+        .l4 = try loadTest(arena, io, zoxy_port, flags, scenario, false),
+        .l7 = try loadTest(arena, io, zoxy_http_port, flags, scenario, false),
+        .l7_tls = try loadTest(arena, io, zoxy_https_port, flags, scenario, true),
+        .tcp = try loadTest(arena, io, haproxy_port, flags, scenario, false),
+        .http = try loadTest(arena, io, haproxy_http_port, flags, scenario, false),
+        .https = try loadTest(arena, io, haproxy_https_port, flags, scenario, true),
     };
 }
 
-fn benchConfig(port: u16, connections: u32, rate: u64, target: []const u8) zrk.cli.Config {
+fn benchConfig(
+    port: u16,
+    connections: u32,
+    rate: u64,
+    target: []const u8,
+    tls: bool,
+) zrk.cli.Config {
     assert(port != 0);
     assert(connections >= 1);
     assert(rate >= 1);
     assert(target.len >= 1 and target[0] == '/');
     return .{
-        .url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = target },
+        .url = .{
+            .scheme = if (tls) .https else .http,
+            .host = "127.0.0.1",
+            .port = port,
+            .target = target,
+        },
+        // The fixtures are self-signed, and chain anchoring is not what a
+        // throughput band measures.
+        .insecure = tls,
         .connections = connections,
         .rate = rate,
         .timeout_ns = 2 * std.time.ns_per_s,
@@ -1100,8 +1205,10 @@ fn printMode(label: []const u8, runs: *const Runs, scenario: Scenario) void {
     printReport("direct      ", &runs.direct, scenario);
     printReport("zoxy L4     ", &runs.l4, scenario);
     printReport("zoxy L7     ", &runs.l7, scenario);
+    printReport("zoxy L7 TLS ", &runs.l7_tls, scenario);
     printReport("haproxy tcp ", &runs.tcp, scenario);
     printReport("haproxy http", &runs.http, scenario);
+    printReport("haproxy https", &runs.https, scenario);
     printOverhead(&runs.direct, &runs.l4, &runs.l7, &runs.tcp, &runs.http);
 }
 
@@ -1134,7 +1241,12 @@ fn rateHeld(
 /// faithfully relayed 4xx/5xx) under 1%.
 fn proxiesHealthy(mode: []const u8, runs: *const Runs) bool {
     assert(mode.len > 0);
-    return proxyHealthy(mode, "L4", &runs.l4) and proxyHealthy(mode, "L7", &runs.l7);
+    // Every zoxy path, TLS included: a terminated band that relays
+    // garbage or stalls has to fail here rather than be read off the
+    // rate line as merely slow.
+    return proxyHealthy(mode, "L4", &runs.l4) and
+        proxyHealthy(mode, "L7", &runs.l7) and
+        proxyHealthy(mode, "L7 TLS", &runs.l7_tls);
 }
 
 /// A single proxied band's health, printing the offending band so a

--- a/bench/run.zig
+++ b/bench/run.zig
@@ -111,10 +111,11 @@ const Flags = struct {
     // rate: an ECDSA signature plus a key exchange per connection tops
     // out near 840/s on a single pinned core, measured, and measured the
     // same for haproxy (843 vs 830 — IMPLEMENTATION_NOTES). Offering
-    // past that makes every path's latency a queueing artefact rather
-    // than a hop cost, which is the opposite of what this band is for:
-    // it is a latency band (the per-request hop cost), never a
-    // throughput number.
+    // past that makes the *terminating* paths' latency a queueing
+    // artefact rather than a hop cost, which is the opposite of what this
+    // band is for: it is a latency band (the per-request hop cost), never
+    // a throughput number. The plaintext paths held 2000/s and were never
+    // the constraint.
     //
     // So the offer is one every path can actually hold, which keeps all
     // seven directly comparable — the whole point of a band. It also
@@ -865,19 +866,38 @@ fn spawnZoxy(
     };
 }
 
-/// haproxy is the state-of-the-art reference band, not a gate: same
-/// origin, same load, `mode tcp` to match zoxy's L4 relay and
-/// `nbthread 1` to match zoxy's single event-loop thread. Timeouts mirror
-/// the generated zoxy config so neither proxy wins by timing out earlier.
-/// The throwaway self-signed fixtures the TLS gates use
-/// (`src/tls/testdata/README.md`), read from the tree rather than
-/// embedded — the bench is its own module, so `@embedFile` cannot reach
-/// across the package boundary, and the harness already assumes a
-/// repo-root cwd (`zig-out/bin/zoxy`, `.zig-cache/…`). Benchmarking the
-/// same certificate the tests use keeps the bands honest about what they
-/// measure.
-const cert_source = "src/tls/testdata/cert.pem";
-const key_source = "src/tls/testdata/key.pem";
+/// What a PEM fixture may be, mirroring `constants.tls_pem_bytes_max`'s
+/// job on the production path: turn "the harness was pointed at the wrong
+/// file" into a named error rather than an arena the size of whatever was
+/// on disk. Spelled rather than imported — the bench is its own module
+/// and does not link the `zoxy` one.
+const pem_bytes_max: usize = 64 * 1024;
+
+/// Read one of the throwaway self-signed fixtures the TLS gates use
+/// (`src/tls/testdata/README.md`).
+///
+/// From the tree rather than embedded: the bench is its own module, so
+/// `@embedFile` cannot reach across the package boundary, and the harness
+/// already assumes a repo-root cwd (`zig-out/bin/zoxy`, `.zig-cache/…`).
+/// Benchmarking the same certificate the tests use keeps the bands honest
+/// about what they measure.
+///
+/// One function for both files so each names itself on failure. The
+/// alternative — a bare `try` on the second — reports an unlabeled error
+/// from a ReleaseFast binary with no return trace, which is the one thing
+/// a setup failure must not do.
+fn readFixture(arena: std.mem.Allocator, io: Io, path: []const u8) ![]u8 {
+    assert(path.len > 0);
+    const bytes = Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(pem_bytes_max)) catch |err| {
+        std.debug.print(
+            "bench: could not read {s} ({t}); run from the repository root\n",
+            .{ path, err },
+        );
+        return err;
+    };
+    assert(bytes.len > 0);
+    return bytes;
+}
 
 /// zoxy reads cert and key as separate files; haproxy wants them
 /// concatenated into one. Written once, before either proxy starts —
@@ -885,17 +905,11 @@ const key_source = "src/tls/testdata/key.pem";
 /// where the error can say which source it came from, rather than as a
 /// proxy that will not start.
 fn writeCertificates(arena: std.mem.Allocator, io: Io) !void {
+    const cert_source = "src/tls/testdata/cert.pem";
+    const key_source = "src/tls/testdata/key.pem";
     const dir = Io.Dir.cwd();
-    const cert = dir.readFileAlloc(io, cert_source, arena, .unlimited) catch |err| {
-        std.debug.print(
-            "bench: could not read {s} ({t}); run from the repository root\n",
-            .{ cert_source, err },
-        );
-        return err;
-    };
-    const key = try dir.readFileAlloc(io, key_source, arena, .unlimited);
-    assert(cert.len > 0);
-    assert(key.len > 0);
+    const cert = try readFixture(arena, io, cert_source);
+    const key = try readFixture(arena, io, key_source);
     try dir.writeFile(io, .{ .sub_path = work_directory ++ "/cert.pem", .data = cert });
     try dir.writeFile(io, .{ .sub_path = work_directory ++ "/key.pem", .data = key });
     const combined = try std.mem.concat(arena, u8, &.{ cert, key });
@@ -903,6 +917,13 @@ fn writeCertificates(arena: std.mem.Allocator, io: Io) !void {
     assert(combined.len == cert.len + key.len);
 }
 
+/// haproxy is the state-of-the-art reference band, not a gate: same
+/// origin, same load, `mode tcp` to match zoxy's L4 relay and
+/// `nbthread 1` to match zoxy's single event-loop thread. Timeouts mirror
+/// the generated zoxy config so neither proxy wins by timing out earlier.
+/// Its `bench_https` listen terminates the same fixture certificate zoxy
+/// does, so the added pair isolates termination cost rather than
+/// comparing two different certificates.
 fn spawnHaproxy(
     arena: std.mem.Allocator,
     io: Io,
@@ -1202,12 +1223,12 @@ fn printMode(label: []const u8, runs: *const Runs, scenario: Scenario) void {
     } else {
         std.debug.print("-- {s} --\n", .{label});
     }
-    printReport("direct      ", &runs.direct, scenario);
-    printReport("zoxy L4     ", &runs.l4, scenario);
-    printReport("zoxy L7     ", &runs.l7, scenario);
-    printReport("zoxy L7 TLS ", &runs.l7_tls, scenario);
-    printReport("haproxy tcp ", &runs.tcp, scenario);
-    printReport("haproxy http", &runs.http, scenario);
+    printReport("direct       ", &runs.direct, scenario);
+    printReport("zoxy L4      ", &runs.l4, scenario);
+    printReport("zoxy L7      ", &runs.l7, scenario);
+    printReport("zoxy L7 TLS  ", &runs.l7_tls, scenario);
+    printReport("haproxy tcp  ", &runs.tcp, scenario);
+    printReport("haproxy http ", &runs.http, scenario);
     printReport("haproxy https", &runs.https, scenario);
     printOverhead(&runs.direct, &runs.l4, &runs.l7, &runs.tcp, &runs.http);
 }

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1442,6 +1442,40 @@ The two known peer-gone errnos still landing in the fallback are queued
 fork work (see "Open questions" above, "libxev fork queue"): the fix for
 a forgotten mapping is to name it, not to crash on it.
 
+## The nightly's second rare event: `tls_handshake_failed` (2026-08-11)
+
+Run 31457966341 failed every shard on the census: `tls_handshake_failed`
+fired ~530 times per million seeds where "never" had held for every
+4096-seed sweep. Same shape as `health_probe_deadline_raced` before it,
+and the same remedy — but only after finding out *what* fires it, which
+took naming the seeds rather than reasoning about them.
+
+Reproduced locally at 36 seeds in 60k (1 in 1667, against the nightly's 1
+in ~1900) by printing the seed whenever the counter moved, then tagging
+each of the five increment sites with `@src().line` to see which. All 36
+land on one: `onTlsRecv`'s `error.EndOfStream` arm, a peer hanging up
+mid-handshake. The causes are two, both the harness:
+
+- **33 of 36: the scenario's own 2 s virtual cap.** `endScenario` is
+  belt-and-braces for stuck work and cancels every client; a client still
+  handshaking closes its socket under a server still reading.
+- **3 of 36: the adversary failing the *client's* send.** `TestClient`'s
+  `onSend` error arm ends the client, same result. Confirmed by printing
+  the error — `error.Unexpected`, the injected-pressure class.
+
+So the counter is right, and the old exemption's argument was wrong: it
+reasoned that "two peers that both mean it" cannot fail a handshake and
+overlooked that the harness ends sessions the proxy was serving
+correctly. `.must_stay_zero` with `at_most_one_per = 750` now — better
+than twice the observed rate, and orders of magnitude under a real
+regression, which would fail a large fraction of the quarter of seeds
+that terminate rather than one in seventeen hundred.
+
+**The lesson is about the census, not about TLS.** Twice now a nightly has
+turned an exemption's "never" into a rate, and both times the entry's
+stated *reason* was the thing that was wrong rather than the counter.
+An exemption is an argument, and a soak large enough is what audits it.
+
 ## Build mode for the simulator — Debug, and ReleaseSafe is a trap (2026-07-28)
 
 Measured while sizing the nightly soak, 20k seeds on the dev box:

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -715,6 +715,48 @@ unshipped. No other production-credible pure-Zig TLS 1.3 server
 exists as of the scan; Geun-Oh/zigtls is aimed the right way but
 0.1.0-dev — watch-list only.
 
+## The TLS bands, with resumption (2026-08-11, #125)
+
+The Tier-1 bands carry `zoxy L7 TLS` and `haproxy https` now, both
+terminating the same fixture certificate in front of the same plaintext
+origin. Run on `main` with session tickets wired, one pinned core for the
+proxy, load and origin off it. Bands, not single numbers.
+
+| band | zoxy L7 TLS | haproxy https |
+|---|---|---|
+| keep-alive, 20k/s offered | 19899–19935 req/s, p50 43–48 µs | 19931–19933 req/s, p50 44–48 µs |
+| large body, 400/s (100 MiB/s) | 398–399 req/s, p50 507–542 µs | 398–399 req/s, p50 383–385 µs |
+| close, 500/s offered | 498 req/s, p50 **158 µs**, p99 2339 µs | 497 req/s, p50 **607 µs**, p99 2591 µs |
+
+**The stall fix worked, and the close band is where it shows.** PR #84
+measured 664 of 2000 req/s offered against haproxy's 831 — behind, and
+failing the rate floor. With tickets: 843 against haproxy's 830 at the
+same 2000/s offer, and at a feasible offer zoxy's p50 is a quarter of
+haproxy's. The post-handshake flight is what a client's Nagle was waiting
+for, and it is no longer waiting.
+
+**The 2000/s close offer was never feasible, for anyone.** Both proxies
+top out near 840/s there — 843 and 830, within 2% of each other — because
+that band is one ECDSA signature and one key exchange per request on a
+single core. Past that the load generator's queue grows without bound and
+every latency it reports is a queueing artefact: the p50 read **2.9
+seconds** on both. So `close_rate` is 500/s now, which every path holds
+and which keeps all seven directly comparable. That is the harness's own
+rule, written into `benchPassed` before this: *haproxy missing the offer
+means the offer is wrong*. It fired on both TLS paths and it was right.
+
+Steady state is parity — 20k req/s at a p50 within a few µs of haproxy,
+which is where a real HTTPS front end lives. Bulk is the one band zoxy is
+behind on: ~507 µs p50 against ~385 µs at the same 100 MiB/s, the record
+layer's per-byte cost showing where the keep-alive band's per-request cost
+does not.
+
+One thing to watch: the RSS ceiling passed with about 1.3 MiB of headroom
+(247896 KiB against a 241038 KiB budget plus 8 MiB slack). The engine
+pool defaults to one per conn slot capped at 1024, so a bench-shaped
+config now prints a ~241 MiB budget where it used to print ~31 MiB, and
+the fixed slack was sized against the smaller number.
+
 ## TLS on the loop — the band that retired the worker pool (2026-07-25)
 
 Measured on the `phase-3a-ztls` branch (ztls engine, ECDSA P-256 fixture

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -726,14 +726,19 @@ proxy, load and origin off it. Bands, not single numbers.
 |---|---|---|
 | keep-alive, 20k/s offered | 19899–19935 req/s, p50 43–48 µs | 19931–19933 req/s, p50 44–48 µs |
 | large body, 400/s (100 MiB/s) | 398–399 req/s, p50 507–542 µs | 398–399 req/s, p50 383–385 µs |
-| close, 500/s offered | 498 req/s, p50 **158 µs**, p99 2339 µs | 497 req/s, p50 **607 µs**, p99 2591 µs |
+| close, 500/s offered | 498 req/s, p50 **158–161 µs**, p99 2339–2375 µs | 497–498 req/s, p50 **429–607 µs**, p99 2531–2591 µs |
 
 **The stall fix worked, and the close band is where it shows.** PR #84
 measured 664 of 2000 req/s offered against haproxy's 831 — behind, and
 failing the rate floor. With tickets: 843 against haproxy's 830 at the
-same 2000/s offer, and at a feasible offer zoxy's p50 is a quarter of
-haproxy's. The post-handshake flight is what a client's Nagle was waiting
-for, and it is no longer waiting.
+same 2000/s offer, and at a feasible offer zoxy's p50 is between a
+quarter and a third of haproxy's. The post-handshake flight is what a
+client's Nagle was waiting for, and it is no longer waiting.
+
+Worth noting which half of that comparison is stable: across two runs
+zoxy's close-band p50 moved 158→161 µs while haproxy's moved 607→429 µs.
+The gap is not in question — every pairing of those ranges is a large
+one — but the *size* of it quoted from a single run would be.
 
 **The 2000/s close offer was never feasible, for anyone.** Both proxies
 top out near 840/s there — 843 and 830, within 2% of each other — because
@@ -747,7 +752,8 @@ means the offer is wrong*. It fired on both TLS paths and it was right.
 
 Steady state is parity — 20k req/s at a p50 within a few µs of haproxy,
 which is where a real HTTPS front end lives. Bulk is the one band zoxy is
-behind on: ~507 µs p50 against ~385 µs at the same 100 MiB/s, the record
+behind on: 507–542 µs p50 against 383–385 µs at the same 100 MiB/s — a
+third to two-fifths slower however the ranges are paired, the record
 layer's per-byte cost showing where the keep-alive band's per-request cost
 does not.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -226,10 +226,14 @@ full handshake.
 > handshake-heavy traffic. Without a post-handshake flight, a client that
 > writes its `Finished` and then its request has the second write held by
 > its own Nagle, waiting for an ACK zoxy has no reason to send — a ~45 ms
-> stall per connection. The ticket flight is what carries that ACK. The
-> Tier-1 bands that measure this have not been re-run since resumption
-> landed; the last reading, without it, was 664 of 2000 requests per
-> second offered on a `Connection: close` workload against HAProxy's 831.
+> stall per connection. The ticket flight is what carries that ACK.
+>
+> Measured: on a `Connection: close` workload — a fresh TLS handshake per
+> request, the worst case — a terminated hop runs at a p50 of 158 µs
+> against HAProxy's 607 µs. On steady keep-alive traffic the two are at
+> parity, ~20k req/s at a p50 within a few µs of each other. Bulk
+> transfer is the one band zoxy trails on: ~507 µs against ~385 µs at the
+> same 100 MiB/s.
 
 ### Routing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -229,11 +229,11 @@ full handshake.
 > stall per connection. The ticket flight is what carries that ACK.
 >
 > Measured: on a `Connection: close` workload — a fresh TLS handshake per
-> request, the worst case — a terminated hop runs at a p50 of 158 µs
-> against HAProxy's 607 µs. On steady keep-alive traffic the two are at
+> request, the worst case — a terminated hop runs at a p50 of 158–161 µs
+> against HAProxy's 429–607 µs. On steady keep-alive traffic the two are at
 > parity, ~20k req/s at a p50 within a few µs of each other. Bulk
-> transfer is the one band zoxy trails on: ~507 µs against ~385 µs at the
-> same 100 MiB/s.
+> transfer is the one band zoxy trails on, by a third to two-fifths:
+> 507–542 µs against 383–385 µs at the same 100 MiB/s.
 
 ### Routing
 

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -174,13 +174,36 @@ const uncovered = [_]Uncovered{
     // it instead.
     .{
         .name = "tls_handshake_failed",
-        .why = .unreached,
-        .reason = "a seeded handshake between two peers that both mean it " ++
-            "does not fail: the adversary reorders, splits and delays but " ++
-            "never corrupts, and a dial it refuses or black-holes never " ++
-            "reaches a handshake at all. src/server_test.zig sends plaintext " ++
-            "at a TLS port, which is the shape a misdirected client or a " ++
-            "scanner actually produces",
+        .why = .must_stay_zero,
+        // A rate, not zero — and the nightly is what proved it. "Never"
+        // held for every 4096-seed sweep and failed on the first soak
+        // that ran a million (run 31457966341, ~530 per shard). Measured
+        // again locally at 36 in 60k, and both causes are the harness
+        // rather than the proxy: 33 of those 36 were scenarios the 2 s
+        // virtual cap force-ended, whose `endScenario` cancels every
+        // client — including one mid-handshake, whose socket then closes
+        // under a server still reading. The other 3 were the adversary
+        // failing the *client's* send, which ends that client the same
+        // way. Both are exactly what the counter says on the tin: a peer
+        // that hung up mid-handshake never became a session.
+        //
+        // One per 750 seeds leaves better than twice the observed rate
+        // as headroom while staying orders of magnitude under any real
+        // regression — a handshake path that broke would fail a large
+        // fraction of the quarter of seeds that terminate, not one in
+        // seventeen hundred.
+        .allowance = .{ .at_most_one_per = 750 },
+        .reason = "the adversary reorders, splits and delays but never " ++
+            "corrupts, and a dial it refuses or black-holes never reaches a " ++
+            "handshake at all — so what remains is a peer that leaves " ++
+            "mid-flight: a scenario force-ended at its 2 s cap with a " ++
+            "handshake still in the air, or a client whose own send the " ++
+            "adversary failed. Both are the harness ending a session the " ++
+            "proxy was serving correctly. A reading past the allowance is " ++
+            "not that: it is handshakes failing on their own account, which " ++
+            "is a bug report. src/server_test.zig sends plaintext at a TLS " ++
+            "port, which is the shape a misdirected client or a scanner " ++
+            "actually produces",
     },
     .{
         .name = "shed_tls_crypto",


### PR DESCRIPTION
Two things: the measurement that closes #125's last item, and the nightly soak's one real finding.

## The stall fix is confirmed

The Tier-1 matrix carries `zoxy L7 TLS` and `haproxy https` now — both terminating the same fixture certificate in front of the same plaintext origin, so the added pair isolates termination cost.

| band | zoxy L7 TLS | haproxy https |
|---|---|---|
| keep-alive, 20k/s | 19899–19935 req/s, p50 43–48 µs | 19931–19933 req/s, p50 44–48 µs |
| large body (100 MiB/s) | 507–542 µs p50 | 383–385 µs p50 |
| **close, 500/s** | 498 req/s, **p50 158–161 µs** | 497–498 req/s, **p50 429–607 µs** |

PR #84 measured **664 of 2000 req/s against HAProxy's 831** and failed the rate floor. With session tickets: **843 against HAProxy's 830**, and at an offer both can hold, zoxy's close-band p50 is between a quarter and a third of HAProxy's. Steady keep-alive is parity — where a real HTTPS front end lives. Bulk is the one band zoxy trails on, by a third to two-fifths.

Ranges rather than single numbers throughout, and for a reason worth stating: across two runs zoxy's close-band p50 moved 158→161 µs while HAProxy's moved 607→429. The gap is not in question; its exact size quoted from one run would be.

The terminating port also joins the saturating warmup: engine slots and the libcrypto heap are the largest lazily-resident pools §5 prints, and a warmup that never handshakes would leave the RSS ceiling passing on memory the run never touched.

## And the 2000/s close offer was never feasible, for anyone

The gate fired again — on **both** TLS paths. Both proxies top out near 840/s there (843 and 830, within 2%), because that band is one ECDSA signature and one key exchange per request on a single core. Past that the generator's queue grows without bound and every latency it reports is a queueing artefact: the p50 read **2.9 seconds** on both.

That is `benchPassed`'s own rule, in the tree before this: *haproxy missing the offer means the offer is wrong*. So `close_rate` is 500/s, which every path holds and which keeps all seven bands directly comparable. The gate working, not a gate loosened. (The plaintext paths held 2000/s and were never the constraint — they lose a data point the band never claimed to provide, since it is documented as a latency band, never a throughput number.)

## The nightly's `tls_handshake_failed`

Run 31457966341 failed every shard: the counter fired ~530 times per million seeds where "never" had held for every 4096-seed sweep ever run.

I named the seeds rather than reasoning about them — printed the seed whenever the counter moved (36 in 60k), then tagged each of the five increment sites with `@src().line`. All 36 land on one arm: `onTlsRecv`'s `error.EndOfStream`. Two causes, **both the harness rather than the proxy**:

- **33 of 36** — scenarios the 2 s virtual cap force-ended. `endScenario` is belt-and-braces for stuck work and cancels every client, including one mid-handshake, whose socket then closes under a server still reading.
- **3 of 36** — the adversary failing the *client's* send (`error.Unexpected`, the injected-pressure class), which ends that client the same way.

So the counter was right and the exemption's **argument** was wrong: it reasoned that two peers that both mean it cannot fail a handshake, and overlooked that the harness ends sessions the proxy was serving correctly. Now `.must_stay_zero` with `at_most_one_per = 750` — better than twice the observed rate, orders of magnitude under a real regression, which would fail a large fraction of the quarter of seeds that terminate rather than one in seventeen hundred.

Verified at 60k seeds from two different starts (`1..60000` and `500000..559999`); the old claim survived neither.

That soak's other numbers are worth stating: 4M seeds, **zero seed failures and zero panics**. The census was its only finding. (The separate 2026-08-08 nightly failure is not a zoxy bug — one shard died in `devenv`/nix evaluation before running anything.)

Gates: 478 tests, 4096 sim seeds, census ok, smoke, heap proof, lint, format — green on Linux and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)