### PR TITLE
docs: track #125's follow-ups as issues, and stop claiming the bands are unmeasured

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -64,21 +64,27 @@ session comes up rather than at the hand-over, behind a `tls_session_up`
 latch on the conn, and the send-error arm blames the handshake only while
 that latch is unset.
 
-Remaining:
+The Tier-1 bands measured it — see "The TLS bands, with resumption"
+below. #125 is closed.
 
-1. **The Tier-1 bands**, whose acceptance is the close-mode rate gate PR
-   #84 could not pass. The tickets above are what is expected to move it,
-   and the bands are what say whether they did — nothing measured yet.
+What it left open, now tracked rather than only recorded here:
 
-Three smaller things the reviews left open: `ResponseBodyPolicy.afterSend`
-credits ciphertext to `bytes_out` where the client-write channel credits
-plaintext, so a streamed TLS response over-counts; the sim's TLS http
-client sends `Connection: close` and a GET, leaving the request-body leg
-reachable by directed tests only; and the sealing key is drawn once at
-`start` and never rotated, so the two-slot rotation `Tickets` is built
-for runs with one slot live for the process. Rotation wants a timer and
-the interval is a policy question (it bounds how long a stolen key is
-worth having), so it is deliberately not guessed at here.
+- **#202 — the sealing key is never rotated.** `Tickets` is built for two
+  slots and `rotate` is called once, at `start`, so both hold one
+  generation for the process's life. The interval *is* the security
+  bound, which makes it a policy question rather than an implementation
+  one, so it was deliberately not guessed at.
+- **#203 — the live gate's https leg wedged once on macOS**, and has not
+  recurred. See the section of that name below for what is ruled out and
+  where to look.
+- **#204 — the simulator's TLS clients are single-connection**, which is
+  what keeps resumption, the keep-alive turnaround and the request-body
+  leg out of the sweep.
+
+One smaller thing still recorded only here, because it is a line rather
+than a project: `ResponseBodyPolicy.afterSend` credits *ciphertext* to
+`bytes_out` where the client-write channel credits plaintext, so a
+streamed TLS response over-counts what it told the client.
 
 ### What the live gate found
 
@@ -1717,7 +1723,7 @@ can only be the proxy's fault. The band now prints the refused/timed-out
 split every run: a threshold whose margin is invisible until it trips is
 how this one sat mis-specified for a week.
 
-## Open: the https leg wedged once on macOS (2026-08-11, #125)
+## Open: the https leg wedged once on macOS (2026-08-11, #203)
 
 The first CI run carrying the Tier-0.5 https leg wedged on the macOS
 runner — the whole 30 s budget, against a run that takes about a second.

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1234,8 +1234,8 @@ fn startTlsClients(harness: *Harness) void {
             // `Connection: close` instead, so the proxy ends the
             // connection and the client finishes on the EOF.
             //
-            // Two gaps that leaves, stated because closing them is the
-            // next work here and not something to rediscover. A
+            // Two gaps that leaves, tracked as #204 and stated here
+            // because closing them is the next work in this file. A
             // `Connection: close` request is one exchange, so the
             // keep-alive turnaround — which is where the head source's
             // first defect lived — is never re-entered; and a GET carries

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -245,7 +245,9 @@ const uncovered = [_]Uncovered{
             "(issue, capture, offer, open) across two connections and " ++
             "asserts the counter; what the sweep would add on top is the " ++
             "adversary's schedules against a resumed handshake, which is " ++
-            "the honest gap and wants a two-connection client to close",
+            "the honest gap, tracked as #204 — it wants a client that ends " ++
+            "on a complete response so a second connection can offer the " ++
+            "first's ticket back",
     },
     .{
         .name = "l7_no_route",

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -277,7 +277,7 @@ pub const tls_tickets_per_handshake: u8 = 2;
 /// how long a stolen ticket is worth carrying. An hour keeps a busy
 /// client's reconnects free while making yesterday's capture useless.
 /// It would also sit comfortably inside a two-key rotation window, once
-/// rotation is wired — see `tls/Tickets.zig`, which today installs one
+/// rotation is wired (#202) — see `tls/Tickets.zig`, which installs one
 /// key at startup and never replaces it.
 pub const tls_ticket_lifetime_s: u32 = 60 * 60;
 

--- a/src/tls/Tickets.zig
+++ b/src/tls/Tickets.zig
@@ -22,7 +22,7 @@
 //! the same generation for the process's life and the bounded-exposure
 //! property above is a property of this module rather than of the running
 //! proxy. What it waits on is a policy decision — the interval *is* the
-//! bound — recorded in IMPLEMENTATION_NOTES under "TLS termination".
+//! bound — so it is tracked as #202 rather than guessed at here.
 //!
 //! 0-RTT is deliberately not offered (`max_early_data_size` is never
 //! set), so a replayed ticket buys an attacker a resumed handshake and


### PR DESCRIPTION
Bookkeeping after #125 closed.

**One false claim removed.** The "Remaining" list still said the Tier-1 bands had "nothing measured yet". They are measured — the section immediately below it is the band table.

**Three follow-ups tracked instead of only described:**

| issue | |
|---|---|
| #202 | the sealing key is never rotated — `rotate` runs once at `start`, so `Tickets`' two slots hold one generation for the process's life |
| #203 | the live gate's https leg wedged once on macOS and has not recurred |
| #204 | the simulator's TLS clients are single-connection, keeping resumption, the keep-alive turnaround and the request-body leg out of the sweep |

Each of the four places in the tree that described one of those gaps now names its issue rather than pointing at where the description lives: `Tickets.zig`'s module comment, `constants.zig`'s ticket lifetime, `deriveTlsClients`, and the `tls_resumed` census entry.

One item stays in IMPLEMENTATION_NOTES rather than becoming an issue, because it is a line rather than a project: `ResponseBodyPolicy.afterSend` credits ciphertext to `bytes_out` where the client-write channel credits plaintext, so a streamed TLS response over-counts what it told the client.

Docs and comments only — no behaviour change. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)