### PR TITLE
build: -Dio-backend=epoll, which reproduces #203 — plus a partial fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,33 @@ pub fn build(b: *std.Build) void {
     build_options.addOption([]const u8, "version", zoxy_version);
     build_options.addOption([]const u8, "build_id", resolveBuildId(b));
 
+    // Which libxev backend `XevIo` builds against, for reproducing
+    // readiness-model behaviour on a box that has io_uring (#203).
+    //
+    // Linux picks io_uring and macOS picks kqueue, and those are two
+    // different models: io_uring *completes* operations, kqueue reports
+    // *readiness* and the backend performs a synchronous syscall. Every
+    // assumption zoxy makes about when an op is delivered is therefore
+    // exercised on one model per platform — and the defects that live in
+    // the other one surface only on a shared macOS runner, twice in
+    // thirteen runs, with no way to reproduce them locally.
+    //
+    // epoll is the readiness model on Linux. It is not kqueue, so a green
+    // run here does not clear macOS; what it buys is that a *failure*
+    // here is reproducible in seconds instead of by pushing and waiting.
+    const io_backend = b.option(
+        IoBackend,
+        "io-backend",
+        "libxev backend: platform default, or epoll to exercise the readiness model on Linux",
+    ) orelse .default;
+    // Its own options module rather than a field on `build_options`: that
+    // one is imported by `src/main.zig`, and a module reached from two
+    // import paths at once is an error ("file exists in modules ... and
+    // ...0"). This is the only thing the library module needs from the
+    // build, so it travels alone.
+    const io_options = b.addOptions();
+    io_options.addOption(IoBackend, "backend", io_backend);
+
     // libxev is pinned by content hash to the zoxy-io fork's
     // zoxy-ring-flags branch: the audited upstream snapshot plus the
     // setup-flags commit (DESIGN.md §4); see build.zig.zon. The pin moves
@@ -55,6 +82,8 @@ pub fn build(b: *std.Build) void {
         },
     });
     linkLibcrypto(zoxy_module);
+    // `src/io/XevIo.zig` reads the backend choice from here.
+    zoxy_module.addOptions("io_options", io_options);
     // The shipped example config is embedded so tests and the fuzz corpus
     // stay in sync with the file users actually copy.
     zoxy_module.addAnonymousImport("example_config", .{
@@ -248,6 +277,10 @@ pub fn build(b: *std.Build) void {
         },
     });
     linkLibcrypto(zoxy_fast_module);
+    // The ReleaseSafe twin of the library module needs the same backend
+    // choice: it is the same `src/root.zig`, so `XevIo` asks it the same
+    // question.
+    zoxy_fast_module.addOptions("io_options", io_options);
     const release_zoxy = b.addExecutable(.{
         .name = "zoxy-release",
         .root_module = b.createModule(.{
@@ -512,3 +545,9 @@ fn linkLibcrypto(module: *std.Build.Module) void {
     module.link_libc = true;
     module.linkSystemLibrary("crypto", .{});
 }
+
+/// The `-Dio-backend` choice. `default` is what the platform picks
+/// (io_uring on Linux, kqueue on macOS); `epoll` overrides it to the
+/// readiness model on Linux — see the option's own comment for why that
+/// is worth being able to ask for.
+const IoBackend = enum { default, epoll };

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -730,13 +730,26 @@ pub fn Server(comptime IoType: type) type {
             assert(server.draining);
             result catch unreachable;
             // The ordinary case: everything finished inside the grace and
-            // the loop is already stopping. `maybeStopAfterDrain` may not
-            // have run yet, so ask the same question it does.
-            if (server.conns.isFullyReleased()) return;
+            // the loop is already stopping. Ask the same *four* questions
+            // `maybeStopAfterDrain` does, not just the first — asking only
+            // about conn slots is how the first version of this reported
+            // "nothing stuck" while the admin plane held an armed accept
+            // that would never be delivered (#203).
+            const conns_done = server.conns.isFullyReleased();
+            const admin_done = server.admin.isQuiescent();
+            const log_done = server.access_log.isQuiescent();
+            const health_done = server.health.isQuiescent();
+            if (conns_done and admin_done and log_done and health_done) return;
             std.debug.print(
-                "zoxy: drain did not finish {d}s after its deadline; " ++
-                    "connections stuck in teardown (#203):\n",
-                .{drain_stuck_grace_ns / std.time.ns_per_s},
+                "zoxy: drain did not finish {d}s after its deadline (#203). " ++
+                    "conns={s} admin={s} access_log={s} health={s}\n",
+                .{
+                    drain_stuck_grace_ns / std.time.ns_per_s,
+                    if (conns_done) "done" else "STUCK",
+                    if (admin_done) "done" else "STUCK",
+                    if (log_done) "done" else "STUCK",
+                    if (health_done) "done" else "STUCK",
+                },
             );
             for (server.conns.slots, 0..) |*conn, index| {
                 if (!server.conns.isAcquired(conn)) continue;

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -11,7 +11,18 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
-const xev = @import("xev");
+/// Which libxev backend this build talks to. The platform's own choice
+/// unless `-Dio-backend=epoll` asks otherwise — see build.zig, but the
+/// short version is that io_uring and kqueue are different *models*
+/// (completion versus readiness), each platform exercises exactly one,
+/// and epoll is the only way to run the other one on a box that has
+/// io_uring. Comptime, so a build is one backend and the conditionals
+/// below fold away.
+const xev_root = @import("xev");
+const xev = switch (@import("io_options").backend) {
+    .default => xev_root,
+    .epoll => xev_root.Epoll,
+};
 
 const constants = @import("../constants.zig");
 const Io = @import("io.zig");
@@ -27,7 +38,7 @@ const XevIo = @This();
 /// inside the ring, so Linux never spawns a thread. Pool threads only
 /// perform the blocking syscall; completion callbacks still run on the
 /// loop thread, so the single-threaded discipline holds.
-const needs_thread_pool = xev.backend == .kqueue;
+const needs_thread_pool = xev.backend != .io_uring;
 /// Whether the provided-buffer group is the kernel's (a registered
 /// buf_ring the fork's `recv_group` op selects from) or an app-side
 /// emulation. Only io_uring has the real thing; everywhere else the
@@ -36,6 +47,32 @@ const needs_thread_pool = xev.backend == .kqueue;
 const uses_buf_ring = xev.backend == .io_uring;
 /// The one buffer group this backend registers (§5's head-buffer ring).
 const buffer_group_id: u16 = 0;
+
+/// Whether a libxev error set can report a cancelled op at all.
+///
+/// It is not universal, and that is the point of asking: io_uring and
+/// kqueue both name `Canceled` on an accept, and epoll does not — its
+/// accept has no cancel to report. Anything that maps such an error has
+/// to ask rather than assume, or it fails to compile on the backend that
+/// cannot.
+fn reportsCanceled(comptime Set: type) bool {
+    for (@typeInfo(Set).error_set.?) |candidate| {
+        if (std.mem.eql(u8, candidate.name, "Canceled")) return true;
+    }
+    return false;
+}
+
+/// `Canceled` where the backend has it, `Unexpected` for everything else
+/// — including, on a backend without it, the cancel that cannot arrive.
+fn mapAcceptError(err: xev.AcceptError) Io.AcceptError {
+    if (comptime reportsCanceled(xev.AcceptError)) {
+        return switch (err) {
+            error.Canceled => error.Canceled,
+            else => error.Unexpected,
+        };
+    }
+    return error.Unexpected;
+}
 /// Which door the OS CSPRNG is behind. Linux has the `getrandom` syscall;
 /// Darwin publishes no stable syscall ABI, so `fillRandom` goes through
 /// libSystem there. Keyed on the OS, not on `xev.backend` — the event
@@ -64,7 +101,7 @@ log_sink_fd: posix.fd_t,
 /// The path behind a `file` sink, or null for stdout — what `logReopen`
 /// opens again at rotation (§8). Config-arena memory, process lifetime.
 log_sink_path: ?[]const u8,
-thread_pool: if (needs_thread_pool) xev.ThreadPool else void,
+thread_pool: if (needs_thread_pool) xev_root.ThreadPool else void,
 notifier_completion: xev.Completion,
 signal_mask: std.atomic.Value(u8),
 signal_callback: ?*const fn (?*anyopaque, Io.Signal) void,
@@ -157,7 +194,7 @@ pub fn init(
     const listeners = configured_listeners + constants.admin_listeners;
     assert(listeners >= 1);
     if (comptime needs_thread_pool) {
-        io.thread_pool = xev.ThreadPool.init(.{});
+        io.thread_pool = xev_root.ThreadPool.init(.{});
     }
     errdefer if (comptime needs_thread_pool) {
         io.thread_pool.shutdown();
@@ -249,7 +286,7 @@ fn initBufferGroup(io: *XevIo, arena: std.mem.Allocator, count: u32, bytes: u32)
 /// Build the event loop with zoxy's ring discipline (§3, §4, §8). Split
 /// from `init` so the setup — the fast-ring flags, the deep CQ, and the
 /// old-kernel degrade — stays under the function-length limit.
-fn initLoop(cq_entries: u32, thread_pool: ?*xev.ThreadPool) !xev.Loop {
+fn initLoop(cq_entries: u32, thread_pool: ?*xev_root.ThreadPool) !xev.Loop {
     // SINGLE_ISSUER + COOP_TASKRUN + DEFER_TASKRUN: completion task-work
     // stays on the loop thread and is batched at the GETEVENTS reap point
     // instead of interrupting it (measured 2026-07-12: eliminates the
@@ -441,10 +478,8 @@ pub fn accept(
             io_inner.recordPressure(accept_completion);
             callback(context.?, if (result) |conn|
                 @as(Socket, @enumFromInt(conn.fd))
-            else |err| switch (err) {
-                error.Canceled => error.Canceled,
-                else => error.Unexpected,
-            });
+            else |err|
+                mapAcceptError(err));
             return .disarm;
         }
     }).adapter);

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -48,6 +48,17 @@ const uses_buf_ring = xev.backend == .io_uring;
 /// The one buffer group this backend registers (§5's head-buffer ring).
 const buffer_group_id: u16 = 0;
 
+/// Whether cancelling an armed accept makes the backend deliver that
+/// accept's completion.
+///
+/// io_uring does: the cancel terminates the op and the CQE arrives with
+/// `Canceled`, which is what every caller of `listenClose` is written
+/// against. The readiness backends do not — libxev's epoll `.cancel` is
+/// `stop_completion`, which drops the op without calling anything back,
+/// and kqueue orphans it in its own way (#203). There the seam owes the
+/// delivery itself, or a caller waiting for its accept waits forever.
+const delivers_accept_cancel = xev.backend == .io_uring;
+
 /// Whether a libxev error set can report a cancelled op at all.
 ///
 /// It is not universal, and that is the point of asking: io_uring and
@@ -140,6 +151,12 @@ pub const Listener = struct {
     index: u16,
 };
 
+/// Which libxev backend this build selected. Exported so a test can ask
+/// the seam rather than re-deriving it from the platform: with
+/// `-Dio-backend`, `@import("xev").backend` and the one `XevIo` actually
+/// talks to are no longer the same answer.
+pub const backend = xev.backend;
+
 pub const Completion = xev.Completion;
 
 const ListenerEntry = struct {
@@ -148,6 +165,13 @@ const ListenerEntry = struct {
     armed_accept: ?*xev.Completion,
     cancel_completion: xev.Completion,
     open: bool,
+    /// Who to tell when a `listenClose` orphans an armed accept, on the
+    /// backends that will not tell them itself (`delivers_accept_cancel`).
+    /// Type-erased because `accept` is generic over its userdata and this
+    /// has to outlive that call — the seam owes the delivery, so the seam
+    /// keeps what it needs to make it.
+    orphan_callback: ?*const fn (*anyopaque, Io.AcceptError!Socket) void,
+    orphan_userdata: ?*anyopaque,
 };
 
 /// `cq_entries` is the completion-queue depth to request for this
@@ -421,6 +445,8 @@ pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
         .armed_accept = null,
         .cancel_completion = .{},
         .open = true,
+        .orphan_callback = null,
+        .orphan_userdata = null,
     };
     io.listeners_count += 1;
     return .{ .index = index };
@@ -440,17 +466,62 @@ pub fn listenClose(io: *XevIo, listener: Listener) void {
     const entry = io.listenerEntry(listener);
     assert(entry.open);
     if (entry.armed_accept) |accept_completion| {
-        loopCancel(
-            &io.loop,
-            accept_completion,
-            &entry.cancel_completion,
-            void,
-            null,
-            onCancelReaped,
-        );
+        if (comptime delivers_accept_cancel) {
+            loopCancel(
+                &io.loop,
+                accept_completion,
+                &entry.cancel_completion,
+                void,
+                null,
+                onCancelReaped,
+            );
+        } else {
+            // The backend will not tell the caller, so the seam does —
+            // on the next tick rather than from inside this call. A
+            // synchronous callback here would re-enter the caller from
+            // the middle of its own drain: `Server.beginDrain` closes
+            // every listener in a loop, and the admin's accept callback
+            // runs `maybeStopAfterDrain`, which may stop the loop. A
+            // zero-delay timer keeps the delivery asynchronous, which is
+            // the shape every caller is already written against.
+            //
+            // The listener's own cancel completion carries it: this arm
+            // never submits a cancel, so it is free, and one delivery per
+            // `listenClose` is exactly one use of it.
+            entry.armed_accept = null;
+            io.timer.run(
+                &io.loop,
+                &entry.cancel_completion,
+                0,
+                ListenerEntry,
+                entry,
+                onOrphanedAccept,
+            );
+        }
     }
     closeFd(entry.fd);
     entry.open = false;
+}
+
+/// Deliver the `Canceled` an armed accept is owed when its listener
+/// closed and the backend dropped the op without a word (#203).
+fn onOrphanedAccept(
+    entry: ?*ListenerEntry,
+    _: *xev.Loop,
+    _: *xev.Completion,
+    result: xev.Timer.RunError!void,
+) xev.CallbackAction {
+    // Nothing cancels this timer: it is armed once per `listenClose` and
+    // the listener does not reopen.
+    result catch unreachable;
+    const listener_entry = entry.?;
+    assert(listener_entry.armed_accept == null); // Cleared at the close.
+    const callback = listener_entry.orphan_callback.?;
+    const userdata = listener_entry.orphan_userdata.?;
+    listener_entry.orphan_callback = null;
+    listener_entry.orphan_userdata = null;
+    callback(userdata, error.Canceled);
+    return .disarm;
 }
 
 pub fn accept(
@@ -465,6 +536,18 @@ pub fn accept(
     assert(entry.open);
     assert(entry.armed_accept == null);
     entry.armed_accept = completion;
+    if (comptime !delivers_accept_cancel) {
+        // Kept only so `listenClose` can make the delivery the backend
+        // will not. Erased through a shim rather than stored generically:
+        // one entry serves every `accept` on this listener, and they all
+        // share the caller's type.
+        entry.orphan_userdata = userdata;
+        entry.orphan_callback = (struct {
+            fn erased(context: *anyopaque, result: Io.AcceptError!Socket) void {
+                callback(@ptrCast(@alignCast(context)), result);
+            }
+        }).erased;
+    }
     const tcp = xev.TCP.initFd(entry.fd);
     tcp.accept(&io.loop, completion, Userdata, userdata, (struct {
         fn adapter(

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -51,13 +51,21 @@ const buffer_group_id: u16 = 0;
 /// Whether cancelling an armed accept makes the backend deliver that
 /// accept's completion.
 ///
-/// io_uring does: the cancel terminates the op and the CQE arrives with
-/// `Canceled`, which is what every caller of `listenClose` is written
-/// against. The readiness backends do not — libxev's epoll `.cancel` is
-/// `stop_completion`, which drops the op without calling anything back,
-/// and kqueue orphans it in its own way (#203). There the seam owes the
-/// delivery itself, or a caller waiting for its accept waits forever.
-const delivers_accept_cancel = xev.backend == .io_uring;
+/// Asked of the backend's own error set rather than of its name, because
+/// the error set is the backend *stating* the answer: a backend that can
+/// deliver a cancelled accept has `Canceled` in `AcceptError`, and one
+/// that cannot does not. io_uring and kqueue both name it. epoll does
+/// not — libxev implements its `.cancel` as `stop_completion`, which
+/// drops the op without calling anything back, so a caller waiting for
+/// its accept waits forever (#203) and the seam owes the delivery.
+///
+/// Keying this on `backend == .io_uring` instead was a real regression:
+/// it put *kqueue* on the synthesized path, changing behaviour on a
+/// shipped platform on the strength of an inference from epoll, and
+/// macOS CI hung. The rule is now that this only ever changes what a
+/// backend does when that backend has said, in its types, that it cannot
+/// do the other thing.
+const delivers_accept_cancel = reportsCanceled(xev.AcceptError);
 
 /// Whether a libxev error set can report a cancelled op at all.
 ///

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -96,7 +96,7 @@ fn initTestIo(xev_io: *XevIo, arena: std.mem.Allocator, cq_entries: u32) !void {
         }
         // The pause is what lets the kernel's deferred frees land; the
         // phenomenon (and the branch) is io_uring-only.
-        if (comptime xev.backend == .io_uring) {
+        if (comptime XevIo.backend == .io_uring) {
             const pause: std.os.linux.timespec = .{
                 .sec = 0,
                 .nsec = 20 * std.time.ns_per_ms,
@@ -622,7 +622,7 @@ test "contract: XevIo requests a nonzero IORING_SETUP_CQSIZE depth" {
     try initTestIo(&xev_io, arena_state.allocator(), 16384);
     defer xev_io.deinit();
 
-    if (comptime xev.backend == .io_uring) {
+    if (comptime XevIo.backend == .io_uring) {
         try std.testing.expect(xev_io.loop.ring.cq.cqes.len >= 16384);
     }
 }
@@ -638,9 +638,8 @@ test "xevio: nowNs refreshes a stale clock instead of returning a frozen value" 
     //
     // io_uring-only: other backends (kqueue on macOS) refresh cached_now
     // every tick and have no now_outdated flag to simulate staleness with.
-    if (comptime !@hasField(@FieldType(xev.Loop, "flags"), "now_outdated")) {
-        return error.SkipZigTest;
-    }
+    if (comptime XevIo.backend != .io_uring) return error.SkipZigTest;
+
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
 
@@ -733,7 +732,7 @@ test "xevio: a send after our own write shutdown is Reset, not kernel pressure" 
     // so on a macOS dev box this scenario would terminate the test binary
     // rather than fail it. Skipping is honest: the arm under test is the
     // io_uring adapter's, and the kqueue path never reaches it.
-    if (comptime xev.backend != .io_uring) return error.SkipZigTest;
+    if (comptime XevIo.backend != .io_uring) return error.SkipZigTest;
 
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -994,7 +993,7 @@ test "xevio: a recv against a linger-RST close is Reset, with the errno pinned" 
     // peer-gone-as-pressure gap the fork queue tracks
     // (docs/IMPLEMENTATION_NOTES.md, "Open questions"), which this test
     // would otherwise report as its own failure.
-    if (comptime xev.backend != .io_uring) return error.SkipZigTest;
+    if (comptime XevIo.backend != .io_uring) return error.SkipZigTest;
 
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -1023,7 +1022,7 @@ test "xevio: a recv against a linger-RST close is Reset, with the errno pinned" 
     try std.testing.expectError(error.Reset, result);
     // Pin WHICH arm fired: the errno the fork kept must be the reset,
     // so this cannot silently start passing via a future EOF mapping.
-    if (comptime xev.backend == .io_uring) {
+    if (comptime XevIo.backend == .io_uring) {
         try std.testing.expectEqual(posix.E.CONNRESET, completion.result_errno);
     }
 }
@@ -1038,7 +1037,7 @@ test "xevio: canceling a stuck dial delivers Canceled and releases the op" {
     // io_uring only: the arm under test is the io_uring adapter's, and
     // BSD accept-queue overflow answers RST where Linux drops — the
     // pending-dial premise does not hold on the kqueue dev box.
-    if (comptime xev.backend != .io_uring) return error.SkipZigTest;
+    if (comptime XevIo.backend != .io_uring) return error.SkipZigTest;
 
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
**Reproduces #203 deterministically and fixes it for epoll. It does not close #203** — see "What is not proven" before merging.

## What #203 is

`XevIo.listenClose` cancels an armed accept and assumes the cancel delivers that accept's completion. That is an **io_uring property, not a universal one**: libxev's epoll `.cancel` is `stop_completion`, which drops the op without calling anything back.

So the admin plane's accept is orphaned → `onAccept` never runs → `quiesceForDrain` never clears `listening` → `isQuiescent()` false forever → `maybeStopAfterDrain` never stops the loop → **SIGTERM stops meaning anything**. Any deployment with `admin` configured is exposed; TLS only shifted the smoke gate's timing onto it.

## The capability, which is the durable part

`-Dio-backend=epoll` builds `XevIo` against libxev's epoll backend — the readiness model, on Linux. Linux ships io_uring and macOS ships kqueue, so every assumption about *when* an op is delivered is exercised on one model per platform, and defects in the other surface only on a shared macOS runner, twice in thirteen runs.

| `zig build smoke -Dio-backend=epoll` | before | after |
|---|---|---|
| | **0 pass, 10 fail** | **10 pass, 0 fail** |

It also makes the contract test `closing a listener cancels its armed accept` fail on epoll without the fix — the gate for this contract existed all along and had never been run against a backend that breaks it.

## The fix, and its scope

The seam makes the delivery the backend will not: exactly one `error.Canceled`, **asynchronously**, via a zero-delay timer on the listener's own cancel completion. Asynchronous is load-bearing — a synchronous callback would re-enter the caller from inside `Server.beginDrain`'s loop over listeners.

**Which backends take it is decided by the backend's own error set**, not by its name: a backend that can deliver a cancelled accept has `Canceled` in `AcceptError`. io_uring and kqueue both do and are untouched **by construction**. epoll does not and takes the synthesized path.

That discriminator started as `backend == .io_uring`, which put kqueue on the synthesized path too and **hung macOS CI**. That was a regression from inferring kqueue's behaviour from epoll's, and it is corrected here.

## What is not proven

- **Whether macOS's hang has this cause.** It was inferred from epoll, and the inference has already been wrong once. Both shipped platforms keep their existing behaviour in this PR, so #203 stays open.
- **The synthesized path hangs the unit-test suite under epoll.** The *proxy* is fine there (smoke 10/10); a contract test is not. epoll also has pre-existing failures unrelated to this (error mapping — a dial to a closed port panics on `Unexpected`). epoll is a diagnostic for the live gate, not a supported test target, and making it one is separate work.

## Also fixed

- **The contract tests had the same class of bug this PR is about.** They import the *root* `xev`, so `backend == .io_uring` stayed true even when `XevIo` was built against epoll — guarding one backend while asserting about another. `XevIo` exports the backend it selected now.
- `needs_thread_pool` said `== .kqueue` where it means "not io_uring".
- **#203's backstop asked the wrong question** — only whether conn slots had released, so on this very defect it printed nothing and returned. It now names the stuck subsystem:
  ```
  zoxy: drain did not finish 5s after its deadline (#203).
  conns=done admin=STUCK access_log=done health=done
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)