### PR TITLE
fix: submit an accept before cancelling it, so kqueue delivers it (#203)

### DIFF
--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -65,6 +65,10 @@ const buffer_group_id: u16 = 0;
 /// macOS CI hung. The rule is now that this only ever changes what a
 /// backend does when that backend has said, in its types, that it cannot
 /// do the other thing.
+///
+/// What the error set promises is *conditional*, and `listenClose` pays
+/// that condition: kqueue delivers the cancel only for an accept it has
+/// already submitted. See `submitPending`, which is how it pays it.
 const delivers_accept_cancel = reportsCanceled(xev.AcceptError);
 
 /// Whether a libxev error set can report a cancelled op at all.
@@ -466,6 +470,41 @@ pub fn listenerAddress(io: *const XevIo, listener: Listener) std.Io.net.IpAddres
     return entry.address;
 }
 
+/// Hand the backend every op still queued, so an op armed during this
+/// tick is one the backend has actually taken.
+///
+/// libxev submits at the top of a tick and never inside its callback
+/// loop, so an accept armed from a callback is still queued when a
+/// `listenClose` later in that same tick cancels it — and cancelling a
+/// queued op only marks it dead: no completion, no callback, and a drain
+/// waiting on that accept waits forever (#203). The admin plane arms
+/// exactly that way, re-arming from `maybeFinish` in the same tick a
+/// signal's `beginDrain` can close the listener in.
+///
+/// Safe to call from inside a callback, which is the whole point: this
+/// fires no callbacks of its own — it is a syscall, not a tick — so it
+/// cannot re-enter the caller mid-drain, the hazard that forces the
+/// synthesized delivery in `listenClose` to be asynchronous.
+fn submitPending(loop: *xev.Loop) void {
+    // What a failed submit costs is the backend's to say, and they do not
+    // say the same thing: io_uring fails before touching its queue, so
+    // the ops are merely still queued — the state this path was in before
+    // it called here at all — while kqueue says plainly that some events
+    // may be lost. Neither is worse than not calling this, which is the
+    // exposure #203 is, and both are exceptional by the backends' own
+    // account. All but one: `CompletionQueueOvercommitted` is the §8
+    // budget violated rather than a submit that did not happen, and it
+    // panics for the same reason `run` panics on it.
+    //
+    // anyerror: that error exists only on io_uring's error set.
+    loop.submit() catch |err| switch (@as(anyerror, err)) {
+        error.CompletionQueueOvercommitted => @panic(
+            "ring budget violated: completion queue overcommitted (DESIGN.md §8)",
+        ),
+        else => {},
+    };
+}
+
 /// Sync listener close (drain, §8). The armed accept — if any — must be
 /// reaped through an async cancel: an io_uring op holds its own file
 /// reference, so closing the fd alone would leave the accept in flight
@@ -475,6 +514,10 @@ pub fn listenClose(io: *XevIo, listener: Listener) void {
     assert(entry.open);
     if (entry.armed_accept) |accept_completion| {
         if (comptime delivers_accept_cancel) {
+            // What the backend promises about a cancelled accept it owes
+            // only for an accept it has already taken (#203) — so make
+            // sure it has taken this one before cancelling it.
+            submitPending(&io.loop);
             loopCancel(
                 &io.loop,
                 accept_completion,

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -981,6 +981,79 @@ test "xevio: closing a listener cancels its armed accept" {
     try std.testing.expectError(error.Canceled, result);
 }
 
+/// The same-tick drain shape (#203): an accept armed inside one callback
+/// and the listener closed inside another, with no loop submission in
+/// between. That is the admin plane's own sequence — `onAccept` re-arms,
+/// and the signal completion's `beginDrain` runs later in the same tick's
+/// batch — and it is the shape `DrainCloser` above deliberately does not
+/// have, because there the accept is submitted before the close.
+const SameTickDrain = struct {
+    io: *XevIo,
+    listener: XevIo.Listener,
+    arm_timer: XevIo.Completion = .{},
+    close_timer: XevIo.Completion = .{},
+    accept_completion: XevIo.Completion = .{},
+    outcome: ?(Io.AcceptError!XevIo.Socket) = null,
+    armed: bool = false,
+    closed: bool = false,
+
+    fn onArm(drain: *SameTickDrain, result: Io.TimerError!void) void {
+        // The only TimerError is Canceled, and nothing cancels this timer.
+        result catch unreachable;
+        // The close must not have run first, or the test is asserting
+        // about a listener that was already gone.
+        assert(!drain.closed);
+        drain.io.accept(
+            drain.listener,
+            &drain.accept_completion,
+            SameTickDrain,
+            drain,
+            onAccept,
+        );
+        drain.armed = true;
+    }
+
+    fn onClose(drain: *SameTickDrain, result: Io.TimerError!void) void {
+        result catch unreachable;
+        assert(drain.armed);
+        drain.io.listenClose(drain.listener);
+        drain.closed = true;
+    }
+
+    fn onAccept(drain: *SameTickDrain, result: Io.AcceptError!XevIo.Socket) void {
+        assert(drain.outcome == null);
+        drain.outcome = result;
+    }
+};
+
+test "xevio: closing a listener cancels an accept armed in the same tick" {
+    // #203: the accept above is armed from outside the loop, so the
+    // backend has submitted it by the time the close lands. The admin
+    // plane's is not — it is re-armed from `onAccept` and the drain runs
+    // in the same tick — and a backend that only delivers a cancelled
+    // accept it has already submitted orphans that one. Same contract as
+    // the test above, one tick earlier.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var xev_io: XevIo = undefined;
+    try initTestIo(&xev_io, arena_state.allocator(), 0);
+    defer xev_io.deinit();
+
+    const listener = try xev_io.listen(
+        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+    );
+    var drain: SameTickDrain = .{ .io = &xev_io, .listener = listener };
+    // Both at zero: one tick's timer batch runs both callbacks, with no
+    // submission between them — which is the whole point.
+    xev_io.timerStart(&drain.arm_timer, 0, SameTickDrain, &drain, SameTickDrain.onArm);
+    xev_io.timerStart(&drain.close_timer, 0, SameTickDrain, &drain, SameTickDrain.onClose);
+    try xev_io.run();
+
+    const result = drain.outcome orelse return error.AcceptNeverCompleted;
+    try std.testing.expectError(error.Canceled, result);
+}
+
 test "xevio: a recv against a linger-RST close is Reset, with the errno pinned" {
     // The ConnectionResetByPeer arm of the read map, deterministic by
     // construction: the close(2) below fires the RST before run() ever


### PR DESCRIPTION
Closes #203.

Closes the macOS half of #203 — reproduced on a dev box rather than inferred from epoll.

## What was wrong

`delivers_accept_cancel` asks the backend's own error set whether cancelling an armed accept delivers that accept's completion. kqueue names `Canceled`, and it does deliver — **but only for an accept it has already taken.**

libxev submits at the top of a tick and never inside its callback loop, so an accept armed *from* a callback is still queued. Cancelling a queued op runs `process_cancellations`, which marks it dead, and then `submit` hands it to `stop_completion`, where a non-active accept falls through `else => {}`. No completion, no callback — epoll's outcome by a different route, on a backend whose types promised otherwise.

The admin plane arms exactly that way: `maybeFinish` re-arms the accept from inside a completion callback, and a signal's `beginDrain` can close the listener later in the same tick. Then `onAccept` never runs, `quiesceForDrain` never clears `listening`, `isQuiescent` is false forever, and the drain hangs — the chain #208's epoll investigation already mapped, reached on kqueue.

So the discriminator was not wrong, it was incomplete. The error set told the truth; that truth is conditional on the backend having taken the op, and nothing in the type system says so.

## The fix

`listenClose` submits before it cancels. `submitPending` is a syscall rather than a tick and fires no callbacks, so it cannot re-enter the caller mid-drain — the hazard that forces the synthesized delivery in the other arm to be asynchronous.

It panics on `CompletionQueueOvercommitted` for the same reason `run` does: that error is the §8 budget violated, not a submit that did not happen, and swallowing it here would degrade quietly into this very hang.

## The test is what found it

`xevio: closing a listener cancels an accept armed in the same tick` is the shape the existing accept-cancel test deliberately does *not* have — that one arms from outside the loop, so the accept is always submitted by the time the close lands. This one arms and closes from two callbacks in one tick.

**Failed 5 of 5 before the fix** with `AcceptNeverCompleted`, passes after. It runs on every backend, so it would have caught the original epoll defect too.

## Verification

- `zig build ci` green on macOS: 38/38 steps, 494/498 tests pass (4 skipped), sim 4096 seeds, smoke clean drain.
- 60 consecutive `zig build smoke` runs before the fix: 0 failures. Blind repetition never was going to find this — the trigger is a race at SIGTERM, which is why the directed test exists.

## What CI still has to answer

**io_uring is unverified in behavior.** A Linux cross-compile got past semantic analysis and failed only at linking host libcrypto, so `submitPending` compiles there; whether io_uring has the same queued-cancel window is for CI to say. The new test runs on every backend, so a Linux run answers it either way.

## Not closed by this PR

#208's known-bad item is untouched and outlives this fix: `zig build test -Dio-backend=epoll` still hangs, so the new test is unverified under epoll. Worth its own issue rather than keeping #203 open — say the word and I'll file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)