### PR TITLE
test(sim): the sweep reaches the TLS keep-alive turnaround, request body, and resumption (#204)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -77,10 +77,8 @@ What it left open, now tracked rather than only recorded here:
 - **#203 — the live gate's https leg wedged once on macOS**, and has not
   recurred. See the section of that name below for what is ruled out and
   where to look.
-- **#204 — the simulator's TLS clients open one connection each**, which
-  still keeps resumption out of the sweep: a ticket can only be offered
-  back on a *second* connection, and nothing opens one. The other two legs
-  it named are closed — see "Ending an exchange by framing" below.
+- ~~**#204 — the simulator's TLS clients are single-connection.**~~ Closed:
+  see "Ending an exchange by framing" below for all three legs.
 
 One smaller thing still recorded only here, because it is a line rather
 than a project: `ResponseBodyPolicy.afterSend` credits *ciphertext* to
@@ -169,9 +167,28 @@ whose origin drew an unsized mode — both honest, and both leaving the
 count *behind*, never ahead. That asymmetry is what makes
 `responsesReceived() <= requestsSent()` a sound per-seed oracle.
 
-What it does not close is resumption. A ticket is offered on a *second
-connection*, and this population still opens one apiece, so
-`tls_resumed`'s census exemption stands.
+Resumption needed the other half: a *second connection*. One resuming
+client now starts from the end hook of whichever session captured a
+ticket, offering it back — the same slot machinery, one extra storage
+slot, and `clients_count` grown before `clientEnded` compares against it
+so the wind-down waits for the resumed session rather than racing it.
+
+Two things it cost, both worth stating because neither was predictable
+from the design. The clean-seed access-log oracle counts one L4 line per
+connection and had the drawn client count hard-coded, which a second
+connection falsifies. And `tls_engines` had to grow by one: the resumer
+dials from the end hook, but the engine of the session it is resuming is
+released a loop turn later, when the server sees the close — so sizing to
+the drawn count shed the resumption on that overlap instead of covering
+it.
+
+Measured over 4096 seeds: the resuming client starts on 86% of runs that
+drew TLS (the rest are first sessions that ended holding no ticket — a
+refused dial, a cut handshake, a shed engine), and of those 83% are
+resumed. `tls_resumed` fires 385 times, so its census exemption is
+**deleted** rather than relaxed. `Counters.reconcile` now also states the
+relationship the two credit paths must keep: `tls_resumed <=
+tls_handshakes_completed`.
 
 ### Pool ceilings — policy we choose, or a range the operator picks?
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -77,9 +77,10 @@ What it left open, now tracked rather than only recorded here:
 - **#203 — the live gate's https leg wedged once on macOS**, and has not
   recurred. See the section of that name below for what is ruled out and
   where to look.
-- **#204 — the simulator's TLS clients are single-connection**, which is
-  what keeps resumption, the keep-alive turnaround and the request-body
-  leg out of the sweep.
+- **#204 — the simulator's TLS clients open one connection each**, which
+  still keeps resumption out of the sweep: a ticket can only be offered
+  back on a *second* connection, and nothing opens one. The other two legs
+  it named are closed — see "Ending an exchange by framing" below.
 
 One smaller thing still recorded only here, because it is a line rather
 than a project: `ResponseBodyPolicy.afterSend` credits *ciphertext* to
@@ -127,6 +128,50 @@ layer costs zero userspace CPU and the `splice` c10k lever (below) stays
 applicable to TLS traffic. Known fiddly parts: KeyUpdate/post-handshake
 control messages arrive via CMSG, and session tickets must be sent
 before the switchover.
+
+### Ending an exchange by framing (#204)
+
+The scripted TLS client was written for an L4 echo, where "the peer has
+answered" means *as many bytes back as went out*. Pointed at a proxied
+listener that rule is not merely imprecise, it is unusable in both
+directions: a response longer than its request satisfies it early, and a
+shorter one never satisfies it at all. So the terminating http population
+sent one `Connection: close` GET and finished on the peer's EOF — one
+exchange, no body, no turnaround.
+
+`TestClient` now chooses between the two rules (`ExchangeEnd`), and the
+framing one counts **complete responses** through `src/http/parser.zig` —
+the §7 wrapper, not a scan of its own. That was a correction during
+review: the first version looked for `Content-Length` itself, which
+agrees with the wrapper on every response this sweep produces (measured:
+the two give bit-identical counts over 4096 seeds) but not on the two
+shapes where a response contradicts its own headers. A HEAD response
+carries a `Content-Length` with no body behind it, so a hand-rolled
+scanner takes the *next* response's opening bytes for this one's body and
+mis-frames everything after — silent, and a mis-frame rather than a
+stall. `checkOptions` now refuses to script a HEAD, which is what lets
+the parser be told `.get` and stay right.
+
+Only the framings that end at a computable offset count. Chunked and
+until-close have no answer to the question being asked — *may the next
+request go yet* — since an until-close response is over when the
+connection is, by which point there is no next request. Both count as
+incomplete, so the client stops sending and ends the way it would have
+anyway. The failure mode that rules out is the one that matters: a
+request written into the middle of a body, which would make the proxy's
+next head start mid-body and read as *its* defect.
+
+The sweep's terminating http clients now send a keep-alive POST and then
+a closing GET. Measured over 4096 seeds, per terminating-http client
+instance: the second request goes out on **62%**, and both responses come
+back whole on **32%**. The rest are seeds whose schedule ended first, or
+whose origin drew an unsized mode — both honest, and both leaving the
+count *behind*, never ahead. That asymmetry is what makes
+`responsesReceived() <= requestsSent()` a sound per-seed oracle.
+
+What it does not close is resumption. A ticket is offered on a *second
+connection*, and this population still opens one apiece, so
+`tls_resumed`'s census exemption stands.
 
 ### Pool ceilings — policy we choose, or a range the operator picks?
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -41,6 +41,11 @@ const clients_max: u8 = 6;
 /// engine-pool wall on a starved seed, which is the one rung that needs
 /// more than one.
 const tls_clients_max: u8 = 2;
+/// One more slot than a seed may draw, for the resuming client (#204).
+/// Exactly one: what it covers is a ticket surviving from one connection
+/// to the next, and a second resumer would only re-cover it while
+/// doubling the handshake crypto every TLS seed pays for.
+const tls_client_slots: u8 = tls_clients_max + 1;
 /// Bytes each terminating client echoes. Small: what this population is
 /// for is the handshake and the transform, not throughput.
 const tls_token_bytes: u8 = 24;
@@ -112,13 +117,26 @@ l7_clients: [clients_max]HttpClient,
 /// harness because the server borrows the table for its life, and because
 /// a `Credentials` owns a libcrypto key that `tearDown` must free — the
 /// arena cannot, it is not arena memory.
-tls_clients_storage: [tls_clients_max]TlsClient,
+tls_clients_storage: [tls_client_slots]TlsClient,
+/// How many terminating clients the seed drew — what sizes the engine
+/// pool — against how many storage slots are in use, which the #204
+/// resuming client makes one larger the moment it starts.
 tls_clients: u8,
+tls_clients_live: u8,
+/// Whether the resuming client has started, and the key material it
+/// starts with. Drawn up front from the scenario stream rather than when
+/// it starts: the draw then sits at a fixed point in that stream instead
+/// of one the delivery order chooses.
+tls_resume_started: bool,
+tls_resume_seeds: [3][32]u8,
+/// Set when the wind-down begins, so nothing dials a listener that has
+/// stopped accepting.
+scenario_ended: bool,
 /// What the terminating listener speaks once the handshake hands over.
 tls_protocol: zoxy.config.Config.Listener.Protocol,
 /// What each terminating client sends, distinct per client so the echo
 /// oracle can tell one session's bytes from another's.
-tls_tokens: [tls_clients_max][tls_token_bytes]u8,
+tls_tokens: [tls_client_slots][tls_token_bytes]u8,
 tls_credentials: [3]?zoxy.tls.Credentials,
 /// The #142 gate drawn for the l4 listener; `populateClients` reads it
 /// to decide whether its clients open with headers.
@@ -800,6 +818,26 @@ fn deriveTlsClients(
     return 1 + random.uintLessThan(u8, tls_clients_max);
 }
 
+/// The §4 engine pool this seed runs with. Zero when it drew no
+/// terminating clients, which keeps the pool free to every scenario that
+/// does not use it.
+///
+/// A starved seed gets exactly one engine against up to two sessions:
+/// the §4 wall, which is what it was drawn to meet, and the only way
+/// `shed_tls_engines` is reached. Every other seed is sized so no session
+/// is shed — and that means the drawn count *plus one*, not the drawn
+/// count. #204's resuming client dials from the end hook of the session
+/// whose ticket it offers, and that session's engine is released a loop
+/// turn later, when the server sees the close; the two overlap, and
+/// sizing to the population would shed the resumption rather than cover
+/// it.
+fn deriveTlsEngines(tls_clients: u8, force_exhaustion: bool) u32 {
+    assert(tls_clients <= tls_clients_max);
+    if (tls_clients == 0) return 0;
+    if (force_exhaustion) return 1;
+    return @as(u32, tls_clients) + 1;
+}
+
 /// The two #159 pages the sweep serves, rendered here exactly as
 /// `config.zig`'s loader renders one — the simulator builds its
 /// `Config` by hand (no filesystem, no parse), so the shape is spelled
@@ -972,14 +1010,15 @@ fn deriveAccessLogBuffer(harness: *const Harness) u32 {
     return floor;
 }
 
-fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: std.Random) !void {
-    // A quarter of adversarial seeds shrink the pools to force the
-    // §8 rungs; clean seeds keep ample pools so golden outcomes
-    // never meet a shed. Decided in `setUp` (see `force_exhaustion`)
-    // because the ring size had to precede `io.init`.
+/// The pool sizes this seed runs the server with. A quarter of
+/// adversarial seeds shrink them to force the §8 rungs; clean seeds keep
+/// ample pools so golden outcomes never meet a shed. Decided in `setUp`
+/// (see `force_exhaustion`) because the ring size had to precede
+/// `io.init`.
+fn deriveInitOptions(harness: *const Harness, random: std.Random) ServerSim.InitOptions {
     const force_exhaustion = harness.force_exhaustion;
     const access_log_buffer_bytes = harness.deriveAccessLogBuffer();
-    const options: ServerSim.InitOptions = if (force_exhaustion)
+    return if (force_exhaustion)
         .{
             // head_buffers ≤ conn_slots is a Server.init precondition, so
             // the slot draw starts at whatever the ring draw chose.
@@ -992,11 +1031,7 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
             // rung itself is relay-shadowed (see sim/main.zig uncovered).
             .upstream_head_buffers = 1,
             .access_log_buffer_bytes = access_log_buffer_bytes,
-            // One engine against up to two sessions: the §4 wall, which
-            // an exhaustion seed is drawn to meet. Zero when the seed
-            // drew no TLS clients, which is what keeps the pool free to
-            // every scenario that does not use it.
-            .tls_engines = if (harness.tls_clients >= 1) 1 else 0,
+            .tls_engines = deriveTlsEngines(harness.tls_clients, force_exhaustion),
         }
     else
         .{
@@ -1018,9 +1053,12 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
             .upstream_slots = 2 * clients_max,
             .head_buffers = harness.head_buffers,
             .upstream_head_buffers = 2 * clients_max,
-            // One each, so a non-starved seed's sessions all get through.
-            .tls_engines = harness.tls_clients,
+            .tls_engines = deriveTlsEngines(harness.tls_clients, force_exhaustion),
         };
+}
+
+fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: std.Random) !void {
+    const options = harness.deriveInitOptions(random);
     try harness.server.init(arena, &harness.io, &harness.config, options);
     harness.tls_credentials = .{ null, null, null };
     if (harness.tls_clients >= 1) {
@@ -1054,6 +1092,34 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
     try harness.origin_http.start(&harness.io, Harness.httpOriginAddress());
 }
 
+/// The terminating population's per-scenario state: the storage, the
+/// slot bookkeeping the resuming client grows, and one echo token per
+/// slot.
+///
+/// A plaintext seed draws nothing here, which is what keeps its stream
+/// position — and so the whole sweep's plaintext coverage — exactly
+/// where it was before TLS existed.
+fn populateTlsClients(harness: *Harness, random: std.Random) void {
+    harness.tls_clients_storage = @splat(undefined);
+    harness.tls_clients_live = harness.tls_clients;
+    harness.tls_resume_started = false;
+    harness.scenario_ended = false;
+    assert(harness.tls_clients <= tls_clients_max);
+    // One token past the drawn count, for the resuming client's slot.
+    const token_count = if (harness.tls_clients >= 1)
+        harness.tls_clients + 1
+    else
+        0;
+    assert(token_count <= tls_client_slots);
+    for (harness.tls_tokens[0..token_count], 0..) |*token, index| {
+        random.bytes(token);
+        // A distinguishable first byte, so an echo oracle comparing the
+        // wrong session's bytes fails on the first one rather than
+        // needing the whole token to collide.
+        token[0] = @intCast(index);
+    }
+}
+
 fn populateClients(harness: *Harness, random: std.Random) void {
     // Each client flips a protocol coin: mixed populations put both
     // serving paths under one schedule and shared pools.
@@ -1064,14 +1130,7 @@ fn populateClients(harness: *Harness, random: std.Random) void {
     harness.l4_count = 0;
     harness.l7_count = 0;
     harness.ended_count = 0;
-    harness.tls_clients_storage = @splat(undefined);
-    for (harness.tls_tokens[0..harness.tls_clients], 0..) |*token, index| {
-        random.bytes(token);
-        // A distinguishable first byte, so an echo oracle comparing the
-        // wrong session's bytes fails on the first one rather than
-        // needing the whole token to collide.
-        token[0] = @intCast(index);
-    }
+    harness.populateTlsClients(random);
     harness.clients = @splat(.{});
     harness.l7_clients = @splat(.{});
     harness.l4_announced_len = @splat(0);
@@ -1217,51 +1276,129 @@ pub fn startClients(harness: *Harness) void {
 fn startTlsClients(harness: *Harness) void {
     var index: u8 = 0;
     while (index < harness.tls_clients) : (index += 1) {
-        const client = &harness.tls_clients_storage[index];
         const random = harness.scenario_prng.random();
         var seeds: [3][32]u8 = undefined;
         for (&seeds) |*seed| random.bytes(seed);
-        client.start(&harness.io, Harness.tlsBindAddress(), .{
-            .host_name = zoxy.tls.testdata.host_name,
-            // An echo token for a relayed session, a real request for a
-            // proxied one — the terminated stream has to be what the
-            // listener behind it expects, or the head parser answers 400
-            // and the transform is never exercised at all.
-            .app_data = if (harness.tls_protocol == .http)
-                tls_http_request
-            else
-                harness.tls_tokens[index][0..tls_token_bytes],
-            // How each population knows its peer answered. A relayed
-            // session gets its own bytes back, so a byte count is exactly
-            // right; a proxied one gets a response, whose length has
-            // nothing to do with its request's, so it needs the framing
-            // rule (#204). Wiring the echo rule to the proxied population
-            // would not fail — it would *hang*, waiting for a response as
-            // long as the request that earned it.
-            .exchange_end = if (harness.tls_protocol == .http)
-                .http_response
-            else
-                .echo,
-            // The second request, on the connection the first left open —
-            // only the proxied population has one, since an echo has no
-            // turnaround to take.
-            .followup_data = if (harness.tls_protocol == .http)
-                tls_http_followup
-            else
-                &.{},
-            // A relayed session closes in protocol once its echo is back:
-            // an in-band EOF no socket EOF follows, which is the §6
-            // half-close a terminated relay can only learn from a decrypt.
-            // A proxied one lets its second request's `Connection: close`
-            // end the connection instead, and finishes on the EOF.
-            .close_after_echo = harness.tls_protocol == .l4,
-            .x25519_seed = seeds[0],
-            .p256_seed = seeds[1],
-            .random = seeds[2],
-        }) catch unreachable; // Seeded keypairs; the inputs are ours.
-        client.on_end = clientEndedHook;
-        client.on_end_context = harness;
+        harness.startTlsClient(index, &seeds, null);
     }
+    if (harness.tls_clients == 0) return;
+    const random = harness.scenario_prng.random();
+    for (&harness.tls_resume_seeds) |*seed| random.bytes(seed);
+}
+
+/// One terminating client into slot `index`, offering `resume_with` if it
+/// has one. Shared by the population and by the resuming client, so the
+/// two differ in exactly the ticket and nothing else — which is what
+/// makes a resumed session's coverage the same coverage, minus a full
+/// handshake.
+fn startTlsClient(
+    harness: *Harness,
+    index: u8,
+    seeds: *const [3][32]u8,
+    resume_with: ?*const zoxy.tls.SessionTicket,
+) void {
+    assert(index < harness.tls_clients_live);
+    const client = &harness.tls_clients_storage[index];
+    client.start(&harness.io, Harness.tlsBindAddress(), .{
+        .host_name = zoxy.tls.testdata.host_name,
+        .resume_with = resume_with,
+        // An echo token for a relayed session, a real request for a
+        // proxied one — the terminated stream has to be what the
+        // listener behind it expects, or the head parser answers 400
+        // and the transform is never exercised at all.
+        .app_data = if (harness.tls_protocol == .http)
+            tls_http_request
+        else
+            harness.tls_tokens[index][0..tls_token_bytes],
+        // How each population knows its peer answered. A relayed
+        // session gets its own bytes back, so a byte count is exactly
+        // right; a proxied one gets a response, whose length has
+        // nothing to do with its request's, so it needs the framing
+        // rule (#204). Wiring the echo rule to the proxied population
+        // would not fail — it would *hang*, waiting for a response as
+        // long as the request that earned it.
+        .exchange_end = if (harness.tls_protocol == .http)
+            .http_response
+        else
+            .echo,
+        // The second request, on the connection the first left open —
+        // only the proxied population has one, since an echo has no
+        // turnaround to take.
+        .followup_data = if (harness.tls_protocol == .http)
+            tls_http_followup
+        else
+            &.{},
+        // A relayed session closes in protocol once its echo is back:
+        // an in-band EOF no socket EOF follows, which is the §6
+        // half-close a terminated relay can only learn from a decrypt.
+        // A proxied one lets its second request's `Connection: close`
+        // end the connection instead, and finishes on the EOF.
+        .close_after_echo = harness.tls_protocol == .l4,
+        .x25519_seed = seeds[0],
+        .p256_seed = seeds[1],
+        .random = seeds[2],
+    }) catch unreachable; // Seeded keypairs; the inputs are ours.
+    // A fresh session holds nothing yet: whatever ticket this slot's
+    // previous occupant captured must not survive into the next one, and
+    // on the resuming slot that is the difference between offering the
+    // issuer's ticket and offering its own.
+    assert(client.capturedTicket() == null);
+    client.on_end = tlsClientEndedHook;
+    client.on_end_context = harness;
+}
+
+/// #204's resumption leg. A ticket can only be offered on a *second*
+/// connection, so this runs off the first one's end: whichever session
+/// captured a ticket, its ticket goes back out on a fresh dial, and the
+/// server's `psk_lookup` either opens what it sealed or falls back to a
+/// full handshake. Both are legal, which is why the counter is the
+/// oracle and not this call succeeding.
+///
+/// `clients_count` grows *before* `clientEnded` compares against it, so
+/// the wind-down waits for the resuming session rather than racing it.
+fn maybeStartResumingClient(harness: *Harness) void {
+    // The hook is wired to terminating clients only, so reaching here at
+    // all means the seed drew some — which is what stops the slot index
+    // below from underflowing.
+    assert(harness.tls_clients >= 1);
+    if (harness.tls_resume_started) return;
+    // The wind-down has stopped the listener accepting, so a dial now
+    // would only ever measure how a refused connect is reaped.
+    if (harness.scenario_ended) return;
+    const issuer = harness.ticketIssuer() orelse return;
+    const ticket = issuer.capturedTicket().?;
+    harness.tls_resume_started = true;
+    harness.tls_clients_live += 1;
+    harness.clients_count += 1;
+    // Exactly one resumer, in exactly the slot past the drawn count —
+    // today only the `tls_resume_started` latch keeps that true, so it is
+    // worth saying out loud rather than inferring from the latch.
+    assert(harness.tls_clients_live == harness.tls_clients + 1);
+    assert(harness.tls_clients_live <= tls_client_slots);
+    harness.startTlsClient(harness.tls_clients_live - 1, &harness.tls_resume_seeds, ticket);
+}
+
+/// The first finished session holding a ticket. A server issues them on
+/// every handshake, so this is normally the first client to end — but a
+/// refused dial, a cut handshake or a shed engine all end a client with
+/// nothing to offer, and on those seeds there is simply no resumption to
+/// cover.
+fn ticketIssuer(harness: *Harness) ?*TlsClient {
+    // The drawn population only: the resuming client's own ticket is
+    // never offered again, and its slot may not even exist yet.
+    assert(harness.tls_clients >= 1);
+    assert(harness.tls_clients <= harness.tls_clients_live);
+    for (harness.tls_clients_storage[0..harness.tls_clients]) |*client| {
+        if (!client.isEnded()) continue;
+        if (client.capturedTicket() != null) return client;
+    }
+    return null;
+}
+
+fn tlsClientEndedHook(context: ?*anyopaque) void {
+    const harness: *Harness = @ptrCast(@alignCast(context.?));
+    harness.maybeStartResumingClient();
+    harness.clientEnded();
 }
 
 fn clientEnded(harness: *Harness) void {
@@ -1280,13 +1417,14 @@ fn onScenarioEnd(harness: *Harness, result: Io.TimerError!void) void {
 }
 
 fn endScenario(harness: *Harness) void {
+    harness.scenario_ended = true;
     for (harness.clients[0..harness.l4_count]) |*client| {
         client.cancelIfStuck();
     }
     for (harness.l7_clients[0..harness.l7_count]) |*client| {
         client.cancelIfStuck();
     }
-    for (harness.tls_clients_storage[0..harness.tls_clients]) |*client| {
+    for (harness.tls_clients_storage[0..harness.tls_clients_live]) |*client| {
         client.cancelIfStuck();
     }
     harness.server.beginDrain();
@@ -1305,7 +1443,7 @@ pub fn tearDown(harness: *Harness) void {
             slot.* = null;
         }
     }
-    for (harness.tls_clients_storage[0..harness.tls_clients]) |*client| {
+    for (harness.tls_clients_storage[0..harness.tls_clients_live]) |*client| {
         client.deinit();
     }
 }
@@ -1364,7 +1502,7 @@ pub fn verify(harness: *Harness) !void {
 fn verifyTlsSessions(harness: *Harness) !void {
     if (harness.tls_clients == 0) return;
     var closed_count: u8 = 0;
-    for (harness.tls_clients_storage[0..harness.tls_clients], 0..) |*client, index| {
+    for (harness.tls_clients_storage[0..harness.tls_clients_live], 0..) |*client, index| {
         const back = client.app_received[0..client.app_received_len];
         if (harness.tls_protocol == .http) {
             // A proxied session gets a response, not its own bytes back.
@@ -1545,12 +1683,12 @@ fn verifyAccessLog(harness: *Harness) !void {
         // clock on admission rather than on first byte — so even the
         // silent clients (`sim/l4.zig` draws some) owe a line, theirs
         // reporting `bytes_in: 0`.
-        // TLS is a phase ahead of the protocol (§4), not a protocol of its
-        // own, so a terminated connection logs whatever it went on to
-        // speak: an `l4` terminator adds L4 lines, an `http` one adds its
-        // exchanges to the HTTP tally the equality above already covers.
+        // TLS is a phase ahead of the protocol (§4), so a terminated
+        // connection logs what it went on to speak: an `l4` terminator
+        // adds L4 lines — live, not drawn, since #204's resumer is a
+        // second connection — and an `http` one adds exchanges above.
         const terminated_l4: u8 =
-            if (harness.tls_protocol == .l4) harness.tls_clients else 0;
+            if (harness.tls_protocol == .l4) harness.tls_clients_live else 0;
         if (tally.l4 != harness.l4_count + terminated_l4) {
             return error.AccessLogL4LinesDiverged;
         }

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -44,11 +44,19 @@ const tls_clients_max: u8 = 2;
 /// Bytes each terminating client echoes. Small: what this population is
 /// for is the handshake and the transform, not throughput.
 const tls_token_bytes: u8 = 24;
-/// What a terminating *http* listener's client sends. The plain GET the
-/// L7 scripts already use, so the origin double answers it exactly as it
-/// answers a plaintext one and the difference under test is the
-/// transform rather than the request.
-const tls_http_request = l7.scripts.get_request_close;
+/// The two requests a terminating *http* listener's client sends, in
+/// order. Both are the L7 scripts' own bytes, so the origin answers them
+/// exactly as it answers a plaintext client's and the difference under
+/// test is the transform rather than the request.
+///
+/// The first is a keep-alive POST: a body, which a GET has none of, and
+/// no `Connection: close`, so the exchange leaves the connection open.
+/// The second closes it, which is how the client ends without waiting on
+/// an idle timeout. Between them is the keep-alive turnaround — the L7
+/// state re-entered on a terminated connection, which is where the head
+/// source's first defect lived (#204).
+const tls_http_request = l7.scripts.post_request;
+const tls_http_followup = l7.scripts.get_request_close;
 /// "203.0.113.255:65535" is 19 bytes; the slack is headroom, not hope.
 const announced_bytes_max: u8 = 32;
 /// Virtual time from scenario start after which stuck work is force-ended.
@@ -1223,39 +1231,29 @@ fn startTlsClients(harness: *Harness) void {
                 tls_http_request
             else
                 harness.tls_tokens[index][0..tls_token_bytes],
+            // How each population knows its peer answered. A relayed
+            // session gets its own bytes back, so a byte count is exactly
+            // right; a proxied one gets a response, whose length has
+            // nothing to do with its request's, so it needs the framing
+            // rule (#204). Wiring the echo rule to the proxied population
+            // would not fail — it would *hang*, waiting for a response as
+            // long as the request that earned it.
+            .exchange_end = if (harness.tls_protocol == .http)
+                .http_response
+            else
+                .echo,
+            // The second request, on the connection the first left open —
+            // only the proxied population has one, since an echo has no
+            // turnaround to take.
+            .followup_data = if (harness.tls_protocol == .http)
+                tls_http_followup
+            else
+                &.{},
             // A relayed session closes in protocol once its echo is back:
             // an in-band EOF no socket EOF follows, which is the §6
             // half-close a terminated relay can only learn from a decrypt.
-            //
-            // A proxied one must not. That option waits for as many bytes
-            // back as went out, which is an echo's shape and not an
-            // exchange's — a response shorter than its request would leave
-            // the client waiting forever. The request carries
-            // `Connection: close` instead, so the proxy ends the
-            // connection and the client finishes on the EOF.
-            //
-            // Two gaps that leaves, tracked as #204 and stated here
-            // because closing them is the next work in this file. A
-            // `Connection: close` request is one exchange, so the
-            // keep-alive turnaround — which is where the head source's
-            // first defect lived — is never re-entered; and a GET carries
-            // no body, so the request-body leg's transform never runs. A
-            // second request and a POST are what cover both, and each
-            // needs the client to end on something other than the peer's
-            // EOF.
-            //
-            // The first gap has since cost a real defect: a close_notify
-            // on a connection idle *between* requests started an access
-            // log entry for a request nobody made (see the directed test
-            // `l7: close_notify between requests writes no access-log
-            // line`, and the Tier-0.5 leg that found it). It is covered
-            // now, but by two hand-picked cases rather than the sweep.
-            // Flipping this option on for `.http` is not the fix — the
-            // paragraph above is the reason, and it is a hang, not a
-            // failure: the option would wait for a response as long as
-            // the request. Closing it properly means teaching the client
-            // to end on a *complete response* rather than a byte count,
-            // which is a change to `TestClient`, not to this call.
+            // A proxied one lets its second request's `Connection: close`
+            // end the connection instead, and finishes on the EOF.
             .close_after_echo = harness.tls_protocol == .l4,
             .x25519_seed = seeds[0],
             .p256_seed = seeds[1],
@@ -1376,6 +1374,17 @@ fn verifyTlsSessions(harness: *Harness) !void {
             // or another session's plaintext.
             if (back.len >= 1 and !std.mem.startsWith(u8, back, "HTTP/1.1 ")) {
                 return error.TlsResponseCorrupted;
+            }
+            // #204: never more answers than questions. The framing rule
+            // the client now ends its exchanges on is what lets it count
+            // them at all, and a count that ran ahead of what it asked
+            // for would mean the transform delivered a response this
+            // session never earned — another connection's, or one
+            // duplicated across the head source's turnaround. Sound on
+            // every seed, since a short schedule can only leave the
+            // count *behind*.
+            if (client.responsesReceived() > client.requestsSent()) {
+                return error.TlsResponseCountDiverged;
             }
             // Response bytes, not `handshake_done`: a client believes it
             // is connected once it has processed the server's flight,

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -165,6 +165,13 @@ pub const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++ "\
 /// left to say.
 pub const get_request_close = "GET /sim HTTP/1.1\r\nHost: sim\r\nConnection: close\r\n" ++
     trace_line ++ "\r\n";
+/// A keep-alive POST for the same caller (#204): the request-body leg,
+/// which a GET cannot reach, on a connection the exchange leaves open so
+/// a second request can follow it. Byte-identical to `post_sized`'s
+/// request, so the origin's §7 oracle judges it by the rule it already
+/// has rather than by a second spelling of the same thing.
+pub const post_request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++
+    "Content-Length: 24\r\n\r\n" ++ post_body;
 /// Deterministic 6000-byte body for `post_big`, cycled so the
 /// origin-side §7 oracle can spot any reordering.
 const big_body = blk: {
@@ -251,8 +258,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .allowed_statuses = statuses_routed,
     },
     .post_sized = .{
-        .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++
-            "Content-Length: 24\r\n\r\n" ++ post_body,
+        .request = post_request,
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 200,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -238,16 +238,17 @@ const uncovered = [_]Uncovered{
         .name = "tls_resumed",
         .why = .unreached,
         .reason = "resumption needs a client that keeps a ticket from one " ++
-            "connection and offers it on the next, and this population's " ++
-            "clients are single-connection by construction — each ends on " ++
-            "its peer's EOF or its own close_notify and never opens a " ++
-            "second. src/http_proxy_test.zig drives the whole round trip " ++
-            "(issue, capture, offer, open) across two connections and " ++
-            "asserts the counter; what the sweep would add on top is the " ++
-            "adversary's schedules against a resumed handshake, which is " ++
-            "the honest gap, tracked as #204 — it wants a client that ends " ++
-            "on a complete response so a second connection can offer the " ++
-            "first's ticket back",
+            "connection and offers it on the next, and this population " ++
+            "opens one connection apiece — a terminating client runs its " ++
+            "whole script on the session it dialled and then ends, so " ++
+            "there is never a second ClientHello to carry a ticket. " ++
+            "src/http_proxy_test.zig drives the whole round trip (issue, " ++
+            "capture, offer, open) across two connections and asserts the " ++
+            "counter; what the sweep would add on top is the adversary's " ++
+            "schedules against a resumed handshake, which is the honest " ++
+            "gap, still tracked as #204 — the exchange-framing half of it " ++
+            "landed, so what remains is a second wave of clients started " ++
+            "from the first's end hook, offering the ticket it captured",
     },
     .{
         .name = "l7_no_route",

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -235,22 +235,6 @@ const uncovered = [_]Uncovered{
             "either, which is the honest gap",
     },
     .{
-        .name = "tls_resumed",
-        .why = .unreached,
-        .reason = "resumption needs a client that keeps a ticket from one " ++
-            "connection and offers it on the next, and this population " ++
-            "opens one connection apiece — a terminating client runs its " ++
-            "whole script on the session it dialled and then ends, so " ++
-            "there is never a second ClientHello to carry a ticket. " ++
-            "src/http_proxy_test.zig drives the whole round trip (issue, " ++
-            "capture, offer, open) across two connections and asserts the " ++
-            "counter; what the sweep would add on top is the adversary's " ++
-            "schedules against a resumed handshake, which is the honest " ++
-            "gap, still tracked as #204 — the exchange-framing half of it " ++
-            "landed, so what remains is a second wave of clients started " ++
-            "from the first's end hook, offering the ticket it captured",
-    },
-    .{
         .name = "l7_no_route",
         .why = .unreached,
         .reason = "the sim's route table is a single \"/\" prefix, which no " ++

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -653,6 +653,13 @@ pub const Counters = struct {
         // Every §7 replay rides a checkout: only a reused connection's
         // early failure is blamed on staleness.
         assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));
+        // A resumed session is a completed handshake that skipped the
+        // certificate, not a separate kind of event — so it can never
+        // outrun the handshakes it is a subset of. Worth stating because
+        // the two are credited on different paths: the completion at the
+        // handover, the resumption from the engine's own view of what it
+        // negotiated.
+        assert(counters.get("tls_resumed") <= counters.get("tls_handshakes_completed"));
         // A probe can only fail if it was sent; an ejection needs at least
         // one failed probe; a restore needs a prior ejection (endpoints
         // start healthy, §7).

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -4377,6 +4377,12 @@ test "l7: close_notify between requests writes no access-log line" {
         // and waiting for a next request when the alert lands, which is
         // the whole state under test.
         .app_data = "GET /x HTTP/1.1\r\nHost: o\r\n\r\n",
+        // The alert waits for the response, and what makes one whole is
+        // its framing, not its size. The echo rule happens to fire here —
+        // this response is longer than its request — but only by accident
+        // of these two literals, and the state under test is precisely
+        // the connection being idle *after* a complete exchange.
+        .exchange_end = .http_response,
         .close_after_echo = true,
     });
     var wind_down: TlsWindDown = .{ .bed = &bed };

--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,9 @@ pub const tls = struct {
     pub const libcrypto_heap = @import("tls/libcrypto_heap.zig");
     pub const Tickets = @import("tls/Tickets.zig");
     pub const TestClient = @import("tls/TestClient.zig").TestClient;
+    /// What a client captures from one session to offer on the next. Named
+    /// here so a gate can hold one without naming ztls itself (§4).
+    pub const SessionTicket = @import("tls/TestClient.zig").SessionTicket;
     /// The throwaway self-signed fixtures (`tls/testdata/README.md`),
     /// re-exported because `@embedFile` cannot escape its module root and
     /// the §9 simulator is its own module. Test material, never a

--- a/src/tls/TestClient.zig
+++ b/src/tls/TestClient.zig
@@ -17,6 +17,11 @@ const ztls = @import("ztls");
 
 const assert = std.debug.assert;
 
+/// What a client captures from one session and offers on the next.
+/// Re-exported because ztls may not be named outside `src/tls/` (§4), and
+/// a gate driving a resumption needs to hold one between two clients.
+pub const SessionTicket = ztls.ClientHandshake.SessionTicket;
+
 /// Generic over the Io backend so the simulator and any socket-backed
 /// test drive the same client.
 pub fn TestClient(comptime IoType: type) type {
@@ -639,6 +644,16 @@ pub fn TestClient(comptime IoType: type) type {
         /// there — what a scenario asks before deciding it may wind down.
         pub fn isEnded(client: *const Self) bool {
             return client.ended;
+        }
+
+        /// The ticket this session was issued, for a later client to offer
+        /// back — null when the server issued none, which is itself a
+        /// legal outcome and so a question rather than an assertion. The
+        /// pointer is into this client's own storage, so whoever offers it
+        /// must not outlive the one that captured it.
+        pub fn capturedTicket(client: *const Self) ?*const ztls.ClientHandshake.SessionTicket {
+            if (!client.ticket_captured) return null;
+            return &client.ticket;
         }
 
         pub fn deinit(client: *Self) void {

--- a/src/tls/TestClient.zig
+++ b/src/tls/TestClient.zig
@@ -11,6 +11,8 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
+const parser = @import("../http/parser.zig");
 const ztls = @import("ztls");
 
 const assert = std.debug.assert;
@@ -64,6 +66,17 @@ pub fn TestClient(comptime IoType: type) type {
         /// as they are produced.
         close_with_data: bool,
         close_in_handshake: bool,
+        /// How this client knows the peer has answered what it last sent
+        /// (`Options.exchange_end`), the payload to send once it has, and
+        /// whether that one has gone.
+        exchange_end: ExchangeEnd,
+        followup_data: []const u8,
+        followup_sent: bool,
+        /// How many application payloads have gone out. The
+        /// `http_response` rule counts responses against this, so a second
+        /// request waits for the first response rather than for any
+        /// response.
+        payloads_sent: u32,
         coalesced: [2048]u8,
         coalesced_len: u32,
         app_received: [65536]u8,
@@ -85,6 +98,21 @@ pub fn TestClient(comptime IoType: type) type {
         on_end_context: ?*anyopaque = null,
 
         const Self = @This();
+
+        /// How a client decides its peer has answered — the gate every
+        /// "send the next thing" step sits behind.
+        pub const ExchangeEnd = enum {
+            /// As many bytes back as went out. An echo's shape, and sound
+            /// only where the peer returns exactly what it got: an L4
+            /// relay to the echo origin, which is what this client was
+            /// first written for and so what it still defaults to.
+            echo,
+            /// A complete HTTP/1.1 response per payload sent. What a
+            /// proxied session needs and a byte count cannot give it: a
+            /// response is not the length of its request, so waiting for
+            /// one by size either fires early or never fires at all.
+            http_response,
+        };
 
         pub const Options = struct {
             /// Must match the certificate's SAN; the fixtures use
@@ -131,6 +159,16 @@ pub fn TestClient(comptime IoType: type) type {
             /// runs its sinks synchronously inside `feed`, so the session
             /// can end underneath the step that is still driving it.
             close_in_handshake: bool = false,
+            /// What counts as the peer having answered. Every gate below
+            /// asks this — the KeyUpdate's ordering, the two echo-shaped
+            /// closes, and `followup_data`.
+            exchange_end: ExchangeEnd = .echo,
+            /// A second payload, sent on the same session once the first
+            /// exchange completes. This is the keep-alive turnaround: one
+            /// connection, two requests, the L7 state re-entered between
+            /// them. Needs `exchange_end = .http_response`, since a byte
+            /// count cannot tell one response from two.
+            followup_data: []const u8 = &.{},
             /// Offer this ticket in the ClientHello, resuming the session
             /// that issued it instead of running a full handshake. The
             /// storage is the caller's and must outlive the client.
@@ -149,6 +187,7 @@ pub fn TestClient(comptime IoType: type) type {
             address: std.Io.net.IpAddress,
             options: Options,
         ) !void {
+            checkOptions(&options);
             const x25519 = try ztls.x25519.KeyPair.generateDeterministic(
                 .init(options.x25519_seed),
             );
@@ -192,12 +231,46 @@ pub fn TestClient(comptime IoType: type) type {
             client.close_sent = false;
             client.close_with_data = options.close_with_data;
             client.close_in_handshake = options.close_in_handshake;
+            client.exchange_end = options.exchange_end;
+            client.followup_data = options.followup_data;
+            client.followup_sent = false;
+            client.payloads_sent = 0;
             client.coalesced_len = 0;
             client.app_received_len = 0;
             client.ticket = .{};
             client.ticket_captured = false;
             client.resume_with = options.resume_with;
             io.connect(address, &client.connect_completion, Self, client, onConnect);
+        }
+
+        /// The `Options` combinations that are not merely unusual but
+        /// contradictory, checked where they are cheapest to explain.
+        fn checkOptions(options: *const Options) void {
+            // A follow-up is gated on the peer having answered, and under
+            // the echo rule that answer is "as many bytes back as went
+            // out" — which two payloads and two responses cannot tell
+            // apart, so the follow-up would go before the first response.
+            assert(options.followup_data.len == 0 or
+                options.exchange_end == .http_response);
+            // The KeyUpdate and both echo-shaped closes hang off that same
+            // gate and their steps run first, so combining any of them
+            // with a follow-up does not suppress it — it *delays* it
+            // behind an unscripted resend of `app_data`. Three requests in
+            // an order nobody chose is worse than either alone, which is
+            // why these are refused rather than ordered.
+            assert(options.followup_data.len == 0 or !options.key_update);
+            assert(options.followup_data.len == 0 or
+                (!options.close_with_data and !options.close_after_echo));
+            // A response's framing is read from its own headers, and HEAD
+            // is the one method whose response contradicts them: a
+            // Content-Length with no body behind it. A scripted HEAD would
+            // make the client take the *next* response's opening bytes for
+            // this one's body and mis-frame everything after, so it is
+            // refused here rather than special-cased there.
+            if (options.exchange_end == .http_response) {
+                assert(!std.mem.startsWith(u8, options.app_data, "HEAD "));
+                assert(!std.mem.startsWith(u8, options.followup_data, "HEAD "));
+            }
         }
 
         fn onConnect(client: *Self, result: anyerror!IoType.Socket) void {
@@ -287,105 +360,8 @@ pub fn TestClient(comptime IoType: type) type {
                 client.armSend();
                 return;
             }
-            // Strictly after the first echo: see `Options.key_update`.
-            if (client.handshake_done and client.key_update_wanted and
-                !client.key_update_sent and client.app_sent and
-                client.app_received_len >= client.app_to_send.len)
-            {
-                client.key_update_sent = true;
-                client.pending_send = client.hs.sendKeyUpdate(
-                    &client.out.buffer,
-                    .update_requested,
-                ) catch {
-                    client.finish();
-                    return;
-                };
-                client.hs.completeWrite();
-                client.armSend();
-                return;
-            }
-            // The second payload: its echo is what arrives while the
-            // KeyUpdate response is still staged.
-            if (client.key_update_sent and !client.app_resent) {
-                client.app_resent = true;
-                client.pending_send = client.hs.sendApplicationData(
-                    client.app_to_send,
-                    &client.out.buffer,
-                ) catch {
-                    client.finish();
-                    return;
-                };
-                client.hs.completeWrite();
-                client.armSend();
-                return;
-            }
-            if (client.handshake_done and !client.app_sent and
-                client.app_to_send.len > 0)
-            {
-                client.app_sent = true;
-                client.pending_send = client.hs.sendApplicationData(
-                    client.app_to_send,
-                    &client.out.buffer,
-                ) catch {
-                    client.finish();
-                    return;
-                };
-                client.hs.completeWrite();
-                client.armSend();
-                return;
-            }
-            // Deliberately *not* waiting for the echo: the point is to
-            // reach the server's handshake drive, not its relay.
-            if (client.close_in_handshake and !client.close_sent and
-                client.handshake_done)
-            {
-                client.close_sent = true;
-                client.pending_send = client.hs.sendAlert(
-                    .close_notify,
-                    &client.out.buffer,
-                ) catch {
-                    client.finish();
-                    return;
-                };
-                client.hs.completeWrite();
-                client.armSend();
-                return;
-            }
-            // Both other close scenarios wait for the first echo, for the same
-            // reason the KeyUpdate does: anything sent before it is consumed
-            // by the server's handshake drive and never reaches the relay.
-            // The coalesced one sends a *second* payload with the alert
-            // riding the same segment, so the relay's final decrypt yields
-            // plaintext and the end of the session together.
-            if (client.close_with_data and !client.close_sent and
-                client.app_sent and
-                client.app_received_len >= client.app_to_send.len)
-            {
-                client.close_sent = true;
-                client.stageCoalescedClose() catch {
-                    client.finish();
-                    return;
-                };
-                client.pending_send = client.coalesced[0..client.coalesced_len];
-                client.armSend();
-                return;
-            }
-            if (client.close_after_echo and !client.close_sent and
-                client.app_sent and
-                client.app_received_len >= client.app_to_send.len)
-            {
-                client.close_sent = true;
-                client.pending_send = client.hs.sendAlert(
-                    .close_notify,
-                    &client.out.buffer,
-                ) catch {
-                    client.finish();
-                    return;
-                };
-                client.hs.completeWrite();
-                client.armSend();
-                return;
-            }
+            if (client.nextDataStep()) return;
+            if (client.nextCloseStep()) return;
             if (client.saw_close) {
                 client.finish();
                 return;
@@ -393,10 +369,171 @@ pub fn TestClient(comptime IoType: type) type {
             client.armRecv();
         }
 
+        /// The steps that put application data on the wire, in the order
+        /// they may fire. True means one did and has armed its write; the
+        /// caller must not fall through to another.
+        fn nextDataStep(client: *Self) bool {
+            // Strictly after the first echo: see `Options.key_update`.
+            if (client.handshake_done and client.key_update_wanted and
+                !client.key_update_sent and client.app_sent and
+                client.exchangeComplete())
+            {
+                client.key_update_sent = true;
+                client.sendKeyUpdate();
+                return true;
+            }
+            // The second payload: its echo is what arrives while the
+            // KeyUpdate response is still staged.
+            if (client.key_update_sent and !client.app_resent) {
+                client.app_resent = true;
+                client.sendPayload(client.app_to_send);
+                return true;
+            }
+            if (client.handshake_done and !client.app_sent and
+                client.app_to_send.len > 0)
+            {
+                client.app_sent = true;
+                client.sendPayload(client.app_to_send);
+                return true;
+            }
+            // The keep-alive turnaround: a second request on the session
+            // the first was answered on, which is how the L7 state gets
+            // re-entered at all. Gated on the first response being
+            // *whole* — a request sent into the middle of one would make
+            // the proxy's next head start mid-body, and that is this
+            // client's defect, not its peer's.
+            if (client.followup_data.len > 0 and !client.followup_sent and
+                client.app_sent and client.exchangeComplete())
+            {
+                client.followup_sent = true;
+                client.sendPayload(client.followup_data);
+                return true;
+            }
+            return false;
+        }
+
+        /// The steps that end the session in protocol. Same contract as
+        /// `nextDataStep`, and reached only once no data step will fire —
+        /// a goodbye is the last thing a client has to say.
+        fn nextCloseStep(client: *Self) bool {
+            // Deliberately *not* waiting for the echo: the point is to
+            // reach the server's handshake drive, not its relay.
+            if (client.close_in_handshake and !client.close_sent and
+                client.handshake_done)
+            {
+                client.close_sent = true;
+                client.sendCloseNotify();
+                return true;
+            }
+            // Both other close scenarios wait for the peer's answer, for the
+            // same reason the KeyUpdate does: anything sent before it is
+            // consumed by the server's handshake drive and never reaches the
+            // relay. The coalesced one sends a *second* payload with the alert
+            // riding the same segment, so the relay's final decrypt yields
+            // plaintext and the end of the session together.
+            if (client.close_with_data and !client.close_sent and
+                client.app_sent and client.exchangeComplete())
+            {
+                client.close_sent = true;
+                client.stageCoalescedClose() catch {
+                    client.finish();
+                    return true;
+                };
+                client.pending_send = client.coalesced[0..client.coalesced_len];
+                client.armSend();
+                return true;
+            }
+            if (client.close_after_echo and !client.close_sent and
+                client.app_sent and client.exchangeComplete())
+            {
+                client.close_sent = true;
+                client.sendCloseNotify();
+                return true;
+            }
+            return false;
+        }
+
+        /// Render one application payload and write it. The three "send
+        /// the next thing" steps differ only in which bytes go, so the
+        /// render / `completeWrite` / arm sequence lives here once —
+        /// `completeWrite` invalidates the previous record, so getting
+        /// that order wrong overwrites bytes that have not left yet.
+        fn sendPayload(client: *Self, bytes: []const u8) void {
+            assert(bytes.len >= 1);
+            assert(client.pending_send.len == 0);
+            client.payloads_sent += 1;
+            client.pending_send = client.hs.sendApplicationData(
+                bytes,
+                &client.out.buffer,
+            ) catch {
+                client.finish();
+                return;
+            };
+            client.hs.completeWrite();
+            client.armSend();
+        }
+
+        /// The in-band goodbye, on the same render-then-arm sequence.
+        /// Both callers set `close_sent` before calling: this is the one
+        /// alert a client sends, and sending it twice is a protocol
+        /// violation, not a retry.
+        fn sendCloseNotify(client: *Self) void {
+            assert(client.close_sent);
+            assert(client.pending_send.len == 0);
+            client.pending_send = client.hs.sendAlert(
+                .close_notify,
+                &client.out.buffer,
+            ) catch {
+                client.finish();
+                return;
+            };
+            client.hs.completeWrite();
+            client.armSend();
+        }
+
+        fn sendKeyUpdate(client: *Self) void {
+            assert(client.key_update_sent);
+            assert(client.pending_send.len == 0);
+            client.pending_send = client.hs.sendKeyUpdate(
+                &client.out.buffer,
+                .update_requested,
+            ) catch {
+                client.finish();
+                return;
+            };
+            client.hs.completeWrite();
+            client.armSend();
+        }
+
+        /// Whether the peer has answered everything sent so far — the gate
+        /// every follow-up step sits behind. What counts as an answer is
+        /// `exchange_end`'s to say, and it has to be: an echo is exactly as
+        /// long as its request, and a response is nothing of the kind.
+        fn exchangeComplete(client: *const Self) bool {
+            assert(client.payloads_sent >= 1);
+            const back = client.app_received[0..client.app_received_len];
+            return switch (client.exchange_end) {
+                .echo => back.len >= client.app_to_send.len,
+                .http_response => completeResponses(back) >= client.payloads_sent,
+            };
+        }
+
+        /// How many complete responses have come back, and how many
+        /// payloads went out to earn them — the pair a scenario oracle
+        /// holds against each other.
+        pub fn responsesReceived(client: *const Self) u32 {
+            return completeResponses(client.app_received[0..client.app_received_len]);
+        }
+
+        pub fn requestsSent(client: *const Self) u32 {
+            return client.payloads_sent;
+        }
+
         /// Render the application data and close_notify back to back into
         /// `coalesced`, so they leave in one segment and arrive in one read.
         fn stageCoalescedClose(client: *Self) !void {
             assert(client.coalesced_len == 0);
+            client.payloads_sent += 1;
             const data = try client.hs.sendApplicationData(
                 client.app_to_send,
                 &client.out.buffer,
@@ -508,4 +645,92 @@ pub fn TestClient(comptime IoType: type) type {
             client.hs.deinit();
         }
     };
+}
+
+/// How many complete HTTP/1.1 responses `bytes` holds, framed by
+/// `src/http/parser.zig` — the wrapper §7 puts every framing and
+/// strictness decision behind. Going through it rather than scanning for
+/// a `Content-Length` here is what makes this client and the simulator's
+/// own L7 oracle agree on what a response *is* by construction, instead
+/// of by two hand-rolled scanners staying in step.
+///
+/// Only the two framings that end at a known offset count. The other two
+/// have no answer to the question being asked, which is "may the next
+/// request go yet": an until-close response is over when the connection
+/// is, by which point there is no next request to send, and a chunked
+/// one needs a scanner this client has no other reason to run. Both
+/// therefore count as incomplete — the client stops sending and ends the
+/// way it would have anyway (its peer's close, or the scenario's
+/// deadline), rather than opening a request in the middle of a body.
+///
+/// Scanned from the front on every call rather than carried as parse
+/// state: the buffer is bounded and the scan is pure, so there is no
+/// cursor to resynchronise after a record arrives split.
+fn completeResponses(bytes: []const u8) u32 {
+    assert(bytes.len <= constants.head_buffer_bytes_max);
+    var count: u32 = 0;
+    var rest = bytes;
+    // Bounded by the buffer: a parsed head is at least one byte, so every
+    // iteration consumes some of a slice that only shrinks.
+    while (rest.len > 0) {
+        var storage: parser.HeaderStorage = undefined;
+        // `.get`, and `checkOptions` refuses to script a HEAD so it stays
+        // true — HEAD is the one method whose response framing
+        // contradicts its own headers.
+        const head = parser.parseResponseHead(rest, false, &storage, .get) catch break;
+        assert(head.head_len >= 1);
+        const body_len: u64 = switch (head.framing) {
+            .content_length => |length| length,
+            .none => 0,
+            .chunked, .until_close => break,
+        };
+        if (rest.len - head.head_len < body_len) break;
+        count += 1;
+        rest = rest[head.head_len + body_len ..];
+    }
+    assert(rest.len <= bytes.len);
+    return count;
+}
+
+test "framing: a sized response counts once it is whole" {
+    const head = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n";
+    try std.testing.expectEqual(@as(u32, 0), completeResponses(head));
+    try std.testing.expectEqual(@as(u32, 0), completeResponses(head ++ "o"));
+    try std.testing.expectEqual(@as(u32, 1), completeResponses(head ++ "ok"));
+    // A second response starts where the first body ended, which is the
+    // whole point: the keep-alive gate counts answers, not bytes.
+    try std.testing.expectEqual(@as(u32, 2), completeResponses(head ++ "ok" ++ head ++ "ok"));
+    // A partial head after a complete response leaves the count at one.
+    try std.testing.expectEqual(@as(u32, 1), completeResponses(head ++ "ok" ++ "HTTP/1.1 20"));
+}
+
+test "framing: a response with no body of its own completes at its head" {
+    // 204 carries no body whatever its headers say, and the parser says
+    // so — which is the whole reason this goes through the wrapper.
+    const no_content = "HTTP/1.1 204 No Content\r\n\r\n";
+    try std.testing.expectEqual(@as(u32, 1), completeResponses(no_content));
+    try std.testing.expectEqual(@as(u32, 2), completeResponses(no_content ++ no_content));
+}
+
+test "framing: a response with no fixed end never completes" {
+    // Chunked and until-close are both legal and neither ends at an
+    // offset this client can compute; counting either would let the next
+    // request go out mid-body.
+    const chunked = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+    try std.testing.expectEqual(@as(u32, 0), completeResponses(chunked));
+    const until_close = "HTTP/1.1 200 OK\r\n\r\nbody";
+    try std.testing.expectEqual(@as(u32, 0), completeResponses(until_close));
+    // Nor does anything that is not a response at all — an L4 echo of the
+    // request, say, which is what the other `ExchangeEnd` is for.
+    try std.testing.expectEqual(@as(u32, 0), completeResponses("GET / HTTP/1.1\r\n\r\n"));
+    try std.testing.expectEqual(@as(u32, 0), completeResponses(""));
+}
+
+test "framing: the length header is read however it is spelled" {
+    const lower = "HTTP/1.1 200 OK\r\ncontent-length:2\r\n\r\nok";
+    try std.testing.expectEqual(@as(u32, 1), completeResponses(lower));
+    // A length in the *body* is not a header, so what follows the first
+    // response's 23 bytes is nothing, and the count is one rather than two.
+    const nested = "HTTP/1.1 200 OK\r\nContent-Length: 23\r\n\r\nContent-Length: 999\r\n\r\n";
+    try std.testing.expectEqual(@as(u32, 1), completeResponses(nested));
 }


### PR DESCRIPTION
`deriveTlsClients` gave every terminating client one connection and one
fixed script, and that single shape kept three §9 legs out of the sweep.
Both are closed here, in two slices.

## The rule underneath all three

`TestClient` ended an exchange by byte count — "as many bytes back as
went out" — because it was written for an L4 echo. Pointed at a proxied
listener that rule is unusable in *both* directions: a response longer
than its request satisfies it early, and a shorter one never satisfies it
at all. Wiring it to the http population would **hang**, not fail, which
is what the harness comment above `close_after_echo` has been warning
about.

`Options.exchange_end` now picks the rule. `.echo` is the old byte count
and stays the default, so every pre-existing caller is byte-for-byte
unchanged; `.http_response` counts complete responses and unlocks
`Options.followup_data`, a second request on the same session.

## Framing goes through the wrapper

The first version of this scanned for `Content-Length` itself. DESIGN.md
§7 forbids that in a consumer, and review caught it. Worth stating why it
mattered, because the numbers were never the argument: the hand-rolled
scan agrees with `parseResponseHead` on **every** response this sweep
produces — measured, bit-identical counts over 4096 seeds.

HEAD is the argument. Its response carries a `Content-Length` with no
body behind it, so a hand-rolled scanner takes the *next* response's
opening bytes for this one's body and mis-frames everything after —
silent corruption, not a stall. `checkOptions` refuses a scripted HEAD,
which is what lets the parser be told `.get` and stay right. 204s come
out right for free.

## What the sweep now reaches

The terminating http population sends a keep-alive POST, then a closing
GET. The POST reaches the request-body transform, which a GET cannot; the
turnaround between them re-enters the L7 state, which one exchange
cannot — and that is where the phantom access-log line lived (#199),
found by the live gate rather than by the sweep.

For resumption, one resuming client starts from the end hook of whichever
session captured a ticket and offers it back on a fresh dial. The
server's `psk_lookup` either opens what it sealed or falls back to a full
handshake; both are legal, which is why the counter is the oracle and not
the call succeeding.

## Two costs the sweep found, rather than the design predicting them

**Seed 1344 — `tls_engines` had to grow by one.** The resumer dials from
the end hook, but the engine of the session it is resuming is released a
loop turn later, when the server sees the close. The two overlap, so
sizing to the drawn client count *shed the resumption* instead of
covering it. A pool has to cover the connection overlap, not the client
count. The "1 vs count + 1" rule now lives once, in `deriveTlsEngines`.

**Seed 4 — the clean-seed access-log oracle** counts one L4 line per
connection with the drawn client count baked in, which a second
connection falsifies.

## Measured over 4096 seeds

Per terminating-http client instance: the POST goes out on **77%**, the
second request on **62%**, both responses come back whole on **32%**. The
rest are schedules that ended first or origins that drew an unsized mode
— both leaving the count *behind*, never ahead, which is what makes
`responsesReceived() <= requestsSent()` a sound per-seed oracle.

The resumer starts on **86%** of runs that drew TLS (the rest are first
sessions that ended holding no ticket: a refused dial, a cut handshake, a
shed engine), and **83%** of those resume. `tls_resumed` fires 385 times.

## Census

57 fired / 17 exempt → **58 / 16**. The `tls_resumed` exemption is
**deleted, not relaxed** — the census itself said so:

> `tls_resumed` fired 385 time(s) against an allowance of 0, and should
> not have. do: a scenario now reaches it, so delete this entry

`Counters.reconcile` also gained the relationship the two credit paths
must keep between them: `tls_resumed <= tls_handshakes_completed`. A
resumed session is a completed handshake that skipped the certificate,
not a separate kind of event.

## Housekeeping

`nextStep` was 110 lines and this added to it, so its four
render/`completeWrite`/arm blocks became `sendPayload` /
`sendCloseNotify` / `sendKeyUpdate`, and the step chain split into
`nextDataStep` / `nextCloseStep` — same order, same reachability, 134
lines down to 13/39/37. `startServerAndOrigins` was already 81 lines
before this branch and 90 after, so its pool-sizing block moved out to
`deriveInitOptions`: 34 now, a pre-existing overage fixed rather than
nudged.

## Gates

`zig build ci` green (4096 seeds, smoke clean), `zig fmt --check` clean,
`zig build lint` clean. Unit tests 478 → 482. Both slices reviewed by
`tiger-style-reviewer`; every violation it raised is fixed in the commit
it applies to.

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)