### PR TITLE
sim: model an op the backend never delivers, and gate the drain backstop (#206)

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -772,7 +772,12 @@ pub fn Server(comptime IoType: type) type {
                 );
             }
             server.dumpMetrics();
-            std.process.exit(drain_stuck_exit_code);
+            // Through the seam, not `std.process.exit`: a raw exit here
+            // would be a syscall outside `src/io/` (§4), and — the reason
+            // that matters — it would make this the one branch no gate
+            // could ever enter, since taking the exit takes the test
+            // process with it.
+            server.io.abort(drain_stuck_exit_code);
         }
 
         fn onSignal(server: *Self, signal: Io.Signal) void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -740,6 +740,39 @@ pub fn Server(comptime IoType: type) type {
             const log_done = server.access_log.isQuiescent();
             const health_done = server.health.isQuiescent();
             if (conns_done and admin_done and log_done and health_done) return;
+            // The forensics are for an operator reading the last thing
+            // this process will ever say. A gate that provokes this path
+            // on purpose wants none of them: stderr from a passing step
+            // makes the build runner print "failed command" under a build
+            // that exited zero, which costs a reader more than the lines
+            // are worth. What the gate asserts is the part with teeth —
+            // that the give-up happened, with the code that names it, and
+            // that the plane it blames is the one that is actually stuck.
+            if (server.io.wantsOperatorDump()) {
+                server.reportStuckDrain(conns_done, admin_done, log_done, health_done);
+            }
+            // Through the seam, not `std.process.exit`: a raw exit here
+            // would be a syscall outside `src/io/` (§4), and — the reason
+            // that matters — it would make this the one branch no gate
+            // could ever enter, since taking the exit takes the test
+            // process with it.
+            server.io.abort(drain_stuck_exit_code);
+        }
+
+        /// What an operator gets from a process that is about to stop
+        /// existing: which of the four planes never finished, what every
+        /// still-held connection slot was waiting on, and the counters.
+        /// Split from the decision above so that decision stays readable,
+        /// and because a gate provoking this path wants the give-up
+        /// without the forensics (`wantsOperatorDump`).
+        fn reportStuckDrain(
+            server: *const Self,
+            conns_done: bool,
+            admin_done: bool,
+            log_done: bool,
+            health_done: bool,
+        ) void {
+            assert(!(conns_done and admin_done and log_done and health_done));
             std.debug.print(
                 "zoxy: drain did not finish {d}s after its deadline (#203). " ++
                     "conns={s} admin={s} access_log={s} health={s}\n",
@@ -772,12 +805,6 @@ pub fn Server(comptime IoType: type) type {
                 );
             }
             server.dumpMetrics();
-            // Through the seam, not `std.process.exit`: a raw exit here
-            // would be a syscall outside `src/io/` (§4), and — the reason
-            // that matters — it would make this the one branch no gate
-            // could ever enter, since taking the exit takes the test
-            // process with it.
-            server.io.abort(drain_stuck_exit_code);
         }
 
         fn onSignal(server: *Self, signal: Io.Signal) void {

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -422,6 +422,46 @@ test "admin: the scrape deadline reaps a client that never finishes" {
     try harness.expectDrained();
 }
 
+test "admin: a drain that cannot finish says which plane is stuck and gives up" {
+    // The other half of the test below, and the one #203 shipped without.
+    // `onDrainStuck` exists because a teardown waiting on an op the backend
+    // never delivers cannot be waited out — the process simply never exits
+    // and SIGTERM stops meaning anything. Proving what it does when
+    // something *is* stuck needs a backend that can strand an op, which is
+    // what #206 added, and a give-up that does not take the test process
+    // with it, which is what `Io.abort` added.
+    //
+    var harness: Harness = undefined;
+    try harness.setUp(testing.allocator, .{
+        .seed = 1,
+        .adversary = .{ .partial_io = false },
+        // The status line still prints — it is the diagnostic under test,
+        // and one line. The counter set does not: an operator wants it, a
+        // gate run before every commit does not want 190 lines of it.
+        .dump_on_abort = false,
+    });
+    defer harness.tearDown();
+
+    // #203's exact shape: the admin plane's accept is armed, and the
+    // backend takes its cancellation and never delivers it. Both armed
+    // accepts go — this seed's proxy listener has one too — but only the
+    // admin's is a plane the drain waits on, so the admin's is the one
+    // that decides the outcome. Asserted rather than assumed: dropping
+    // nothing would leave a healthy drain and a test that passes for the
+    // wrong reason.
+    try testing.expectEqual(@as(u32, 2), harness.sim_io.dropPendingOps(.accept));
+
+    harness.server.beginDrain();
+    try harness.sim_io.run();
+
+    // Not hung: the grace expires and the server gives up, with the code
+    // that says which backstop it was.
+    try testing.expectEqual(@as(?u8, 4), harness.sim_io.abortedWith());
+    // And it gave up for the right reason — the admin plane is the one
+    // that never reached quiescence, which is what its report names.
+    try testing.expect(!harness.server.admin.isQuiescent());
+}
+
 test "admin: draining an idle-and-accepting listener releases cleanly" {
     // A direct, timing-independent reproduction of the once-fixed drain bug:
     // a Canceled accept during drain must clear `listening` so the loop can

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -125,6 +125,9 @@ stopped: bool,
 /// spent on a process exit. Null until one does.
 aborted: ?u8,
 dump_on_deadlock: bool,
+/// Whether a give-up should print the whole counter set (see
+/// `wantsOperatorDump`).
+dump_on_abort: bool,
 /// FNV-1a over every delivery; two runs of one seed must end equal (§9).
 trace_hash: u64,
 /// Completions delivered so far, by op kind (§9). `trace_hash` says two
@@ -216,6 +219,9 @@ pub const Options = struct {
     /// Print pending-op forensics when a deadlock is detected. Tests
     /// that deliberately provoke a deadlock turn this off.
     dump_on_deadlock: bool = true,
+    /// Print the whole counter set when a caller gives up (§8 drain
+    /// backstop). Gates that provoke that path on purpose turn it off.
+    dump_on_abort: bool = true,
     /// The provided-buffer group `recvGroup` selects from — the simulated
     /// twin of the io_uring buf_ring (§5's head-buffer ring). Selection is
     /// deterministic (lowest free id), so a seed replays the same buffer
@@ -241,6 +247,11 @@ pub const Completion = struct {
     userdata: ?*anyopaque = null,
     callback: ErasedCallback = undefined,
     state: State = .dead,
+    /// An op the backend took and will never deliver (`dropPendingOps`).
+    /// It stays pending for the rest of the scenario, holding whatever it
+    /// references, which is the one thing this simulator could not
+    /// express before #206 — and the shape of #203.
+    dropped: bool = false,
 
     pub const State = enum(u8) { dead, pending };
 };
@@ -469,6 +480,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.stopped = false;
     io.aborted = null;
     io.dump_on_deadlock = options.dump_on_deadlock;
+    io.dump_on_abort = options.dump_on_abort;
     io.trace_hash = std.hash.Fnv1a_64.init().value;
     io.delivered = @splat(0);
     io.blackholed_addresses = undefined;
@@ -987,6 +999,48 @@ pub fn abortedWith(io: *const SimIo) ?u8 {
     return io.aborted;
 }
 
+/// Whether a caller about to give up should also spend its whole counter
+/// set on stderr. True everywhere a human reads that output, which is why
+/// XevIo's is a constant; a gate that provokes the give-up on purpose
+/// turns it off, because 190 lines of forensics bury the two that say
+/// what was stuck. Same switch, same reason, as `dump_on_deadlock`.
+pub fn wantsOperatorDump(io: *const SimIo) bool {
+    return io.dump_on_abort;
+}
+
+/// Take every pending op of `kind` and never deliver it (#206). Returns
+/// how many were taken, so a caller can tell "I dropped the accept" from
+/// "there was no accept to drop" — the difference between a scenario
+/// that tested something and one that quietly tested nothing.
+///
+/// This is the class of defect no seed could reach before. Everything
+/// else this simulator does completes: a shutdown delivers EOF to an
+/// armed recv, a close delivers to the peer, a cancel lands. That is
+/// faithful to io_uring, and it is why a readiness backend's "accepted
+/// but never delivered" went unfound by four million nightly seeds and
+/// was caught twice in thirteen runs by a shared macOS runner (#203).
+///
+/// Deliberately *pending* ops rather than the next one enqueued: what
+/// #203 needs is an op that was armed and then had its completion taken
+/// away, which is what a cancel that does not deliver looks like from
+/// above. Marking at enqueue would model a different thing — a backend
+/// that refuses work — and that one already has a name (`Unexpected`).
+pub fn dropPendingOps(io: *SimIo, kind: OpKind) u32 {
+    assert(kind != .none);
+    var dropped: u32 = 0;
+    for (io.pending[0..io.pending_count]) |completion| {
+        if (completion.op != kind) continue;
+        if (completion.dropped) continue;
+        completion.dropped = true;
+        dropped += 1;
+    }
+    // Into the trace, so a run that dropped a different number of ops
+    // cannot hash equal to one that dropped this many.
+    io.mix(@intFromEnum(kind));
+    io.mix(dropped);
+    return dropped;
+}
+
 /// Schedule a signal delivery — drain is just another scheduled event (§4).
 pub fn injectSignal(io: *SimIo, signal: Io.Signal) void {
     io.scheduleSignal(signal, io.now_ns_value);
@@ -1158,6 +1212,11 @@ fn dumpPendingOps(io: *const SimIo) void {
         io.pending_count,
     });
     for (io.pending[0..io.pending_count]) |completion| {
+        // A dropped op is stuck because the scenario asked for it. Saying
+        // so is what keeps this dump readable: without it, a deliberate
+        // hang and a liveness bug print identically, and the forensics
+        // exist precisely to tell them apart.
+        if (completion.dropped) std.debug.print("  [dropped]", .{});
         switch (completion.op) {
             .recv => |op| std.debug.print(
                 "  recv socket={d} gen={d}\n",
@@ -1212,6 +1271,11 @@ fn collectReady(io: *SimIo, buffer: []*Completion) []*Completion {
 
 fn opReady(io: *SimIo, completion: *Completion) bool {
     assert(completion.state == .pending);
+    // The one choke point every kind of readiness passes through, which
+    // is why the drop lives here rather than in each arm: an op the
+    // backend never delivers is not "not ready yet", it is never ready,
+    // whatever its socket or listener goes on to do.
+    if (completion.dropped) return false;
     return switch (completion.op) {
         .none => unreachable,
         .accept => |op| ready: {
@@ -1530,7 +1594,12 @@ fn deliverDueSignals(io: *SimIo) void {
 fn earliestWakeNs(io: *const SimIo) u64 {
     var earliest: u64 = never_ns;
     for (io.pending[0..io.pending_count]) |completion| {
-        const wake = switch (completion.op) {
+        // A dropped op wakes nothing. Only the three kinds below schedule
+        // at all, so a dropped accept or recv was already inert here —
+        // but a dropped connect or timer still carries the deadline it
+        // was armed with, and honouring it would advance the clock for a
+        // completion `opReady` then refuses to deliver.
+        const wake = if (completion.dropped) never_ns else switch (completion.op) {
             .connect, .log_write => completion.ready_at_ns,
             .timer => |op| op.fire_at_ns,
             else => never_ns,

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -121,6 +121,9 @@ pending_set_option_errors: u8,
 pressure_cause: Io.Pressure.Cause,
 last_pressure: Io.Pressure,
 stopped: bool,
+/// The code a caller gave up with (`abort`), which production would have
+/// spent on a process exit. Null until one does.
+aborted: ?u8,
 dump_on_deadlock: bool,
 /// FNV-1a over every delivery; two runs of one seed must end equal (§9).
 trace_hash: u64,
@@ -464,6 +467,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.pressure_cause = .out_of_buffers;
     io.last_pressure = Io.Pressure.none;
     io.stopped = false;
+    io.aborted = null;
     io.dump_on_deadlock = options.dump_on_deadlock;
     io.trace_hash = std.hash.Fnv1a_64.init().value;
     io.delivered = @splat(0);
@@ -962,6 +966,25 @@ pub fn nowNs(io: *SimIo) u64 {
 
 pub fn stop(io: *SimIo) void {
     io.stopped = true;
+}
+
+/// The seam's give-up, which in production is a process exit and here is
+/// a recorded fact plus a stopped loop. Recording it rather than taking
+/// the process down is the entire reason `abort` is on the seam: the one
+/// path a caller reaches when it has decided it cannot continue is
+/// otherwise the one path no gate can enter.
+pub fn abort(io: *SimIo, code: u8) void {
+    assert(code != 0); // A give-up is never a success.
+    // A second one would mean the first stopped nothing.
+    assert(io.aborted == null);
+    io.aborted = code;
+    io.stop();
+}
+
+/// The code a scenario's server gave up with, or null if it never did —
+/// what an oracle asks instead of watching for an exit it cannot survive.
+pub fn abortedWith(io: *const SimIo) ?u8 {
+    return io.aborted;
 }
 
 /// Schedule a signal delivery — drain is just another scheduled event (§4).

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1426,6 +1426,14 @@ pub fn stop(io: *XevIo) void {
     io.loop.stop();
 }
 
+/// Always: this process's stderr is an operator's, and a give-up is the
+/// last thing it will ever say. Only the simulator has a reason to answer
+/// otherwise.
+pub fn wantsOperatorDump(io: *const XevIo) bool {
+    _ = io;
+    return true;
+}
+
 /// Give up on this process: the caller has found a state it cannot
 /// recover from and has already said what it was (§8's drain backstop is
 /// the one caller). Behind the seam because a raw process exit is a
@@ -1433,6 +1441,7 @@ pub fn stop(io: *XevIo) void {
 /// directly can never be gated: the simulator would lose the process it
 /// is running the scenario in, so the one path that matters would be the
 /// one no test could enter.
+///
 /// Not `noreturn`, though this one never returns: the signature is the
 /// seam's, and the simulator's implementation has to come back so the
 /// scenario it is running can be asked what happened.

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1426,6 +1426,22 @@ pub fn stop(io: *XevIo) void {
     io.loop.stop();
 }
 
+/// Give up on this process: the caller has found a state it cannot
+/// recover from and has already said what it was (§8's drain backstop is
+/// the one caller). Behind the seam because a raw process exit is a
+/// syscall, and those live here — but also because a caller that exits
+/// directly can never be gated: the simulator would lose the process it
+/// is running the scenario in, so the one path that matters would be the
+/// one no test could enter.
+/// Not `noreturn`, though this one never returns: the signature is the
+/// seam's, and the simulator's implementation has to come back so the
+/// scenario it is running can be asked what happened.
+pub fn abort(io: *XevIo, code: u8) void {
+    assert(code != 0); // A give-up is never a success.
+    _ = io;
+    std.process.exit(code);
+}
+
 fn onNotifierWake(
     context: ?*XevIo,
     loop: *xev.Loop,

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -562,6 +562,29 @@ test "contract: fillRandom on XevIo" {
     try runRandomContract(XevIo, &xev_io);
 }
 
+// `abort` is the one seam decl this file cannot run on both backends,
+// and the asymmetry is the point rather than a gap: XevIo's *is* a
+// process exit, so calling it would take the test runner with it. What
+// holds it to the contract is the compile-time `required_decls` check
+// (`assertIoInterface`) plus `Server.onDrainStuck`'s single caller,
+// which is gated on SimIo in `server_test.zig`. Recorded here with the
+// other per-arm verdicts above, so it is decided rather than omitted.
+test "simio: abort records the code and stops the loop" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{ .seed = 11 });
+    try std.testing.expectEqual(@as(?u8, null), sim_io.abortedWith());
+
+    sim_io.abort(4);
+    try std.testing.expectEqual(@as(?u8, 4), sim_io.abortedWith());
+    // Stopped, so `run` returns rather than draining what is left: a
+    // process that has given up does not take another tick.
+    try sim_io.run();
+    try std.testing.expectEqual(@as(?u8, 4), sim_io.abortedWith());
+}
+
 test "simio: one seed replays one key stream, and a different seed does not" {
     // The §9 property TLS rides on: a seeded run's handshake is byte-exact,
     // which is only true if the key material replays with everything else.

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -567,8 +567,9 @@ test "contract: fillRandom on XevIo" {
 // process exit, so calling it would take the test runner with it. What
 // holds it to the contract is the compile-time `required_decls` check
 // (`assertIoInterface`) plus `Server.onDrainStuck`'s single caller,
-// which is gated on SimIo in `server_test.zig`. Recorded here with the
-// other per-arm verdicts above, so it is decided rather than omitted.
+// which is gated on SimIo in `admin_test.zig` (the stuck-drain test).
+// Recorded here with the other per-arm verdicts above, so it is decided
+// rather than omitted.
 test "simio: abort records the code and stops the loop" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -583,6 +584,66 @@ test "simio: abort records the code and stops the loop" {
     // process that has given up does not take another tick.
     try sim_io.run();
     try std.testing.expectEqual(@as(?u8, 4), sim_io.abortedWith());
+}
+
+const DroppedAccept = struct {
+    io: *SimIo,
+    completion: SimIo.Completion = .{},
+    outcome: ?(Io.AcceptError!SimIo.Socket) = null,
+
+    fn onAccept(self: *DroppedAccept, result: Io.AcceptError!SimIo.Socket) void {
+        assert(self.outcome == null);
+        self.outcome = result;
+    }
+};
+
+// #206's whole point, in the shape #203 took: an accept the backend
+// took and then never delivered, so the op stays armed for the rest of
+// the process's life and whatever is waiting on it waits forever.
+test "simio: a dropped accept is never delivered, where a live one is" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    // The control first: closing a listener completes its armed accept
+    // with Canceled, which is what every backend the seam supports does
+    // and what the rest of this simulator has always modelled.
+    var live_io: SimIo = undefined;
+    try live_io.init(arena_state.allocator(), .{ .seed = 3 });
+    var live: DroppedAccept = .{ .io = &live_io };
+    const live_listener = try live_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301"));
+    live_io.accept(live_listener, &live.completion, DroppedAccept, &live, DroppedAccept.onAccept);
+    live_io.listenClose(live_listener);
+    try live_io.run();
+    try std.testing.expectError(error.Canceled, live.outcome.?);
+
+    // Now the same sequence with the accept dropped. The close still
+    // happens; the completion never comes. `run` has nothing left that
+    // can become ready and nothing that ever will, which is a deadlock —
+    // and a deadlock is exactly what a hung process looks like from
+    // inside, so this is the outcome the gate wants to see.
+    var stuck_io: SimIo = undefined;
+    try stuck_io.init(arena_state.allocator(), .{
+        .seed = 3,
+        // The hang is the assertion, so its forensics are noise here.
+        .dump_on_deadlock = false,
+    });
+    var stuck: DroppedAccept = .{ .io = &stuck_io };
+    const stuck_listener = try stuck_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301"));
+    stuck_io.accept(
+        stuck_listener,
+        &stuck.completion,
+        DroppedAccept,
+        &stuck,
+        DroppedAccept.onAccept,
+    );
+    try std.testing.expectEqual(@as(u32, 1), stuck_io.dropPendingOps(.accept));
+    stuck_io.listenClose(stuck_listener);
+    try std.testing.expectError(error.Deadlock, stuck_io.run());
+    try std.testing.expect(stuck.outcome == null);
+
+    // And dropping what is not armed is a no-op that says so, so a
+    // scenario can tell "I dropped it" from "there was nothing to drop".
+    try std.testing.expectEqual(@as(u32, 0), stuck_io.dropPendingOps(.recv));
 }
 
 test "simio: one seed replays one key stream, and a different seed does not" {

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -49,6 +49,12 @@
 //!   nowNs(io) u64                                       (per-tick clock, §4)
 //!   nowWallNs(io) u64                                   (epoch clock, §8 log)
 //!   run(io) RunError!void, stop(io) void
+//!   abort(io, code) void                                (give up on this
+//!       process — a real exit in production, a recorded fact in the
+//!       simulator, so the one path a caller takes when it cannot
+//!       continue is not the one path no gate can enter, §8/#206)
+//!   wantsOperatorDump(io) bool                          (whether a
+//!       give-up should also spend the whole counter set on stderr)
 
 const std = @import("std");
 
@@ -254,6 +260,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "run",
             "stop",
             "abort",
+            "wantsOperatorDump",
         };
         for (required_decls) |decl_name| {
             if (!@hasDecl(IoType, decl_name)) {

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -253,6 +253,7 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "nowWallNs",
             "run",
             "stop",
+            "abort",
         };
         for (required_decls) |decl_name| {
             if (!@hasDecl(IoType, decl_name)) {


### PR DESCRIPTION
The simulator completed everything it was given: a shutdown delivers EOF
to an armed recv, a close delivers to the peer, a cancel lands. That is
faithful to io_uring, and it is why the sweep is as good as it is. It
also put one class of defect out of reach of any number of seeds — an op
the backend accepts and never delivers.

#203 was exactly that class. Four million nightly seeds could not have
found it; a shared macOS runner did, twice in thirteen runs.

This is slices 1–3 of the issue's four. The fourth — a seeded drop
carried by a fraction of sweep seeds — is deliberately held back until
the numbers at the bottom could be measured, which needed slices 1–3 to
exist first.

## Giving up, through the seam

`Server.onDrainStuck` ended in `std.process.exit(4)`. The smaller problem
is that a raw process exit is a syscall and §4 keeps those under
`src/io/`. The larger one is that a caller which exits directly can never
be tested: entering the branch takes the test process with it, so the one
path that matters — what the backstop does when something *is* stuck —
was the one path no gate could reach. That is part of why the backstop
shipped ungated.

`Io.abort(code)` joins the seam. XevIo's is the exit it always was;
SimIo's records the code, stops the loop, and answers `abortedWith()`.
Not `noreturn`, though XevIo's never returns: the simulator's has to come
back so the scenario can be asked what happened.

## The drop

Half of it already existed — a black-holed connect has always sat at
`ready_at_ns = never_ns`, which is this idea for one op kind.
`Completion.dropped` generalises it, checked at the top of `opReady`, the
one choke point every kind of readiness passes through. `earliestWakeNs`
ignores a dropped op too, or a dropped connect would advance the clock
for a completion that will not be delivered.

`dropPendingOps(kind)` takes *pending* ops rather than ops at enqueue,
and that distinction is the design. #203's shape is an op that was armed
and then had its completion taken away — what a cancel that does not
deliver looks like from above. Marking at enqueue would model a backend
refusing work, which already has a name. It returns how many it took, so
a scenario can tell "I dropped the accept" from "there was no accept to
drop": the difference between testing something and quietly testing
nothing. `dumpPendingOps` marks them `[dropped]`, so a deliberate hang
and a liveness bug stop printing identically.

## The gate the backstop shipped without

`admin_test.zig` strands the admin plane's armed accept, drains, and
asserts the server reports, blames the plane that is actually stuck, and
gives up with code 4 rather than hanging. That is #203 reproduced
in-tree, deterministically, from the seam rather than from a runner.

Mutation-checked: forcing `onDrainStuck` to return early fails the test.

## One thing the test forced on production code, stated plainly

`onDrainStuck` ends in `dumpMetrics` — 190 lines. Right for an operator
reading the last thing a process ever says; wrong for a gate run before
every commit, and worse than wrong, because stderr from a passing build
step makes Zig's build runner print `failed command:` under a build that
exited zero. I lost three runs to that myself before noticing the build
was green and I was reading `grep`'s exit status rather than zig's. It
would cost the next reader the same, repeatedly.

So the forensics sit behind `Io.wantsOperatorDump()` — constant `true` on
XevIo, an option on SimIo, sibling to the existing `dump_on_deadlock`,
which exists for precisely this reason. `zig build ci` output is
byte-identical to what it was before this branch: three lines.

The cost is real and worth naming: the report's *wording* is no longer
exercised by any gate. What the gate asserts is the give-up, its code,
and which plane it blames — the part with teeth. Nothing that was
verified before got weaker.

## What slice 4 now knows

Measured across the sweep — what is armed when a drain begins, which is
what a #203-shaped drop would strand:

| op kind | calls with ≥1 | total ops |
|---|---|---|
| `accept` | ~8300 | 31656 |
| `timer` | ~8300 | 20314 |
| `recv` | 4476 | 8258 |
| `log_write` | 2148 | 2148 |
| `connect` | 2006 | 2256 |
| `timer_cancel` | 1206 | 1266 |
| `recv_group` | 834 | 864 |
| `connect_cancel` | 112 | 114 |
| `send` | 96 | 106 |
| `close` | **0** | 0 |

Four things that settles:

- **Drop by kind, not by uniform pick.** `accept` and `timer` are ~80% of
  all pending ops, so "drop one random pending op" would reach `send` or
  `connect_cancel` about once in a hundred seeds. The seed should choose
  a kind first.
- **The two shapes the issue named are both plentiful** — `accept`
  (#203's own) on ~100% of runs, `recv` mid-teardown on ~55%. Neither
  needs the sweep bent to reach it.
- **`close` is never armed at drain time**, so "a slot that can never be
  released" is not reachable by dropping at the drain. It needs a
  different moment. A real gap, and better known before the knob is
  designed than after.
- Dropping `accept` or `timer` would fire the backstop on nearly every
  seed carrying a drop, so the inverted oracle is the majority outcome,
  not an edge case — which argues for the issue's own suggestion of a
  separate scenario flag over folding it into the general adversary.

## Gates

`zig build ci` rc=0 with its output unchanged at three lines,
`zig fmt --check` clean, `zig build lint` clean, 486/486 tests. Both
slices reviewed by `tiger-style-reviewer`; every violation raised is
fixed in the commit it applies to.

Part of #206; the seeded sweep drop stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)