### PR TITLE
tls: rotate the sealing key from the seal, not from a timer (#202)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -517,6 +517,17 @@ stops sealing before it stops opening and why none of them ever reaches
 disk — a restart costs every returning client one full handshake, and
 makes a stolen disk worthless.
 
+The interval a key seals for is that security question's answer: six
+hours, against a ticket lifetime of one. Rotation is driven from the seal
+rather than from a timer, because what the bound is *about* is how long
+one key goes on sealing — a proxy serving no handshakes seals nothing, so
+a rotation it slept through would buy nothing, while a periodic timer
+would buy an armed op the drain has to cancel and quiescence has to
+count. Six hours being several lifetimes is what makes two slots enough:
+a ticket sealed the instant before a rotation stays openable for every
+second it is valid, and the constants assert that relation rather than
+leaving it to whoever edits one of them next.
+
 The access log (§8) adds one fixed reservation beside the pools — two
 staging buffers, 64 KiB together by default — and nothing at all when it
 is off. It is in the printed total, because §5's promise is that the

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -69,11 +69,9 @@ below. #125 is closed.
 
 What it left open, now tracked rather than only recorded here:
 
-- **#202 — the sealing key is never rotated.** `Tickets` is built for two
-  slots and `rotate` is called once, at `start`, so both hold one
-  generation for the process's life. The interval *is* the security
-  bound, which makes it a policy question rather than an implementation
-  one, so it was deliberately not guessed at.
+- ~~**#202 — the sealing key is never rotated.**~~ Closed: six hours
+  against a one-hour ticket lifetime, driven from the seal rather than
+  from a timer. See "Rotating from the seal" below.
 - **#203 — the live gate's https leg wedged once on macOS**, and has not
   recurred. See the section of that name below for what is ruled out and
   where to look.
@@ -126,6 +124,45 @@ layer costs zero userspace CPU and the `splice` c10k lever (below) stays
 applicable to TLS traffic. Known fiddly parts: KeyUpdate/post-handshake
 control messages arrive via CMSG, and session tickets must be sent
 before the switchover.
+
+### Rotating from the seal (#202)
+
+The interval was the open question, not the mechanism — six hours against
+a ticket lifetime of one. Several lifetimes, so the two slots always
+cover a ticket's whole validity; short enough that a key stolen from
+memory ages out the same day rather than living as long as the process.
+`constants.zig` asserts the relation (`rotation_s >= lifetime_s`) rather
+than trusting whoever edits one of them next: shrink the interval below
+the lifetime and resumption silently starts failing for tickets that have
+not expired.
+
+What is worth recording is the *mechanism*, because the obvious one was
+wrong. A periodic timer is the reflex, and it costs more than it looks:
+an armed op that the drain has to cancel, a cancel completion to own it,
+and a fifth question in `onDrainStuck`'s report — all so that a proxy
+sitting idle at 4am can replace a key that is sealing nothing.
+
+Driving it from the seal instead (`Tickets.dueForRotation`, asked at the
+top of `stageTlsTickets`) gets the property the bound is actually about —
+no key ever seals a ticket after sealing for longer than its interval —
+with no armed op, no drain interaction and no quiescence change. The
+counter then reads as intervals *that saw traffic*, which is the honest
+reading rather than a miss: a key that sealed nothing has nothing to
+expose.
+
+Two edges the directed tests pin. The boundary belongs to the rotation (a
+key that has sealed for its whole interval is done). And a wall clock
+that steps backwards — NTP, a VM restore — must read as "not due":
+saturating there, rather than rotating, is what stops a clock correction
+from replacing the key on every handshake and turning itself into a
+resumption outage.
+
+The sweep cannot reach any of this: six hours against a two-second
+scenario. The census entry refuses the tempting fix — shortening the
+interval for the sweep would gate a different proxy than the one that
+ships — and names the directed tests instead. Reaching it properly needs
+a wall clock a scenario can jump hours forward, which nothing models
+today.
 
 ### Ending an exchange by framing (#204)
 

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -235,6 +235,24 @@ const uncovered = [_]Uncovered{
             "either, which is the honest gap",
     },
     .{
+        .name = "tls_ticket_keys_rotated",
+        .why = .unreached,
+        .reason = "the sealing key rotates after six hours of sealing and a " ++
+            "scenario advances the wall clock by one virtual second, so no " ++
+            "seed can reach it. Shortening the interval for the sweep is " ++
+            "the one fix worth " ++
+            "refusing: that interval is the security bound itself, so a " ++
+            "sweep run against a smaller one would be gating a different " ++
+            "proxy than the one that ships. src/tls/Tickets.zig drives the " ++
+            "whole rule directly — due exactly on the interval and not " ++
+            "before, re-based when taken so one overdue key is one rotation, " ++
+            "held off by a clock that steps backwards, and a ticket that " ++
+            "outlives one rotation and not two. What the sweep would add is " ++
+            "the adversary's schedules across a rotation, and reaching that " ++
+            "needs a wall clock the scenario can jump hours forward — " ++
+            "nothing models that today",
+    },
+    .{
         .name = "l7_no_route",
         .why = .unreached,
         .reason = "the sim's route table is a single \"/\" prefix, which no " ++

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -594,8 +594,34 @@ pub fn Server(comptime IoType: type) type {
         fn installTicketKey(server: *Self) void {
             var key: [Tickets.key_bytes]u8 = undefined;
             server.io.fillRandom(&key);
-            server.tls_tickets.rotate(key);
+            server.tls_tickets.rotate(key, server.nowUnix());
             assert(server.tls_tickets.ready());
+        }
+
+        /// Replace the sealing key if it has been sealing for its whole
+        /// interval (#202). Asked here, at the one place a key is used to
+        /// seal, rather than on a timer — see `tls/Tickets.zig` for why
+        /// that is the bound worth holding and the cheaper one to hold.
+        fn maybeRotateTicketKey(server: *Self) void {
+            // Reached only from the seal, which the caller has already
+            // established has a key to seal with.
+            assert(server.tls_tickets.ready());
+            if (!server.tls_tickets.dueForRotation(
+                server.nowUnix(),
+                constants.tls_ticket_key_rotation_s,
+            )) return;
+            server.installTicketKey();
+            server.counters.increment("tls_ticket_keys_rotated");
+            assert(!server.tls_tickets.dueForRotation(
+                server.nowUnix(),
+                constants.tls_ticket_key_rotation_s,
+            ));
+        }
+
+        /// The §8 wall clock in seconds, which is what a ticket's issue
+        /// time and its key's sealing clock are both measured on.
+        fn nowUnix(server: *const Self) u64 {
+            return @divFloor(server.io.nowWallNs(), std.time.ns_per_s);
         }
 
         pub fn start(server: *Self) Io.ListenError!void {
@@ -1341,7 +1367,7 @@ pub fn Server(comptime IoType: type) type {
                 // would offer resumption it could not honour, and every
                 // ticket it opened would be one it never sealed.
                 .tickets = if (server.tls_tickets.ready()) &server.tls_tickets else null,
-                .now_unix = @divFloor(server.io.nowWallNs(), std.time.ns_per_s),
+                .now_unix = server.nowUnix(),
             }) catch {
                 // Deriving the ephemeral keypair is the one fallible step,
                 // and under the OpenSSL backend it *allocates*
@@ -1904,6 +1930,9 @@ pub fn Server(comptime IoType: type) type {
             assert(engine.isConnected());
             assert(engine.outbound().len == 0);
             if (engine.tickets == null) return false;
+            // Before the first seal of this handshake, so the key these
+            // tickets are sealed under is never older than its interval.
+            server.maybeRotateTicketKey();
 
             // One counter, not two: `break` leaves before the index
             // advances, so "how many were staged" and "how far the loop

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -276,16 +276,33 @@ pub const tls_tickets_per_handshake: u8 = 2;
 /// sealing key that opens it lives only in memory, so the real question is
 /// how long a stolen ticket is worth carrying. An hour keeps a busy
 /// client's reconnects free while making yesterday's capture useless.
-/// It would also sit comfortably inside a two-key rotation window, once
-/// rotation is wired (#202) — see `tls/Tickets.zig`, which installs one
-/// key at startup and never replaces it.
+/// It also sits comfortably inside the two-key rotation window below.
 pub const tls_ticket_lifetime_s: u32 = 60 * 60;
+
+/// How long one sealing key may go on sealing before it is replaced
+/// (#202). This interval *is* the security bound: a key that seals for
+/// six hours is a key whose theft compromises at most six hours of
+/// issued tickets, each of which is itself worth only an hour.
+///
+/// Six against the lifetime's one is deliberate on both sides. It is
+/// several lifetimes, so the two slots always cover a ticket's whole
+/// validity with room to spare; and it is short enough that a key stolen
+/// from memory ages out the same day rather than living as long as the
+/// process does.
+pub const tls_ticket_key_rotation_s: u32 = 6 * 60 * 60;
 
 comptime {
     assert(tls_tickets_per_handshake >= 1);
     // RFC 8446 §4.6.1: "Servers MUST NOT use any value greater than
     // 604800 seconds (7 days)."
     assert(tls_ticket_lifetime_s <= 7 * 24 * 60 * 60);
+    // What makes two key slots enough. A key stops sealing at a rotation
+    // and stops opening at the next one, so it opens for one interval
+    // after its last seal; a ticket sealed in that last instant must stay
+    // openable for its whole lifetime, which needs the interval to be at
+    // least the lifetime. Shrink the interval below the lifetime and
+    // resumption starts failing for tickets that have not expired.
+    assert(tls_ticket_key_rotation_s >= tls_ticket_lifetime_s);
 }
 
 /// The fixed heap libcrypto allocates from (§4, `tls/libcrypto_heap.zig`),

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -369,6 +369,14 @@ pub const Counters = struct {
     /// tell them apart. Also the one that moves the handshake CPU: a
     /// resumed handshake skips the signature entirely.
     tls_resumed: Value = Value.init(0),
+    /// Sealing keys replaced (#202). Rotation is driven from the seal, so
+    /// this counts intervals *that saw traffic* — a proxy idle across one
+    /// rotates once, at its next handshake, and that is the intended
+    /// reading rather than a miss: a key that sealed nothing has nothing
+    /// to expose. An operator watching this flat while
+    /// `tls_tickets_issued` climbs is watching a clock that is not
+    /// advancing.
+    tls_ticket_keys_rotated: Value = Value.init(0),
     /// Accept completions that landed after the drain began (§8).
     shed_draining: Value = Value.init(0),
     /// Drain deadline tore down stragglers (§8).

--- a/src/tls/Tickets.zig
+++ b/src/tls/Tickets.zig
@@ -17,12 +17,15 @@
 //! outstanding ticket, which costs one full handshake per returning
 //! client and keeps a stolen disk worthless.
 //!
-//! **The rotation half of that is not wired yet.** The server installs
-//! one key at startup and never calls `rotate` again, so both slots hold
-//! the same generation for the process's life and the bounded-exposure
-//! property above is a property of this module rather than of the running
-//! proxy. What it waits on is a policy decision — the interval *is* the
-//! bound — so it is tracked as #202 rather than guessed at here.
+//! Rotation is driven from the seal (`dueForRotation`), not from a timer:
+//! the bound that matters is how long one key goes on *sealing*, and a
+//! proxy serving no handshakes seals nothing, so a rotation it slept
+//! through would buy nothing — while an armed periodic timer would buy an
+//! op the drain must cancel and quiescence must count. The interval is
+//! `constants.tls_ticket_key_rotation_s` and is asserted to be at least a
+//! ticket's lifetime, which is what makes two slots enough: a ticket
+//! sealed the instant before a rotation is still openable for every
+//! second it is valid.
 //!
 //! 0-RTT is deliberately not offered (`max_early_data_size` is never
 //! set), so a replayed ticket buys an attacker a resumed handshake and
@@ -79,6 +82,10 @@ const Slot = struct {
 /// older cannot be opened, which is what bounds a key's exposure.
 slots: [2]Slot,
 current: u1,
+/// When the current key became the sealing key, in Unix seconds. What
+/// `dueForRotation` measures against — the bound this module claims is
+/// on how long one key goes on *sealing*, not on how long it exists.
+sealing_since_unix: u64,
 /// Monotonic generation counter, so a wrapped `id` never lets a stale
 /// ticket match a fresh key.
 next_id: u8,
@@ -91,21 +98,42 @@ pub fn init(tickets: *Tickets) void {
     tickets.slots = @splat(.{ .id = 0, .key = @splat(0), .live = false });
     tickets.current = 0;
     tickets.next_id = 1;
+    tickets.sealing_since_unix = 0;
     // The property `ready` exists to report, pinned where it is
     // established: an uninitialised slot must never seal or open.
     assert(!tickets.ready());
 }
 
 /// Install `key` as the sealing key, demoting the previous one to
-/// opening-only. Called at startup — and, once rotation is wired, on
-/// every interval; today the startup call is the only one.
-pub fn rotate(tickets: *Tickets, key: [key_bytes]u8) void {
+/// opening-only, and start its sealing clock at `now_unix`. Called at
+/// startup and then whenever `dueForRotation` says so.
+pub fn rotate(tickets: *Tickets, key: [key_bytes]u8, now_unix: u64) void {
     const next: u1 = if (tickets.current == 0) 1 else 0;
     tickets.slots[next] = .{ .id = tickets.next_id, .key = key, .live = true };
     tickets.current = next;
+    tickets.sealing_since_unix = now_unix;
     // Skip 0 on wrap: it is the id of a dead slot.
     tickets.next_id = if (tickets.next_id == 255) 1 else tickets.next_id + 1;
     assert(tickets.slots[tickets.current].live);
+}
+
+/// Whether the current key has been sealing for `interval_s` or longer
+/// (#202). Asked at the seal, not on a timer: the bound that matters is
+/// how long one key goes on sealing, and a proxy with no handshakes is
+/// sealing nothing — so a rotation it slept through would buy nothing,
+/// while an armed timer would buy a periodic op the drain has to cancel
+/// and quiescence has to count.
+///
+/// Saturating, so a wall clock that steps backwards reads as "not due"
+/// rather than as a rotation every seal. A clock that steps *forwards*
+/// rotates once and re-bases, which is the right answer to both.
+pub fn dueForRotation(tickets: *const Tickets, now_unix: u64, interval_s: u32) bool {
+    assert(interval_s >= 1);
+    if (!tickets.ready()) return false;
+    if (now_unix < tickets.sealing_since_unix) return false;
+    const sealing_for = now_unix - tickets.sealing_since_unix;
+    assert(sealing_for <= now_unix);
+    return sealing_for >= interval_s;
 }
 
 /// True once a key has been installed; false means resumption is off.
@@ -221,7 +249,7 @@ fn testKey(fill: u8) [key_bytes]u8 {
 test "tickets: a sealed ticket opens to what went into it" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x11));
+    tickets.rotate(testKey(0x11), 0);
 
     const psk = [_]u8{0xab} ** 32;
     var buf: [ticket_bytes]u8 = undefined;
@@ -244,10 +272,48 @@ test "tickets: sealing needs a key" {
     );
 }
 
+test "tickets: rotation comes due on the interval, and re-bases when taken" {
+    const constants = @import("../constants.zig");
+    const interval = constants.tls_ticket_key_rotation_s;
+    var tickets: Tickets = undefined;
+    tickets.init();
+    // Before a key exists there is nothing to rotate, so nothing is due —
+    // the seal path asks this before it asks whether it can seal at all.
+    try testing.expect(!tickets.dueForRotation(1_000_000, interval));
+
+    tickets.rotate(testKey(0x11), 1_000_000);
+    try testing.expect(!tickets.dueForRotation(1_000_000, interval));
+    try testing.expect(!tickets.dueForRotation(1_000_000 + interval - 1, interval));
+    // The boundary belongs to the rotation: a key that has sealed for its
+    // whole interval has finished its whole interval.
+    try testing.expect(tickets.dueForRotation(1_000_000 + interval, interval));
+
+    // Taking it re-bases the clock, so one overdue key is one rotation
+    // and not one per seal for the rest of the interval.
+    tickets.rotate(testKey(0x22), 1_000_000 + interval);
+    try testing.expect(!tickets.dueForRotation(1_000_000 + interval, interval));
+    try testing.expect(tickets.dueForRotation(1_000_000 + 2 * interval, interval));
+}
+
+test "tickets: a wall clock that steps backwards does not rotate every seal" {
+    // NTP, a VM restore, an operator with a shell. A backwards step must
+    // read as "not due" — the alternative is a key replaced on every
+    // handshake, which throws away every outstanding ticket each time and
+    // turns a clock correction into a resumption outage.
+    var tickets: Tickets = undefined;
+    tickets.init();
+    tickets.rotate(testKey(0x11), 2_000_000);
+    try testing.expect(!tickets.dueForRotation(1_000_000, 3600));
+    // And the key still seals while the clock is behind: rotation being
+    // undue is not the same as the key being unusable.
+    var buf: [ticket_bytes]u8 = undefined;
+    _ = try tickets.seal(&buf, &[_]u8{0xab} ** 32, .aes_128_gcm_sha256, 1_000_000, @splat(2));
+}
+
 test "tickets: a ticket outlives one rotation and not two" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x11));
+    tickets.rotate(testKey(0x11), 0);
 
     const psk = [_]u8{0xcd} ** 32;
     var buf: [ticket_bytes]u8 = undefined;
@@ -259,18 +325,18 @@ test "tickets: a ticket outlives one rotation and not two" {
     // One rotation: the sealing key becomes the previous key, still able
     // to open. This is the point of two slots — a client holding a
     // ticket issued a moment ago does not lose it to a rotation tick.
-    tickets.rotate(testKey(0x22));
+    tickets.rotate(testKey(0x22), 0);
     try testing.expect(tickets.open(&ticket, &psk_out, 100, 3600) != null);
 
     // Two rotations: the key is gone and so is the ticket.
-    tickets.rotate(testKey(0x33));
+    tickets.rotate(testKey(0x33), 0);
     try testing.expect(tickets.open(&ticket, &psk_out, 100, 3600) == null);
 }
 
 test "tickets: an expired ticket does not open" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x44));
+    tickets.rotate(testKey(0x44), 0);
 
     var buf: [ticket_bytes]u8 = undefined;
     const ticket = try tickets.seal(&buf, &[_]u8{0x01} ** 32, .aes_128_gcm_sha256, 100, @splat(2));
@@ -285,7 +351,7 @@ test "tickets: an expired ticket does not open" {
 test "tickets: a tampered ticket does not open" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x55));
+    tickets.rotate(testKey(0x55), 0);
 
     var buf: [ticket_bytes]u8 = undefined;
     const sealed = try tickets.seal(&buf, &[_]u8{0x02} ** 32, .aes_128_gcm_sha256, 0, @splat(3));
@@ -304,10 +370,10 @@ test "tickets: a tampered ticket does not open" {
 test "tickets: a ticket from another server does not open" {
     var mine: Tickets = undefined;
     mine.init();
-    mine.rotate(testKey(0x66));
+    mine.rotate(testKey(0x66), 0);
     var theirs: Tickets = undefined;
     theirs.init();
-    theirs.rotate(testKey(0x77));
+    theirs.rotate(testKey(0x77), 0);
 
     var buf: [ticket_bytes]u8 = undefined;
     const ticket = try theirs.seal(&buf, &[_]u8{0x03} ** 32, .aes_128_gcm_sha256, 0, @splat(4));
@@ -319,7 +385,7 @@ test "tickets: a ticket from another server does not open" {
 test "tickets: a wrong-sized identity is not a ticket" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x88));
+    tickets.rotate(testKey(0x88), 0);
     var psk_out: [psk_bytes_max]u8 = undefined;
     try testing.expect(tickets.open(&.{}, &psk_out, 0, 3600) == null);
     try testing.expect(tickets.open(&[_]u8{0} ** 8, &psk_out, 0, 3600) == null);
@@ -329,7 +395,7 @@ test "tickets: a wrong-sized identity is not a ticket" {
 test "tickets: a ticket's length says nothing about the suite" {
     var tickets: Tickets = undefined;
     tickets.init();
-    tickets.rotate(testKey(0x99));
+    tickets.rotate(testKey(0x99), 0);
 
     var short_buf: [ticket_bytes]u8 = undefined;
     var long_buf: [ticket_bytes]u8 = undefined;


### PR DESCRIPTION
`Tickets` is built for two slots and `rotate` was called once, at
`start`, so both held one generation for the process's life. The
bounded-exposure property the module documents was a property of the
*module*, not of the running proxy: anyone holding that one key could
recover every PSK it had ever sealed, for as long as the process ran.

## The interval

Six hours, against a ticket lifetime of one. Several lifetimes, so the
two slots always cover a ticket's whole validity; short enough that a key
stolen from memory ages out the same day rather than living as long as
the process does.

`constants.zig` asserts `rotation_s >= lifetime_s` rather than trusting
whoever edits one of them next. Shrink the interval below the lifetime
and resumption silently starts failing for tickets that have not expired
— a failure that would read as a client bug.

That relation is exactly right rather than off by one, and it is worth
showing the derivation since the assert is load-bearing. A key's last
possible seal is strictly before `sealing_since + interval` (a seal at or
after that instant rotates first). Its eviction from the two slots cannot
happen sooner than `2 * interval` after install, because each rotation
individually needs a full interval to elapse. Tightest case:
`2*interval - 1 >= (interval - 1) + lifetime`, which reduces to
`interval >= lifetime`. Sparse traffic only ever adds slack — rotations
land later than nominal, never sooner — so back-to-back is the binding
case.

## No timer, and why

A periodic timer is the reflex. It costs an armed op the drain has to
cancel, a cancel completion to own it, and a fifth question in
`onDrainStuck`'s four-way report — all so a proxy idle at 4am can replace
a key that is sealing nothing.

`Tickets.dueForRotation` is asked at the top of `stageTlsTickets`
instead, immediately before a handshake's first seal. That gets the
property the bound is actually about — no key ever seals a ticket after
sealing for longer than its interval — with no armed op, no drain
interaction and no quiescence change.

It covers every path, not most of them: `Tickets.seal` has exactly one
production caller chain, `Engine.sendSessionTicket` ← `stageTlsTickets`,
and the rotation check is the first statement after the no-key guard.
Because `dueForRotation` is a stateless query re-evaluated at every seal,
no two seals under one key generation can be more than an interval apart,
however bursty or idle the traffic in between.

`tls_ticket_keys_rotated` therefore counts intervals *that saw traffic*.
That is the intended reading rather than a miss, and the counter says so:
a key that sealed nothing has nothing to expose.

## Two edges the directed tests pin

The boundary belongs to the rotation — a key that has sealed for its
whole interval is done — and taking the rotation re-bases the clock, so
one overdue key is one rotation rather than one per seal for the rest of
the interval.

And a wall clock that steps backwards (NTP, a VM restore, an operator
with a shell) reads as *not due*. Rotating there would replace the key on
every handshake, throwing away every outstanding ticket each time, and
turn a clock correction into a resumption outage.

## What the sweep cannot do

Six hours against a scenario that advances the wall clock by one virtual
second. The census entry refuses the tempting fix and says why: that
interval *is* the security bound, so a sweep run against a shortened one
would be gating a different proxy than the one that ships. It names the
three directed tests instead.

Reaching it properly needs a wall clock a scenario can jump hours
forward, which nothing models today. Worth noting that #206's remaining
slice wants the same missing capability — it needs a drop placed
mid-teardown rather than at the drain. One clock primitive would unexempt
this entry and unblock that slice.

## Gates

`zig build ci` rc=0 (census 58 fired / 17 exempt), `zig fmt --check`
clean, `zig build lint` clean, 488/488 tests. Reviewed by
`tiger-style-reviewer`; its one violation — a stitched doc-comment
fragment that still claimed rotation was unwired, in the commit that
wires it — is fixed here.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)