### PR TITLE
sim: a wall clock a scenario can step, and with it the key rotation (#202)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -157,12 +157,40 @@ saturating there, rather than rotating, is what stops a clock correction
 from replacing the key on every handshake and turning itself into a
 resumption outage.
 
-The sweep cannot reach any of this: six hours against a two-second
-scenario. The census entry refuses the tempting fix — shortening the
-interval for the sweep would gate a different proxy than the one that
-ships — and names the directed tests instead. Reaching it properly needs
-a wall clock a scenario can jump hours forward, which nothing models
-today.
+The sweep reaches it now, through `SimIo.advanceWallClock` — a step to
+the wall clock that leaves the monotonic clock alone. The asymmetry is
+what production actually does (an NTP correction, a VM restore, a leap
+second) and it is also the only version that works: moving the monotonic
+clock would fire every armed deadline at once. The census exemption this
+section used to describe is deleted.
+
+Two things that cost a rewrite each, both worth keeping.
+
+**Virtual time only advances when a timer comes due.** The first version
+armed the jump at a drawn instant in the first fifth of the scenario, and
+measured **9 rotations across 4096 seeds**. A whole population can
+handshake, exchange and close at the same virtual instant, so the timer
+fired long after every seal it was meant to precede. Hanging the jump off
+the first terminating session *ending* instead measures **198**. The
+lesson generalises past this feature: in this simulator, "early in the
+scenario" is not a time, it is an event.
+
+**One clock ages the key and the ticket together.** The placement was
+also chosen because it is where #204's resuming client dials, and the
+comment claimed it therefore covered the two-slot property — a key
+opening after it has stopped sealing. Measurement said otherwise: with a
+jump longer than a ticket's lifetime, every outstanding ticket is expired
+before the two-slot question arises. What the sweep actually shows is a
+rotation under adversarial schedules, plus a carried ticket failing to
+resume across the jump: 372 runs fail that way, against 384 unjumped runs
+that resume.
+
+Reaching two slots needs the key old and the ticket young at once, which
+one jump cannot produce: two jumps, one before the seal and a smaller one
+after, landing inside the window where a ticket is still valid and its
+key no longer seals. Deliberately not built — `Tickets.zig` pins that
+property directly, and the arithmetic to place two jumps correctly is
+more fragile than the thing it would test.
 
 ### Ending an exchange by framing (#204)
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -66,6 +66,11 @@ const tls_http_followup = l7.scripts.get_request_close;
 const announced_bytes_max: u8 = 32;
 /// Virtual time from scenario start after which stuck work is force-ended.
 const scenario_end_ns: u64 = 2_000_000_000;
+/// How far a #202 seed steps the wall clock: one whole rotation interval
+/// plus a second, so the key is unambiguously overdue rather than
+/// balanced on the boundary the directed tests already pin.
+const clock_jump_ns: u64 =
+    (@as(u64, zoxy.constants.tls_ticket_key_rotation_s) + 1) * std.time.ns_per_s;
 /// The slowest §7 probe pacing a non-outage seed may draw. Named so the
 /// origin-capacity bound below is derived from the same number the draw
 /// uses, not restated in prose.
@@ -182,6 +187,12 @@ end_timer_completion: SimIo.Completion,
 /// never sees its outage, which is fine — the sweep needs the schedule
 /// to land often, not on every draw.
 http_origin_stop_at_ns: u64,
+/// Whether this seed steps the wall clock past a sealing key's rotation
+/// interval (#202), and whether it has. Drawn only on seeds that
+/// terminate TLS: a plaintext seed seals no ticket, so a jump there would
+/// move nothing while shifting the whole sweep's stream position.
+clock_jump_wanted: bool,
+clock_jumped: bool,
 http_origin_stop_completion: SimIo.Completion,
 /// Virtual instant at which the drain begins, or 0 for "at the
 /// scenario's end like every other seed".
@@ -529,6 +540,22 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     };
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
+    harness.proxy_protocol_l4 = deriveProxyProtocol(random);
+    harness.deriveTerminatingDraws(random);
+    harness.wireListeners(deriveForwarded(random));
+    harness.deriveServerConfig(random, connect_timeout_ms, health.interval_ms);
+}
+
+/// The §4 terminating draws, split from `deriveTopology` when the #202
+/// clock jump pushed that one past the length limit — the same reason,
+/// and the same remedy, as `deriveServerConfig`.
+///
+/// Order is load-bearing rather than incidental: everything here is drawn
+/// from the scenario stream, and `deriveClockJump` deliberately draws
+/// nothing when the seed took no terminating clients, so a plaintext
+/// seed's stream position — and with it every plaintext seed's coverage —
+/// stays exactly where it was before any of this existed.
+fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
     // The terminating listener rides the l4 cluster's endpoint but keeps
     // its own route, so `verifyUpstreamIdentities` can tell a terminated
     // connection's origin conn from a plaintext one's.
@@ -537,15 +564,15 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
         .prefix = "/",
         .cluster_index = if (harness.tls_protocol == .http) 1 else 0,
     }};
-    harness.proxy_protocol_l4 = deriveProxyProtocol(random);
     harness.tls_clients = deriveTlsClients(
         random,
         harness.proxy_protocol_send_l4,
         harness.force_exhaustion,
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
-    harness.wireListeners(deriveForwarded(random));
-    harness.deriveServerConfig(random, connect_timeout_ms, health.interval_ms);
+    harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
+    assert(harness.listeners_count <= harness.listener_configs.len);
+    assert(harness.tls_clients >= 1 or !harness.clock_jump_wanted);
 }
 
 /// The top-level `Config` draw — the timeouts, the deadlines, and the
@@ -838,6 +865,17 @@ fn deriveTlsEngines(tls_clients: u8, force_exhaustion: bool) u32 {
     return @as(u32, tls_clients) + 1;
 }
 
+/// Whether a seed steps its wall clock past a rotation interval (#202).
+/// Half of the seeds that terminate TLS, and none of the rest: a
+/// plaintext seed seals no ticket, so a jump there would move nothing
+/// while shifting the whole sweep's stream position — the same argument
+/// that keeps the terminating listener off a plaintext seed's budgets.
+fn deriveClockJump(tls_clients: u8, random: std.Random) bool {
+    assert(tls_clients <= tls_clients_max);
+    if (tls_clients == 0) return false;
+    return random.boolean();
+}
+
 /// The two #159 pages the sweep serves, rendered here exactly as
 /// `config.zig`'s loader renders one — the simulator builds its
 /// `Config` by hand (no filesystem, no parse), so the shape is spelled
@@ -1104,6 +1142,7 @@ fn populateTlsClients(harness: *Harness, random: std.Random) void {
     harness.tls_clients_live = harness.tls_clients;
     harness.tls_resume_started = false;
     harness.scenario_ended = false;
+    harness.clock_jumped = false;
     assert(harness.tls_clients <= tls_clients_max);
     // One token past the drawn count, for the resuming client's slot.
     const token_count = if (harness.tls_clients >= 1)
@@ -1397,6 +1436,10 @@ fn ticketIssuer(harness: *Harness) ?*TlsClient {
 
 fn tlsClientEndedHook(context: ?*anyopaque) void {
     const harness: *Harness = @ptrCast(@alignCast(context.?));
+    // Before the resumer dials, so its handshake is the one that finds
+    // the key overdue and its offered ticket the one sealed under the key
+    // being retired.
+    harness.maybeJumpClock();
     harness.maybeStartResumingClient();
     harness.clientEnded();
 }
@@ -1411,6 +1454,38 @@ fn clientEnded(harness: *Harness) void {
 
 /// Belt and suspenders: fires even if some client never ends (a
 /// black-holed connect, a stuck exchange) and force-ends the run.
+/// #202, on the seeds that drew it: step the wall clock past a sealing
+/// key's whole rotation interval while the loop's own clock keeps
+/// ticking. The next handshake to seal a ticket finds its key overdue and
+/// replaces it — the only way a sweep whose scenarios last a virtual
+/// second reaches a bound measured in hours.
+///
+/// Hung off the first terminating session *ending*, not off a virtual
+/// instant. Virtual time only advances when a timer comes due, so a whole
+/// population can handshake, exchange and close at the same instant — a
+/// timer-driven jump measured 9 rotations across the entire sweep,
+/// because it fired long after every seal it was meant to precede. This
+/// placement measures 198.
+///
+/// What it covers, measured rather than assumed: a rotation under the
+/// adversary's schedules, and a ticket carried across a jump longer than
+/// its own lifetime failing to resume: 372 runs fail that way, against
+/// 384 unjumped runs that resume. It does *not* cover the two-slot
+/// property — a key
+/// opening after it has stopped sealing — and cannot, with one jump. One
+/// clock ages the key and the ticket together, so a jump big enough to
+/// retire a six-hour key also ages every outstanding ticket past its one
+/// hour. Reaching that state needs the key old and the ticket young: two
+/// jumps, one before the seal and a smaller one after, landing inside the
+/// window where the ticket is still valid and its key no longer seals.
+/// Left undone deliberately; `src/tls/Tickets.zig` pins it directly.
+fn maybeJumpClock(harness: *Harness) void {
+    if (!harness.clock_jump_wanted) return;
+    if (harness.clock_jumped) return;
+    harness.clock_jumped = true;
+    harness.io.advanceWallClock(clock_jump_ns);
+}
+
 fn onScenarioEnd(harness: *Harness, result: Io.TimerError!void) void {
     result catch return;
     harness.endScenario();

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -235,24 +235,6 @@ const uncovered = [_]Uncovered{
             "either, which is the honest gap",
     },
     .{
-        .name = "tls_ticket_keys_rotated",
-        .why = .unreached,
-        .reason = "the sealing key rotates after six hours of sealing and a " ++
-            "scenario advances the wall clock by one virtual second, so no " ++
-            "seed can reach it. Shortening the interval for the sweep is " ++
-            "the one fix worth " ++
-            "refusing: that interval is the security bound itself, so a " ++
-            "sweep run against a smaller one would be gating a different " ++
-            "proxy than the one that ships. src/tls/Tickets.zig drives the " ++
-            "whole rule directly — due exactly on the interval and not " ++
-            "before, re-based when taken so one overdue key is one rotation, " ++
-            "held off by a clock that steps backwards, and a ticket that " ++
-            "outlives one rotation and not two. What the sweep would add is " ++
-            "the adversary's schedules across a rotation, and reaching that " ++
-            "needs a wall clock the scenario can jump hours forward — " ++
-            "nothing models that today",
-    },
-    .{
         .name = "l7_no_route",
         .why = .unreached,
         .reason = "the sim's route table is a single \"/\" prefix, which no " ++

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -120,6 +120,10 @@ pending_set_option_errors: u8,
 /// none of.
 pressure_cause: Io.Pressure.Cause,
 last_pressure: Io.Pressure,
+/// What `advanceWallClock` has added to the wall clock, on top of
+/// however far virtual time has moved. Zero on every seed that does not
+/// ask, which keeps the two clocks agreeing in the ordinary case.
+wall_offset_ns: u64,
 stopped: bool,
 /// The code a caller gave up with (`abort`), which production would have
 /// spent on a process exit. Null until one does.
@@ -470,9 +474,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.pending_signals_count = 0;
     io.signal_callback = null;
     io.signal_userdata = null;
-    io.now_ns_value = clock_start_ns;
-    io.prng = std.Random.DefaultPrng.init(options.seed);
-    io.key_prng = std.Random.DefaultPrng.init(options.seed ^ key_seed_salt);
+    io.initClocksAndStreams(options.seed);
     io.adversary = options.adversary;
     io.pending_set_option_errors = 0;
     io.pressure_cause = .out_of_buffers;
@@ -794,13 +796,55 @@ pub fn localAddress(io: *SimIo, socket: Socket) std.Io.net.IpAddress {
     return io.socketEntry(socket).local_address;
 }
 
-/// The simulated wall clock (§8): the fixed epoch base plus however far
-/// virtual time has advanced. Derived from `now_ns_value` rather than
-/// tracked separately so the two clocks can never disagree about how much
-/// time a scenario took.
+/// The simulated wall clock (§8): the fixed epoch base, however far
+/// virtual time has advanced, and whatever `advanceWallClock` has added
+/// on top. The first two keep the ordinary case honest — a scenario's two
+/// clocks agree about how much time it took — and the third is what lets
+/// a scenario reach a deadline measured in hours.
 pub fn nowWallNs(io: *const SimIo) u64 {
     assert(io.now_ns_value >= clock_start_ns);
-    return wall_clock_base_ns + (io.now_ns_value - clock_start_ns);
+    return wall_clock_base_ns + (io.now_ns_value - clock_start_ns) +
+        io.wall_offset_ns;
+}
+
+/// The two clocks and the two random streams a seed starts from. Split
+/// out of `init` when the wall-clock offset pushed it past the length
+/// limit, and they belong together anyway: these are the whole of what
+/// makes one seed replay identically.
+///
+/// Two streams, not one, and salted apart: key material is drawn from
+/// `key_prng` so that how much of it a scenario asks for cannot shift the
+/// adversary's schedule, which would make a handshake's mere existence
+/// change every delivery after it.
+fn initClocksAndStreams(io: *SimIo, seed: u64) void {
+    io.now_ns_value = clock_start_ns;
+    io.wall_offset_ns = 0;
+    io.prng = std.Random.DefaultPrng.init(seed);
+    io.key_prng = std.Random.DefaultPrng.init(seed ^ key_seed_salt);
+    assert(io.now_ns_value == clock_start_ns);
+    assert(io.wall_offset_ns == 0);
+}
+
+/// Step the wall clock forward without touching the monotonic one.
+///
+/// The asymmetry is the whole point, and it is what production actually
+/// does: an NTP correction, a VM restore or a leap second moves the wall
+/// clock while the loop's clock keeps ticking uniformly. Moving the
+/// monotonic clock instead would fire every armed deadline at once —
+/// idle, request, drain, health — which is a different scenario and not a
+/// useful one.
+///
+/// It exists because some bounds are measured in hours against scenarios
+/// that run for a virtual second: a ticket's lifetime and its sealing
+/// key's rotation interval (#202) are both unreachable otherwise, so the
+/// sweep would be gating a proxy whose keys never turn over.
+pub fn advanceWallClock(io: *SimIo, delta_ns: u64) void {
+    assert(delta_ns >= 1);
+    // Into the trace: two runs of one seed must jump the same way, and a
+    // run that jumped differently must not hash equal to one that did not.
+    io.mix(delta_ns);
+    io.wall_offset_ns += delta_ns;
+    assert(io.wall_offset_ns >= delta_ns);
 }
 
 /// Targeted scenario control: the next `logWrite` fails, driving the

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -646,6 +646,34 @@ test "simio: a dropped accept is never delivered, where a live one is" {
     try std.testing.expectEqual(@as(u32, 0), stuck_io.dropPendingOps(.recv));
 }
 
+// #202: some bounds are measured in hours against scenarios that run for
+// a virtual second. XevIo has no counterpart and needs none — this is
+// scenario control like `injectLogWriteError`, not a seam decl.
+test "simio: a wall-clock step leaves the monotonic clock alone" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{ .seed = 13 });
+    const mono_before = sim_io.nowNs();
+    const wall_before = sim_io.nowWallNs();
+
+    const step_ns: u64 = 6 * 60 * 60 * std.time.ns_per_s;
+    sim_io.advanceWallClock(step_ns);
+
+    // The asymmetry is the point: moving the monotonic clock instead
+    // would fire every armed deadline at once, which is a different
+    // scenario and not a useful one.
+    try std.testing.expectEqual(mono_before, sim_io.nowNs());
+    try std.testing.expectEqual(wall_before + step_ns, sim_io.nowWallNs());
+
+    // Steps accumulate rather than replace, so a scenario can cross a
+    // bound twice.
+    sim_io.advanceWallClock(step_ns);
+    try std.testing.expectEqual(wall_before + 2 * step_ns, sim_io.nowWallNs());
+    try std.testing.expectEqual(mono_before, sim_io.nowNs());
+}
+
 test "simio: one seed replays one key stream, and a different seed does not" {
     // The §9 property TLS rides on: a seeded run's handshake is byte-exact,
     // which is only true if the key material replays with everything else.


### PR DESCRIPTION
#202 shipped a six-hour rotation interval that no seed could reach — a
scenario advances the wall clock by one virtual second. That left a
census exemption naming directed tests, which is the honest fallback and
not the same thing as coverage. This removes it.

## The primitive

`SimIo.advanceWallClock(delta_ns)` steps the wall clock and leaves the
monotonic clock alone.

The asymmetry is the design, not a shortcut. It is what production
actually does — an NTP correction, a VM restore, a leap second — and it
is also the only version that works: moving the monotonic clock would
fire every armed deadline at once (idle, request, drain, health), which
is a different scenario and not a useful one.

`nowWallNs` was previously derived purely from virtual time, on the
argument that a scenario's two clocks should never disagree about how
long it took. They still do not, on every seed that does not ask.

Half of the seeds that terminate TLS now jump. Census: 58 counters fired
/ 17 exempt → **59 / 16**.

## Two rewrites, both worth recording

**Virtual time only advances when a timer comes due.** The first version
armed the jump at a drawn instant in the scenario's first fifth and
measured **nine** rotations across 4096 seeds. A whole population can
handshake, exchange and close at one virtual instant, so the timer fired
long after every seal it was meant to precede. Hanging it off the first
terminating session *ending* measures **198**. The lesson generalises
past this feature: in this simulator, "early in the scenario" is not a
time, it is an event.

**The placement does not cover what I first claimed.** It sits exactly
where #204's resuming client dials, so the obvious reading is that it
tests the two-slot property — a key opening after it has stopped sealing.
Measurement refuted that. One clock ages the key and the ticket together,
so a jump long enough to retire a six-hour key ages every outstanding
ticket past its one-hour lifetime; the ticket is expired before the
two-slot question can arise.

What the sweep does cover, measured rather than assumed: a rotation under
the adversary's schedules, and a carried ticket failing to resume across
the jump — 372 runs fail that way, against 384 unjumped runs that resume.

Reaching two slots needs the key old and the ticket young at once, which
one jump cannot produce: two jumps, one before the seal and a smaller one
after, landing inside the window where a ticket is still valid and its
key no longer seals. Deliberately not built — `Tickets.zig` pins that
property directly, and the arithmetic to place two jumps correctly is
more fragile than the thing it would test. Both the harness comment and
IMPLEMENTATION_NOTES say so, so the next reader does not re-derive it.

## Review caught a real bug

`clock_jumped` was declared and never initialized. `populateTlsClients`
resets its two sibling latches and this one was missed, so `maybeJumpClock`
read an uninitialized bool out of an `undefined`-initialized harness.

The sweep passed anyway, which is the interesting part: Debug and
ReleaseSafe fill `undefined` with `0xaa` and a `bool` load truncates that
to `false`. That is this compiler's lowering, not a language guarantee.
The sharp edge is specific to this harness — `checkSeed` runs each seed
**twice** to compare traces, so under a build that does not poison-fill,
different stack garbage across the two calls could make the jump fire on
one run and not the other, tripping the sweep's own nondeterminism check
for a reason that has nothing to do with nondeterminism.

Fixed by initializing it beside its siblings.

## Housekeeping

`deriveTopology` was 77 lines before this branch and 78 after, so the
terminating draws moved to `deriveTerminatingDraws` — the same split, for
the same reason, this file already applied to `deriveServerConfig`.
`SimIo.init` went 71 → 72 and is now 69 via `initClocksAndStreams`.

## Gates

`zig build ci` rc=0 (census 59 fired / 16 exempt), `zig fmt --check`
clean, `zig build lint` clean, 489/489 tests. Reviewed by
`tiger-style-reviewer`; both violations it raised are fixed here.

Follows #202 (merged). Leaves #206's slice 4 as the last open piece,
which needs a drop placed at a chosen moment rather than anything
clock-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)