### PR TITLE
sim: a seeded fraction strands an op the backend never delivers (#206)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -72,11 +72,16 @@ What it left open, now tracked rather than only recorded here:
 - ~~**#202 — the sealing key is never rotated.**~~ Closed: six hours
   against a one-hour ticket lifetime, driven from the seal rather than
   from a timer. See "Rotating from the seal" below.
-- **#203 — the live gate's https leg wedged once on macOS**, and has not
-  recurred. See the section of that name below for what is ruled out and
-  where to look.
+- ~~**#203 — the live gate's https leg wedged on macOS.**~~ Closed on both
+  backends: `listenClose` assumed a cancelled accept delivers its own
+  completion, which is an io_uring property. Epoll drops it outright;
+  kqueue delivers one it has already submitted and drops one still queued,
+  which is what an accept re-armed from inside a callback always is.
 - ~~**#204 — the simulator's TLS clients are single-connection.**~~ Closed:
   see "Ending an exchange by framing" below for all three legs.
+- **#206 — the sweep could not model an op the backend never delivers.**
+  Mostly closed; see "Stranding an op" below for what the sweep reaches
+  now and the one shape still out of its reach.
 
 One smaller thing still recorded only here, because it is a line rather
 than a project: `ResponseBodyPolicy.afterSend` credits *ciphertext* to
@@ -124,6 +129,89 @@ layer costs zero userspace CPU and the `splice` c10k lever (below) stays
 applicable to TLS traffic. Known fiddly parts: KeyUpdate/post-handshake
 control messages arrive via CMSG, and session tickets must be sent
 before the switchover.
+
+### Stranding an op the backend never delivers (#206)
+
+Everything this simulator did completed. A shutdown delivers EOF to an
+armed recv, a close delivers to the peer, a cancel lands. That is
+faithful to io_uring and it is why the sweep is as good as it is — and it
+put one whole class of defect out of reach of any number of seeds. #203
+was that class, and four million nightly seeds could not have found it.
+
+Half the mechanism already existed: a black-holed connect has always sat
+at `ready_at_ns = never_ns`. `Completion.dropped` generalises it, checked
+at the top of `opReady` — the one choke point every kind of readiness
+passes through. `dropPendingOps(kind)` takes *pending* ops rather than
+ops at enqueue, which is the distinction that matters: #203's shape is an
+op that was armed and then had its completion taken away, which is what a
+cancel that does not deliver looks like from above. Marking at enqueue
+would model a backend refusing work, and that already has a name.
+
+**The give-up had to come out from behind `std.process.exit` first.**
+`onDrainStuck` ended in one, which made it the single branch no gate
+could enter — taking the exit takes the test process with it. That is
+part of why the backstop shipped ungated. `Io.abort` puts it on the seam:
+a real exit in production, a recorded code in the simulator.
+
+**The sweep's oracle is an alternative for every seed, not a branch on
+whether one stranded anything.** Either the ordinary invariants hold, or
+the server gave up with the code that names which backstop it was. What
+that phrasing buys is the property actually worth holding — no schedule
+may end with the loop alive and nobody the wiser — rather than a
+weaker "stranded seeds are excused". 52 runs per 4096-seed sweep take the
+second branch.
+
+The abort is only excused on a seed that actually stranded something,
+which needs the draw and the strand kept as two facts rather than one
+cleared value. Without that gate the branch would accept any stuck drain
+as "#206 working as intended" — including one a future *release* bug
+produced with every op delivered, which is the exact defect the backstop
+exists to catch and the last thing a sweep should swallow.
+
+Clean seeds never draw a strand, for the reason every sibling
+perturbation states: their oracle is each script's exact golden outcome,
+and a stranded op ends the run at the give-up before those oracles run —
+for every client in the scenario, not only the one the strand touched. A
+silently unanswered exchange passing as "the backstop worked" is
+precisely what clean seeds exist to forbid.
+
+**Draw the kind, not the op.** Measured at a wind-down, `accept` and
+`timer` are four fifths of everything pending, so picking a random *op*
+would spend the whole fraction on those two and reach `recv_group` about
+once per sweep.
+
+Two kinds are excluded, for opposite reasons, and both are findings.
+
+`close` is **never** armed at a wind-down — zero occurrences across the
+sweep. So "a slot that can never be released", arguably the scarier half
+of the #203 class, is not reachable by dropping at the drain however the
+seed picks. It needs a drop placed mid-teardown, which is a different
+hook and is what keeps #206 open.
+
+`timer` is worse, and it is the finding worth carrying: **`onDrainStuck`
+cannot catch a stranded timer, because it is one.** A seed that strands
+the drain deadline strands the thing that would have reported it, and the
+run ends in the simulator's own deadlock with no diagnostic at all — seed
+2302, three dropped timers and nothing else pending. That is a true
+statement about the reach of #203's fix rather than a defect this sweep
+can hold the proxy to, so the kind is excluded and the case pinned by a
+directed test in `contract_test.zig` instead — the form that breaks
+loudly if it ever stops being true, where a comment would not. Covering
+it for real would need a watchdog that is not a timer, which is a design
+question and not a gate.
+
+A trap worth naming while it is fresh: the draw indexes a `kinds` array,
+so adding, removing or reordering an entry silently re-rolls which seed
+draws which kind. Seed 2302 above will not reproduce against the shipped
+list, because `.timer` is no longer in it. Any seed number pinned against
+this function has the same short shelf life.
+
+The sweep runs with `dump_on_abort = false`. A stranded seed reaches the
+give-up on purpose and its operator forensics are two hundred lines
+apiece, while the verdict here is `abortedWith` and not the wording. That
+switch exists because stderr from a *passing* build step makes Zig's
+build runner print `failed command:` under a build that exited zero —
+which cost three runs to diagnose the first time.
 
 ### Rotating from the seal (#202)
 
@@ -1850,18 +1938,38 @@ can only be the proxy's fault. The band now prints the refused/timed-out
 split every run: a threshold whose margin is invisible until it trips is
 how this one sat mis-specified for a week.
 
-## Open: the https leg wedged once on macOS (2026-08-11, #203)
+## Closed: the https leg wedged on macOS (2026-08-11, #203)
 
 The first CI run carrying the Tier-0.5 https leg wedged on the macOS
 runner — the whole 30 s budget, against a run that takes about a second.
-Every run since has passed there, on the same commit and on later ones,
-so this is **intermittent and unexplained**, not a platform that cannot
-terminate TLS. Recorded rather than waved off: an intermittently red gate
-is worse than a red one, because the first instinct on seeing it green
-again is to stop looking.
+It then passed for a while, which is the dangerous shape: an
+intermittently red gate is worse than a red one, because the first
+instinct on seeing it green again is to stop looking. Two in thirteen
+runs, in the end.
 
-What is known. Linux has never reproduced it, over dozens of local runs
-and every CI run. The commit before — the same TLS listener, configured
+**It had nothing to do with TLS.** The https leg was the first thing to
+configure an admin listener alongside a terminating one, and the bug was
+in `listenClose`: it cancelled an armed accept and assumed the cancel
+delivers that accept's completion. That is an io_uring property. Epoll's
+`.cancel` is `stop_completion`, which drops the op without calling
+anything back; kqueue delivers a cancelled accept it has already
+*submitted* and drops one still queued — and libxev submits at the top of
+a tick, never inside its callback loop, so an accept re-armed from inside
+a callback is always still queued. The admin plane re-arms exactly that
+way. Its accept was orphaned, `listening` never cleared,
+`maybeStopAfterDrain` never stopped the loop, and SIGTERM stopped meaning
+anything. Any deployment with `admin` configured was exposed.
+
+The diagnosis below is kept because the reasoning is still worth reading,
+and because its standing suspicion — "a lost wakeup in the kqueue path,
+since the TLS legs are the one place a data op is armed outside the
+provided-buffer ring" — was half right in a way that cost two days: the
+lost wakeup was real, the kqueue path was right, and *the TLS legs had
+nothing to do with it*. The correlation was that the https leg was the
+first test to drain a process with two listeners.
+
+What was known at the time, kept as written. Linux has never reproduced
+it, over dozens of local runs and every CI run. The commit before — the same TLS listener, configured
 and started, but with no client connecting to it — passed macOS, so the
 listener, the certificate load and the libcrypto heap install are not it;
 the first macOS execution of the *handshake and exchange* path is also
@@ -1877,10 +1985,28 @@ The instrumentation to catch it next time is in: the watchdog names the
 wait it died in (and, for the requests, which one), and it now SIGTERMs
 the proxy and lets it drain before killing it, so the report carries the
 proxy's own counters. The first wedge had neither — it said only that
-thirty seconds had passed, which is what made it un-diagnosable. The
-standing suspicion to test first is a lost wakeup in the kqueue path,
-since the TLS legs are the one place a data op is armed outside the
-provided-buffer ring, and a race there would present exactly this way.
+thirty seconds had passed, which is what made it un-diagnosable.
+
+What actually closed it was making the failure reproducible instead of
+waiting for it: `-Dio-backend=epoll` builds against libxev's epoll
+backend on Linux, which is the *readiness* model that macOS ships and
+Linux's default is not. It took #203 from "two in thirteen runs on a
+shared runner" to ten of ten locally, in seconds. Green there does not
+clear macOS — they are different backends — but a failure is
+reproducible, and that turned out to be the whole difficulty.
+
+One mistake worth not repeating. The first fix keyed the new delivery
+path on `xev.backend == .io_uring`, which put *kqueue* on it too —
+changing behaviour on a shipped platform on the strength of an inference
+from epoll. macOS CI hung for 23 minutes. The rule since: only change
+what a backend does where that backend has said, in its own types, that
+it cannot do the other thing. Here that is
+`reportsCanceled(xev.AcceptError)`, since a backend that can deliver a
+cancelled accept names `Canceled` and one that cannot does not. That rule
+was still not sufficient — kqueue names `Canceled` and still drops a
+queued accept — but it was sufficient to stop the regression, and the
+real fix (submit before cancelling) came from reproducing on the dev box
+rather than from another inference.
 
 ## The live gate's measured numbers (2026-08-02, #144)
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -193,6 +193,13 @@ http_origin_stop_at_ns: u64,
 /// move nothing while shifting the whole sweep's stream position.
 clock_jump_wanted: bool,
 clock_jumped: bool,
+/// The #206 op kind this seed strands at its wind-down, or null; and
+/// whether the strand has happened. Two fields for the reason the pair
+/// above is two: what a seed drew and what it did are different facts,
+/// and `verify` needs the draw to still be there when it decides whether
+/// a stuck drain was asked for.
+drop_kind: ?SimIo.OpKind,
+drop_taken: bool,
 http_origin_stop_completion: SimIo.Completion,
 /// Virtual instant at which the drain begins, or 0 for "at the
 /// scenario's end like every other seed".
@@ -270,6 +277,11 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
         .seed = seed,
         .adversary = deriveAdversary(random, harness.clean),
         .buffer_group_count = harness.head_buffers,
+        // #206: a stranded seed reaches the §8 give-up on purpose, and
+        // the operator forensics it prints there are two hundred lines
+        // apiece. The sweep's verdict is `abortedWith`, not the wording,
+        // and a gate whose output scrolls is a gate nobody reads.
+        .dump_on_abort = false,
     });
     // Which cause the sim reports for every failure it injects (§8).
     // Production reads it off an errno; a virtual socket table has none,
@@ -288,6 +300,19 @@ pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
     harness.injectOneShotFaults(random);
     harness.populateClients(random);
 
+    harness.armScenarioTimers();
+}
+
+/// The three timers a scenario runs on: the force-end that outlives any
+/// stuck work, the optional early drain, and the optional origin outage.
+/// Split from `setUp` when the #206 drop pushed that one past the length
+/// limit — the same remedy `deriveTopology` took twice before it.
+///
+/// Every one is armed *after* the population exists, so nothing can fire
+/// against a half-built scenario, and every optional one asserts it lands
+/// before the force-end — a timer scheduled past that is a timer whose
+/// scenario is already over.
+fn armScenarioTimers(harness: *Harness) void {
     harness.end_timer_completion = .{};
     harness.io.timerStart(
         &harness.end_timer_completion,
@@ -571,6 +596,7 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
+    harness.drop_kind = deriveDropKind(harness.clean, random);
     assert(harness.listeners_count <= harness.listener_configs.len);
     assert(harness.tls_clients >= 1 or !harness.clock_jump_wanted);
 }
@@ -1143,6 +1169,7 @@ fn populateTlsClients(harness: *Harness, random: std.Random) void {
     harness.tls_resume_started = false;
     harness.scenario_ended = false;
     harness.clock_jumped = false;
+    harness.drop_taken = false;
     assert(harness.tls_clients <= tls_clients_max);
     // One token past the drawn count, for the resuming client's slot.
     const token_count = if (harness.tls_clients >= 1)
@@ -1452,8 +1479,85 @@ fn clientEnded(harness: *Harness) void {
     }
 }
 
-/// Belt and suspenders: fires even if some client never ends (a
-/// black-holed connect, a stuck exchange) and force-ends the run.
+/// #206, on the seeds that drew it: take every armed op of one kind and
+/// never deliver it, at the instant the wind-down begins. That is the
+/// class of defect no other seed can reach — everything else this
+/// simulator does completes, which is faithful to io_uring and blind to
+/// what a readiness backend did in #203.
+///
+/// At the wind-down because that is where the ops worth stranding are
+/// armed. Measured over the sweep, ops pending when a drain begins:
+/// accept and timer on essentially every run, recv on 55%, log_write 26%,
+/// connect 24%, recv_group 10% — and `close` on *none*, which is why the
+/// kinds below are the ones they are and why "a slot that can never be
+/// released" is still out of reach from here. Reaching that one needs a
+/// drop placed mid-teardown, which is a different hook.
+///
+/// The kind is drawn rather than the op, deliberately: accept and timer
+/// are four fifths of everything pending, so picking a random *op* would
+/// spend the whole fraction on those two and reach recv_group about once
+/// in a sweep.
+fn maybeStrandOps(harness: *Harness) void {
+    const kind = harness.drop_kind orelse return;
+    if (harness.drop_taken) return;
+    // A latch rather than clearing the draw, for the reason the clock
+    // jump keeps two fields: what the seed *drew* and what it *did* are
+    // different facts, and `verify` needs the first one to still be
+    // there when it decides whether a stuck drain was asked for.
+    harness.drop_taken = true;
+    const dropped = harness.io.dropPendingOps(kind);
+    // Nothing armed of that kind is a legal outcome, not a failed draw —
+    // the sweep's job is to try, and the oracle holds either way. A
+    // stranded op stays *pending*, so the table it was counted out of is
+    // still the bound; more than that would mean one was counted twice.
+    assert(dropped <= harness.io.pending_count);
+}
+
+/// Which op kind a seed strands, or null for the fifteen in sixteen that
+/// strand nothing. A small fraction on purpose: a stranded run trades
+/// every other oracle for the one it exists to check, since a drain that
+/// cannot finish leaves pools held and counters unreconciled by design.
+///
+/// The kinds are the ones actually armed at a wind-down, minus two that
+/// are left out for opposite reasons.
+///
+/// `close` is never armed there at all, so naming it would be a draw that
+/// silently tested nothing. Reaching it needs a drop placed mid-teardown.
+///
+/// `timer` is excluded because stranding one is the shape the §8 backstop
+/// provably cannot catch: `onDrainStuck` is itself a timer, so a seed
+/// that strands the drain deadline strands the thing that would have
+/// reported it, and the run ends in `SimIo`'s deadlock rather than in a
+/// diagnostic. Found by drawing it — seed 2302 deadlocked with three
+/// dropped timers and nothing else pending, though that seed will not
+/// reproduce it against the list as shipped: the draw indexes `kinds`,
+/// so adding, removing or reordering an entry silently re-rolls which
+/// seed draws which kind. The case is pinned by a directed test instead
+/// (`src/io/contract_test.zig`), which is the form that breaks loudly if
+/// it ever stops being true. That is a true statement
+/// about the backstop's reach and not a defect this sweep can hold the
+/// proxy to, so it is recorded rather than asserted; covering it would
+/// need a watchdog that is not a timer, which is a design question and
+/// not a gate.
+fn deriveDropKind(clean: bool, random: std.Random) ?SimIo.OpKind {
+    // Adversarial seeds only, for the reason every sibling draw states:
+    // a clean seed's oracle is each script's exact golden outcome, and a
+    // stranded op ends the run at the give-up before those oracles are
+    // reached — for every client in the scenario, not just the one the
+    // strand touched. A silently unanswered exchange passing as "the
+    // backstop worked" is precisely what clean seeds exist to forbid.
+    if (clean) return null;
+    if (random.uintLessThan(u8, 16) != 0) return null;
+    const kinds = [_]SimIo.OpKind{
+        .accept,
+        .recv,
+        .connect,
+        .log_write,
+        .recv_group,
+    };
+    return kinds[random.uintLessThan(usize, kinds.len)];
+}
+
 /// #202, on the seeds that drew it: step the wall clock past a sealing
 /// key's whole rotation interval while the loop's own clock keeps
 /// ticking. The next handshake to seal a ticket finds its key overdue and
@@ -1486,12 +1590,18 @@ fn maybeJumpClock(harness: *Harness) void {
     harness.io.advanceWallClock(clock_jump_ns);
 }
 
+/// Belt and suspenders: fires even if some client never ends (a
+/// black-holed connect, a stuck exchange) and force-ends the run. Its
+/// sentence spent a while attached to the wrong function — restored here
+/// rather than deleted, because "some client never ends" is exactly the
+/// case #206 now creates on purpose.
 fn onScenarioEnd(harness: *Harness, result: Io.TimerError!void) void {
     result catch return;
     harness.endScenario();
 }
 
 fn endScenario(harness: *Harness) void {
+    harness.maybeStrandOps();
     harness.scenario_ended = true;
     for (harness.clients[0..harness.l4_count]) |*client| {
         client.cancelIfStuck();
@@ -1535,6 +1645,25 @@ pub fn verify(harness: *Harness) !void {
     harness.origin.closeRemaining();
     harness.origin_http.closeRemaining();
 
+    // #206: a seed that stranded an op the drain waits on cannot finish
+    // it, and must not be asked to. What is demanded instead is that the
+    // proxy *noticed* — a drain that cannot complete is allowed, a drain
+    // that hangs without saying so is not.
+    //
+    // Written as an alternative for every seed rather than a branch on
+    // whether this one dropped anything, because that is the property
+    // worth holding: no schedule, dropped op or not, may end with the
+    // loop alive and nobody the wiser.
+    if (harness.io.abortedWith()) |code| {
+        if (code != ServerSim.drain_stuck_exit_code) return error.UnexpectedAbort;
+        // Only a seed that stranded something is excused. Without this,
+        // the branch would accept any stuck drain as "#206 working as
+        // intended" — including one a future release bug produced with
+        // every op delivered, which is the exact defect this backstop
+        // exists to catch and the last thing the sweep should swallow.
+        if (!harness.drop_taken) return error.DrainStuckWithoutStrand;
+        return;
+    }
     if (!harness.server.isIdle()) return error.PoolLeak;
     if (!harness.server.reconcile()) return error.CountersDiverged;
     if (!harness.io.sockets.isFullyReleased()) return error.SocketLeak;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -741,7 +741,7 @@ pub fn Server(comptime IoType: type) type {
 
         /// Distinct from every ordinary exit so a supervisor can tell "the
         /// drain failed" from "the config was bad" without parsing output.
-        const drain_stuck_exit_code: u8 = 4;
+        pub const drain_stuck_exit_code: u8 = 4;
 
         /// The drain could not finish. Say what it is waiting on and stop.
         ///

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -646,6 +646,55 @@ test "simio: a dropped accept is never delivered, where a live one is" {
     try std.testing.expectEqual(@as(u32, 0), stuck_io.dropPendingOps(.recv));
 }
 
+const StrandedTimer = struct {
+    io: *SimIo,
+    completion: SimIo.Completion = .{},
+    fired: bool = false,
+
+    fn onTimer(self: *StrandedTimer, result: Io.TimerError!void) void {
+        result catch return;
+        self.fired = true;
+    }
+};
+
+// #206: the one shape §8's drain backstop cannot catch, pinned so it
+// breaks loudly if it ever stops being true.
+//
+// `Server.onDrainStuck` is a timer. A backend that strands timers strands
+// that one too, so the process has nothing left to notice with and the
+// run ends in the simulator's deadlock rather than in a diagnostic. The
+// sweep therefore does not draw `.timer` (see `sim/Harness.zig`), which
+// would otherwise fail honest seeds — this is where the limitation lives
+// instead of only in a comment. Covering it for real needs a watchdog
+// that is not a timer, which is a design question and not a gate.
+test "simio: a stranded timer has nothing left to report it" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{
+        .seed = 17,
+        // The deadlock is the assertion; its forensics are noise here.
+        .dump_on_deadlock = false,
+    });
+
+    var watchdog: StrandedTimer = .{ .io = &sim_io };
+    sim_io.timerStart(
+        &watchdog.completion,
+        std.time.ns_per_s,
+        StrandedTimer,
+        &watchdog,
+        StrandedTimer.onTimer,
+    );
+    try std.testing.expectEqual(@as(u32, 1), sim_io.dropPendingOps(.timer));
+
+    try std.testing.expectError(error.Deadlock, sim_io.run());
+    // Stated as an assertion rather than left implicit: the watchdog
+    // never ran, so whatever it was watching went unreported.
+    try std.testing.expect(!watchdog.fired);
+    try std.testing.expectEqual(@as(?u8, null), sim_io.abortedWith());
+}
+
 // #202: some bounds are measured in hours against scenarios that run for
 // a virtual second. XevIo has no counterpart and needs none — this is
 // scenario control like `injectLogWriteError`, not a seam decl.


### PR DESCRIPTION
Slices 1-3 (merged) gave `SimIo` the ability to accept an op and never
deliver it, put the process give-up behind the seam so the branch could
be entered at all, and gated `Server.onDrainStuck` with one directed
test. This puts the capability in the sweep: one adversarial seed in
sixteen takes every armed op of one drawn kind at its wind-down and never
delivers it.

**52 runs per 4096-seed sweep** now reach a class no seed could reach
before — the one #203 lived in, that four million nightly seeds could not
have found.

## The oracle

Written as an alternative for *every* seed rather than a branch on
whether this one stranded anything, because that is the property worth
holding: no schedule, dropped op or not, may end with the loop alive and
nobody the wiser. Either the ordinary invariants hold, or the server gave
up with the code that says which backstop it was.

The abort is only excused on a seed that **actually stranded something**,
which is why the draw and the strand are two fields rather than one
cleared value. Without that gate the branch would accept any stuck drain
as "#206 working as intended" — including one a future *release* bug
produced with every op delivered, which is the exact defect this backstop
exists to catch and the last thing a sweep should swallow.

Clean seeds never draw a strand, for the reason every sibling
perturbation in that file already states: their oracle is each script's
exact golden outcome, and a stranded op ends the run at the give-up
before those oracles run — for every client in the scenario, not only the
one the strand touched. A silently unanswered exchange passing as "the
backstop worked" is precisely what clean seeds exist to forbid.

Both of those came out of review, and both were real weakenings rather
than style.

## Draw the kind, not the op

Measured at a wind-down, `accept` and `timer` are four fifths of
everything pending, so picking a random *op* would spend the whole
fraction on those two and reach `recv_group` about once per sweep.

Two kinds are excluded, for opposite reasons, and both are findings.

**`close` is never armed at a wind-down** — zero occurrences across the
sweep. So "a slot that can never be released", arguably the scarier half
of the #203 class, is not reachable by dropping at the drain however the
seed picks. It needs a drop placed mid-teardown, which is a different
hook. That is what keeps #206 open.

**`timer` is the shape §8's backstop provably cannot catch, because
`onDrainStuck` is itself a timer.** A seed that strands the drain
deadline strands the thing that would have reported it, and the run ends
in the simulator's own deadlock with no diagnostic at all. That is a true
statement about the reach of #203's fix rather than a defect this sweep
can hold the proxy to, so the kind stays out of the draw and the case is
pinned by a directed test in `contract_test.zig` — asserting the
deadlock, that the watchdog never fired, and that nothing aborted. Prose
would have rotted; a test breaks loudly if it ever stops being true.
Covering it for real needs a watchdog that is not a timer, which is a
design question and not a gate.

**A trap named while it is fresh:** the draw indexes a `kinds` array, so
adding, removing or reordering an entry silently re-rolls which seed
draws which kind. The seed that originally exhibited the timer deadlock
does not reproduce against the shipped list, because `.timer` is no
longer in it. Any seed number pinned against that function has the same
short shelf life, and both the code and the notes say so.

## Housekeeping

The sweep runs with `dump_on_abort = false`: a stranded seed reaches the
give-up on purpose and its operator forensics are two hundred lines
apiece, while the verdict here is `abortedWith` and not the wording.

`setUp` was 79 lines before this branch and 84 after, so its three
scenario timers moved to `armScenarioTimers` — the same split
`deriveTopology` has already taken twice.

The docs also close out **#203**, which was still recorded as "open" and
"intermittent and unexplained". The old diagnosis is kept below the new
one rather than deleted, because its standing suspicion is instructive:
*"a lost wakeup in the kqueue path, since the TLS legs are the one place
a data op is armed outside the provided-buffer ring."* The lost wakeup
was real and the kqueue path was right — and the TLS legs had nothing to
do with it. The correlation was only that the https leg was the first
test to drain a process with two listeners.

## Gates

`zig build ci` rc=0 (census 59 fired / 16 exempt), `zig fmt --check`
clean, `zig build lint` clean, 490/490 tests. Reviewed by
`tiger-style-reviewer`; all four violations it raised are fixed here.

Part of #206 — the mid-teardown hook that would reach `close` stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)