### PR TITLE
ci: build releases on native runners, not by cross-compiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,52 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: build binaries & publish release
-    runs-on: ubuntu-latest
+  # One runner per target, natively.
+  #
+  # These used to cross-compile from a single Linux runner, which stopped
+  # working the moment zoxy gained a C dependency: `linkSystemLibrary("crypto")`
+  # resolves libcrypto out of the *host's* nix store, so every target but the
+  # host's own architecture fails to link ("libcrypto.so is incompatible with
+  # aarch64linux"). It failed on the 0.2.0 tag, after TLS termination (#125)
+  # made libcrypto load-bearing, and it took the release from four platforms to
+  # one — including both macOS targets, whose SIGTERM hang (#203) was the very
+  # thing that release existed to fix.
+  #
+  # Building natively also means every artifact is produced on the platform it
+  # runs on, which is the only way the release checklist's "smoke the actual
+  # artifact" step can ever stop being manual.
+  build:
+    name: build ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: x86_64-linux
+            os: ubuntu-latest
+            zig_target: x86_64-linux-musl
+            # x86_64 gets v3 (AVX2/BMI2/FMA, Haswell 2013+ / Zen 2017+): the
+            # default baseline is plain SSE2, which caps hparse's vector width
+            # at 128 bits (std.simd.suggestVectorLength keys off target CPU
+            # features, DESIGN.md §7); v3 doubles it to 256.
+            cpu: x86_64_v3
+          - label: aarch64-linux
+            os: ubuntu-24.04-arm
+            zig_target: aarch64-linux-musl
+            # aarch64 keeps its default baseline — NEON is mandatory in
+            # ARMv8-A, so there is no wider portable win to take.
+            cpu: ''
+          - label: x86_64-macos
+            os: macos-13
+            zig_target: x86_64-macos
+            cpu: x86_64_v3
+          - label: aarch64-macos
+            os: macos-latest
+            zig_target: aarch64-macos
+            cpu: ''
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
-      # Zig cross-compiles every target from this one Linux runner, using the
-      # exact Zig 0.16 the flake pins.
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v35
         with:
@@ -46,49 +84,98 @@ jobs:
           echo "tag=$ref" >> "$GITHUB_OUTPUT"
           echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and package all targets
+      - name: Build and package
         run: |
           set -euo pipefail
           version="${{ steps.ver.outputs.version }}"
           mkdir -p dist
+          # -Dbuild-id is passed rather than left to build.zig's `git
+          # describe` fallback: this checkout is shallow and carries no
+          # tags, so describe would fall back to a bare commit SHA and
+          # stamp every release binary with one. Handing it the tag makes
+          # the identifier equal the version, which `zoxy --version`
+          # recognises and omits — a release says `zoxy 0.0.7` and
+          # nothing else, whatever the checkout depth happens to be.
+          devenv shell -- zig build \
+            -Dtarget="${{ matrix.zig_target }}" \
+            ${{ matrix.cpu && format('-Dcpu={0}', matrix.cpu) || '' }} \
+            -Doptimize=ReleaseSafe \
+            -Dbuild-id="${{ steps.ver.outputs.tag }}" --prefix out
 
-          # zig-target : release-archive-label : -Dcpu value (empty = default)
-          #
-          # x86_64 gets -Dcpu=x86_64_v3 (AVX2/BMI2/FMA, Haswell 2013+ / Zen
-          # 2017+): the default cross-compile baseline is plain SSE2, which
-          # caps hparse's vector width at 128 bits (std.simd.suggestVectorLength
-          # keys off target CPU features, DESIGN.md §7); v3 doubles it to 256.
-          # aarch64 is left at its default baseline — NEON is mandatory in
-          # ARMv8-A, so there is no wider portable win to take there.
-          targets="
-            x86_64-linux-musl:x86_64-linux:x86_64_v3
-            aarch64-linux-musl:aarch64-linux:
-            x86_64-macos:x86_64-macos:x86_64_v3
-            aarch64-macos:aarch64-macos:
-          "
-          for pair in $targets; do
-            zig_t="$(echo "$pair" | cut -d: -f1)"
-            label="$(echo "$pair" | cut -d: -f2)"
-            cpu="$(echo "$pair" | cut -d: -f3)"
-            echo "::group::$label ($zig_t${cpu:+, -Dcpu=$cpu})"
-            # -Dbuild-id is passed rather than left to build.zig's `git
-            # describe` fallback: this checkout is shallow and carries no
-            # tags, so describe would fall back to a bare commit SHA and
-            # stamp every release binary with one. Handing it the tag makes
-            # the identifier equal the version, which `zoxy --version`
-            # recognises and omits — a release says `zoxy 0.0.7` and
-            # nothing else, whatever the checkout depth happens to be.
-            devenv shell -- zig build \
-              -Dtarget="$zig_t" ${cpu:+-Dcpu="$cpu"} -Doptimize=ReleaseSafe \
-              -Dbuild-id="${{ steps.ver.outputs.tag }}" --prefix "out/$label"
-            tar czf "dist/zoxy-$version-$label.tar.gz" -C "out/$label/bin" zoxy
-            echo "::endgroup::"
+          # The binary runs on the machine that built it now, so the
+          # cheapest possible confidence is free: ask it what it is. A
+          # release that reports the wrong version is the failure the
+          # version-bump-before-tag rule exists to prevent, and this is
+          # where it would show.
+          reported="$(./out/bin/zoxy --version)"
+          echo "built: $reported"
+          case "$reported" in
+            *"$version"*) ;;
+            *) echo "::error::binary reports '$reported', expected $version"; exit 1 ;;
+          esac
+
+          tar czf "dist/zoxy-$version-${{ matrix.label }}.tar.gz" -C out/bin zoxy
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zoxy-${{ matrix.label }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v35
+        with:
+          nix_conf: |
+            experimental-features = nix-command flakes
+
+      - name: Set up devenv binary cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: devenv
+          skipPush: true
+
+      - name: Install devenv
+        run: nix profile install --accept-flake-config github:cachix/devenv/v2.1.2
+
+      - name: Resolve version
+        id: ver
+        run: |
+          ref="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=$ref" >> "$GITHUB_OUTPUT"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: staging
+
+      - name: Collect artifacts and checksum
+        run: |
+          set -euo pipefail
+          version="${{ steps.ver.outputs.version }}"
+          mkdir -p dist
+          find staging -name '*.tar.gz' -exec mv {} dist/ \;
+
+          # Every platform or none. A partial release is how a four-target
+          # matrix quietly becomes a one-target one — which is exactly what
+          # the cross-compile it replaced did on the 0.2.0 tag, and the
+          # `fail-fast: false` above means a single broken target no longer
+          # cancels the others into looking like they were never tried.
+          for label in x86_64-linux aarch64-linux x86_64-macos aarch64-macos; do
+            test -f "dist/zoxy-$version-$label.tar.gz" \
+              || { echo "::error::missing artifact for $label"; exit 1; }
           done
 
           # The config JSON Schema is target-independent, so emit it once
           # (§5). It is generated from the Zig config definitions, never
           # committed; shipping it here as an asset keeps a single source of
-          # truth. The sha256sum step below checksums it with the archives.
+          # truth.
           devenv shell -- zig build schema
           cp zig-out/config.schema.json "dist/zoxy-$version-config.schema.json"
 


### PR DESCRIPTION
**The 0.2.0 tag published nothing.** The release job cross-compiled all
four targets from one x86-64 Linux runner, and `linkSystemLibrary("crypto")`
resolves libcrypto out of the *host's* nix store:

```
ld.lld: .../openssl-3.6.2/lib/libcrypto.so is incompatible with aarch64linux
```

Not a flake, and not new to that tag — it is what TLS termination (#125)
cost. libcrypto is zoxy's one C dependency (DESIGN.md §4's scoped
exception), and a C dependency is precisely what a from-one-host
cross-compile cannot carry.

| target | 0.1.0 | 0.2.0 as tagged |
|---|---|---|
| x86_64-linux | ✅ | ✅ (matches the host) |
| aarch64-linux | ✅ | ❌ |
| x86_64-macos | ✅ | ❌ |
| aarch64-macos | ✅ | ❌ |

Four platforms to one, and the three it dropped include **both** macOS
targets — whose SIGTERM hang (#203) is the headline fix of the release
that could not build for them. An x86_64-linux-only 0.2.0 would have
delivered that fix exclusively to the platform that never had the bug.

## The change

One runner per target: `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-13`,
`macos-latest`. Each links a libcrypto of its own architecture, which is
the whole fix. The build matrix uploads artifacts; a separate `publish`
job collects them so the schema, checksums, GitHub release and Homebrew
formula still happen exactly once.

Two things the split buys beyond linking.

**Every binary now runs on the platform that built it**, so the build
asks it `--version` and fails the job if the answer is not the version
being released. That is the failure the bump-before-tag rule exists to
prevent, and nothing checked it until now — the release checklist says to
smoke the artifact by hand precisely because the workflow never did.

**`fail-fast: false` plus an explicit every-platform-or-none check** in
the publish job. A partial release is how a four-target matrix quietly
becomes a one-target one, which is what happened here; the check makes it
loud instead of silent.

## Risks worth naming

- `macos-13` is GitHub's Intel runner and is on a deprecation path. If it
  is already gone, this PR's `x86_64-macos` leg fails and we will see it
  here rather than at a tag. That is the point of finding out now.
- `ubuntu-24.04-arm` is a comparatively recent runner label; same
  reasoning.

Both are things a cross-compile hid and a native build surfaces, which is
the trade being made.

## After this merges

`v0.2.0` currently points at `8a482d7`, which does not contain this fix,
and it published nothing — so nothing has consumed it. Cleanest recovery
is to delete and re-tag on the new `main`, so the tag contains the
workflow that built it. I will not do that without a word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)