### PR TITLE
build: link libcrypto statically for releases, and prove the artifact runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,20 +44,35 @@ jobs:
             # at 128 bits (std.simd.suggestVectorLength keys off target CPU
             # features, DESIGN.md §7); v3 doubles it to 256.
             cpu: x86_64_v3
+            static: true
           - label: aarch64-linux
             os: ubuntu-24.04-arm
             zig_target: aarch64-linux-musl
             # aarch64 keeps its default baseline — NEON is mandatory in
             # ARMv8-A, so there is no wider portable win to take.
             cpu: ''
-          - label: x86_64-macos
-            os: macos-13
-            zig_target: x86_64-macos
-            cpu: x86_64_v3
+            static: true
+          # x86_64-macos is deliberately absent as of 0.2.0. Building it
+          # natively needs an Intel macOS runner, and GitHub's `macos-13`
+          # is retired: the 0.2.0 attempt sat queued for seven hours and
+          # never started. That is the worse failure mode — a wrong runner
+          # label does not fail, it *hangs*, so it blocks every other leg
+          # rather than reporting. Cross-compiling it from Apple Silicon
+          # is what this whole file just stopped doing, and for the same
+          # reason: libcrypto would come from the wrong architecture.
+          #
+          # Intel Macs can build from source until an Intel runner exists
+          # again. Revisit if GitHub ships a supported label.
           - label: aarch64-macos
             os: macos-latest
             zig_target: aarch64-macos
             cpu: ''
+            # Darwin has no static libc, so a macOS binary cannot be fully
+            # static and must not ask to be. libcrypto still comes from the
+            # archive pkg-config names — what stays dynamic is libSystem,
+            # which every macOS machine has. The nix-store check below is
+            # what holds that distinction to its promise.
+            static: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -84,7 +99,23 @@ jobs:
           echo "tag=$ref" >> "$GITHUB_OUTPUT"
           echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
 
+      # libcrypto has to come from a *static*, target-ABI build, and the
+      # only lever that reaches every consumer is pkg-config: zig resolves
+      # `-lcrypto` through it, and so does ztls's own build.zig, which is
+      # a pinned dependency this repo cannot reach into. Point pkg-config
+      # at a static openssl and both link the archive; point it anywhere
+      # else and the release links a shared library that is not on the
+      # machines it ships to.
+      - name: Resolve a static libcrypto
+        id: crypto
+        run: |
+          set -euo pipefail
+          dev="$(nix build --no-link --print-out-paths 'nixpkgs#pkgsStatic.openssl^dev')"
+          echo "pkg_config_path=$dev/lib/pkgconfig" >> "$GITHUB_OUTPUT"
+
       - name: Build and package
+        env:
+          PKG_CONFIG_PATH: ${{ steps.crypto.outputs.pkg_config_path }}
         run: |
           set -euo pipefail
           version="${{ steps.ver.outputs.version }}"
@@ -99,14 +130,42 @@ jobs:
           devenv shell -- zig build \
             -Dtarget="${{ matrix.zig_target }}" \
             ${{ matrix.cpu && format('-Dcpu={0}', matrix.cpu) || '' }} \
+            ${{ matrix.static && '-Dstatic' || '' }} \
             -Doptimize=ReleaseSafe \
             -Dbuild-id="${{ steps.ver.outputs.tag }}" --prefix out
 
-          # The binary runs on the machine that built it now, so the
-          # cheapest possible confidence is free: ask it what it is. A
-          # release that reports the wrong version is the failure the
-          # version-bump-before-tag rule exists to prevent, and this is
-          # where it would show.
+          # Nothing from the build machine may follow the binary out.
+          #
+          # This is the check the 0.2.0 tag needed and did not have. TLS
+          # termination gave zoxy a C dependency, `linkSystemLibrary`
+          # links it shared, and the Linux artifact silently became one
+          # that wants a musl loader and a musl-ABI libcrypto.so.3 at
+          # runtime — unrunnable on a stock box, and indistinguishable
+          # from a good build until someone tried to start it.
+          #
+          # A nix store path baked into a release is the same failure
+          # wearing macOS clothes, so both are refused here rather than
+          # discovered by whoever downloads it.
+          case "${{ runner.os }}" in
+            Linux)
+              if readelf -d ./out/bin/zoxy 2>/dev/null | grep -q NEEDED; then
+                echo "::error::not static:"; readelf -d ./out/bin/zoxy | grep NEEDED
+                exit 1
+              fi
+              ;;
+            macOS)
+              if otool -L ./out/bin/zoxy | grep -q /nix/store; then
+                echo "::error::links the build machine's nix store:"
+                otool -L ./out/bin/zoxy | grep /nix/store
+                exit 1
+              fi
+              ;;
+          esac
+
+          # And it runs, on the platform it was built for, and says it is
+          # the version being released. A release that reports the wrong
+          # version is the failure the bump-before-tag rule exists to
+          # prevent; this is where it shows.
           reported="$(./out/bin/zoxy --version)"
           echo "built: $reported"
           case "$reported" in
@@ -167,7 +226,7 @@ jobs:
           # the cross-compile it replaced did on the 0.2.0 tag, and the
           # `fail-fast: false` above means a single broken target no longer
           # cancels the others into looking like they were never tried.
-          for label in x86_64-linux aarch64-linux x86_64-macos aarch64-macos; do
+          for label in x86_64-linux aarch64-linux aarch64-macos; do
             test -f "dist/zoxy-$version-$label.tar.gz" \
               || { echo "::error::missing artifact for $label"; exit 1; }
           done
@@ -198,7 +257,6 @@ jobs:
           tag="${{ steps.ver.outputs.tag }}"
 
           sha_aarch64_macos=$(grep "zoxy-$version-aarch64-macos.tar.gz" dist/SHA256SUMS.txt | awk '{print $1}')
-          sha_x86_64_macos=$(grep  "zoxy-$version-x86_64-macos.tar.gz"  dist/SHA256SUMS.txt | awk '{print $1}')
           sha_aarch64_linux=$(grep "zoxy-$version-aarch64-linux.tar.gz" dist/SHA256SUMS.txt | awk '{print $1}')
           sha_x86_64_linux=$(grep  "zoxy-$version-x86_64-linux.tar.gz"  dist/SHA256SUMS.txt | awk '{print $1}')
 
@@ -222,14 +280,15 @@ jobs:
               strategy :github_latest
             end
 
+            # Apple Silicon only. There is no Intel macOS bottle from
+            # 0.2.0 on: building one needs an Intel macOS runner, and
+            # GitHub's is retired. Homebrew on an Intel Mac will report
+            # that no bottle is available rather than download one that
+            # cannot run, which is the failure worth having.
             on_macos do
               on_arm do
                 url "https://github.com/zoxy-io/zoxy/releases/download/$tag/zoxy-$version-aarch64-macos.tar.gz"
                 sha256 "$sha_aarch64_macos"
-              end
-              on_intel do
-                url "https://github.com/zoxy-io/zoxy/releases/download/$tag/zoxy-$version-x86_64-macos.tar.gz"
-                sha256 "$sha_x86_64_macos"
               end
             end
 

--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,16 @@ pub fn build(b: *std.Build) void {
     const io_options = b.addOptions();
     io_options.addOption(IoBackend, "backend", io_backend);
 
+    // Release builds link libcrypto statically; everything else links the
+    // shared one its shell provides. See `static_link` for why the
+    // distinction is not cosmetic, and for why the *choice of libcrypto*
+    // is made through pkg-config rather than here.
+    static_link = b.option(
+        bool,
+        "static",
+        "link the executable statically, libcrypto included (release artifacts)",
+    ) orelse false;
+
     // libxev is pinned by content hash to the zoxy-io fork's
     // zoxy-ring-flags branch: the audited upstream snapshot plus the
     // setup-flags commit (DESIGN.md §4); see build.zig.zon. The pin moves
@@ -100,6 +110,12 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zoxy", .module = zoxy_module },
             },
         }),
+        // A release binary is handed to strangers, so it needs nothing on
+        // the box it lands on. Without this the musl target still asks
+        // for a musl loader, which stock Linux does not have — the
+        // artifact links correctly and then refuses to start, which is
+        // exactly what the 0.2.0 tag produced.
+        .linkage = if (static_link) .static else null,
     });
     // src/main.zig reads its version from this module (also added to the
     // ReleaseSafe `release_zoxy` below, the other build of that same source).
@@ -543,8 +559,33 @@ fn resolveBuildId(b: *std.Build) []const u8 {
 /// here, so they are set in one place rather than repeated per module.
 fn linkLibcrypto(module: *std.Build.Module) void {
     module.link_libc = true;
+    // Static where the caller asked for it (`-Dstatic-crypto`), which the
+    // release builds do and nothing else does.
+    //
+    // A dev or CI build links the shared libcrypto its shell provides and
+    // runs on that machine, which is all it needs. A *release* binary is
+    // handed to strangers, and a musl target that dynamically links
+    // libcrypto is not the artifact anyone thinks it is: it wants a musl
+    // loader and a musl-ABI `libcrypto.so.3` at runtime, so a stock
+    // Linux box cannot execute it at all. That shipped unnoticed the
+    // moment TLS termination (#125) gave zoxy a C dependency — before it,
+    // the musl target had nothing to link and was static by default.
     module.linkSystemLibrary("crypto", .{});
 }
+
+/// Set from `-Dstatic` in `build`, read where the executable is declared.
+/// A file global because that is the only other place it is needed and a
+/// parameter would have to travel through code that does not care.
+///
+/// *Which* libcrypto `-lcrypto` resolves to is not decided here. Zig
+/// asks pkg-config, so the answer is whatever `PKG_CONFIG_PATH` names —
+/// which is also the only lever that reaches **ztls's** own
+/// `linkSystemLibrary("crypto")`, since that lives in a pinned dependency
+/// this build cannot reach into. A release therefore points pkg-config at
+/// a static, target-ABI openssl and gets one everywhere; naming an
+/// archive here would have fixed only half the link and left ztls still
+/// pulling in the shared one.
+var static_link: bool = false;
 
 /// The `-Dio-backend` choice. `default` is what the platform picks
 /// (io_uring on Linux, kqueue on macOS); `epoll` overrides it to the


### PR DESCRIPTION
The 0.2.0 tag produced a Linux binary that could not start:

```
./out/bin/zoxy: cannot execute: required file not found
```

Not a missing file — a missing **loader**. TLS termination (#125) gave
zoxy a C dependency, `linkSystemLibrary("crypto")` links it shared, and
the `-linux-musl` release target quietly stopped being static:

```
interpreter /lib/ld-musl-x86_64.so.1
NEEDED  libcrypto.so.3
NEEDED  libc.so
```

A stock Linux box has neither the musl loader nor a musl-ABI
`libcrypto.so.3`. Before #125 the musl target had nothing to link and was
static by accident, which is why nobody noticed the property was
load-bearing until it was gone.

## The fix, and the wrong turn on the way to it

`-Dstatic` links the executable statically, releases only (default off,
so dev and CI builds are untouched).

*Which* libcrypto `-lcrypto` resolves to is decided by **pkg-config**,
not by `build.zig`, and that indirection is the whole point. Zig asks
pkg-config — and so does **ztls's own `build.zig`**, which lives in a
pinned dependency this repo cannot reach into.

My first attempt named the archive explicitly (`addObjectFile`) and fixed
exactly half the link: my modules took the static archive, ztls kept
pulling in the shared one, and the executable still failed with "using
shared libraries requires dynamic linking". A link-mode *preference*
(`preferred_link_mode = .static`) failed differently and more quietly —
it emits `-search_paths_first_static`, but a nix shell puts the dynamic
libcrypto's `-L` first, so the search found `.so` before it ever reached
the static path.

Pointing `PKG_CONFIG_PATH` at a static, target-ABI openssl fixes every
consumer at once, including the one in the dependency.

Verified on the real release target rather than argued:

```
ELF 64-bit LSB executable, x86-64, statically linked
readelf -d: There is no dynamic section in this file.
$ ./zoxy --version
zoxy 0.2.0
```

## The check that was missing

Every release build now proves its artifact carries nothing from the
build machine, before packaging: no `NEEDED` on Linux, no `/nix/store` in
`otool -L` on macOS. Then it runs the binary and checks it reports the
version being released.

A release that cannot start is indistinguishable from a good one until
somebody tries it. Nothing tried. That is why a broken artifact reached a
tag.

macOS keeps a dynamic libSystem — Darwin has no static libc — so what the
nix-store check holds it to is that nothing *else* follows it out.

## x86_64-macos is dropped

Building it natively needs an Intel macOS runner and GitHub's `macos-13`
is retired. The 0.2.0 attempt sat **queued for seven hours** and never
started, which is the worse failure mode: a wrong runner label does not
fail, it hangs, and blocks every other leg. Cross-compiling it is what
this file just stopped doing, for the same libcrypto reason.

The Homebrew formula loses its `on_intel` macOS branch, so brew reports
no available bottle rather than serving one that cannot run. Intel Macs
can still build from source. Called out in the release notes.

## Gates

`zig build ci` rc=0, `zig fmt --check` clean. The `-Dstatic` default is
off, so nothing about the normal build path changes — census 59 fired /
16 exempt, 4096 seeds, smoke clean, as before.

After this merges: retag `v0.2.0` and watch. `publish` needs `build`, so
any remaining problem fails without publishing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)