### PR TITLE
ci: set PKG_CONFIG_PATH inside the devenv shell, not outside it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,6 @@ jobs:
           echo "pkg_config_path=$dev/lib/pkgconfig" >> "$GITHUB_OUTPUT"
 
       - name: Build and package
-        env:
-          PKG_CONFIG_PATH: ${{ steps.crypto.outputs.pkg_config_path }}
         run: |
           set -euo pipefail
           version="${{ steps.ver.outputs.version }}"
@@ -127,7 +125,16 @@ jobs:
           # the identifier equal the version, which `zoxy --version`
           # recognises and omits — a release says `zoxy 0.0.7` and
           # nothing else, whatever the checkout depth happens to be.
-          devenv shell -- zig build \
+          # `env` *inside* the devenv shell, not on the step. `devenv
+          # shell` establishes its own environment and replaces
+          # PKG_CONFIG_PATH with one naming the shell's dynamic openssl,
+          # so a value exported outside is silently discarded — the build
+          # then links the shared library and the artifact fails to start.
+          # That is precisely how the first static-linking attempt
+          # regressed: it was verified by invoking zig directly, where
+          # there is no shell to overwrite anything.
+          devenv shell -- env PKG_CONFIG_PATH="${{ steps.crypto.outputs.pkg_config_path }}" \
+            zig build \
             -Dtarget="${{ matrix.zig_target }}" \
             ${{ matrix.cpu && format('-Dcpu={0}', matrix.cpu) || '' }} \
             ${{ matrix.static && '-Dstatic' || '' }} \


### PR DESCRIPTION
The retagged `v0.2.0` failed all three legs:

```
error: using shared libraries requires dynamic linking
```

and the emitted command named **openssl 3.6.2** — the shell's *dynamic*
one — where the step had exported a path to the static 3.6.3.

`devenv shell` establishes its own environment and replaces
`PKG_CONFIG_PATH` with one naming the packages it provides. A value
exported by the workflow step is discarded before zig ever asks
pkg-config. The variable was set; nothing read it.

```
$ PKG_CONFIG_PATH=<static> devenv shell -- sh -c 'echo $PKG_CONFIG_PATH'
/nix/store/…-openssl-3.6.2-dev/lib/pkgconfig      # the shell's own

$ devenv shell -- env PKG_CONFIG_PATH=<static> sh -c 'echo $PKG_CONFIG_PATH'
/nix/store/…-openssl-static-…-musl-3.6.3-dev/lib/pkgconfig
```

## This was my verification gap, not a surprise

I proved the static build locally by invoking `zig` directly. CI runs
`devenv shell -- zig build`. That difference is the entire bug, and it is
exactly the kind a near-enough local reproduction hides.

Re-verified this time against the command shape CI actually runs rather
than an approximation of it:

```
$ devenv shell -- env PKG_CONFIG_PATH=<static> zig build \
    -Dtarget=x86_64-linux-musl -Dcpu=x86_64_v3 -Dstatic ...
ELF 64-bit LSB executable, x86-64, statically linked
```

## Not a new gate, an existing one working

Nothing was published. `publish` needs all three builds, and the
every-platform-or-none check would have caught a partial set even if a
leg had produced something. The artifact checks added alongside these —
no `NEEDED`, no `/nix/store`, run it and read its version — are still the
reason a broken binary cannot reach a release again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)