### PR TITLE
sim: a drain with no deadline has no give-up to strand (#206)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -206,6 +206,41 @@ draws which kind. Seed 2302 above will not reproduce against the shipped
 list, because `.timer` is no longer in it. Any seed number pinned against
 this function has the same short shelf life.
 
+**A third case of the same shape, and the one that shipped broken: a
+drain with no deadline has no backstop to provoke.** `drain_deadline_ms =
+0` is "no cap" (§5) — `beginDrain` arms no timer, and since
+`onDrainStuck` is started by `onDrainDeadline` and nothing else, the
+give-up does not exist on those seeds. A strand there is the `timer` case
+by another route: the drain waits for the last connection however long
+that takes, exactly as configured, and the run ends in `SimIo`'s deadlock
+with no diagnostic. The proxy is right and the gate was wrong — it
+demanded a report the configuration deliberately declined.
+
+Nightly run #18 (2026-08-13) found it. All four shards hit the 16-failure
+cap early in their million-seed slices — shard 0 at 36k — so the night
+swept 163k of its 4M block and every one of the 64 named seeds had drawn
+both a mid-scenario drain with the no-cap deadline and a drop. The draws
+are independent and both are minorities, which is why 4096 seeds per
+change missed it and a million-seed block did not: at roughly 7 such
+seeds per 4096, `ci` clears whole runs without producing one.
+
+`maybeStrandOps` skips the strand when the deadline is zero, rather than
+`deriveDropKind` skipping the draw. `drop_kind` is drawn in
+`deriveTerminatingDraws` and the deadline one call later in
+`deriveServerConfig`, adjacent siblings under `deriveTopology` in that
+order, so gating at the draw means drawing the deadline first — and
+swapping two calls re-rolls every draw after them for the whole sweep,
+census margins included, to fix an 0.2% case. Skipping at the strand
+leaves `drop_taken` false, so the seed is held to the ordinary invariants
+like any seed that stranded nothing. Measured cost over a 4096-seed
+sweep: 7 seeds draw a drop they cannot use, against 159 that draw one
+they can.
+
+The two rates are worth keeping apart: 7 per 4096 is the *draw* rate, and
+the observed failure rate was about a quarter of that (16 across shard
+0's 36k). A drawn kind with nothing armed of it strands nothing, so most
+of what this skip costs was never going to reach the give-up anyway.
+
 The sweep runs with `dump_on_abort = false`. A stranded seed reaches the
 give-up on purpose and its operator forensics are two hundred lines
 apiece, while the verdict here is `abortedWith` and not the wording. That

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1500,6 +1500,37 @@ fn clientEnded(harness: *Harness) void {
 fn maybeStrandOps(harness: *Harness) void {
     const kind = harness.drop_kind orelse return;
     if (harness.drop_taken) return;
+    // A zero `drain_deadline_ms` is "no cap" (§5), and the deadline timer
+    // is the only thing that ever arms the give-up: `onDrainStuck` is
+    // started by `onDrainDeadline`, so a drain with no deadline has no
+    // backstop to provoke. Stranding an op there asks the proxy for a
+    // report the configuration deliberately declined — the drain waits
+    // for the last connection however long that takes, by design — and
+    // the run ends in `SimIo`'s own deadlock with no diagnostic, which is
+    // the same shape the excluded `timer` kind has and just as much a
+    // true statement about the backstop's reach rather than a defect.
+    //
+    // Skipped at the strand rather than at the draw because `drop_kind` is
+    // drawn in `deriveTerminatingDraws` and the deadline one call later in
+    // `deriveServerConfig` — adjacent siblings under `deriveTopology`, in
+    // that order. Gating the draw needs the deadline first, and swapping
+    // two calls re-rolls every draw after them for the whole sweep, taking
+    // the §9 census margins with it. A one-line skip here is the cheaper
+    // half of that trade by a wide margin. It leaves `drop_taken` false, so
+    // `verify` holds this seed to the ordinary invariants — exactly what a
+    // seed that stranded nothing is for — and costs only the seeds where
+    // the backstop does not exist: measured over a 4096-seed sweep, 7 seeds
+    // draw a drop against a no-cap deadline against 159 that draw one they
+    // can use.
+    //
+    // Found by the nightly soak (run #18, 2026-08-13). All four shards hit
+    // the 16-failure cap early in their slices — shard 0 at 36k — and every
+    // named seed had drawn both a mid-scenario drain with the no-cap
+    // deadline and a drop. Only a quarter or so of the seeds this skips
+    // would have deadlocked at all: a drawn kind with nothing armed of it
+    // strands nothing, which is why the draw rate above is the higher
+    // number.
+    if (harness.config.drain_deadline_ms == 0) return;
     // A latch rather than clearing the draw, for the reason the clock
     // jump keeps two fields: what the seed *drew* and what it *did* are
     // different facts, and `verify` needs the first one to still be


### PR DESCRIPTION
Nightly soak [run #18](https://github.com/zoxy-io/zoxy/actions/runs/31668179996) failed 64 seeds across all four shards, every one a `SimIo` deadlock naming `[dropped]` ops. It is one class, and it is a gate bug rather than a proxy bug.

## What broke

`drain_deadline_ms = 0` is "no cap" (§5): `beginDrain` arms no timer, the drain waits for the last connection however long that takes, and whoever sent the signal owns the upper bound. `onDrainStuck` — the sole caller of `io.abort` — is started by `onDrainDeadline` and nothing else, which is itself armed only when the deadline is non-zero. So on those seeds the §8 give-up does not exist at all.

#206's strand then asks the proxy for a report the configuration deliberately declined. The stranded op sits pending forever, nothing else is armed, and the simulator correctly reports its own deadlock.

That is the `timer` exclusion by another route. #206 reasoned that case through — stranding the drain deadline strands the thing that would have reported it — and this is the same statement about the backstop's reach, reached by a config draw instead of a kind draw. It was the half not noticed.

## Why it shipped

Both draws are minorities and they are independent: the drop is 1-in-16 of adversarial seeds, and the zero deadline is a quarter of the quarter that drain mid-scenario. At roughly 7 such seeds per 4096, `ci` clears whole runs without producing one. It took a million-seed block.

The cost was most of the night: all four shards hit the 16-failure cap early — shard 0 at 36k — so the soak swept 163k of its 4M block. Ranges are keyed to the run number, so **that remainder is not revisited on its own.** Once this is on `main`, a `workflow_dispatch` with `start_seed` `52000001` is what reclaims it.

## The fix

`maybeStrandOps` skips the strand when the deadline is zero, rather than `deriveDropKind` skipping the draw.

`drop_kind` is drawn in `deriveTerminatingDraws` and the deadline one call later in `deriveServerConfig`, adjacent siblings under `deriveTopology` in that order. Gating at the draw means drawing the deadline first, and swapping two calls re-rolls every draw after them for the whole sweep, census margins included — a large blast radius for an 0.2% case. Skipping at the strand leaves `drop_taken` false, so the seed is held to the ordinary invariants like any seed that stranded nothing.

Measured cost over a 4096-seed sweep: 7 seeds draw a drop they cannot use, against 159 that draw one they can. The docs keep that apart from the failure rate it does not equal (16 across shard 0's 36k, about a quarter) — a drawn kind with nothing armed of it strands nothing, so most of what the skip costs was never going to reach the give-up.

No production code changes.

## Verification

- All 16 of shard 0's seeds, and six spot-checked across shards 1–3, fail before and pass after — bit-identically on macOS/arm64, so the sim is deterministic across platforms
- 200k-seed sweep over `52000001..52200000`: clean, `census ok, 59 counter(s) fired, 16 exempt; 9 seam op(s), 1 exempt`
- `zig build ci` green — 4096-seed sim + census, boundary lint, Tier-0.5 live smoke gate
- `zig fmt --check` clean
- `tiger-style-reviewer` pass: no violations. It caught a wrong function citation in the first draft of the comment (`startServerAndOrigins`, which plays no part in the ordering); corrected in both the comment and the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
