### PR TITLE
sim: make the give-up branch assert something (#206)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -168,6 +168,41 @@ as "#206 working as intended" — including one a future *release* bug
 produced with every op delivered, which is the exact defect the backstop
 exists to catch and the last thing a sweep should swallow.
 
+That gate shipped one step short of what the paragraph above claims.
+`drop_taken` was latched on *reaching* the strand rather than on
+stranding anything, and a draw whose kind has nothing armed of it strands
+nothing — so those seeds carried the excuse without having earned it, and
+a genuine stuck drain landing on one would have been waved through. The
+latch is now `dropped >= 1`. It cost no coverage: the give-up branch is
+still taken 52 times per 4096-seed sweep, because a seed that stranded
+nothing had no reason to reach it.
+
+**What the give-up branch asserts.** Reaching it used to end the seed:
+the exit code was checked, the strand was checked, and nothing else. Two
+oracles now run there, because "the proxy gave up" is a weaker claim than
+this issue asked for.
+
+`SimIo.pendingOpsReferenceLiveSockets` answers #206's second ask — no
+slot released while an op still references it. Every ordinary use of a
+handle goes through `socketEntry`, which asserts the entry is acquired
+and the generation matches, so a stale handle panics where it is used. A
+*dropped* op never reaches that check, which makes the abort path the one
+place the §5 corruption could hide. It is asked **before** `verify`'s
+cleanup, and the order is load-bearing: a strand takes harness-side ops
+too, and closing the doubles' sockets reads as the server having freed a
+slot under a live reference. Seed 591 says live before the cleanup and
+stale after, with nothing wrong in between.
+
+`strandCanExplainStuck` demands the give-up blame a plane the strand can
+account for. Mis-blaming is the #203 defect itself — the first
+`onDrainStuck` said "nothing stuck" while the admin plane held an armed
+accept. It is permissive on purpose: *some* stuck plane must be able to
+own an op of the drawn kind, never a named one. Which plane a strand
+lands on is a property of the schedule, and pinning it would fail on the
+rare seed rather than on a defect. Mutation-checked rather than assumed —
+pointing `log_write` at conns instead of the log fails seed 587, so the
+oracle is reached and can fail.
+
 Clean seeds never draw a strand, for the reason every sibling
 perturbation states: their oracle is each script's exact golden outcome,
 and a stranded op ends the run at the give-up before those oracles run —
@@ -183,10 +218,38 @@ once per sweep.
 Two kinds are excluded, for opposite reasons, and both are findings.
 
 `close` is **never** armed at a wind-down — zero occurrences across the
-sweep. So "a slot that can never be released", arguably the scarier half
-of the #203 class, is not reachable by dropping at the drain however the
-seed picks. It needs a drop placed mid-teardown, which is a different
-hook and is what keeps #206 open.
+sweep — so naming it would be a draw that silently tested nothing.
+
+An earlier version of this section drew a second conclusion from that
+measurement and it was wrong, so it is corrected here rather than
+quietly dropped: it said "a slot that can never be released", the
+scarier half of the #203 class, was therefore out of reach until a
+mid-teardown hook existed. Slot release does not wait on a close.
+`continueTeardown` returns early while `armedCount() != 0`, and once that
+reaches zero it closes **synchronously** with `closeNow` and releases in
+the same call; a connection's armed set is two data directions,
+`connect`, `connect_cancel`, `deadline`, `deadline_cancel`, and no close.
+There is no close op to drop because the teardown path arms none.
+Stranding any conn-armed op therefore produces an unreleasable slot
+already: recording the stuck plane at each give-up over a 4096-seed
+sweep gives `recv` 16 runs and `recv_group` 6 on conns, `connect` 8 on
+health and 2 on conns, and `log_write` 20 on the access log — 24 of the
+52 holding a conn slot that never released.
+
+What a wind-down drop genuinely cannot reach is the pair of cancels
+`beginTeardown` arms, since it arms them *after* the strand lands. That
+is the real argument for the mid-teardown hook, and it is not the
+argument this section used to make.
+
+Three kinds are armed at a wind-down and absent from the draw with no
+reason recorded, which is its own small finding: `timer_cancel` at ~15%
+of wind-downs — more common there than `recv_group`, which is in the
+draw — and `send` and `connect_cancel` at ~1.3%. Stranding a
+`timer_cancel` leaves `armed.deadline_cancel` set forever, an
+unreleasable slot by a route the sweep does not take, and it does not hit
+the `timer` self-reference below because nothing cancels the drain-stuck
+timer. The other two are near the noise floor. Adding `timer_cancel`
+looks like a free coverage win and is not done here.
 
 `timer` is worse, and it is the finding worth carrying: **`onDrainStuck`
 cannot catch a stranded timer, because it is one.** A seed that strands

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1531,17 +1531,114 @@ fn maybeStrandOps(harness: *Harness) void {
     // strands nothing, which is why the draw rate above is the higher
     // number.
     if (harness.config.drain_deadline_ms == 0) return;
+    const dropped = harness.io.dropPendingOps(kind);
     // A latch rather than clearing the draw, for the reason the clock
     // jump keeps two fields: what the seed *drew* and what it *did* are
     // different facts, and `verify` needs the first one to still be
     // there when it decides whether a stuck drain was asked for.
-    harness.drop_taken = true;
-    const dropped = harness.io.dropPendingOps(kind);
+    //
+    // Latched on `dropped >= 1`, not on reaching this line. The excuse
+    // `verify` grants is "this seed stranded something, so it may end at
+    // the give-up", and a draw that found nothing armed of its kind
+    // stranded nothing — it is an ordinary seed and owes the ordinary
+    // invariants. Latching on the attempt instead would hand that excuse
+    // to every such seed, so a genuine stuck drain arriving on one would
+    // be waved through as "#206 working as intended": the same hole the
+    // `drop_taken` gate was added to close, one step further out.
+    if (dropped >= 1) harness.drop_taken = true;
+    // The excuse is earned by stranding, not by arriving: this is the
+    // whole content of the paragraph above, in the form that breaks if a
+    // later edit reintroduces the unconditional latch.
+    assert(harness.drop_taken == (dropped >= 1));
     // Nothing armed of that kind is a legal outcome, not a failed draw —
     // the sweep's job is to try, and the oracle holds either way. A
     // stranded op stays *pending*, so the table it was counted out of is
     // still the bound; more than that would mean one was counted twice.
     assert(dropped <= harness.io.pending_count);
+}
+
+/// What a seed that ended at the §8 give-up owes instead of the ordinary
+/// invariants (#206). A seed that stranded an op the drain waits on
+/// cannot finish it and must not be asked to; what is demanded is that
+/// the proxy *noticed*. A drain that cannot complete is allowed, a drain
+/// that hangs without saying so is not.
+///
+/// Reached as an alternative for every seed rather than a branch on
+/// whether this one dropped anything, because that is the property worth
+/// holding: no schedule, dropped op or not, may end with the loop alive
+/// and nobody the wiser.
+///
+/// Split from `verify` when the two oracles below took it to the 70-line
+/// limit — the same remedy `setUp` and `deriveTopology` took before it.
+/// `pending_ops_live` is passed in rather than asked here because it has
+/// to be read before `verify` closes the harness's own sockets.
+fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void {
+    if (code != ServerSim.drain_stuck_exit_code) return error.UnexpectedAbort;
+    // Only a seed that stranded something is excused. Without this, the
+    // branch would accept any stuck drain as "#206 working as intended" —
+    // including one a future release bug produced with every op
+    // delivered, which is the exact defect this backstop exists to catch
+    // and the last thing the sweep should swallow.
+    if (!harness.drop_taken) return error.DrainStuckWithoutStrand;
+    // The give-up is allowed to leave work unfinished. It is not allowed
+    // to have freed a slot an op still points at: that is the §5
+    // corruption the generation counter exists to catch, and this is the
+    // one path where it could hide, since a dropped op never reaches the
+    // stale-handle assert every delivered op passes through. #206 asked
+    // for this oracle by name.
+    if (!pending_ops_live) return error.SlotReleasedUnderPendingOp;
+    if (!harness.strandCanExplainStuck()) return error.StrandCannotExplainStuck;
+}
+
+/// Whether the strand this seed took could account for a plane the
+/// give-up found stuck. Mis-blaming is not hypothetical: the first
+/// `onDrainStuck` reported "nothing stuck" while the admin plane held an
+/// armed accept (#203), and a backstop that names the wrong plane sends
+/// an operator somewhere useless with the process already gone.
+///
+/// Deliberately permissive — it asks that *some* stuck plane could own an
+/// op of the drawn kind, never that a named one is stuck. Which plane a
+/// strand lands on is a property of the schedule, and an oracle that
+/// pinned it would fail on the rare seed rather than on a defect. That
+/// bill was just paid once: #220's deadlock was a gate demanding an
+/// outcome the configuration had declined.
+///
+/// Measured over a 4096-seed sweep, for the shape rather than the rule:
+/// `log_write` lands on the access log 20 runs in 20, `recv` and
+/// `recv_group` on conns 22 in 22, `connect` on health 8 and conns 2.
+fn strandCanExplainStuck(harness: *const Harness) bool {
+    const kind = harness.drop_kind.?;
+    assert(harness.drop_taken);
+    const conns_stuck = !harness.server.conns.isFullyReleased();
+    const admin_stuck = !harness.server.admin.isQuiescent();
+    const log_stuck = !harness.server.access_log.isQuiescent();
+    const health_stuck = !harness.server.health.isQuiescent();
+    // `onDrainStuck` aborts only when one of the four is unfinished, so a
+    // give-up with all four done is the backstop firing at nothing.
+    assert(conns_stuck or admin_stuck or log_stuck or health_stuck);
+    return switch (kind) {
+        // The head ring is the connection path's alone (§5).
+        .recv_group => conns_stuck,
+        // Nothing but the access log writes one.
+        .log_write => log_stuck,
+        // Connections read, the admin plane reads its scrape, and the
+        // prober reads its probe; all three dial except the admin one.
+        .recv => conns_stuck or admin_stuck or health_stuck,
+        .connect => conns_stuck or health_stuck,
+        // A listener's accept feeds admission and the admin plane.
+        .accept => conns_stuck or admin_stuck,
+        // Out of the draw, so unreachable rather than defaulted: adding
+        // one to `deriveDropKind`'s list without giving it an arm here
+        // panics every seed that draws it, and a named arm is what makes
+        // that obvious to whoever adds the next kind.
+        .none,
+        .send,
+        .close,
+        .timer,
+        .timer_cancel,
+        .connect_cancel,
+        => unreachable,
+    };
 }
 
 /// Which op kind a seed strands, or null for the fifteen in sixteen that
@@ -1579,6 +1676,10 @@ fn deriveDropKind(clean: bool, random: std.Random) ?SimIo.OpKind {
     // backstop worked" is precisely what clean seeds exist to forbid.
     if (clean) return null;
     if (random.uintLessThan(u8, 16) != 0) return null;
+    // Adding an entry here needs a matching arm in `strandCanExplainStuck`,
+    // which lists the kinds out of the draw as `unreachable`. Without one
+    // the new kind panics every seed that draws it — on top of re-rolling
+    // which seed draws what, the trap the paragraph above describes.
     const kinds = [_]SimIo.OpKind{
         .accept,
         .recv,
@@ -1665,6 +1766,15 @@ pub fn tearDown(harness: *Harness) void {
 }
 
 pub fn verify(harness: *Harness) !void {
+    // #206: asked *before* the cleanup below, and the order is the whole
+    // point. A strand takes harness-side ops too — the doubles and the
+    // clients arm recvs of their own — and the tidying closes their
+    // sockets, so asking afterwards reads the harness putting its own
+    // things away as the server having freed a slot under a live
+    // reference. Measured on seed 591: live before the cleanup, stale
+    // after, with nothing wrong in between. What the oracle is about is
+    // the state the run ended in, not the state the tidying leaves.
+    const pending_ops_live = harness.io.pendingOpsReferenceLiveSockets();
     // The loop may stop before harness-side terminal completions
     // deliver; close what remains so the socket-leak check is exact.
     for (harness.clients[0..harness.l4_count]) |*client| {
@@ -1676,24 +1786,8 @@ pub fn verify(harness: *Harness) !void {
     harness.origin.closeRemaining();
     harness.origin_http.closeRemaining();
 
-    // #206: a seed that stranded an op the drain waits on cannot finish
-    // it, and must not be asked to. What is demanded instead is that the
-    // proxy *noticed* — a drain that cannot complete is allowed, a drain
-    // that hangs without saying so is not.
-    //
-    // Written as an alternative for every seed rather than a branch on
-    // whether this one dropped anything, because that is the property
-    // worth holding: no schedule, dropped op or not, may end with the
-    // loop alive and nobody the wiser.
     if (harness.io.abortedWith()) |code| {
-        if (code != ServerSim.drain_stuck_exit_code) return error.UnexpectedAbort;
-        // Only a seed that stranded something is excused. Without this,
-        // the branch would accept any stuck drain as "#206 working as
-        // intended" — including one a future release bug produced with
-        // every op delivered, which is the exact defect this backstop
-        // exists to catch and the last thing the sweep should swallow.
-        if (!harness.drop_taken) return error.DrainStuckWithoutStrand;
-        return;
+        return harness.verifyGaveUp(code, pending_ops_live);
     }
     if (!harness.server.isIdle()) return error.PoolLeak;
     if (!harness.server.reconcile()) return error.CountersDiverged;

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1085,6 +1085,51 @@ pub fn dropPendingOps(io: *SimIo, kind: OpKind) u32 {
     return dropped;
 }
 
+/// #206's other ask: no slot may be released while an op still
+/// references it. Every ordinary use of a handle goes through
+/// `socketEntry`, which asserts the entry is still acquired and its
+/// generation still matches, so a stale handle in the data path panics
+/// where it is used. A *dropped* op never reaches that check — it is
+/// never delivered — and a stranded seed is exactly where a slot freed
+/// under a live reference would go unseen. So ask the pending table
+/// directly rather than waiting for a use that will never come.
+///
+/// Only the four kinds naming an already-open socket can be checked.
+/// `accept` names a listener, `connect` a socket that does not exist
+/// until it completes, the two cancels name another completion, and
+/// `log_write` and `timer` name no socket at all.
+///
+/// Enumerated rather than defaulted, like every other correctness switch
+/// over `op` here (`opReady`, the `Result` construction) and unlike the
+/// single-kind filters that may safely say `else`. This one is a §5
+/// corruption oracle: a socket-bearing kind added later must fail to
+/// compile until someone decides whether it belongs, not slip through an
+/// `else => continue` and shrink what the oracle covers in silence.
+pub fn pendingOpsReferenceLiveSockets(io: *const SimIo) bool {
+    assert(io.pending_count <= pending_ops_max);
+    for (io.pending[0..io.pending_count]) |completion| {
+        const socket = switch (completion.op) {
+            .recv => |op| op.socket,
+            .recv_group => |op| op.socket,
+            .send => |op| op.socket,
+            .close => |op| op.socket,
+            .none,
+            .accept,
+            .connect,
+            .log_write,
+            .timer,
+            .timer_cancel,
+            .connect_cancel,
+            => continue,
+        };
+        assert(socket.index < sockets_max);
+        const entry = &io.sockets.slots[socket.index];
+        if (!io.sockets.isAcquired(entry)) return false;
+        if (@as(u16, @truncate(entry.generation)) != socket.generation) return false;
+    }
+    return true;
+}
+
 /// Schedule a signal delivery — drain is just another scheduled event (§4).
 pub fn injectSignal(io: *SimIo, signal: Io.Signal) void {
     io.scheduleSignal(signal, io.now_ns_value);


### PR DESCRIPTION
Reaching the §8 give-up used to end a seed: the exit code was checked, the strand was checked, and nothing else. #206 asked for more and the ask went unbuilt, so 52 runs per sweep arrived at the one branch that issue exists to exercise and were waved through.

Follow-on to #220. No production code changes — `src/io/SimIo.zig` gains a read-only oracle; everything else is the harness and the docs.

## The excuse was granted a step too early

`drop_taken` latched on *reaching* the strand rather than on stranding anything, and a draw whose kind has nothing armed of it strands nothing. Those seeds carried the excuse without earning it, so a genuine stuck drain landing on one would have been accepted as "#206 working as intended" — the same hole the flag was added to close, one step further out.

Now latched on `dropped >= 1`, with an assertion pinning it. It costs no coverage: the branch is still taken 52 times per 4096-seed sweep, because a seed that stranded nothing had no reason to reach it.

## Two oracles on the branch

**`pendingOpsReferenceLiveSockets`** answers the ask this issue made by name — no slot released while an op still references it. Every ordinary use of a handle goes through `socketEntry`, which asserts the entry is acquired and the generation matches, so a stale handle panics where it is used. A dropped op never gets there, which makes the abort path the one place the §5 corruption could hide. Enumerated over every `OpKind` rather than defaulted, matching the other correctness switches in that file: a socket-bearing kind added later must fail to compile, not quietly shrink what the oracle covers.

It is read **before** `verify` closes the harness's own sockets, and that order is load-bearing. A strand takes harness-side ops too, and the tidying closes the doubles' sockets, so asking afterward reads the harness putting its things away as the server having freed a slot under a live reference. Seed 591 failed the first draft of this oracle for exactly that reason — live before the cleanup, stale after, nothing wrong in between — which is how the ordering was found.

**`strandCanExplainStuck`** demands the give-up blame a plane the strand can account for. Mis-blaming is the #203 defect itself: the first `onDrainStuck` reported "nothing stuck" while the admin plane held an armed accept. Permissive on purpose — *some* stuck plane must be able to own an op of the drawn kind, never a named one. Which plane a strand lands on is a property of the schedule, and pinning it would fail on the rare seed rather than on a defect, which is the bill #220 had just finished paying.

## A documented conclusion, corrected in place

The notes recorded "a slot that can never be released" as out of reach until a mid-teardown hook existed, reasoning from the true measurement that `close` is never armed at a wind-down. The measurement holds; the inference does not.

Release does not wait on a close. `continueTeardown` returns early while `armedCount() != 0`, then closes **synchronously** with `closeNow` and releases in the same call, and `Conn.Armed` holds no close bit at all. Stranding any conn-armed op already produces an unreleasable slot — recording the stuck plane at each give-up over 4096 seeds gives 24 of the 52 holding one.

What a wind-down drop genuinely cannot reach is the pair of cancels `beginTeardown` arms *after* the strand lands. That is the real argument for the hook, and it is not the one the section used to make. Also recorded: three kinds are armed at a wind-down and absent from the draw with no reason given — `timer_cancel` (~15%, more common there than `recv_group`, which is in the draw), `send` and `connect_cancel` (~1.3%). `timer_cancel` looks like a free coverage win and is deliberately left for a separate slice.

Full detail in https://github.com/zoxy-io/zoxy/issues/206#issuecomment-5276953836.

## Verification

- `zig build ci` green — 4096-seed sim + census, boundary lint, Tier-0.5 live smoke gate
- **350k seeds** swept clean across `4097..354096`, census holding at `59 fired / 16 exempt`
- Give-up branch still reached 52 times per sweep — the tightened latch cost nothing
- **Both oracles mutation-checked**, not merely observed green: pointing `log_write` at conns fails seed 587, and the placement bug that seed 591 caught is what fixed the other. An oracle that cannot fail is worse than no oracle
- `verify` hit exactly the 70-line limit, so the branch moved to `verifyGaveUp` (the `setUp`/`deriveTopology` remedy); `verify` is now 46
- `tiger-style-reviewer`: no violations. Its four judgement calls — switch exhaustiveness, the `unreachable` arms, the missing latch assertion, and the 70-line ceiling — are all applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
