### PR TITLE
fix(tls): the 100% CPU livelock above ~650 concurrent TLS connections (#222)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -185,9 +185,38 @@
         // whole 16 KiB capacity rather than the bytes actually used, at
         // ~3% of handshake throughput (IMPLEMENTATION_NOTES.md). Bounding
         // it narrows what is zeroed, never what is retained.
+        //
+        // Re-audit for 634567a (zoxy-io/ztls#1, upstream
+        // mattrobenolt/ztls#88): `p256`/`p384` `KeyPair.generate` retried
+        // `while (true) … catch continue`, a bound sized for the
+        // once-in-2^32 scalar outside [1, n-1] but applied to the whole
+        // error set — including the six allocation paths that answer
+        // `LibcryptoFailed`. With our fixed heap full, every attempt failed
+        // identically and the loop never ended: #222's 100% CPU livelock,
+        // on the loop thread, taking both listeners and the admin plane.
+        //
+        // The diff is a classification and the propagation that follows
+        // from it. `EC_KEY_set_private_key`/`set_public_key`/`check_key`
+        // judge the scalar, so they now answer `IdentityElement`, leaving
+        // `LibcryptoFailed` to mean the library failed — the two were
+        // indistinguishable before, which is why no caller could have
+        // handled this. `generate` returns `Error!KeyPair`, retries only
+        // `IdentityElement`, bounds that at 4 attempts, and propagates
+        // `LibcryptoFailed` on the first. No change to key derivation, the
+        // record layer, or any byte on the wire; the ephemeral scalars are
+        // still drawn from `entropy.fill` and still checked by the same
+        // three OpenSSL calls, only under a different error name.
+        //
+        // Blast radius here is one `try` in `tls/Engine.zig`: the error now
+        // reaches `Server.acquireTlsEngine`, which already released the
+        // engine and returned `CryptoUnavailable` for exactly this — a rung
+        // (`shed_tls_crypto`) that until now could never fire. Two upstream
+        // tests that pinned the old mapping moved with it; zero is the
+        // "draw again" case they describe. Still open upstream, so this
+        // rides the fork like the other four.
         .ztls = .{
-            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#dba5cdf93483ccdb9a76c30c5f979912440a791e",
-            .hash = "ztls-0.0.0-SHHDXhqPFQAt_KHHb6p-5wgcImq3pWtCP1UEESUPjXVr",
+            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#634567aedb66ed7c8abcd0d6b2e4fefdba6b6cb5",
+            .hash = "ztls-0.0.0-SHHDXm2kFQB_YpgKnzsrxFllS1bq1WTSN-HTr8fAdAYr",
         },
     },
     .paths = .{

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -482,7 +482,7 @@ a raised `RLIMIT_NOFILE`:
 | head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
 | upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | tls engines | 0, or min(conn slots, 1024) | 1024 | ~132 KiB + plaintext |
-| **pool memory** | **~34 MiB** | **~288 MiB** | |
+| **pool memory** | **~34 MiB** | **~294 MiB** | |
 
 `head_buffer_bytes` defaults to 8 KiB and is the largest head accepted
 (oversize → 414/431, §7), with a 1 KiB floor and a 1 MiB ceiling: a size
@@ -501,9 +501,16 @@ orders of magnitude past a head buffer. One-per-slot at the c10k ceiling would b
 default is conn slots *capped* at 1024 and a deployment past that sheds
 rather than reserves. It is zero — the whole feature free — unless some
 listener carries a `tls` block. Beside the per-engine cost sits one
-process-wide reservation: the fixed heap libcrypto allocates from, 4 MiB,
-which is what makes zero-allocation-after-startup provable with a C
-library underneath (§4).
+process-wide reservation: the fixed heap libcrypto allocates from, which
+is what makes zero-allocation-after-startup provable with a C library
+underneath (§4). It is sized *from the engine pool* — 2 MiB plus 8 KiB
+per engine, so 10 MiB at the 1024-engine default — because its occupancy
+is per concurrent session rather than per process. It was a flat 4 MiB
+until #222: that number came from measuring *sequential* handshakes,
+where each one's blocks return to their size class before the next asks
+and the frontier never grows. Concurrent sessions each hold their own, so
+the heap ran out at ~675 of them — and the process livelocked rather than
+shed, because the dependency retried that allocation failure forever.
 
 Session resumption adds nothing to either. A resumption ticket has to
 carry its session's PSK back to us, and the obvious shape — a table keyed

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -978,10 +978,57 @@ long-lived proxy. Measured by `zig build tls-heap-proof`, Debug, OpenSSL
 So one handshake's distinct block footprint is ~1 MiB and every
 subsequent handshake is free. Sabotaging `free` to drop blocks instead of
 listing them takes the same run to 2,484,864 B, which is what the
-plateau assertion is there to catch. The 4 MiB reservation is sized
-against the plateau with room for the concurrency the frontier has not
-seen yet — revisit once many handshakes are genuinely *in flight*
-together, which this sequential proof does not exercise.
+plateau assertion is there to catch.
+
+### The concurrency the sequential proof did not exercise (2026-08-13, #222)
+
+This note used to end by sizing the reservation at a flat 4 MiB and saying
+"revisit once many handshakes are genuinely *in flight* together". That
+revisit is done, and the flat number was wrong — not by a margin, by a
+category. **The plateau is a property of sequential handshakes only.** Each
+one's blocks return to their class before the next asks, so the frontier
+never moves: 1811 sequential handshakes at 50 concurrency held it at
+960 KiB. Run them *concurrently* and every live session holds its own
+blocks, so the frontier is linear in the session count:
+
+| concurrent sessions | 50 | 100 | 200 | 400 |
+|---|---|---|---|---|
+| frontier | 1024 KiB | 1280 KiB | 1792 KiB | 2752 KiB |
+
+~4.9 KiB marginal per session (5.12 KiB across 100→200, 4.80 across
+200→400) over a ~1 MiB base. Against a flat 4 MiB that predicts exhaustion
+at ~675 concurrent sessions, and the cliff was observed at exactly that:
+healthy at 600, dead at 700.
+
+Dead rather than degraded, because ztls retried the resulting allocation
+failure forever (`p256.KeyPair.generate`'s `while (true) … catch continue`,
+[mattrobenolt/ztls#88](https://github.com/mattrobenolt/ztls/issues/88)).
+The proxy spun at 100% CPU inside one never-returning call on the loop
+thread, so the TLS listener, the plaintext listener and the admin plane
+went dark together and `SIGTERM` was ignored. `shed_tls_crypto` — the rung
+built for precisely this — read zero throughout, because the error never
+came back for `acquireTlsEngine` to see.
+
+So the reservation is derived now rather than picked:
+`libcryptoHeapBytes(tls_engines)` = 2 MiB base + 8 KiB per engine, the
+measured ~5 KiB with margin for the no-coalescing classes. It stays
+comptime — the storage must be BSS, see the atexit crash above — by
+deriving at `tls_engines_max`, which the loader already enforces; the
+banner prices the whole static array, since that is what is held. At the
+default 1024 engines
+that is 10 MiB against the old 4.
+
+Verified: the 1200-connection run that used to livelock now leaves
+`shed_tls_crypto` at 0 and sheds on `shed_tls_engines` instead — the pool
+ceiling, which is the correct wall — with the proxy healthy at 0% idle CPU
+afterwards. That holds against the *unfixed* ztls, which is the point: the
+sizing removes the trigger, and the ztls fix makes the failure survivable
+if another deployment reaches it anyway.
+
+One thing this does **not** fix: once the heap has been exhausted even
+once, it never recovers, because ztls never drains OpenSSL's error queue
+and those entries allocate through the same hooks. Measured in the same
+issue; a restart is the only cure until that lands.
 
 Two shapes of this got found rather than reasoned:
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1030,6 +1030,45 @@ once, it never recovers, because ztls never drains OpenSSL's error queue
 and those entries allocate through the same hooks. Measured in the same
 issue; a restart is the only cure until that lands.
 
+### `shed_tls_crypto` has no gate, and why the obvious one does not work
+
+The rung is now *reachable* — that is what the ztls pin move buys — but
+nothing in §9 exercises it, and this is a known gap rather than an
+oversight. Its sibling `shed_tls_engines` has both a unit test and a sim
+scenario; `CryptoUnavailable` has neither.
+
+The obvious gate is a third heap-proof-shaped binary: install a heap too
+small to serve a handshake, assert the keygen returns `LibcryptoFailed`
+rather than spinning. **It deadlocks**, and not in our code. With a 1 KiB
+heap the stack is:
+
+```
+ossl_init_base_ossl_  ->  CRYPTO_THREAD_lock_new  ->  CRYPTO_zalloc
+  ->  CRYPTO_malloc      (fails: our heap)
+  ->  ERR_new            (record the failure)
+  ->  ossl_err_get_state_int  ->  OPENSSL_init_crypto
+  ->  CRYPTO_THREAD_run_once  ->  pthread_once     <-- already inside it
+```
+
+OpenSSL reports an allocation failure by calling `ERR_new`, which
+initializes the error machinery, which re-enters the very `pthread_once`
+whose initializer was allocating. An allocation failure *during
+`OPENSSL_init_crypto`* is a self-deadlock in libcrypto, so a heap below
+init's own needs never yields a clean error to assert on.
+
+That is worth knowing for its own sake: our floor is not just "big enough
+for a handshake" but "big enough for libcrypto's one-time init", and below
+that the process hangs at startup instead of refusing. The 2 MiB base is
+comfortably past it, and the `libcrypto_heap_bytes >= 2 * 1024 * 1024`
+comptime assert in `constants.zig` is what keeps it there.
+
+Sizing a heap into the window between "init completes" and "a keygen
+fails" would work, but the window is the keygen's own ~5 KiB against an
+init cost that moves with the libcrypto build — a test that would rot
+silently into passing for the wrong reason. A real gate wants a fault
+injection seam on `Engine.init` instead, so the rung can be driven without
+starving libcrypto at all. Not built here.
+
 Two shapes of this got found rather than reasoned:
 
 - The heap must be a static, not a caller's. `CRYPTO_set_mem_functions`

--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -17,6 +17,30 @@ and the **proxy-specific deltas**. When in doubt, read the original.
   `FailingAllocator` in tests to prove it.
 - **Put a limit on everything.** Every loop and every queue has a fixed upper
   bound. An event loop that cannot terminate must *assert* that it cannot.
+- **No unbounded `while (true)`** (`zig build lint`). A loop with no syntactic
+  bound must state one where a reviewer can see it — an asserted counter at the
+  top of the body:
+
+  ```zig
+  while (true) : (passes += 1) {
+      assert(passes <= pending_ops_max);
+  ```
+
+  A loop whose bound is structural rather than counted (a JSON scanner that
+  terminates on its own `}`) says so at the site with
+  `lint:unbounded-ok — <why>`, on the header line or the comment directly above
+  it. Both forms turn "this always eventually terminates" from an assumption
+  into a claim someone can check.
+- **A retry loop retries transient errors only.** Classify before you retry:
+  a *terminal* error (out of memory, a pool exhausted, a closed fd) must
+  propagate on the first occurrence, because retrying it changes nothing but
+  burns the CPU the rest of the process needs to recover. Never `catch continue`
+  over a whole error set — name the retryable members. This is
+  [#222](https://github.com/zoxy-io/zoxy/issues/222): a `while (true) … catch
+  continue` sized for a once-in-2^32 bad scalar met a persistently full heap and
+  spun at 100% CPU forever, taking both listeners and the admin plane with it.
+  The shed rung that should have handled it (`shed_tls_crypto`) was unreachable
+  because the error never came back.
 - **No recursion.** All bounded executions stay bounded; no unbounded stack.
 - **Assertion density ≥ 2 per function** on average. Assert all arguments,
   return values, pre/postconditions, and invariants — positive space (what you

--- a/scripts/lint.zig
+++ b/scripts/lint.zig
@@ -56,6 +56,41 @@ const boundaries = [_]Boundary{
     },
 };
 
+/// TIGER_STYLE's "put a limit on everything", made mechanical: `while
+/// (true)` states no bound of its own, so it must carry one where a
+/// reviewer can see it. Two shapes count.
+///
+/// An asserted counter — what `SimIo.stop` and `contract_test.initTestIo`
+/// already use:
+///
+///     while (true) : (passes += 1) {
+///         assert(passes <= pending_ops_max);
+///
+/// Or a bound the syntax cannot show — a JSON scanner that terminates on
+/// its own `}`, the three `config.zig` object loops — which says so at the
+/// site with the marker below and a reason.
+///
+/// The rule exists because of zoxy-io/zoxy#222: ztls's `p256.KeyPair.
+/// generate` retried `while (true) ... catch continue` on the assumption
+/// that its error was a once-in-2^32 bad scalar. When the error became a
+/// persistent one instead (the fixed libcrypto heap full), the retry spun
+/// at 100% CPU forever and took the whole event loop — both listeners and
+/// the admin plane — with it. An unbounded loop is a claim that some
+/// condition always eventually holds; this makes the claim reviewable
+/// instead of implicit.
+const unbounded_loop_needle = "while (true)";
+const unbounded_loop_marker = "lint:unbounded-ok";
+const unbounded_loop_message =
+    "unbounded `while (true)`: assert a counter bound in the loop body, " ++
+    "or mark it `lint:unbounded-ok — <why>` (TIGER_STYLE: put a limit on everything)";
+
+/// Lines after the loop header within which the bound assertion must
+/// appear. The assertion belongs at the top of the body, so this is
+/// deliberately short — far enough to clear a comment between header and
+/// assert, near enough that an unrelated `assert` deeper in the loop
+/// cannot satisfy it by accident.
+const loop_bound_lookahead_lines: u32 = 6;
+
 /// The only `std.posix.` members main.zig may name (rlimits + sigaction);
 /// everything else — sockets, files, pipes — stays behind the Io seam.
 /// These are matched as fully-qualified `std.posix.<name>` occurrences,
@@ -128,7 +163,133 @@ fn lintFile(
         }
     }
     assert(line_number >= 1);
+    return violation_count + lintUnboundedLoops(contents, path);
+}
+
+/// Flag every `while (true)` whose bound is neither asserted nor
+/// declared. A pass of its own rather than a `lintLine` rule because the
+/// evidence is not on the line: the bound lives in the body below the
+/// header, which is exactly why a line-at-a-time reader — human or lint —
+/// missed it for as long as it did.
+fn lintUnboundedLoops(contents: []const u8, path: []const u8) u32 {
+    assert(path.len > 0);
+    var violation_count: u32 = 0;
+    var offset: usize = 0;
+    while (nextUnboundedLoop(contents, offset)) |at| {
+        offset = at + unbounded_loop_needle.len;
+        assert(offset > at);
+        std.debug.print("{s}:{d}: {s}\n", .{
+            path,
+            lineNumberAt(contents, at),
+            unbounded_loop_message,
+        });
+        violation_count += 1;
+    }
     return violation_count;
+}
+
+/// Offset of the next unbounded `while (true)` at or after `from`, or null
+/// when the rest is clean. The decision lives here, apart from the report,
+/// so a test can make it without printing a violation it went looking for
+/// — the same split `lintLine` has for the boundary rules.
+fn nextUnboundedLoop(contents: []const u8, from: usize) ?usize {
+    assert(from <= contents.len);
+    var offset = from;
+    // Bounded: every iteration moves `offset` past the match it found, so
+    // this runs at most once per occurrence in a file `lintFile` has
+    // already held under `file_bytes_max`.
+    while (std.mem.indexOfPos(u8, contents, offset, unbounded_loop_needle)) |at| {
+        offset = at + unbounded_loop_needle.len;
+        assert(offset > at);
+        const start = lineStartOf(contents, at);
+        const end = lineEndOf(contents, at);
+        assert(start <= at);
+        assert(end >= at);
+        const line = contents[start..end];
+        // A loop named in prose — this file's own doc comment above, or a
+        // `// Bounded: …` note — is not a loop.
+        if (lineIsComment(line)) continue;
+        if (markedUnboundedOk(contents, start, line)) continue;
+        if (boundAssertedWithin(contents[end..], loop_bound_lookahead_lines)) continue;
+        return at;
+    }
+    return null;
+}
+
+/// The count without the report — what the tests below assert on.
+fn countUnboundedLoops(contents: []const u8) u32 {
+    var count: u32 = 0;
+    var offset: usize = 0;
+    while (nextUnboundedLoop(contents, offset)) |at| {
+        offset = at + unbounded_loop_needle.len;
+        assert(offset > at);
+        count += 1;
+    }
+    return count;
+}
+
+/// True when the loop declares itself structurally bounded: the marker
+/// sits either on the header line or on the comment line directly above
+/// it. Both are accepted because the reason is what matters and it rarely
+/// fits after `while (true) {` — this codebase explains a construct in the
+/// block above it, which is where such a reason belongs.
+fn markedUnboundedOk(contents: []const u8, start: usize, line: []const u8) bool {
+    assert(start <= contents.len);
+    if (std.mem.indexOf(u8, line, unbounded_loop_marker) != null) return true;
+    if (start == 0) return false;
+    const above_end = start - 1; // The '\n' that ended the line above.
+    const above_start = lineStartOf(contents, above_end);
+    assert(above_start <= above_end);
+    const above = contents[above_start..above_end];
+    if (!lineIsComment(above)) return false;
+    return std.mem.indexOf(u8, above, unbounded_loop_marker) != null;
+}
+
+/// True when one of the next `lines_max` lines asserts an upper bound —
+/// any `assert` naming a `<` relation. Deliberately shape-based rather
+/// than parsing the counter out of the loop header: the point is that a
+/// bound is stated near the top of the body, and every way of writing
+/// `assert(n <= max)` should satisfy it.
+fn boundAssertedWithin(rest: []const u8, lines_max: u32) bool {
+    assert(lines_max >= 1);
+    var lines = std.mem.splitScalar(u8, rest, '\n');
+    var seen: u32 = 0;
+    while (lines.next()) |line| {
+        if (seen == lines_max) return false;
+        seen += 1;
+        if (std.mem.indexOf(u8, line, "assert(") == null) continue;
+        // `<=` contains `<`, so the one test covers both relations.
+        if (std.mem.indexOfScalar(u8, line, '<') != null) return true;
+    }
+    assert(seen <= lines_max);
+    return false;
+}
+
+fn lineStartOf(contents: []const u8, at: usize) usize {
+    assert(at < contents.len);
+    const newline = std.mem.lastIndexOfScalar(u8, contents[0..at], '\n') orelse return 0;
+    assert(newline < at);
+    return newline + 1;
+}
+
+fn lineEndOf(contents: []const u8, at: usize) usize {
+    assert(at < contents.len);
+    const newline = std.mem.indexOfScalarPos(u8, contents, at, '\n') orelse return contents.len;
+    assert(newline >= at);
+    return newline;
+}
+
+fn lineNumberAt(contents: []const u8, at: usize) u32 {
+    assert(at < contents.len);
+    return @intCast(std.mem.count(u8, contents[0..at], "\n") + 1);
+}
+
+/// True when the line's first non-blank characters are `//` — a doc
+/// comment, a module comment, or an ordinary one.
+fn lineIsComment(line: []const u8) bool {
+    const trimmed = std.mem.trimStart(u8, line, " \t");
+    assert(trimmed.len <= line.len);
+    return std.mem.startsWith(u8, trimmed, "//");
 }
 
 comptime {
@@ -262,6 +423,112 @@ test "lintLine: ztls import is confined to the TLS engine wrapper" {
     // not even the parts that are already past a trust boundary of their own.
     try std.testing.expect(lintLine("const ztls = @import(\"ztls\");", "http/parser.zig") != null);
     try std.testing.expect(lintLine("const ztls = @import(\"ztls\");", "io/XevIo.zig") != null);
+}
+
+test "lintUnboundedLoops: a bare while (true) is a violation" {
+    const source =
+        \\fn spin() void {
+        \\    while (true) {
+        \\        step();
+        \\    }
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 1), countUnboundedLoops(source));
+}
+
+test "lintUnboundedLoops: an asserted counter bound satisfies the rule" {
+    // The `SimIo.stop` shape: counter in the continue expression, bound
+    // asserted at the top of the body.
+    const source =
+        \\fn flush() void {
+        \\    var passes: u32 = 0;
+        \\    while (true) : (passes += 1) {
+        \\        assert(passes <= pending_ops_max);
+        \\        if (done()) break;
+        \\    }
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countUnboundedLoops(source));
+}
+
+test "lintUnboundedLoops: the marker exempts a structurally-bounded loop" {
+    const source =
+        \\fn parse() !void {
+        \\    while (true) { // lint:unbounded-ok — the scanner ends it at `}`
+        \\        if (try next() == .object_end) break;
+        \\    }
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countUnboundedLoops(source));
+}
+
+test "lintUnboundedLoops: the marker is accepted on the line above" {
+    const source =
+        \\fn parse() !void {
+        \\    // lint:unbounded-ok — the scanner ends the object at `}`
+        \\    while (true) {
+        \\        if (try next() == .object_end) break;
+        \\    }
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countUnboundedLoops(source));
+    // Only *directly* above: a blank line between them breaks the pairing,
+    // so a stale marker cannot drift onto an unrelated loop.
+    const detached =
+        \\fn parse() !void {
+        \\    // lint:unbounded-ok — the scanner ends the object at `}`
+        \\
+        \\    while (true) {
+        \\        step();
+        \\    }
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 1), countUnboundedLoops(detached));
+}
+
+test "lintUnboundedLoops: prose about a loop is not a loop" {
+    const source =
+        \\/// Bounded, unlike a bare `while (true)`, which this is not.
+        \\fn ok() void {}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countUnboundedLoops(source));
+}
+
+test "lintUnboundedLoops: an assert too far below the header does not count" {
+    // The bound must be at the top of the body: an `assert` seven lines
+    // down is an unrelated invariant, not this loop's limit.
+    const source =
+        \\while (true) {
+        \\    a();
+        \\    b();
+        \\    c();
+        \\    d();
+        \\    e();
+        \\    f();
+        \\    assert(n <= max);
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 1), countUnboundedLoops(source));
+}
+
+test "lintUnboundedLoops: each unbounded loop in a file is counted" {
+    const source =
+        \\while (true) {
+        \\    a();
+        \\}
+        \\while (true) {
+        \\    b();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 2), countUnboundedLoops(source));
 }
 
 test "pathIsUnder: exact files, directory prefixes, and near misses" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -2132,6 +2132,7 @@ pub const BodiesJson = struct {
         // Terminated by the object's own `}` or by the input running
         // out, which the scanner reports as an error — every map here
         // carries the same bound.
+        // lint:unbounded-ok — the scanner's `}`/error is the bound
         while (true) {
             const token = try source.nextAlloc(allocator, .alloc_if_needed);
             const name: []const u8 = switch (token) {
@@ -2172,6 +2173,10 @@ pub const ErrorPagesJson = struct {
         if (try source.next() != .object_begin) {
             return error.UnexpectedToken;
         }
+        // Terminated by the object's own `}` or by the input running out,
+        // which the scanner reports as an error — the same bound the other
+        // maps here carry.
+        // lint:unbounded-ok — the scanner's `}`/error is the bound
         while (true) {
             const token = try source.nextAlloc(allocator, .alloc_if_needed);
             const status: []const u8 = switch (token) {
@@ -2362,6 +2367,7 @@ pub const ClustersJson = struct {
         // other array in this config now has, and the reason the old
         // `keys_seen_max` backstop is gone: with no ceiling above it, that
         // 4096 would have quietly become the new cluster limit.
+        // lint:unbounded-ok — the scanner's `}`/error is the bound
         while (true) {
             const token = try source.nextAlloc(allocator, .alloc_if_needed);
             const name: []const u8 = switch (token) {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -305,13 +305,60 @@ comptime {
     assert(tls_ticket_key_rotation_s >= tls_ticket_lifetime_s);
 }
 
+/// What one *concurrent* TLS session costs the fixed heap on top of the
+/// base below: libcrypto's per-session state, live for as long as that
+/// session holds an engine.
+///
+/// Measured 2026-08-13 (ECDSA P-256, TLS_AES_128_GCM_SHA256, 1 KiB body)
+/// by reading the heap's own frontier at steady concurrency:
+///
+///     concurrent sessions    50     100    200    400
+///     heap frontier        1024K  1280K  1792K  2752K
+///
+/// The marginal cost is flat — 5.12 KiB across 100→200, 4.80 KiB across
+/// 200→400 — so this term is linear in the *session* count and not in the
+/// handshake count: 1811 sequential handshakes moved the frontier not at
+/// all, because each one's blocks return to their class before the next
+/// asks. Reserved at 8 KiB rather than the measured ~5: the heap is
+/// segregated-fits with no coalescing, so a class whose free list is empty
+/// cannot be served out of another's, and the slack absorbs that.
+pub const libcrypto_heap_bytes_per_engine: u32 = 8 * 1024;
+
+/// What the heap costs before any session: libcrypto's one-time tables
+/// plus the first handshake's distinct block footprint, which every later
+/// handshake reuses off the class free lists rather than growing
+/// (IMPLEMENTATION_NOTES.md). Measured at ~1 MiB — 384 KiB at startup,
+/// ~960 KiB once the first handshakes settle — reserved at 2 MiB.
+pub const libcrypto_heap_base_bytes: u32 = 2 * 1024 * 1024;
+
 /// The fixed heap libcrypto allocates from (§4, `tls/libcrypto_heap.zig`),
-/// reserved at startup exactly when some listener terminates TLS. Sized
-/// against the measured plateau — ~1 MiB for one handshake's distinct
-/// block footprint, with every later handshake free once the size classes
-/// have filled (IMPLEMENTATION_NOTES.md) — plus headroom for the
-/// concurrency that measurement did not exercise.
-pub const libcrypto_heap_bytes: u32 = 4 * 1024 * 1024;
+/// reserved at startup exactly when some listener terminates TLS.
+///
+/// Scales with the engine pool, because the heap's occupancy does. The
+/// previous fixed 4 MiB was sized against a *sequential* measurement — one
+/// handshake at a time, each freeing before the next — which is true
+/// serially and false concurrently, and the gap was an outage rather than
+/// a rounding error: the heap ran out at ~675 concurrent sessions, and
+/// because ztls retried that allocation failure forever, the process
+/// livelocked at 100% CPU with every listener dark (#222).
+pub fn libcryptoHeapBytes(tls_engines: u32) u32 {
+    assert(tls_engines <= tls_engines_max);
+    // Zero exactly when no listener terminates TLS — the same condition
+    // that makes the engine pool itself free (§5).
+    if (tls_engines == 0) return 0;
+    return libcrypto_heap_base_bytes + tls_engines * libcrypto_heap_bytes_per_engine;
+}
+
+/// The compiled reservation: what the deepest pool a config may ask for
+/// needs, so one static array covers every admissible `limits.tls_engines`
+/// (the loader holds it to `tls_engines_max`).
+///
+/// It has to be comptime. The heap is BSS rather than arena memory because
+/// `OPENSSL_cleanup` frees through our hooks from an atexit handler, after
+/// `main` has returned and the arena with it (see `main.zig`) — so sizing
+/// for the ceiling is what a static reservation costs, and BSS pages a
+/// smaller deployment never touches never become resident.
+pub const libcrypto_heap_bytes: u32 = libcryptoHeapBytes(tls_engines_max);
 
 /// The most a certificate or key PEM file may be. A bound on a startup
 /// read, so its job is only to turn "the operator pointed at the wrong
@@ -329,6 +376,16 @@ comptime {
     // The heap must hold more than one handshake's measured plateau, or
     // the first connection exhausts it.
     assert(libcrypto_heap_bytes >= 2 * 1024 * 1024);
+    // …and every session the deepest admissible pool can hold at once, or
+    // a full pool exhausts it — which is the shape of #222. The compiled
+    // reservation is derived at that ceiling, so this is the derivation
+    // pinned rather than a second opinion about it.
+    assert(libcrypto_heap_bytes >= libcryptoHeapBytes(tls_engines_max));
+    assert(libcrypto_heap_bytes > tls_engines_max * libcrypto_heap_bytes_per_engine);
+    // The measured marginal cost with the no-coalescing margin on top. A
+    // reservation below what was measured would be a number that had
+    // stopped tracking the thing it was derived from.
+    assert(libcrypto_heap_bytes_per_engine >= 5 * 1024);
     // A PEM that could not carry the DER it wraps would make the tighter
     // chain bound unreachable — base64 costs a third on top.
     assert(tls_pem_bytes_max > tls_cert_chain_bytes_max * 2);
@@ -1208,10 +1265,18 @@ pub const PoolSizes = struct {
     /// for the widest use any of them may be put to.
     tls_plaintext_bytes: u64 = 0,
     /// The fixed heap libcrypto allocates from (§4), reserved exactly
-    /// when some listener terminates TLS. Not per-engine — one
-    /// process-wide reservation, priced here for the same reason the
-    /// access log's buffers are: §5's promise is that the printed total
-    /// covers every byte this process holds for its life.
+    /// when some listener terminates TLS. One process-wide reservation
+    /// rather than a per-engine buffer, but sized *from* the engine count
+    /// (`libcryptoHeapBytes`) because that is what its occupancy tracks —
+    /// priced here for the same reason the access log's buffers are: §5's
+    /// promise is that the printed total covers every byte this process
+    /// holds for its life.
+    ///
+    /// Priced at the whole compiled reservation rather than this config's
+    /// share of it: the storage is one static array (it must outlive the
+    /// arena), so the process holds all of it whatever `tls_engines` says.
+    /// `libcryptoHeapBytes` is what *derives* that array's size, at
+    /// `tls_engines_max`; it is not a per-config subtotal to print.
     libcrypto_heap_bytes: u64 = 0,
 };
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -377,10 +377,10 @@ comptime {
     // the first connection exhausts it.
     assert(libcrypto_heap_bytes >= 2 * 1024 * 1024);
     // …and every session the deepest admissible pool can hold at once, or
-    // a full pool exhausts it — which is the shape of #222. The compiled
-    // reservation is derived at that ceiling, so this is the derivation
-    // pinned rather than a second opinion about it.
-    assert(libcrypto_heap_bytes >= libcryptoHeapBytes(tls_engines_max));
+    // a full pool exhausts it — which is the shape of #222. Stated against
+    // the per-engine term rather than against `libcryptoHeapBytes` itself:
+    // the reservation *is* that call, so comparing the two would be a
+    // value checked against its own definition.
     assert(libcrypto_heap_bytes > tls_engines_max * libcrypto_heap_bytes_per_engine);
     // The measured marginal cost with the no-coalescing margin on top. A
     // reservation below what was measured would be a number that had

--- a/src/main.zig
+++ b/src/main.zig
@@ -506,6 +506,11 @@ fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
             0
         else
             zoxy.tls.Engine.plaintextBytesFor(limits.head_buffer_bytes),
+        // The whole compiled reservation, not this config's share of it:
+        // the storage is one static array sized at `tls_engines_max` (it
+        // must outlive the arena — see `libcrypto_heap_storage`), so that
+        // is what the process holds for its life whatever `tls_engines`
+        // says, and §5 prices what is held.
         .libcrypto_heap_bytes = if (limits.tls_engines == 0)
             0
         else

--- a/src/tls/Engine.zig
+++ b/src/tls/Engine.zig
@@ -291,7 +291,12 @@ pub fn init(engine: *Engine, config: *const Config) !void {
     engine.tickets = config.tickets;
     engine.now_unix = config.now_unix;
     engine.hs = .init(.{
-        .keypairs = .init(keypair),
+        // Fallible since ztls 634567a: generating the P-256 half can fail,
+        // and a failure it would repeat — the fixed heap full — is ours to
+        // shed rather than ztls's to retry past (#222). The error lands in
+        // `acquireTlsEngine`, which gives the slot back and answers
+        // `CryptoUnavailable`.
+        .keypairs = try .init(keypair),
         .random = .init(config.random),
         .reassembly = &engine.reassembly.buffer,
         // Offered only when this deployment can actually open one. A

--- a/src/tls/heap_proof_test.zig
+++ b/src/tls/heap_proof_test.zig
@@ -77,7 +77,7 @@ test "a handshake runs entirely on the fixed libcrypto heap" {
 fn handshake(credentials: *const Credentials) !void {
     const server_keypair = try ztls.x25519.KeyPair.generateDeterministic(.init(@splat(0x42)));
     var server: ztls.ServerHandshake = .init(.{
-        .keypairs = .init(server_keypair),
+        .keypairs = try .init(server_keypair),
         .random = .init(@splat(0x43)),
     });
     defer server.deinit();

--- a/src/tls/spike_test.zig
+++ b/src/tls/spike_test.zig
@@ -142,7 +142,7 @@ const Server = struct {
     fn init(server: *Server, credentials: *const Credentials) !void {
         const keypair = try ztls.x25519.KeyPair.generateDeterministic(.init(server_x25519_seed));
         server.handshake = .init(.{
-            .keypairs = .init(keypair),
+            .keypairs = try .init(keypair),
             .random = .init(server_random),
         });
         server.handshake.setCredentials(credentials.chain, credentials.signer());


### PR DESCRIPTION
Closes #222.

With a TLS listener, zoxy stopped serving somewhere between 600 and 700
concurrent connections and never recovered — 100% CPU, nothing served, both
listeners and the admin plane dark, nothing logged, `SIGTERM` ignored.

Reproduced locally (1 CPU, four-node nginx origin, zrk at 1200 connections) and
root-caused by gdb stack sampling plus instrumenting the heap. Two independent
causes, one commit each, plus the lint that would have made the class visible.

## What it was

**Not** CQ overflow, which was the standing hypothesis in #222 — the io_uring
ring is completely idle during the hang (SQ/CQ empty and frozen, no overflow
list). The spin is entirely in userspace.

Four backtraces sampled two seconds apart are the *same call*, same engine
pointer, never returning:

```
EC_POINT_mul  <-  p256PrivateKeyFromSecret  <-  p256.KeyPair.generate   <-- loop
              <-  KeyPairs.init  <-  Engine.init  <-  admit  <-  onAccept
```

ztls's `generate` retried `while (true) … catch continue` over its whole error
set. Correct for the once-in-2³² scalar outside `[1, n-1]`; wrong for the six
allocation paths that answer `LibcryptoFailed`, because with our fixed heap full
every attempt fails identically. Instrumented: 400,000+ retries and climbing.

And the heap filled because its 4 MiB was derived from a **sequential**
measurement — one handshake at a time, each freeing before the next. True of
sequential handshakes, silent about concurrent ones:

| concurrent sessions | 50 | 100 | 200 | 400 |
|---|---|---|---|---|
| heap frontier | 1024 KiB | 1280 KiB | 1792 KiB | 2752 KiB |

~4.9 KiB per live session over a ~1 MiB base. That predicts exhaustion at ~675
concurrent sessions; the cliff was healthy at 600, dead at 700.

## What changed

- **`deps: ztls 634567a`** — upstream could not distinguish a bad scalar from a
  failing library, so the fix classifies first (`EC_KEY_*` scalar checks answer
  `IdentityElement`), then retries only that, bounded, and propagates
  `LibcryptoFailed` immediately. Here it is one `try`: the error reaches
  `acquireTlsEngine`, which already released the engine and answered
  `CryptoUnavailable` for exactly this. Filed upstream as
  [mattrobenolt/ztls#88](https://github.com/mattrobenolt/ztls/issues/88), carried
  on the fork as [zoxy-io/ztls#1](https://github.com/zoxy-io/ztls/pull/1).
- **`tls: size the libcrypto heap from the engine pool`** —
  `libcryptoHeapBytes` = 2 MiB + 8 KiB/engine, derived at `tls_engines_max` so it
  stays comptime (the storage must be BSS: `OPENSSL_cleanup` frees through our
  hooks after the arena is gone). 4 MiB → 10 MiB at the default 1024 engines.
- **`lint: an unbounded while (true) must say what bounds it`** — the rule
  existed in TIGER_STYLE and nothing checked it. Now `zig build lint` requires an
  asserted counter bound or a `lint:unbounded-ok — <why>` marker. It would *not*
  have caught #222 (that loop is in a dependency); it catches the next one here.

## Result

The 1200-connection run that used to livelock:

| | before | after |
|---|---|---|
| CPU after run | 99% forever | **0%** |
| tls / admin | `000` / `000` | **200** / **200** |
| `shed_tls_crypto` | 0 (unreachable rung) | **0** — heap never exhausts |
| `shed_tls_engines` | 22 | **37** — the pool ceiling, the correct wall |

The two fixes are complementary and were verified independently: correct sizing
removes the trigger even against the *unfixed* ztls, and the pin move makes the
failure survivable if a differently-tuned deployment reaches it anyway.

`zig build ci` green — 517 tests, lint, 4096 sim seeds, live smoke with clean
drain.

## Known, not fixed here

ztls never drains OpenSSL's error queue, and those entries allocate through
`mem_hooks`. So once the heap is exhausted even once it never recovers — with
these changes that path should not be reached, but a deployment that reaches it
anyway needs a restart. Measured and reproduced in ztls#88; wants a fix at the
backend's error boundaries.

*Investigated and patched by Claude (Anthropic).*
