### PR TITLE
sim: strand what the schedule armed, at both instants that matter (#206)

### DIFF
--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -158,8 +158,8 @@ whether one stranded anything.** Either the ordinary invariants hold, or
 the server gave up with the code that names which backstop it was. What
 that phrasing buys is the property actually worth holding — no schedule
 may end with the loop alive and nobody the wiser — rather than a
-weaker "stranded seeds are excused". 52 runs per 4096-seed sweep take the
-second branch.
+weaker "stranded seeds are excused". 112 runs per 4096-seed sweep take
+the second branch.
 
 The abort is only excused on a seed that actually stranded something,
 which needs the draw and the strand kept as two facts rather than one
@@ -168,14 +168,14 @@ as "#206 working as intended" — including one a future *release* bug
 produced with every op delivered, which is the exact defect the backstop
 exists to catch and the last thing a sweep should swallow.
 
-That gate shipped one step short of what the paragraph above claims.
-`drop_taken` was latched on *reaching* the strand rather than on
-stranding anything, and a draw whose kind has nothing armed of it strands
-nothing — so those seeds carried the excuse without having earned it, and
-a genuine stuck drain landing on one would have been waved through. The
-latch is now `dropped >= 1`. It cost no coverage: the give-up branch is
-still taken 52 times per 4096-seed sweep, because a seed that stranded
-nothing had no reason to reach it.
+That gate shipped one step short of what the paragraph above claims. The
+excuse was latched on *reaching* the strand rather than on stranding
+anything, and a draw whose kind had nothing armed of it stranded nothing
+— so those seeds carried the excuse without having earned it, and a
+genuine stuck drain landing on one would have been waved through. What
+`verify` reads is now `drop_kind`, recorded only after a drop that took
+at least one op. It cost no coverage, because a seed that stranded
+nothing had no reason to reach the branch anyway.
 
 **What the give-up branch asserts.** Reaching it used to end the seed:
 the exit code was checked, the strand was checked, and nothing else. Two
@@ -210,66 +210,87 @@ for every client in the scenario, not only the one the strand touched. A
 silently unanswered exchange passing as "the backstop worked" is
 precisely what clean seeds exist to forbid.
 
-**Draw the kind, not the op.** Measured at a wind-down, `accept` and
-`timer` are four fifths of everything pending, so picking a random *op*
-would spend the whole fraction on those two and reach `recv_group` about
-once per sweep.
+**Pick the kind out of what is armed, not before the run.** Measured at a
+wind-down, `accept` and `timer` are four fifths of everything pending, so
+picking a random *op* would spend nearly every strand on those two and
+reach `recv_group` about once per sweep. Picking a *kind* fixes that. The
+first version picked it with the rest of the topology, before the
+scenario ran — which is a bet on what the wind-down will hold. The share
+of wind-downs holding at least one op of a kind, over a 4096-seed sweep:
 
-Two kinds are excluded, for opposite reasons, and both are findings.
+| kind | armed | kind | armed |
+| --- | --- | --- | --- |
+| `timer` | 98% | `log_write` | 24% |
+| `accept` | 98% | `timer_cancel` | 15% |
+| `recv` | 53% | `recv_group` | 10% |
+| `connect` | 24% | `send` | 1.2% |
+| | | `connect_cancel` | 1.0% |
+| | | `close` | 0% |
 
-`close` is **never** armed at a wind-down — zero occurrences across the
-sweep — so naming it would be a draw that silently tested nothing.
+The bet lost more often than it won: 230 of the 368 runs that drew a kind
+found none of it armed and stranded nothing, and the kinds armed under a
+fifth of the time were out of reach in practice — a blind draw finds
+`send` armed about once in five sweeps. `drawStrandKind` asks the pending
+table instead and picks uniformly among the kinds that are there. Every
+drawn run now strands: 316 strands per sweep against 124, and 112 runs
+reaching the give-up against 52. The strand is no longer settled before
+the run starts, which nothing needed — `verify` reads what was stranded,
+never what was going to be.
+
+It also empties the exclusion list down to one entry. `close` used to be
+excluded for being armed at *no* wind-down, ever; an armed-set pick
+spends nothing on a kind that is not there, so the exclusion bought
+nothing and would have been a census baked into the code, going stale the
+first time the admin plane's `submitClose` — the proxy's only `io.close`
+— is still in flight when a drain begins.
 
 An earlier version of this section drew a second conclusion from that
-measurement and it was wrong, so it is corrected here rather than
-quietly dropped: it said "a slot that can never be released", the
-scarier half of the #203 class, was therefore out of reach until a
-mid-teardown hook existed. Slot release does not wait on a close.
-`continueTeardown` returns early while `armedCount() != 0`, and once that
-reaches zero it closes **synchronously** with `closeNow` and releases in
-the same call; a connection's armed set is two data directions,
-`connect`, `connect_cancel`, `deadline`, `deadline_cancel`, and no close.
-There is no close op to drop because the teardown path arms none.
-Stranding any conn-armed op therefore produces an unreleasable slot
-already: recording the stuck plane at each give-up over a 4096-seed
-sweep gives `recv` 16 runs and `recv_group` 6 on conns, `connect` 8 on
-health and 2 on conns, and `log_write` 20 on the access log — 24 of the
-52 holding a conn slot that never released.
+zero and it was wrong, so it is corrected here rather than quietly
+dropped: it said "a slot that can never be released", the scarier half of
+the #203 class, was therefore out of reach until a mid-teardown hook
+existed. Slot release does not wait on a close. `continueTeardown`
+returns early while `armedCount() != 0`, and once that reaches zero it
+closes **synchronously** with `closeNow` and releases in the same call; a
+connection's armed set is two data directions, `connect`,
+`connect_cancel`, `deadline`, `deadline_cancel`, and no close. There is
+no close op to drop because the teardown path arms none. Stranding any
+conn-armed op therefore produces an unreleasable slot already: recording
+the stuck plane at each give-up over a 4096-seed sweep gives `recv` 46
+runs, `timer_cancel` 12, `recv_group` 10, `connect` 4, `send` 2 and
+`connect_cancel` 2 on conns, `connect` 10 on health, `timer_cancel` 2 on
+both, and `log_write` 24 on the access log — 76 of the 112 holding a conn
+slot that never released. `accept` is the one kind that strands without
+ever leaving a plane stuck: 88 strands per sweep, no give-up. The admin
+plane is never the stuck one.
 
 What a wind-down drop genuinely cannot reach is the pair of cancels
 `beginTeardown` arms, since it arms them *after* the strand lands. That
 is the real argument for the mid-teardown hook, and it is not the
 argument this section used to make.
 
-Three kinds are armed at a wind-down and absent from the draw with no
-reason recorded, which is its own small finding: `timer_cancel` at ~15%
-of wind-downs — more common there than `recv_group`, which is in the
-draw — and `send` and `connect_cancel` at ~1.3%. Stranding a
-`timer_cancel` leaves `armed.deadline_cancel` set forever, an
-unreleasable slot by a route the sweep does not take, and it does not hit
-the `timer` self-reference below because nothing cancels the drain-stuck
-timer. The other two are near the noise floor. Adding `timer_cancel`
-looks like a free coverage win and is not done here.
+`timer` is the one kind still excluded, and it is the finding worth
+carrying: **`onDrainStuck` cannot catch a stranded timer, because it is
+one.** A seed that strands the drain deadline strands the thing that
+would have reported it, and the run ends in the simulator's own deadlock
+with no diagnostic at all — seed 2302, three dropped timers and nothing
+else pending. That is a true statement about the reach of #203's fix
+rather than a defect this sweep can hold the proxy to, so the kind is
+excluded and the case pinned by a directed test in `contract_test.zig`
+instead — the form that breaks loudly if it ever stops being true, where
+a comment would not. Covering it for real would need a watchdog that is
+not a timer, which is a design question and not a gate.
 
-`timer` is worse, and it is the finding worth carrying: **`onDrainStuck`
-cannot catch a stranded timer, because it is one.** A seed that strands
-the drain deadline strands the thing that would have reported it, and the
-run ends in the simulator's own deadlock with no diagnostic at all — seed
-2302, three dropped timers and nothing else pending. That is a true
-statement about the reach of #203's fix rather than a defect this sweep
-can hold the proxy to, so the kind is excluded and the case pinned by a
-directed test in `contract_test.zig` instead — the form that breaks
-loudly if it ever stops being true, where a comment would not. Covering
-it for real would need a watchdog that is not a timer, which is a design
-question and not a gate.
+A trap worth naming while it is fresh: what a given seed strands is not
+stable across edits to this machinery. It was already true when the draw
+indexed a fixed array — adding, removing or reordering an entry re-rolled
+which seed drew which kind, which is why seed 2302 above will not
+reproduce against the shipped code — and picking from the armed set adds
+a second way for it to move, since anything that changes what a schedule
+has in flight at its wind-down changes what there is to pick. Seed
+numbers pinned against a *kind* have a short shelf life; the directed
+tests in `contract_test.zig` are where a case goes to stay reproducible.
 
-A trap worth naming while it is fresh: the draw indexes a `kinds` array,
-so adding, removing or reordering an entry silently re-rolls which seed
-draws which kind. Seed 2302 above will not reproduce against the shipped
-list, because `.timer` is no longer in it. Any seed number pinned against
-this function has the same short shelf life.
-
-**A third case of the same shape, and the one that shipped broken: a
+**The `timer` shape by another route, and the one that shipped broken: a
 drain with no deadline has no backstop to provoke.** `drain_deadline_ms =
 0` is "no cap" (§5) — `beginDrain` arms no timer, and since
 `onDrainStuck` is started by `onDrainDeadline` and nothing else, the
@@ -288,21 +309,24 @@ change missed it and a million-seed block did not: at roughly 7 such
 seeds per 4096, `ci` clears whole runs without producing one.
 
 `maybeStrandOps` skips the strand when the deadline is zero, rather than
-`deriveDropKind` skipping the draw. `drop_kind` is drawn in
-`deriveTerminatingDraws` and the deadline one call later in
+`deriveDropWanted` skipping the draw. The draw runs in
+`deriveTerminatingDraws` and the deadline is settled one call later in
 `deriveServerConfig`, adjacent siblings under `deriveTopology` in that
 order, so gating at the draw means drawing the deadline first — and
 swapping two calls re-rolls every draw after them for the whole sweep,
 census margins included, to fix an 0.2% case. Skipping at the strand
-leaves `drop_taken` false, so the seed is held to the ordinary invariants
+leaves `drop_kind` null, so the seed is held to the ordinary invariants
 like any seed that stranded nothing. Measured cost over a 4096-seed
-sweep: 7 seeds draw a drop they cannot use, against 159 that draw one
+sweep: 8 seeds draw a drop they cannot use, against 158 that draw one
 they can.
 
-The two rates are worth keeping apart: 7 per 4096 is the *draw* rate, and
-the observed failure rate was about a quarter of that (16 across shard
-0's 36k). A drawn kind with nothing armed of it strands nothing, so most
-of what this skip costs was never going to reach the give-up anyway.
+Under the pre-armed draw those two rates were worth keeping apart — the
+observed failure rate was about a quarter of the draw rate (16 across
+shard 0's 36k), because a drawn kind with nothing armed of it stranded
+nothing. Picking from the armed set closes that gap: no seed in a 4096
+sweep reaches the strand with nothing to take, so all 8 skipped seeds are
+seeds that would have stranded — the skip's full price, where it used to
+be about a quarter of it.
 
 The sweep runs with `dump_on_abort = false`. A stranded seed reaches the
 give-up on purpose and its operator forensics are two hundred lines

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -158,8 +158,9 @@ whether one stranded anything.** Either the ordinary invariants hold, or
 the server gave up with the code that names which backstop it was. What
 that phrasing buys is the property actually worth holding — no schedule
 may end with the loop alive and nobody the wiser — rather than a
-weaker "stranded seeds are excused". 112 runs per 4096-seed sweep take
-the second branch.
+weaker "stranded seeds are excused". 358 runs per 4096-seed sweep take
+the second branch — 112 from the wind-down hook and 246 from the teardown
+latch below.
 
 The abort is only excused on a seed that actually stranded something,
 which needs the draw and the strand kept as two facts rather than one
@@ -263,11 +264,52 @@ slot that never released. `accept` is the one kind that strands without
 ever leaving a plane stuck: 88 strands per sweep, no give-up. The admin
 plane is never the stuck one.
 
-What a wind-down drop genuinely cannot reach is the pair of cancels
-`beginTeardown` arms, since it arms them *after* the strand lands. That
-is the real argument for the mid-teardown hook, and it is not the
-argument this section used to make.
+What a wind-down drop cannot reach is the pair of cancels `beginTeardown`
+arms, since it arms them *after* the strand lands. That is the real
+argument for the mid-teardown hook — not the one this section used to
+make — and it is what the second hook was built on.
 
+**The second hook: strand an op that does not exist yet.** A drop can
+only take what is in the pending table, and the cancels a teardown arms
+are not in it when either drain entry runs. `SimIo.armDropNext(kinds)`
+latches instead: the next op submitted of a kind in the set is born
+dropped, and the latch closes on that one op. Everything downstream is
+unchanged — a dropped op is still checked at the top of `opReady`, still
+holds whatever it references, still never delivers.
+
+Seeds draw *where* they strand, not whether: `.wind_down` takes one of
+the sixteen values, `.teardown` two, out of the same single draw that
+used to mean "strand or not". Keeping it one draw is deliberate — the
+sweep's whole stream position hangs off how many values are drawn here,
+so a second draw would re-roll every seed after it and take the §9 census
+margins along.
+
+The result is the sharpest signal this issue has produced. Per 4096-seed
+sweep, 246 of the 784 `.teardown` runs find a cancel to take, and **all
+246 reach the give-up** — against 112 of the 316 wind-down strands. 168
+leave the connection plane stuck, which is #203's shape exactly: a cancel
+armed during teardown and never delivered leaves that connection's armed
+set non-empty forever, `continueTeardown` returns early for as long as
+that holds, and the slot is never released. The other 78 are the prober's
+own dial cancel. The 538 runs that find nothing to take are held to the
+ordinary invariants, having taken nothing — the price of waiting for an
+op that does not exist yet, and why the mode is drawn twice as often.
+
+**Where the latch is armed decides what it catches**, which took two
+measurements to get right:
+
+| latch armed | runs that strand | strands on conns |
+| --- | --- | --- |
+| before the doubles' `cancelIfStuck` burst | 82% | — (a fifth took a client double's cancel) |
+| after the doubles, before `beginDrain` returns | 75% | 7% |
+| after `beginDrain` returns | 31% | 68% |
+
+The first two spend the latch on cancels submitted from inside the drain
+— the harness's own doubles, then the prober being stopped — and the
+connection teardowns never get a look in. The third strands on fewer runs
+precisely because those are gone by the time it arms, which is the point.
+It arms at both drain entries, since a seed that drains mid-scenario
+tears its connections down there.
 `timer` is the one kind still excluded, and it is the finding worth
 carrying: **`onDrainStuck` cannot catch a stranded timer, because it is
 one.** A seed that strands the drain deadline strands the thing that
@@ -308,15 +350,15 @@ are independent and both are minorities, which is why 4096 seeds per
 change missed it and a million-seed block did not: at roughly 7 such
 seeds per 4096, `ci` clears whole runs without producing one.
 
-`maybeStrandOps` skips the strand when the deadline is zero, rather than
-`deriveDropWanted` skipping the draw. The draw runs in
+Both hooks skip the strand when the deadline is zero (`giveUpCanExist`),
+rather than `deriveDropMode` skipping the draw. The draw runs in
 `deriveTerminatingDraws` and the deadline is settled one call later in
 `deriveServerConfig`, adjacent siblings under `deriveTopology` in that
 order, so gating at the draw means drawing the deadline first — and
 swapping two calls re-rolls every draw after them for the whole sweep,
 census margins included, to fix an 0.2% case. Skipping at the strand
-leaves `drop_kind` null, so the seed is held to the ordinary invariants
-like any seed that stranded nothing. Measured cost over a 4096-seed
+leaves the seed having taken nothing, so it is held to the ordinary
+invariants like any seed that stranded nothing. Measured cost over a 4096-seed
 sweep: 8 seeds draw a drop they cannot use, against 158 that draw one
 they can.
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -83,6 +83,19 @@ const health_interval_floor_ms: u32 = 100;
 const probe_sweeps_max: u64 =
     scenario_end_ns / (health_interval_floor_ms * std.time.ns_per_ms) + 1;
 
+/// Where a stranding seed places its drop (#206). Two hooks, because the
+/// two halves of the class need different instants: `wind_down` takes ops
+/// already armed when the drain begins, `teardown` waits for the first
+/// cancel submitted once it is under way. Neither is a superset of the
+/// other — see `maybeStrandOps` and `armTeardownStrand`.
+const DropMode = enum { wind_down, teardown };
+
+/// What the teardown latch waits for. `beginTeardown` arms exactly these
+/// two — a pending dial's `connect_cancel` and a live deadline's
+/// `timer_cancel` — and it arms them *after* a wind-down drop has already
+/// landed, which is what puts them out of that hook's reach.
+const teardown_strand_kinds = [_]SimIo.OpKind{ .timer_cancel, .connect_cancel };
+
 comptime {
     // Passing probes consume origin conn slots (accept-and-vanish, never
     // recycled), on top of each origin's client-driven worst case: one
@@ -193,15 +206,18 @@ http_origin_stop_at_ns: u64,
 /// move nothing while shifting the whole sweep's stream position.
 clock_jump_wanted: bool,
 clock_jumped: bool,
-/// Whether this seed strands ops at its wind-down (#206), and — once it
-/// has — which kind it stranded. Two fields for the reason the pair above
-/// is two: what a seed drew and what it did are different facts, and
-/// `verify` needs the second one to decide whether a stuck drain was
-/// asked for. The kind is not part of the draw: it is chosen at the
-/// wind-down from the kinds actually armed there, so a strand never
-/// stands for ops that were not there to take.
-drop_wanted: bool,
+/// Where this seed strands an op, or null for the seeds that strand none
+/// (#206) — and, once one has been taken at the wind-down, which kind it
+/// was. Separate fields for the reason the pair above is two: what a seed
+/// drew and what it did are different facts, and `verify` needs the
+/// second to decide whether a stuck drain was asked for. The kind is
+/// never part of the draw; both modes take what the schedule armed rather
+/// than what a die named (`drawStrandKind`, `armDropNext`).
+drop_mode: ?DropMode,
 drop_kind: ?SimIo.OpKind,
+/// Whether the teardown mode's latch has been armed, so the second
+/// wind-down a scenario can have does not arm it twice.
+drop_latch_armed: bool,
 http_origin_stop_completion: SimIo.Completion,
 /// Virtual instant at which the drain begins, or 0 for "at the
 /// scenario's end like every other seed".
@@ -420,6 +436,7 @@ fn deriveDrainDeadlineMs(drain_at_ns: u64, random: std.Random) u32 {
 fn onDrainStart(harness: *Harness, result: Io.TimerError!void) void {
     result catch return;
     harness.server.beginDrain();
+    harness.armTeardownStrand();
 }
 
 /// The one-shot faults the sweep would otherwise never pull (§9).
@@ -598,7 +615,7 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
-    harness.drop_wanted = deriveDropWanted(harness.clean, random);
+    harness.drop_mode = deriveDropMode(harness.clean, random);
     assert(harness.listeners_count <= harness.listener_configs.len);
     assert(harness.tls_clients >= 1 or !harness.clock_jump_wanted);
 }
@@ -1172,6 +1189,7 @@ fn populateTlsClients(harness: *Harness, random: std.Random) void {
     harness.scenario_ended = false;
     harness.clock_jumped = false;
     harness.drop_kind = null;
+    harness.drop_latch_armed = false;
     assert(harness.tls_clients <= tls_clients_max);
     // One token past the drawn count, for the resuming client's slot.
     const token_count = if (harness.tls_clients >= 1)
@@ -1481,11 +1499,11 @@ fn clientEnded(harness: *Harness) void {
     }
 }
 
-/// #206, on the seeds that drew it: take every armed op of one kind and
-/// never deliver it, at the instant the wind-down begins. That is the
-/// class of defect no other seed can reach — everything else this
-/// simulator does completes, which is faithful to io_uring and blind to
-/// what a readiness backend did in #203.
+/// #206's first hook, on the seeds that drew `.wind_down`: take every
+/// armed op of one kind and never deliver it, at the instant the
+/// wind-down begins. That is the class of defect no other seed can reach
+/// — everything else this simulator does completes, which is faithful to
+/// io_uring and blind to what a readiness backend did in #203.
 ///
 /// At the wind-down because that is where the ops worth stranding are
 /// armed. Measured over a 4096-seed sweep, the share of wind-downs
@@ -1510,31 +1528,9 @@ fn clientEnded(harness: *Harness) void {
 /// random op would spend nearly every strand on those two and reach
 /// recv_group about once in a sweep.
 fn maybeStrandOps(harness: *Harness) void {
-    if (!harness.drop_wanted) return;
+    if (harness.drop_mode != .wind_down) return;
     if (harness.drop_kind != null) return;
-    // A zero `drain_deadline_ms` is "no cap" (§5), and the deadline timer
-    // is the only thing that ever arms the give-up: `onDrainStuck` is
-    // started by `onDrainDeadline`, so a drain with no deadline has no
-    // backstop to provoke. Stranding an op there asks the proxy for a
-    // report the configuration deliberately declined — the drain waits
-    // for the last connection however long that takes, by design — and
-    // the run ends in `SimIo`'s own deadlock with no diagnostic, which is
-    // the same shape the excluded `timer` kind has and just as much a
-    // true statement about the backstop's reach rather than a defect.
-    //
-    // Skipped at the strand rather than at the draw because the draw runs
-    // in `deriveTerminatingDraws` and the deadline is settled one call
-    // later in `deriveServerConfig`. Gating the draw needs the deadline
-    // first, and swapping two calls re-rolls every draw after them for the
-    // whole sweep, taking the §9 census margins with it. The skip leaves
-    // `drop_kind` null, so `verify` holds this seed to the ordinary
-    // invariants — exactly what a seed that stranded nothing is for.
-    //
-    // Found by the nightly soak (run #18, 2026-08-13). All four shards hit
-    // the 16-failure cap early in their slices — shard 0 at 36k — and every
-    // named seed had drawn both a mid-scenario drain with the no-cap
-    // deadline and a drop.
-    if (harness.config.drain_deadline_ms == 0) return;
+    if (!harness.giveUpCanExist()) return;
     const kind = harness.drawStrandKind() orelse return;
     const dropped = harness.io.dropPendingOps(kind);
     // The kind came out of the armed set, so a strand that took nothing is
@@ -1549,6 +1545,99 @@ fn maybeStrandOps(harness: *Harness) void {
     // after the drop rather than before it, because the excuse it grants
     // ("this run may end at the give-up") is earned by stranding.
     harness.drop_kind = kind;
+}
+
+/// #206's second hook, on the seeds that drew `.teardown`: strand the
+/// first cancel submitted once the drain is already under way, rather
+/// than one that was in flight when it began.
+///
+/// This is the half a wind-down drop cannot reach, and the issue's own
+/// argument for it was wrong the first time round, so it is worth being
+/// exact. It is *not* that a slot which can never be released is
+/// otherwise unreachable — stranding any conn-armed op leaves one, 76
+/// runs a sweep do it. It is that `beginTeardown` arms `connect_cancel`
+/// and `deadline_cancel` *after* a wind-down drop has landed, so those
+/// two are the only ops in a connection's armed set no drop placed at the
+/// wind-down can be holding. #203 was a cancel submitted and never
+/// delivered; this hook models it where it happened.
+///
+/// It waits rather than takes, which is the difference from
+/// `drawStrandKind`: an op armed later is in no table to be read now, so
+/// this hook cannot know whether it will find anything. Measured over a
+/// 4096-seed sweep, 246 of the 784 runs that draw it find a cancel to
+/// take; the other 538 are held to the ordinary invariants, having taken
+/// nothing. That is the price of reaching an op that does not exist yet,
+/// and the mode is drawn twice as often as `.wind_down` to pay it.
+///
+/// What it buys is the sharpest signal in this issue: **all 246 reach the
+/// §8 give-up**, against 112 of the 316 wind-down strands, and 168 of
+/// them leave the *connection* plane stuck. A cancel armed during
+/// teardown and never delivered leaves that connection's armed set
+/// non-empty forever, and `continueTeardown` returns early for as long as
+/// that is true — a connection stuck in teardown with its slot held,
+/// which is #203 exactly. The other 78 are the prober's, which cancels a
+/// dial of its own when the drain stops it.
+///
+/// **Where it is armed decides what it catches**, which took two
+/// measurements to get right and is the sort of thing that rots quietly.
+/// Per run that drew the mode, and per strand it took:
+///
+///   - Armed *before* the doubles' `cancelIfStuck` burst: 82% strand, but
+///     a fifth of those took a client double's cancel — the server's
+///     drain never waits on one, so the run drained clean and the strand
+///     bought nothing.
+///   - Armed after the doubles and *before* `beginDrain` returns: 75%
+///     strand, and 7% of those land on conns. The prober's stop-cancel is
+///     submitted first, from inside the drain, and takes the other 93%.
+///   - Armed after `beginDrain` returns: 31% strand, and 68% of those land
+///     on conns.
+///
+/// The last is what ships. It strands on fewer runs because the cancels
+/// submitted from inside the drain are gone by then, and that is the
+/// point: what is left is the teardown of a connection that was still
+/// working when the drain started. Armed at both drain entries, since a
+/// seed that drains mid-scenario tears its connections down there.
+fn armTeardownStrand(harness: *Harness) void {
+    if (harness.drop_mode != .teardown) return;
+    if (harness.drop_latch_armed) return;
+    if (!harness.giveUpCanExist()) return;
+    // Nothing can have been stranded yet: the wind-down hook does not run
+    // in this mode, and the latch itself takes nothing until a submit
+    // answers it.
+    assert(harness.strandedKind() == null);
+    harness.drop_latch_armed = true;
+    // Both kinds at once, not one drawn of the two: `beginTeardown` arms
+    // whichever the connection's state calls for, and a latch naming the
+    // other spends the whole scenario waiting for an op that never comes.
+    harness.io.armDropNext(&teardown_strand_kinds);
+}
+
+/// Whether this seed's drain has a give-up to provoke at all. A zero
+/// `drain_deadline_ms` is "no cap" (§5), and the deadline timer is the
+/// only thing that ever arms one: `onDrainStuck` is started by
+/// `onDrainDeadline`, so a drain with no deadline has no backstop.
+/// Stranding an op there asks the proxy for a report the configuration
+/// deliberately declined — the drain waits for the last connection
+/// however long that takes, by design — and the run ends in `SimIo`'s own
+/// deadlock with no diagnostic, which is the same shape the excluded
+/// `timer` kind has and just as much a true statement about the
+/// backstop's reach rather than a defect.
+///
+/// Asked at the strand rather than at the draw because the draw runs in
+/// `deriveTerminatingDraws` and the deadline is settled one call later in
+/// `deriveServerConfig`. Gating the draw needs the deadline first, and
+/// swapping two calls re-rolls every draw after them for the whole sweep,
+/// taking the §9 census margins with it. Skipping here leaves both hooks
+/// having taken nothing, so `verify` holds the seed to the ordinary
+/// invariants — exactly what a seed that stranded nothing is for.
+///
+/// Found by the nightly soak (run #18, 2026-08-13). All four shards hit
+/// the 16-failure cap early in their slices — shard 0 at 36k — and every
+/// named seed had drawn both a mid-scenario drain with the no-cap
+/// deadline and a drop.
+fn giveUpCanExist(harness: *const Harness) bool {
+    assert(harness.drop_mode != null);
+    return harness.config.drain_deadline_ms != 0;
 }
 
 /// One kind out of those armed at this wind-down, or null when the
@@ -1635,7 +1724,7 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
     // including one a future release bug produced with every op
     // delivered, which is the exact defect this backstop exists to catch
     // and the last thing the sweep should swallow.
-    if (harness.drop_kind == null) return error.DrainStuckWithoutStrand;
+    if (harness.strandedKind() == null) return error.DrainStuckWithoutStrand;
     // The give-up is allowed to leave work unfinished. It is not allowed
     // to have freed a slot an op still points at: that is the §5
     // corruption the generation counter exists to catch, and this is the
@@ -1644,6 +1733,25 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
     // for this oracle by name.
     if (!pending_ops_live) return error.SlotReleasedUnderPendingOp;
     if (!harness.strandCanExplainStuck()) return error.StrandCannotExplainStuck;
+}
+
+/// What this seed actually stranded, by whichever hook took it, or null
+/// for the seeds that stranded nothing — the fact `verify` reads when it
+/// decides whether a stuck drain was asked for. The wind-down drop
+/// records its kind on the harness; the teardown latch records its in the
+/// backend, because what it took was decided by a submit that happened
+/// long after the hook ran.
+fn strandedKind(harness: *const Harness) ?SimIo.OpKind {
+    const latched = harness.io.droppedNextOp();
+    // The modes are alternatives, never both: one draw picks one hook, so
+    // a seed with two strands would mean a hook ran outside its mode.
+    assert(harness.drop_kind == null or latched == null);
+    if (harness.drop_kind != null) assert(harness.drop_mode == .wind_down);
+    if (latched) |kind| {
+        assert(harness.drop_mode == .teardown);
+        assert(kind == .timer_cancel or kind == .connect_cancel);
+    }
+    return harness.drop_kind orelse latched;
 }
 
 /// Whether the strand this seed took could account for a plane the
@@ -1660,13 +1768,15 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
 /// outcome the configuration had declined.
 ///
 /// Measured over a 4096-seed sweep, for the shape rather than the rule —
-/// which plane each stranded kind left stuck, in runs: `recv` conns 46,
+/// which plane each wind-down strand left stuck, in runs: `recv` conns 46,
 /// `log_write` the log 24, `timer_cancel` conns 12 and conns+health 2,
 /// `connect` health 10 and conns 4, `recv_group` conns 10, `send` conns 2,
 /// `connect_cancel` conns 2. `accept` never leaves anything stuck at all —
-/// 88 strands, no give-up — and admin is never the stuck plane.
+/// 88 strands, no give-up — and admin is never the stuck plane. The
+/// teardown latch adds 246 runs of its own: 168 on conns, the shape it
+/// exists for, and 78 on the prober's dial cancel.
 fn strandCanExplainStuck(harness: *const Harness) bool {
-    const kind = harness.drop_kind.?;
+    const kind = harness.strandedKind().?;
     // Only `verifyGaveUp` calls this, and only after both of its own
     // gates: the run ended at an abort, and this seed stranded something.
     assert(harness.io.abortedWith() != null);
@@ -1710,21 +1820,35 @@ fn strandCanExplainStuck(harness: *const Harness) bool {
     };
 }
 
-/// Whether this seed strands anything at its wind-down: one in sixteen
-/// adversarial ones. A small fraction on purpose — a stranded run trades
-/// every other oracle for the one it exists to check, since a drain that
-/// cannot finish leaves pools held and counters unreconciled by design.
-/// Which kind it takes is not decided here; `drawStrandKind` picks that
-/// from what the wind-down actually holds.
-fn deriveDropWanted(clean: bool, random: std.Random) bool {
+/// Where this seed strands, or null for the thirteen in sixteen
+/// adversarial seeds that strand nowhere. A small fraction on purpose — a
+/// stranded run trades every other oracle for the one it exists to check,
+/// since a drain that cannot finish leaves pools held and counters
+/// unreconciled by design. Which kind is taken is not decided here;
+/// `drawStrandKind` and `armDropNext` take what the schedule armed.
+///
+/// One draw for both modes, and `.wind_down` keeps the value that used to
+/// mean "strand": the sweep's whole stream position hangs off how many
+/// values are drawn here, so widening this into a second draw would
+/// re-roll every seed after it and take the §9 census margins with it.
+/// `.teardown` gets two of the sixteen values to `.wind_down`'s one,
+/// because it strands on under a third of the seeds that draw it — see
+/// `armTeardownStrand` for why that is a property of what it waits for
+/// rather than a fixable one. The two hooks end up perturbing comparable
+/// numbers of runs: 316 wind-down strands a sweep against 246.
+fn deriveDropMode(clean: bool, random: std.Random) ?DropMode {
     // Adversarial seeds only, for the reason every sibling draw states:
     // a clean seed's oracle is each script's exact golden outcome, and a
     // stranded op ends the run at the give-up before those oracles are
     // reached — for every client in the scenario, not just the one the
     // strand touched. A silently unanswered exchange passing as "the
     // backstop worked" is precisely what clean seeds exist to forbid.
-    if (clean) return false;
-    return random.uintLessThan(u8, 16) == 0;
+    if (clean) return null;
+    return switch (random.uintLessThan(u8, 16)) {
+        0 => .wind_down,
+        1, 2 => .teardown,
+        else => null,
+    };
 }
 
 /// #202, on the seeds that drew it: step the wall clock past a sealing
@@ -1782,6 +1906,7 @@ fn endScenario(harness: *Harness) void {
         client.cancelIfStuck();
     }
     harness.server.beginDrain();
+    harness.armTeardownStrand();
     harness.origin.stopListening();
     harness.origin_http.stopListening();
 }

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -193,13 +193,15 @@ http_origin_stop_at_ns: u64,
 /// move nothing while shifting the whole sweep's stream position.
 clock_jump_wanted: bool,
 clock_jumped: bool,
-/// The #206 op kind this seed strands at its wind-down, or null; and
-/// whether the strand has happened. Two fields for the reason the pair
-/// above is two: what a seed drew and what it did are different facts,
-/// and `verify` needs the draw to still be there when it decides whether
-/// a stuck drain was asked for.
+/// Whether this seed strands ops at its wind-down (#206), and — once it
+/// has — which kind it stranded. Two fields for the reason the pair above
+/// is two: what a seed drew and what it did are different facts, and
+/// `verify` needs the second one to decide whether a stuck drain was
+/// asked for. The kind is not part of the draw: it is chosen at the
+/// wind-down from the kinds actually armed there, so a strand never
+/// stands for ops that were not there to take.
+drop_wanted: bool,
 drop_kind: ?SimIo.OpKind,
-drop_taken: bool,
 http_origin_stop_completion: SimIo.Completion,
 /// Virtual instant at which the drain begins, or 0 for "at the
 /// scenario's end like every other seed".
@@ -596,7 +598,7 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
-    harness.drop_kind = deriveDropKind(harness.clean, random);
+    harness.drop_wanted = deriveDropWanted(harness.clean, random);
     assert(harness.listeners_count <= harness.listener_configs.len);
     assert(harness.tls_clients >= 1 or !harness.clock_jump_wanted);
 }
@@ -1169,7 +1171,7 @@ fn populateTlsClients(harness: *Harness, random: std.Random) void {
     harness.tls_resume_started = false;
     harness.scenario_ended = false;
     harness.clock_jumped = false;
-    harness.drop_taken = false;
+    harness.drop_kind = null;
     assert(harness.tls_clients <= tls_clients_max);
     // One token past the drawn count, for the resuming client's slot.
     const token_count = if (harness.tls_clients >= 1)
@@ -1486,20 +1488,30 @@ fn clientEnded(harness: *Harness) void {
 /// what a readiness backend did in #203.
 ///
 /// At the wind-down because that is where the ops worth stranding are
-/// armed. Measured over the sweep, ops pending when a drain begins:
-/// accept and timer on essentially every run, recv on 55%, log_write 26%,
-/// connect 24%, recv_group 10% — and `close` on *none*, which is why the
-/// kinds below are the ones they are and why "a slot that can never be
-/// released" is still out of reach from here. Reaching that one needs a
-/// drop placed mid-teardown, which is a different hook.
+/// armed. Measured over a 4096-seed sweep, the share of wind-downs
+/// holding at least one op of a kind: timer 98%, accept 98%, recv 53%,
+/// connect 24%, log_write 24%, timer_cancel 15%, recv_group 10%, send
+/// 1.2%, connect_cancel 1.0% — and `close` on none of them.
 ///
-/// The kind is drawn rather than the op, deliberately: accept and timer
-/// are four fifths of everything pending, so picking a random *op* would
-/// spend the whole fraction on those two and reach recv_group about once
-/// in a sweep.
+/// The kind is picked here, out of what is armed, rather than drawn with
+/// the rest of the topology, and the spread above is why. A kind named
+/// before the run spends its seed whether or not the wind-down holds one:
+/// 230 of the 368 runs that drew a kind found none of it armed and
+/// stranded nothing, and the kinds armed under a fifth of the time were
+/// out of reach in practice — a blind draw finds `send` armed about once
+/// in five sweeps. Picking from the armed set makes every drawn run
+/// strand: 316 strands against 124, and 112 runs reaching the §8 give-up
+/// against 52. What it costs is a seed's strand being settled before the
+/// run starts, which nothing needed — `verify` reads what was stranded,
+/// never what was going to be.
+///
+/// Uniform over *kinds* rather than over pending *ops*, deliberately:
+/// accept and timer are four fifths of everything pending, so picking a
+/// random op would spend nearly every strand on those two and reach
+/// recv_group about once in a sweep.
 fn maybeStrandOps(harness: *Harness) void {
-    const kind = harness.drop_kind orelse return;
-    if (harness.drop_taken) return;
+    if (!harness.drop_wanted) return;
+    if (harness.drop_kind != null) return;
     // A zero `drain_deadline_ms` is "no cap" (§5), and the deadline timer
     // is the only thing that ever arms the give-up: `onDrainStuck` is
     // started by `onDrainDeadline`, so a drain with no deadline has no
@@ -1510,51 +1522,95 @@ fn maybeStrandOps(harness: *Harness) void {
     // the same shape the excluded `timer` kind has and just as much a
     // true statement about the backstop's reach rather than a defect.
     //
-    // Skipped at the strand rather than at the draw because `drop_kind` is
-    // drawn in `deriveTerminatingDraws` and the deadline one call later in
-    // `deriveServerConfig` — adjacent siblings under `deriveTopology`, in
-    // that order. Gating the draw needs the deadline first, and swapping
-    // two calls re-rolls every draw after them for the whole sweep, taking
-    // the §9 census margins with it. A one-line skip here is the cheaper
-    // half of that trade by a wide margin. It leaves `drop_taken` false, so
-    // `verify` holds this seed to the ordinary invariants — exactly what a
-    // seed that stranded nothing is for — and costs only the seeds where
-    // the backstop does not exist: measured over a 4096-seed sweep, 7 seeds
-    // draw a drop against a no-cap deadline against 159 that draw one they
-    // can use.
+    // Skipped at the strand rather than at the draw because the draw runs
+    // in `deriveTerminatingDraws` and the deadline is settled one call
+    // later in `deriveServerConfig`. Gating the draw needs the deadline
+    // first, and swapping two calls re-rolls every draw after them for the
+    // whole sweep, taking the §9 census margins with it. The skip leaves
+    // `drop_kind` null, so `verify` holds this seed to the ordinary
+    // invariants — exactly what a seed that stranded nothing is for.
     //
     // Found by the nightly soak (run #18, 2026-08-13). All four shards hit
     // the 16-failure cap early in their slices — shard 0 at 36k — and every
     // named seed had drawn both a mid-scenario drain with the no-cap
-    // deadline and a drop. Only a quarter or so of the seeds this skips
-    // would have deadlocked at all: a drawn kind with nothing armed of it
-    // strands nothing, which is why the draw rate above is the higher
-    // number.
+    // deadline and a drop.
     if (harness.config.drain_deadline_ms == 0) return;
+    const kind = harness.drawStrandKind() orelse return;
     const dropped = harness.io.dropPendingOps(kind);
-    // A latch rather than clearing the draw, for the reason the clock
-    // jump keeps two fields: what the seed *drew* and what it *did* are
-    // different facts, and `verify` needs the first one to still be
-    // there when it decides whether a stuck drain was asked for.
-    //
-    // Latched on `dropped >= 1`, not on reaching this line. The excuse
-    // `verify` grants is "this seed stranded something, so it may end at
-    // the give-up", and a draw that found nothing armed of its kind
-    // stranded nothing — it is an ordinary seed and owes the ordinary
-    // invariants. Latching on the attempt instead would hand that excuse
-    // to every such seed, so a genuine stuck drain arriving on one would
-    // be waved through as "#206 working as intended": the same hole the
-    // `drop_taken` gate was added to close, one step further out.
-    if (dropped >= 1) harness.drop_taken = true;
-    // The excuse is earned by stranding, not by arriving: this is the
-    // whole content of the paragraph above, in the form that breaks if a
-    // later edit reintroduces the unconditional latch.
-    assert(harness.drop_taken == (dropped >= 1));
-    // Nothing armed of that kind is a legal outcome, not a failed draw —
-    // the sweep's job is to try, and the oracle holds either way. A
-    // stranded op stays *pending*, so the table it was counted out of is
+    // The kind came out of the armed set, so a strand that took nothing is
+    // a contradiction rather than the legal outcome it used to be: either
+    // the pick read a table the drop then disagreed with, or an op left
+    // the table between the two calls — and nothing runs in between.
+    assert(dropped >= 1);
+    // A stranded op stays *pending*, so the table it was counted out of is
     // still the bound; more than that would mean one was counted twice.
     assert(dropped <= harness.io.pending_count);
+    // What the seed *did*, which is the fact `verify` reads — recorded
+    // after the drop rather than before it, because the excuse it grants
+    // ("this run may end at the give-up") is earned by stranding.
+    harness.drop_kind = kind;
+}
+
+/// One kind out of those armed at this wind-down, or null when the
+/// wind-down holds nothing but timers — the one kind left out below.
+///
+/// `timer` is left out because stranding one is the shape the §8 backstop
+/// provably cannot catch: `onDrainStuck` is itself a timer, so a seed that
+/// strands the drain deadline strands the thing that would have reported
+/// it, and the run ends in `SimIo`'s deadlock rather than in a diagnostic.
+/// Found by drawing it — seed 2302, three dropped timers and nothing else
+/// pending. That is a true statement about the backstop's reach and not a
+/// defect this sweep can hold the proxy to, so it is recorded here and
+/// pinned by a directed test (`src/io/contract_test.zig`) instead, which
+/// is the form that breaks loudly if it ever stops being true. Covering it
+/// for real needs a watchdog that is not a timer: a design question, not a
+/// gate.
+///
+/// Nothing else is left out, including `close` — the one kind measured at
+/// zero wind-downs in 4096 seeds. Naming it as an exclusion would be a
+/// census baked into the code, going stale the first time the admin plane
+/// (`submitClose`, the sole `io.close` caller) is still closing its scrape
+/// when a drain begins. Asking the pending table instead spends nothing on
+/// a kind that is not there and picks one up the run it appears. Its
+/// absence is a property of the teardown path rather than an accident:
+/// `continueTeardown` waits for `armedCount()` to reach zero and closes
+/// *synchronously*, so a connection never has a close to take away — which
+/// costs this hook nothing, since every conn-armed kind it can strand
+/// already leaves a slot that cannot be released.
+///
+/// Drawn from the scenario stream at the wind-down, so it consumes nothing
+/// on the fifteen in sixteen seeds that strand nothing and leaves their
+/// stream position — and with it the whole sweep's coverage — where it was.
+fn drawStrandKind(harness: *Harness) ?SimIo.OpKind {
+    // Adding a kind here needs a matching arm in `strandCanExplainStuck`,
+    // which lists `timer` and `none` as `unreachable`: without one the new
+    // kind panics every seed that strands it, which is the loudest way to
+    // ask whoever adds it which planes it can leave stuck.
+    const strandable = [_]SimIo.OpKind{
+        .accept,
+        .connect,
+        .recv,
+        .recv_group,
+        .send,
+        .close,
+        .log_write,
+        .timer_cancel,
+        .connect_cancel,
+    };
+    var armed: [strandable.len]SimIo.OpKind = undefined;
+    var armed_count: usize = 0;
+    for (strandable) |kind| {
+        if (!harness.io.hasPendingOp(kind)) continue;
+        armed[armed_count] = kind;
+        armed_count += 1;
+    }
+    assert(armed_count <= armed.len);
+    if (armed_count == 0) return null;
+    const kind = armed[harness.scenario_prng.random().uintLessThan(usize, armed_count)];
+    // The pick is the whole point: a kind returned here is one the strand
+    // that follows can actually take.
+    assert(harness.io.hasPendingOp(kind));
+    return kind;
 }
 
 /// What a seed that ended at the §8 give-up owes instead of the ordinary
@@ -1579,7 +1635,7 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
     // including one a future release bug produced with every op
     // delivered, which is the exact defect this backstop exists to catch
     // and the last thing the sweep should swallow.
-    if (!harness.drop_taken) return error.DrainStuckWithoutStrand;
+    if (harness.drop_kind == null) return error.DrainStuckWithoutStrand;
     // The give-up is allowed to leave work unfinished. It is not allowed
     // to have freed a slot an op still points at: that is the §5
     // corruption the generation counter exists to catch, and this is the
@@ -1597,18 +1653,23 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
 /// an operator somewhere useless with the process already gone.
 ///
 /// Deliberately permissive — it asks that *some* stuck plane could own an
-/// op of the drawn kind, never that a named one is stuck. Which plane a
+/// op of the stranded kind, never that a named one is stuck. Which plane a
 /// strand lands on is a property of the schedule, and an oracle that
 /// pinned it would fail on the rare seed rather than on a defect. That
 /// bill was just paid once: #220's deadlock was a gate demanding an
 /// outcome the configuration had declined.
 ///
-/// Measured over a 4096-seed sweep, for the shape rather than the rule:
-/// `log_write` lands on the access log 20 runs in 20, `recv` and
-/// `recv_group` on conns 22 in 22, `connect` on health 8 and conns 2.
+/// Measured over a 4096-seed sweep, for the shape rather than the rule —
+/// which plane each stranded kind left stuck, in runs: `recv` conns 46,
+/// `log_write` the log 24, `timer_cancel` conns 12 and conns+health 2,
+/// `connect` health 10 and conns 4, `recv_group` conns 10, `send` conns 2,
+/// `connect_cancel` conns 2. `accept` never leaves anything stuck at all —
+/// 88 strands, no give-up — and admin is never the stuck plane.
 fn strandCanExplainStuck(harness: *const Harness) bool {
     const kind = harness.drop_kind.?;
-    assert(harness.drop_taken);
+    // Only `verifyGaveUp` calls this, and only after both of its own
+    // gates: the run ended at an abort, and this seed stranded something.
+    assert(harness.io.abortedWith() != null);
     const conns_stuck = !harness.server.conns.isFullyReleased();
     const admin_stuck = !harness.server.admin.isQuiescent();
     const log_stuck = !harness.server.access_log.isQuiescent();
@@ -1622,72 +1683,48 @@ fn strandCanExplainStuck(harness: *const Harness) bool {
         // Nothing but the access log writes one.
         .log_write => log_stuck,
         // Connections read, the admin plane reads its scrape, and the
-        // prober reads its probe; all three dial except the admin one.
-        .recv => conns_stuck or admin_stuck or health_stuck,
+        // prober reads its probe; all three dial except the admin one, and
+        // all three write.
+        .recv, .send => conns_stuck or admin_stuck or health_stuck,
         .connect => conns_stuck or health_stuck,
         // A listener's accept feeds admission and the admin plane.
         .accept => conns_stuck or admin_stuck,
-        // Out of the draw, so unreachable rather than defaulted: adding
-        // one to `deriveDropKind`'s list without giving it an arm here
-        // panics every seed that draws it, and a named arm is what makes
-        // that obvious to whoever adds the next kind.
-        .none,
-        .send,
-        .close,
-        .timer,
-        .timer_cancel,
-        .connect_cancel,
-        => unreachable,
+        // A timer cancel belongs to a conn's deadline, the prober's own
+        // pacing timer, or the admin plane's scrape deadline.
+        .timer_cancel => conns_stuck or admin_stuck or health_stuck,
+        // Only the first two of those three dial, so only they can have a
+        // connect to cancel.
+        .connect_cancel => conns_stuck or health_stuck,
+        // `submitClose` is the proxy's only `io.close`, and it is the admin
+        // plane's; a connection's closes are `closeNow`, which leaves no
+        // completion to strand. No seed has reached this arm — `close` has
+        // never been armed at a wind-down — and it is written out anyway,
+        // because the alternative is an exclusion list, and
+        // `drawStrandKind` records why this hook no longer keeps one.
+        .close => admin_stuck,
+        // Out of `drawStrandKind`'s list, so unreachable rather than
+        // defaulted: adding one there without giving it an arm here panics
+        // every seed that strands it, and a named arm is what makes that
+        // obvious to whoever adds the next kind.
+        .none, .timer => unreachable,
     };
 }
 
-/// Which op kind a seed strands, or null for the fifteen in sixteen that
-/// strand nothing. A small fraction on purpose: a stranded run trades
+/// Whether this seed strands anything at its wind-down: one in sixteen
+/// adversarial ones. A small fraction on purpose — a stranded run trades
 /// every other oracle for the one it exists to check, since a drain that
 /// cannot finish leaves pools held and counters unreconciled by design.
-///
-/// The kinds are the ones actually armed at a wind-down, minus two that
-/// are left out for opposite reasons.
-///
-/// `close` is never armed there at all, so naming it would be a draw that
-/// silently tested nothing. Reaching it needs a drop placed mid-teardown.
-///
-/// `timer` is excluded because stranding one is the shape the §8 backstop
-/// provably cannot catch: `onDrainStuck` is itself a timer, so a seed
-/// that strands the drain deadline strands the thing that would have
-/// reported it, and the run ends in `SimIo`'s deadlock rather than in a
-/// diagnostic. Found by drawing it — seed 2302 deadlocked with three
-/// dropped timers and nothing else pending, though that seed will not
-/// reproduce it against the list as shipped: the draw indexes `kinds`,
-/// so adding, removing or reordering an entry silently re-rolls which
-/// seed draws which kind. The case is pinned by a directed test instead
-/// (`src/io/contract_test.zig`), which is the form that breaks loudly if
-/// it ever stops being true. That is a true statement
-/// about the backstop's reach and not a defect this sweep can hold the
-/// proxy to, so it is recorded rather than asserted; covering it would
-/// need a watchdog that is not a timer, which is a design question and
-/// not a gate.
-fn deriveDropKind(clean: bool, random: std.Random) ?SimIo.OpKind {
+/// Which kind it takes is not decided here; `drawStrandKind` picks that
+/// from what the wind-down actually holds.
+fn deriveDropWanted(clean: bool, random: std.Random) bool {
     // Adversarial seeds only, for the reason every sibling draw states:
     // a clean seed's oracle is each script's exact golden outcome, and a
     // stranded op ends the run at the give-up before those oracles are
     // reached — for every client in the scenario, not just the one the
     // strand touched. A silently unanswered exchange passing as "the
     // backstop worked" is precisely what clean seeds exist to forbid.
-    if (clean) return null;
-    if (random.uintLessThan(u8, 16) != 0) return null;
-    // Adding an entry here needs a matching arm in `strandCanExplainStuck`,
-    // which lists the kinds out of the draw as `unreachable`. Without one
-    // the new kind panics every seed that draws it — on top of re-rolling
-    // which seed draws what, the trap the paragraph above describes.
-    const kinds = [_]SimIo.OpKind{
-        .accept,
-        .recv,
-        .connect,
-        .log_write,
-        .recv_group,
-    };
-    return kinds[random.uintLessThan(usize, kinds.len)];
+    if (clean) return false;
+    return random.uintLessThan(u8, 16) == 0;
 }
 
 /// #202, on the seeds that drew it: step the wall clock past a sealing

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1085,6 +1085,22 @@ pub fn dropPendingOps(io: *SimIo, kind: OpKind) u32 {
     return dropped;
 }
 
+/// Whether any op of `kind` is pending and still deliverable — what a
+/// caller about to strand one asks first, so it picks a kind the schedule
+/// actually armed instead of spending its seed on a kind that is not
+/// there (#206). Already-dropped ops do not count: they are pending
+/// forever by construction, and stranding them again would take nothing.
+pub fn hasPendingOp(io: *const SimIo, kind: OpKind) bool {
+    assert(kind != .none);
+    assert(io.pending_count <= pending_ops_max);
+    for (io.pending[0..io.pending_count]) |completion| {
+        if (completion.op != kind) continue;
+        if (completion.dropped) continue;
+        return true;
+    }
+    return false;
+}
+
 /// #206's other ask: no slot may be released while an op still
 /// references it. Every ordinary use of a handle goes through
 /// `socketEntry`, which asserts the entry is still acquired and its

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -177,6 +177,13 @@ group_free: []bool,
 group_count: u32,
 group_bytes: u32,
 group_in_use: u32,
+/// The kinds `armDropNext` is waiting for, one bit per `OpKind`, and the
+/// kind that finally matched (#206). Zero and null on every scenario that
+/// does not ask. A latch rather than a count: one op is the whole
+/// perturbation, and clearing it on the first match is what keeps a
+/// stranded scenario reporting *which* op it took.
+drop_next_kinds: u16,
+drop_next_taken: ?OpKind,
 
 const blackholed_addresses_max: u8 = 4;
 const connect_error_addresses_max: u8 = 4;
@@ -509,6 +516,8 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.group_count = options.buffer_group_count;
     io.group_bytes = options.buffer_group_bytes;
     io.group_in_use = 0;
+    io.drop_next_kinds = 0;
+    io.drop_next_taken = null;
     assert(io.sockets.isFullyReleased());
 }
 
@@ -1085,6 +1094,46 @@ pub fn dropPendingOps(io: *SimIo, kind: OpKind) u32 {
     return dropped;
 }
 
+/// Strand the next op this scenario submits of any kind in `kinds`, and
+/// only that one (#206). Where `dropPendingOps` takes what is armed
+/// *now*, this waits for an arming that has not happened yet — the only
+/// way to reach an op that teardown arms after the strand instant has
+/// gone by, which is what the two cancels `beginTeardown` submits are and
+/// the shape #203 took.
+///
+/// A set rather than one kind because the wait is on the future: which
+/// cancel a teardown reaches for is the schedule's business, and a latch
+/// naming one of the two would spend most of its scenarios waiting for an
+/// op that never comes.
+pub fn armDropNext(io: *SimIo, kinds: []const OpKind) void {
+    assert(io.drop_next_kinds == 0);
+    assert(io.drop_next_taken == null);
+    assert(kinds.len >= 1);
+    for (kinds) |kind| {
+        assert(kind != .none);
+        io.drop_next_kinds |= kindBit(kind);
+    }
+    assert(io.drop_next_kinds != 0);
+    // Into the trace: a run waiting for a different set is a different
+    // run, whether or not the wait is ever answered.
+    io.mix(io.drop_next_kinds);
+}
+
+/// Which kind the latch took, or null when nothing it waited for was ever
+/// submitted — the same distinction `dropPendingOps` draws with its
+/// count, between a scenario that stranded something and one that quietly
+/// stranded nothing.
+pub fn droppedNextOp(io: *const SimIo) ?OpKind {
+    if (io.drop_next_taken) |kind| assert(kind != .none);
+    return io.drop_next_taken;
+}
+
+fn kindBit(kind: OpKind) u16 {
+    comptime assert(std.enums.values(OpKind).len <= @bitSizeOf(u16));
+    assert(kind != .none);
+    return @as(u16, 1) << @intCast(@intFromEnum(kind));
+}
+
 /// Whether any op of `kind` is pending and still deliverable — what a
 /// caller about to strand one asks first, so it picks a kind the schedule
 /// actually armed instead of spending its seed on a kind that is not
@@ -1345,10 +1394,30 @@ fn dumpPendingOps(io: *const SimIo) void {
 fn enqueue(io: *SimIo, completion: *Completion) void {
     assert(io.pending_count < pending_ops_max);
     assert(completion.op != .none);
+    io.maybeDropOnSubmit(completion);
     io.pending[io.pending_count] = completion;
     completion.pending_index = io.pending_count;
     completion.state = .pending;
     io.pending_count += 1;
+}
+
+/// The submit-time half of the strand (`armDropNext`): an op the latch
+/// was waiting for is born dropped. Every submit path assigns the
+/// completion a fresh struct first, so `dropped` is false here on an op
+/// that has never been taken — a completion still dropped from an earlier
+/// strand is pending forever and can never be re-armed.
+fn maybeDropOnSubmit(io: *SimIo, completion: *Completion) void {
+    assert(completion.op != .none);
+    assert(!completion.dropped);
+    if (io.drop_next_kinds == 0) return;
+    const kind: OpKind = completion.op;
+    if (io.drop_next_kinds & kindBit(kind) == 0) return;
+    completion.dropped = true;
+    // One op is the whole perturbation: the latch closes on the first
+    // match, so the rest of the teardown proceeds as the schedule wrote it.
+    io.drop_next_kinds = 0;
+    io.drop_next_taken = kind;
+    io.mix(@intFromEnum(kind));
 }
 
 fn unlink(io: *SimIo, completion: *Completion) void {

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -636,7 +636,13 @@ test "simio: a dropped accept is never delivered, where a live one is" {
         &stuck,
         DroppedAccept.onAccept,
     );
+    // What the sweep picks a kind to strand from (`sim/Harness.zig`):
+    // armed now, and *not* armed once taken, so a later pick cannot spend
+    // itself on ops that are already stranded.
+    try std.testing.expect(stuck_io.hasPendingOp(.accept));
+    try std.testing.expect(!stuck_io.hasPendingOp(.recv));
     try std.testing.expectEqual(@as(u32, 1), stuck_io.dropPendingOps(.accept));
+    try std.testing.expect(!stuck_io.hasPendingOp(.accept));
     stuck_io.listenClose(stuck_listener);
     try std.testing.expectError(error.Deadlock, stuck_io.run());
     try std.testing.expect(stuck.outcome == null);

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -701,6 +701,66 @@ test "simio: a stranded timer has nothing left to report it" {
     try std.testing.expectEqual(@as(?u8, null), sim_io.abortedWith());
 }
 
+const LatchedCancel = struct {
+    timer: SimIo.Completion = .{},
+    cancel: SimIo.Completion = .{},
+    timer_delivered: bool = false,
+    cancel_delivered: bool = false,
+
+    fn onTimer(self: *LatchedCancel, result: Io.TimerError!void) void {
+        result catch {};
+        self.timer_delivered = true;
+    }
+
+    fn onCancel(self: *LatchedCancel) void {
+        self.cancel_delivered = true;
+    }
+};
+
+// #206's second strand, pinned: `armDropNext` waits for an op that is in
+// no table yet — the cancel a teardown arms once the drain is already
+// under way — where `dropPendingOps` can only take what is armed now.
+//
+// The end state is what makes it the #203 shape. The cancel never lands,
+// so the caller's armed set never empties and its slot is never released;
+// the timer it was cancelling completes on its own schedule, so nothing
+// about the run *looks* stuck from the inside. Only a backstop that
+// notices the drain never finished can report it.
+test "simio: a latched cancel is stranded when it is finally submitted" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{
+        .seed = 23,
+        // The deadlock is the assertion; its forensics are noise here.
+        .dump_on_deadlock = false,
+    });
+
+    var state: LatchedCancel = .{};
+    sim_io.timerStart(
+        &state.timer,
+        std.time.ns_per_ms,
+        LatchedCancel,
+        &state,
+        LatchedCancel.onTimer,
+    );
+    // Armed while the only pending op is one the latch is not waiting for:
+    // nothing is taken until the cancel below is submitted.
+    sim_io.armDropNext(&[_]SimIo.OpKind{ .timer_cancel, .connect_cancel });
+    try std.testing.expectEqual(@as(?SimIo.OpKind, null), sim_io.droppedNextOp());
+
+    sim_io.timerCancel(&state.timer, &state.cancel, LatchedCancel, &state, LatchedCancel.onCancel);
+    try std.testing.expectEqual(@as(?SimIo.OpKind, .timer_cancel), sim_io.droppedNextOp());
+
+    try std.testing.expectError(error.Deadlock, sim_io.run());
+    // The cancel never delivered, so whoever armed it still counts it as
+    // in flight — and the timer it named ran to completion instead of
+    // being cancelled, which is why nothing else looks wrong.
+    try std.testing.expect(!state.cancel_delivered);
+    try std.testing.expect(state.timer_delivered);
+}
+
 // #202: some bounds are measured in hours against scenarios that run for
 // a virtual second. XevIo has no counterpart and needs none — this is
 // scenario control like `injectLogWriteError`, not a seam decl.


### PR DESCRIPTION
Two slices on #206, each measured against a 4096-seed sweep plus 16384 seeds beyond it (4097..20480).

## 1. Strand the kind the wind-down actually armed

The op kind a seed stranded was drawn with the rest of the topology, before the scenario ran — a bet on what the wind-down would hold, and it lost more often than it won. 230 of the 368 runs that drew a kind found none of it armed and stranded nothing, and the kinds armed under a fifth of the time were out of reach in practice: `timer_cancel` at 15% of wind-downs, `send` and `connect_cancel` at about 1%, all three absent from the draw with no reason recorded.

`drawStrandKind` asks the pending table at the wind-down instead and picks uniformly among the kinds that are there.

| | before | after |
| --- | --- | --- |
| strands per sweep | 124 | 316 |
| draws that stranded nothing | 230 | 0 |
| runs reaching the §8 give-up | 52 | 112 |

The exclusion list is down to `timer` alone. `close` was named for being armed at no wind-down ever; an armed-set pick spends nothing on a kind that is not there, so the exclusion bought nothing and would have gone stale the first time the admin plane's `submitClose` were still in flight when a drain began.

## 2. Strand a cancel the teardown arms, not one it inherited

The two cancels `beginTeardown` arms are not in the pending table when the wind-down hook runs — it arms them *after* the strand lands. They are therefore the only ops in a connection's armed set no wind-down drop can be holding, and #203 was exactly that: a cancel submitted and never delivered.

`SimIo.armDropNext(kinds)` latches rather than takes: the next op submitted of a kind in the set is born dropped. Seeds draw *where* they strand out of the single value that used to mean "strand or not", so the sweep's stream position — and the §9 census margins hanging off it — do not move.

Per sweep, 246 of the 784 teardown runs find a cancel to take and **all 246 reach the give-up**, 168 of them holding a connection slot that can never be released.

Where the latch is armed decides what it catches, which took two measurements to get right:

| latch armed | runs that strand | strands on conns |
| --- | --- | --- |
| before the doubles' `cancelIfStuck` burst | 82% | — (a fifth took a client double's cancel) |
| after the doubles, before `beginDrain` returns | 75% | 7% |
| after `beginDrain` returns | 31% | 68% |

The first two spend the latch on cancels submitted from inside the drain — the harness's own doubles, then the prober being stopped. The third strands on fewer runs precisely because those are gone by then.

## Net

Give-up coverage went 52 → 358 runs per sweep, 244 of them holding an unreleasable slot. Both #206 oracles (`SlotReleasedUnderPendingOp`, `StrandCannotExplainStuck`) now run against both hooks, and `contract_test.zig` gains a directed pin for the latch.

`zig build ci` green; `zig build sim -- 4097 16384 keep-going` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)