### PR TITLE
sim: judge a terminated session's responses, and let it draw what it sends (#215)

### DIFF
--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -969,7 +969,12 @@ fn renderSimPage(comptime status: u16, comptime body: []const u8) zoxy.config.Co
     };
 }
 
-fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
+/// The §7 request rules and the #175 response rules the http listener
+/// runs — and, on the seeds whose tls listener terminates http, that one
+/// too (#215). Split from `wireListeners` when attaching the second
+/// listener's chain took it past the length limit; the two halves are
+/// what a listener is made of, in the order the config reads.
+fn wireFilters(harness: *Harness) void {
     harness.request_filters_http = .{
         .{
             .match = .{ .path_prefix = "/reject" },
@@ -1021,6 +1026,14 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .edits = &.{.{ .kind = .set, .name = l7.canon.response_never_name, .value = "1" }},
         },
     };
+}
+
+fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forwarded) void {
+    harness.wireFilters();
+    // One binding for both filter fields: a tls listener either runs the
+    // http listener's whole chain or none of it, and two spellings of the
+    // same condition are two chances to edit one and not the other.
+    const terminates_http = harness.tls_protocol == .http;
     harness.listener_configs = .{
         .{
             .bind_address = bindAddress(),
@@ -1043,6 +1056,18 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             // client's. Which cluster it points at follows the protocol:
             // an http terminator has to reach an origin that speaks HTTP.
             .routes = &harness.routes_tls,
+            // The same filter chain the plaintext http listener runs
+            // (#215). The claim termination rests on is that TLS is a
+            // phase ahead of the protocol and not a protocol of its own —
+            // the same render, the same filters, the same stamps — and a
+            // listener configured with no filters cannot test any of it:
+            // the response oracle these clients now run would be asking
+            // for a stamp the config never ordered. Only on the http
+            // draw, since filters on an l4 listener are a config error
+            // (`ListenerL4ResponseFilters`) and an l4 relay has no head to
+            // apply them to.
+            .request_filters = if (terminates_http) &harness.request_filters_http else &.{},
+            .response_filters = if (terminates_http) &harness.response_filters_http else &.{},
             // Both, across seeds. Termination is a phase ahead of the
             // protocol (§4), so the two combinations exercise genuinely
             // different code — the L4 relay's transform hooks against the
@@ -1984,34 +2009,70 @@ pub fn verify(harness: *Harness) !void {
 /// own statement that it got everything, and a client that then holds
 /// fewer bytes than it sent is a contradiction.
 ///
-/// Not conditioned on `clean`, deliberately. A TLS session costs several
-/// more virtual round trips than a plaintext one, so it can legitimately
-/// meet the scenario's end mid-echo on a seed where every plaintext
-/// client finished — that is the schedule being short, not the proxy
-/// being wrong, and an oracle that called it a truncation would fail
-/// honest runs.
+/// A proxied session's responses go through the plaintext population's
+/// own oracle (#215), which is the point: the argument for terminating
+/// in-process is that TLS is a phase ahead of the protocol and not a
+/// protocol of its own — the same render, the same filters, the same
+/// stamps — and an unexamined response is exactly what leaves that claim
+/// untested. It was untested: the #178 sticky stamp shipped 0.2.0
+/// omitting `Secure` on terminated connections and `zig build ci` passed
+/// identically either side, because all this asked was that the bytes
+/// started with "HTTP/1.1 ".
+///
+/// Not conditioned on `clean`, deliberately, and that is where this stops
+/// short of the plaintext oracle. A TLS session costs several more
+/// virtual round trips than a plaintext one, so it can legitimately meet
+/// the scenario's end mid-exchange on a seed where every plaintext client
+/// finished — that is the schedule being short, not the proxy being
+/// wrong, and an oracle demanding the golden *count* would fail honest
+/// runs. What is demanded is everything that does not depend on how far
+/// the schedule got: every complete response parses, carries an allowed
+/// status, a canonical body, the #175 stamp its render owes and the #178
+/// stamp its cluster owes, and no surplus response beyond the pair.
+///
+/// Mutation-checked rather than assumed, both directions:
+///
+///   - Restoring the pre-#125 stamp — no `Secure` on a terminated
+///     connection, with the assert that shipped beside it — fails seeds
+///     61, 129, 176, 295 and 501 of the first 512. That is the 0.2.0 bug,
+///     and this oracle is what would have caught it.
+///   - Taking the response filters back off the tls listener fails ~10%
+///     of the first 512 on `ResponseEditMissing`, which is how the
+///     listener's own filter chain is held to running at all.
+///
+/// A violation surfaces under the plaintext oracle's own error name.
+/// Which population raised it is not in the name, and does not need to
+/// be: the plaintext clients verify first, so an error arriving from here
+/// is one their transcripts did not have.
 fn verifyTlsSessions(harness: *Harness) !void {
     if (harness.tls_clients == 0) return;
+    assert(harness.tls_clients_live <= harness.tls_clients_storage.len);
     var closed_count: u8 = 0;
     for (harness.tls_clients_storage[0..harness.tls_clients_live], 0..) |*client, index| {
         const back = client.app_received[0..client.app_received_len];
         if (harness.tls_protocol == .http) {
-            // A proxied session gets a response, not its own bytes back.
-            // What is checkable without restating the L7 oracle is that
-            // anything which arrived is a *response* — an origin's answer
-            // relayed through the transform, not the request echoing back
-            // or another session's plaintext.
-            if (back.len >= 1 and !std.mem.startsWith(u8, back, "HTTP/1.1 ")) {
-                return error.TlsResponseCorrupted;
-            }
+            // The spec the walk judges by describes the pair this
+            // population sends, so what went out cannot exceed it — the
+            // check that catches the two drifting apart, since a wider
+            // send would be judged against a transcript that never
+            // mentions it.
+            assert(client.requestsSent() <= l7.scripts.terminating_pair.expected_responses);
+            const walk = HttpClient.walkResponses(
+                back,
+                l7.scripts.terminating_pair,
+                .{ .sticky = harness.sticky_http, .terminated = true },
+            );
+            if (walk.violation) |violation| return violation;
             // #204: never more answers than questions. The framing rule
-            // the client now ends its exchanges on is what lets it count
-            // them at all, and a count that ran ahead of what it asked
-            // for would mean the transform delivered a response this
-            // session never earned — another connection's, or one
-            // duplicated across the head source's turnaround. Sound on
-            // every seed, since a short schedule can only leave the
-            // count *behind*.
+            // the client ends its exchanges on is what lets it count them
+            // at all, and a count that ran ahead of what it asked for
+            // would mean the transform delivered a response this session
+            // never earned — another connection's, or one duplicated
+            // across the head source's turnaround. Sound on every seed,
+            // since a short schedule can only leave the count *behind*.
+            // Kept beside the walk rather than folded into it: the walk
+            // bounds responses by the transcript, this bounds them by
+            // what this session actually sent.
             if (client.responsesReceived() > client.requestsSent()) {
                 return error.TlsResponseCountDiverged;
             }

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -60,7 +60,6 @@ const tls_token_bytes: u8 = 24;
 /// an idle timeout. Between them is the keep-alive turnaround — the L7
 /// state re-entered on a terminated connection, which is where the head
 /// source's first defect lived (#204).
-const tls_http_request = l7.scripts.post_request;
 const tls_http_followup = l7.scripts.get_request_close;
 /// "203.0.113.255:65535" is 19 bytes; the slack is headroom, not hope.
 const announced_bytes_max: u8 = 32;
@@ -153,8 +152,16 @@ scenario_ended: bool,
 /// What the terminating listener speaks once the handshake hands over.
 tls_protocol: zoxy.config.Config.Listener.Protocol,
 /// What each terminating client sends, distinct per client so the echo
-/// oracle can tell one session's bytes from another's.
+/// oracle can tell one session's bytes from another's. Read only by the
+/// l4 draw; an http terminator sends its script's request instead.
 tls_tokens: [tls_client_slots][tls_token_bytes]u8,
+/// The script each terminating client sends over an http terminator
+/// (#215), one per storage slot including the resuming client's. Drawn
+/// rather than fixed so the filter, redirect, static, rejection and
+/// sticky paths ride the transform too — the population used to send one
+/// POST-then-GET pair, which exercised the response render's happy path
+/// and nothing else.
+tls_scripts: [tls_client_slots]l7.Script,
 tls_credentials: [3]?zoxy.tls.Credentials,
 /// The #142 gate drawn for the l4 listener; `populateClients` reads it
 /// to decide whether its clients open with headers.
@@ -614,6 +621,11 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
         harness.force_exhaustion,
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
+    for (&harness.tls_scripts) |*script| {
+        script.* = l7.scripts.terminating_scripts[
+            random.uintLessThan(usize, l7.scripts.terminating_scripts.len)
+        ];
+    }
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
     harness.drop_mode = deriveDropMode(harness.clean, random);
     assert(harness.listeners_count <= harness.listener_configs.len);
@@ -1410,6 +1422,14 @@ fn startTlsClient(
 ) void {
     assert(index < harness.tls_clients_live);
     const client = &harness.tls_clients_storage[index];
+    // What this slot drew, and the one property of it the session's shape
+    // turns on: a script whose response is judged exactly as a plain
+    // GET's can be followed by one (#204's keep-alive turnaround, judged
+    // as `terminating_pair`), and one whose response is a static, a
+    // redirect, a rejection or an un-stamped 200 cannot — a single spec
+    // could not describe both halves of that pair.
+    const entry = l7.scripts.spec(harness.tls_scripts[index]);
+    const pairs = harness.tls_protocol == .http and entry.routed_canonical;
     client.start(&harness.io, Harness.tlsBindAddress(), .{
         .host_name = zoxy.tls.testdata.host_name,
         .resume_with = resume_with,
@@ -1418,7 +1438,7 @@ fn startTlsClient(
         // listener behind it expects, or the head parser answers 400
         // and the transform is never exercised at all.
         .app_data = if (harness.tls_protocol == .http)
-            tls_http_request
+            entry.request
         else
             harness.tls_tokens[index][0..tls_token_bytes],
         // How each population knows its peer answered. A relayed
@@ -1435,16 +1455,21 @@ fn startTlsClient(
         // The second request, on the connection the first left open —
         // only the proxied population has one, since an echo has no
         // turnaround to take.
-        .followup_data = if (harness.tls_protocol == .http)
-            tls_http_followup
-        else
-            &.{},
+        .followup_data = if (pairs) tls_http_followup else &.{},
         // A relayed session closes in protocol once its echo is back:
         // an in-band EOF no socket EOF follows, which is the §6
         // half-close a terminated relay can only learn from a decrypt.
-        // A proxied one lets its second request's `Connection: close`
-        // end the connection instead, and finishes on the EOF.
-        .close_after_echo = harness.tls_protocol == .l4,
+        // A paired one lets its second request's `Connection: close` end
+        // the connection instead, and finishes on the EOF.
+        //
+        // An unpaired proxied session takes the relayed shape, and has
+        // to: its script's request carries no `Connection: close`, so
+        // without this the answered connection would sit in keep-alive
+        // until the drain reaped it — holding a conn slot for the rest of
+        // the scenario on a fifth of the terminating clients. Closing in
+        // protocol instead is the §6 half-close arriving mid-keep-alive,
+        // which nothing else in the sweep produces.
+        .close_after_echo = !pairs,
         .x25519_seed = seeds[0],
         .p256_seed = seeds[1],
         .random = seeds[2],
@@ -2051,15 +2076,24 @@ fn verifyTlsSessions(harness: *Harness) !void {
     for (harness.tls_clients_storage[0..harness.tls_clients_live], 0..) |*client, index| {
         const back = client.app_received[0..client.app_received_len];
         if (harness.tls_protocol == .http) {
-            // The spec the walk judges by describes the pair this
-            // population sends, so what went out cannot exceed it — the
-            // check that catches the two drifting apart, since a wider
-            // send would be judged against a transcript that never
-            // mentions it.
-            assert(client.requestsSent() <= l7.scripts.terminating_pair.expected_responses);
+            // What this slot drew, and the same pairing rule
+            // `startTlsClient` sent it under: a `routed_canonical` script
+            // took a follow-up GET, so its transcript is the pair's;
+            // anything else sent one request and owes its own script's
+            // transcript exactly.
+            const drawn = l7.scripts.spec(harness.tls_scripts[index]);
+            const entry = if (drawn.routed_canonical)
+                l7.scripts.terminating_pair
+            else
+                drawn;
+            // The spec the walk judges by describes what this session was
+            // asked to send, so what went out cannot exceed it — the check
+            // that catches the two drifting apart, since a wider send
+            // would be judged against a transcript that never mentions it.
+            assert(client.requestsSent() <= entry.expected_responses);
             const walk = HttpClient.walkResponses(
                 back,
-                l7.scripts.terminating_pair,
+                entry,
                 .{ .sticky = harness.sticky_http, .terminated = true },
             );
             if (walk.violation) |violation| return violation;

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -58,6 +58,14 @@ pub const sticky_tag = "b4a7ea22f14bfcac";
 /// included — one spelling shared by the oracle so it cannot drift.
 pub const sticky_set_cookie_value =
     sticky_cookie_name ++ "=" ++ sticky_tag ++ "; Path=/; HttpOnly";
+/// The same stamp on a connection zoxy terminated (#125, #178): there the
+/// proxy knows the client-facing scheme is https, so the cookie carries
+/// `Secure` and a browser will not hand it back over plaintext. Spelled
+/// as the plaintext value plus the attribute rather than as a second
+/// literal, so the two cannot drift apart — which is the failure the
+/// terminating population's oracle exists to catch, the attribute having
+/// shipped missing once already.
+pub const sticky_set_cookie_value_secure = sticky_set_cookie_value ++ "; Secure";
 
 /// The #159 configured bodies. `error_page_body` is the harness's page
 /// for `403` — the one status a script earns from a filter reject — so

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -25,6 +25,7 @@ const scripts = @import("scripts.zig");
 const Io = zoxy.Io;
 const parser = zoxy.http.parser;
 const Script = scripts.Script;
+const Spec = scripts.Spec;
 
 const assert = std.debug.assert;
 
@@ -230,7 +231,7 @@ pub fn Client(comptime IoType: type) type {
             assert(client.received_len <= client.receive_buffer.len);
             const walk = walkResponses(
                 client.receive_buffer[0..client.received_len],
-                client.script,
+                scripts.spec(client.script),
                 client.sticky,
             );
             client.maybeSendSecondRequest(&walk);
@@ -340,11 +341,11 @@ pub fn Client(comptime IoType: type) type {
             assert(client.received_len <= client.receive_buffer.len);
             if (client.overrun) return ClientError.ResponseOverrun;
             const bytes = client.receive_buffer[0..client.received_len];
-            const walk = walkResponses(bytes, client.script, client.sticky);
+            const entry = scripts.spec(client.script);
+            const walk = walkResponses(bytes, entry, client.sticky);
             if (walk.violation) |violation| return violation;
             assert(walk.offset <= client.received_len);
             if (client.clean) {
-                const entry = scripts.spec(client.script);
                 if (walk.complete_count != entry.expected_responses) {
                     return ClientError.GoldenOutcomeMissed;
                 }
@@ -364,7 +365,7 @@ pub fn Client(comptime IoType: type) type {
             }
         }
 
-        const Walk = struct {
+        pub const Walk = struct {
             complete_count: u8,
             offset: u32,
             statuses: [responses_max]u16,
@@ -380,8 +381,7 @@ pub fn Client(comptime IoType: type) type {
         /// a legal prefix (the adversary cuts mid-anything); bytes that
         /// can never extend to a legal transcript — or one complete
         /// response more than the transcript contains — are a violation.
-        fn walkResponses(bytes: []const u8, script: Script, sticky: bool) Walk {
-            const entry = scripts.spec(script);
+        pub fn walkResponses(bytes: []const u8, entry: Spec, sticky: bool) Walk {
             var walk = Walk{
                 .complete_count = 0,
                 .offset = 0,
@@ -409,11 +409,11 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = ClientError.ResponseStatusUnexpected;
                     return walk;
                 }
-                if (responseEditViolation(script, &response)) |violation| {
+                if (responseEditViolation(entry, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
                 }
-                if (stickyViolation(sticky, script, &response)) |violation| {
+                if (stickyViolation(sticky, entry, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
                 }
@@ -428,7 +428,7 @@ pub fn Client(comptime IoType: type) type {
                     }
                 }
                 const body = bytes[walk.offset + response.head_len ..];
-                const verdict = walkBody(response, body, script) orelse return walk;
+                const verdict = walkBody(response, body, entry) orelse return walk;
                 if (verdict.violation) |violation| {
                     walk.violation = violation;
                     return walk;
@@ -456,7 +456,7 @@ pub fn Client(comptime IoType: type) type {
         /// means the class predicate fired on a class the origin never
         /// answers. Distinguishes the two render paths from outside the
         /// process, under every schedule the adversary produces.
-        fn responseEditViolation(script: Script, response: *const parser.ResponseHead) ?ClientError {
+        fn responseEditViolation(entry: Spec, response: *const parser.ResponseHead) ?ClientError {
             assert(response.status >= 100);
             assert(response.headers.len <= zoxy.constants.headers_max);
             const stamped = headerEquals(
@@ -468,7 +468,7 @@ pub fn Client(comptime IoType: type) type {
             // is sent from immutable memory and never crosses the
             // response render, so the stamp on one would mean a
             // configured body had grown filter edits.
-            const from_memory = pageBodyFor(script, response.status) != null;
+            const from_memory = pageBodyFor(entry, response.status) != null;
             if (response.status == 200 and !from_memory) {
                 if (!stamped) {
                     return ClientError.ResponseEditMissing;
@@ -497,7 +497,7 @@ pub fn Client(comptime IoType: type) type {
         /// under every schedule the adversary produces.
         fn stickyViolation(
             sticky: bool,
-            script: Script,
+            entry: Spec,
             response: *const parser.ResponseHead,
         ) ?ClientError {
             assert(response.status >= 100);
@@ -511,18 +511,19 @@ pub fn Client(comptime IoType: type) type {
             // reaches no origin and runs no response render, so a
             // cookie on one would be the stamp path firing for an
             // exchange that never happened.
-            if (response.status != 200 or pageBodyFor(script, response.status) != null) {
+            if (response.status != 200 or pageBodyFor(entry, response.status) != null) {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
-            switch (script) {
-                .sticky_follow => if (named) return ClientError.StickyStampForged,
-                else => if (!headerEquals(
-                    response.headers,
-                    "set-cookie",
-                    canon.sticky_set_cookie_value,
-                )) return ClientError.StickyStampMissing,
+            if (entry.sticky_request_pinned) {
+                if (named) return ClientError.StickyStampForged;
+                return null;
             }
+            if (!headerEquals(
+                response.headers,
+                "set-cookie",
+                canon.sticky_set_cookie_value,
+            )) return ClientError.StickyStampMissing;
             return null;
         }
 
@@ -581,7 +582,7 @@ pub fn Client(comptime IoType: type) type {
         /// cookie. The three oracles below all key off this one
         /// predicate, so the sweep cannot come to disagree with itself
         /// about which responses were rendered.
-        fn pageBodyFor(script: Script, status: u16) ?[]const u8 {
+        fn pageBodyFor(entry: Spec, status: u16) ?[]const u8 {
             assert(status >= 100);
             assert(status <= 599);
             if (status == 403) {
@@ -591,7 +592,7 @@ pub fn Client(comptime IoType: type) type {
                 assert(canon.error_page_body.len >= 1);
                 return canon.error_page_body;
             }
-            if (status == 200 and script == .filter_respond) {
+            if (status == 200 and entry.respond_page) {
                 assert(canon.respond_body.len >= 1);
                 return canon.respond_body;
             }
@@ -610,8 +611,8 @@ pub fn Client(comptime IoType: type) type {
         /// framing (the proxy relays body wire bytes verbatim), and
         /// every legal non-200 is a static with Content-Length 0 — so a
         /// corrupted length fails even before its body arrives.
-        fn walkBody(response: parser.ResponseHead, body: []const u8, script: Script) ?BodyVerdict {
-            const page_body = pageBodyFor(script, response.status);
+        fn walkBody(response: parser.ResponseHead, body: []const u8, entry: Spec) ?BodyVerdict {
+            const page_body = pageBodyFor(entry, response.status);
             switch (response.framing) {
                 .content_length => |length| {
                     // A configured page's body, byte-exact (#159): it is

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -64,6 +64,18 @@ pub const ClientError = error{
     StickyStampForged,
 };
 
+/// What the connection under the responses was, which two of the
+/// oracles below need and no script can describe: the same request over a
+/// terminated listener earns a different stamp from the same render.
+pub const Connection = struct {
+    /// The seed drew the #178 cookie-keyed cluster, so every routed 200
+    /// owes the stamp.
+    sticky: bool,
+    /// The client reached the proxy over a listener that terminates TLS,
+    /// so that stamp owes `Secure` (#125).
+    terminated: bool = false,
+};
+
 pub fn Client(comptime IoType: type) type {
     return struct {
         io: *IoType = undefined,
@@ -232,7 +244,7 @@ pub fn Client(comptime IoType: type) type {
             const walk = walkResponses(
                 client.receive_buffer[0..client.received_len],
                 scripts.spec(client.script),
-                client.sticky,
+                .{ .sticky = client.sticky },
             );
             client.maybeSendSecondRequest(&walk);
             if (walk.violation == null and walk.complete_count >= responsesTarget(client.script, &walk)) {
@@ -342,7 +354,7 @@ pub fn Client(comptime IoType: type) type {
             if (client.overrun) return ClientError.ResponseOverrun;
             const bytes = client.receive_buffer[0..client.received_len];
             const entry = scripts.spec(client.script);
-            const walk = walkResponses(bytes, entry, client.sticky);
+            const walk = walkResponses(bytes, entry, .{ .sticky = client.sticky });
             if (walk.violation) |violation| return violation;
             assert(walk.offset <= client.received_len);
             if (client.clean) {
@@ -381,7 +393,7 @@ pub fn Client(comptime IoType: type) type {
         /// a legal prefix (the adversary cuts mid-anything); bytes that
         /// can never extend to a legal transcript — or one complete
         /// response more than the transcript contains — are a violation.
-        pub fn walkResponses(bytes: []const u8, entry: Spec, sticky: bool) Walk {
+        pub fn walkResponses(bytes: []const u8, entry: Spec, connection: Connection) Walk {
             var walk = Walk{
                 .complete_count = 0,
                 .offset = 0,
@@ -413,7 +425,7 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = violation;
                     return walk;
                 }
-                if (stickyViolation(sticky, entry, &response)) |violation| {
+                if (stickyViolation(connection, entry, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
                 }
@@ -496,14 +508,14 @@ pub fn Client(comptime IoType: type) type {
         /// distinguishes the render paths from outside the process,
         /// under every schedule the adversary produces.
         fn stickyViolation(
-            sticky: bool,
+            connection: Connection,
             entry: Spec,
             response: *const parser.ResponseHead,
         ) ?ClientError {
             assert(response.status >= 100);
             assert(response.headers.len <= zoxy.constants.headers_max);
             const named = stickyNamePresent(response.headers);
-            if (!sticky) {
+            if (!connection.sticky) {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
@@ -519,11 +531,17 @@ pub fn Client(comptime IoType: type) type {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
-            if (!headerEquals(
-                response.headers,
-                "set-cookie",
-                canon.sticky_set_cookie_value,
-            )) return ClientError.StickyStampMissing;
+            // The one place the two populations differ, and the reason
+            // this oracle needs to know which it is serving: where zoxy
+            // terminated, the render knows the client-facing scheme is
+            // https and the stamp carries `Secure` (#125).
+            const expected = if (connection.terminated)
+                canon.sticky_set_cookie_value_secure
+            else
+                canon.sticky_set_cookie_value;
+            if (!headerEquals(response.headers, "set-cookie", expected)) {
+                return ClientError.StickyStampMissing;
+            }
             return null;
         }
 

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -156,6 +156,15 @@ pub const Spec = struct {
     /// Every other routed request is assigned or repicked and owes the
     /// pinned cookie.
     sticky_request_pinned: bool = false,
+    /// This script routes to an origin and its 200 is the canonical body
+    /// with the standard stamps — nothing about the response tells it
+    /// apart from a plain `get`'s. That is what lets the terminating
+    /// population (#215) follow one with a second request and judge the
+    /// pair by a single spec; a script whose response is a static, a
+    /// redirect, a rejection or an un-stamped 200 cannot be paired that
+    /// way, because one spec cannot describe both halves. Held to its
+    /// meaning by the comptime block below rather than trusted.
+    routed_canonical: bool = false,
 };
 
 const post_body = "request-body-24-bytes-ab";
@@ -268,6 +277,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .post_sized = .{
         .request = post_request,
@@ -276,6 +286,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .post,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .post_big = .{
         .request = "POST /big HTTP/1.1\r\nHost: sim\r\n" ++
@@ -285,6 +296,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .post,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .post_chunked = .{
         .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
@@ -294,6 +306,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .post,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .post_chunked_malformed = .{
         // "Z" is no chunk-size digit: the framing violation is in the
@@ -388,6 +401,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     // §7 filter scripts: a distinct path per action so the listener's
     // rules fire only for these, never the others.
@@ -438,6 +452,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .filter_rewrite = .{
         .request = "GET /rewrite HTTP/1.1\r\nHost: sim\r\n\r\n",
@@ -446,6 +461,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     // §7 client-address forwarding: both route and forward like a plain
     // GET, so the §8 rungs and a killed dial can precede the 200. What
@@ -462,6 +478,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     .forwarded_oversize = .{
         .request = forwarded_oversize_head,
@@ -470,6 +487,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
     // #178: both route and forward like a plain GET, so the §8 rungs and
     // a killed dial can precede the 200. What they change is the sticky
@@ -495,6 +513,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
     },
 });
 
@@ -532,6 +551,58 @@ comptime {
     assert(!terminating_pair.sticky_request_pinned);
 }
 
+/// What the §4 terminating population may draw (#215). Every script but
+/// two: this client sends the drawn request over a terminated listener,
+/// so the filter, redirect, static, rejection and sticky paths finally
+/// ride the transform instead of only the plaintext listener.
+///
+/// `silent` is out because it sends nothing — a session with no request
+/// completes no exchange, never closes, and would test only the
+/// scenario-end reaper the L4 population already exercises.
+///
+/// `keepalive_pair` is out because its second request is a *runtime*
+/// decision: the plaintext client sends it only once the first response
+/// settles reusable, read off its own walk. The terminating client's
+/// follow-up is unconditional, so drawing that script would send a second
+/// request into a connection the first response may have closed. The
+/// turnaround it exists for is covered anyway — every `routed_canonical`
+/// draw takes a follow-up.
+pub const terminating_scripts = [_]Script{
+    .get,
+    .post_sized,
+    .post_big,
+    .post_chunked,
+    .post_chunked_malformed,
+    .malformed_head,
+    .oversize_uri,
+    .connect_method,
+    .pipelined,
+    .confusion,
+    .filter_reject,
+    .filter_redirect,
+    .filter_respond,
+    .filter_edit,
+    .filter_rewrite,
+    .forwarded_inbound,
+    .forwarded_oversize,
+    .sticky_follow,
+    .sticky_repick,
+};
+
+comptime {
+    // Every script is either drawable there or one of the two named
+    // exceptions, so a script added to the table cannot quietly skip the
+    // terminating population — someone has to decide which it is.
+    for (std.enums.values(Script)) |script| {
+        const excepted = script == .silent or script == .keepalive_pair;
+        var drawable = false;
+        for (terminating_scripts) |candidate| {
+            if (candidate == script) drawable = true;
+        }
+        assert(drawable != excepted);
+    }
+}
+
 pub fn spec(script: Script) Spec {
     return specs.get(script);
 }
@@ -558,5 +629,23 @@ comptime {
         // that routes, which a page never does.
         if (entry.respond_page) assert(entry.golden_status == 200);
         if (entry.respond_page) assert(!entry.sticky_request_pinned);
+        // "Judged exactly as a plain GET is", spelled out: same legal
+        // status set, same golden outcome, neither render exception, and
+        // one response per request. A script that drifts from any of
+        // those stops being pairable and has to say so here first.
+        if (entry.routed_canonical) {
+            assert(std.mem.eql(u16, entry.allowed_statuses, statuses_routed));
+            assert(entry.golden_status == 200);
+            assert(entry.expected_responses == 1);
+            assert(entry.transcript_cap == 1);
+            assert(!entry.respond_page);
+            assert(!entry.sticky_request_pinned);
+            // And the one bound the substitution rests on: a paired
+            // transcript is judged by `terminating_pair`'s method, so a
+            // script whose responses parse under a *different* body rule
+            // cannot be paired. GET and POST share theirs; HEAD does not,
+            // and would have its bodiless responses read as truncated.
+            assert(entry.method != .head);
+        }
     }
 }

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -498,6 +498,40 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     },
 });
 
+/// The §4 terminating population's transcript (#215): the fixed
+/// POST-then-close-GET pair the harness sends over a terminated
+/// listener, described so the plaintext response oracle can judge those
+/// responses too. Both requests are the ones the table already holds —
+/// `post_request` is `post_sized`'s bytes and the follow-up is `get`'s
+/// with an explicit close — so what comes back owes exactly what a
+/// plaintext client's would.
+///
+/// A `Spec` and not a `Script`, deliberately: the plaintext population
+/// draws its script with `enumValue`, so a member added for a population
+/// that never draws would re-roll every seed's script and take the §9
+/// census margins with it. This population sends its pair.
+///
+/// The method is the first request's. It reaches the parser only as the
+/// HEAD-shaped body rule, which POST and GET share, so one context is
+/// right for both responses.
+pub const terminating_pair: Spec = .{
+    .request = post_request,
+    .expected_responses = 2,
+    .transcript_cap = 2,
+    .golden_status = 200,
+    .method = .post,
+    .allowed_statuses = statuses_routed,
+};
+
+comptime {
+    // The pair is the two requests the harness actually sends, and the
+    // oracle reads the first one's spelling from here.
+    assert(std.mem.eql(u8, terminating_pair.request, post_request));
+    assert(terminating_pair.expected_responses == terminating_pair.transcript_cap);
+    assert(!terminating_pair.respond_page);
+    assert(!terminating_pair.sticky_request_pinned);
+}
+
 pub fn spec(script: Script) Spec {
     return specs.get(script);
 }

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -144,6 +144,18 @@ pub const Spec = struct {
     /// the pipelined shape: the proxy serves the first request and
     /// refuses to look at the second.
     golden_first_announces_close: bool = false,
+    /// This script's 200 is answered from a configured page (#159) rather
+    /// than proxied, so it crosses neither response-side render — no #175
+    /// stamp, no #178 cookie — and its body is the page's, byte for byte.
+    /// A property of the request's path, which only the table knows: 403
+    /// pages are blanket by status, but a 200 from memory is
+    /// indistinguishable from a proxied one without this.
+    respond_page: bool = false,
+    /// The request already names an endpoint in the #178 grammar, so its
+    /// proxied 200 owes *no* re-stamp — idempotence is the contract.
+    /// Every other routed request is assigned or repicked and owes the
+    /// pinned cookie.
+    sticky_request_pinned: bool = false,
 };
 
 const post_body = "request-body-24-bytes-ab";
@@ -415,6 +427,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = &.{ 200, 503 },
+        .respond_page = true,
     },
     .filter_edit = .{
         // Routes and forwards like a plain GET, so the §8 rungs and a
@@ -472,6 +485,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 200,
         .method = .get,
         .allowed_statuses = statuses_routed,
+        .sticky_request_pinned = true,
     },
     .sticky_repick = .{
         .request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++
@@ -505,5 +519,10 @@ comptime {
         }
         if (entry.second_request_when_reusable) assert(entry.expected_responses == 2);
         if (entry.golden_first_announces_close) assert(entry.transcript_cap == 2);
+        // A page is answered from memory, so its script can only ever see
+        // the one status the page carries — and a pinned request is one
+        // that routes, which a page never does.
+        if (entry.respond_page) assert(entry.golden_status == 200);
+        if (entry.respond_page) assert(!entry.sticky_request_pinned);
     }
 }


### PR DESCRIPTION
Closes #215.

The simulator had two L7 oracles and only one of them ran over TLS. The plaintext population walks every response through the parser and holds it to parseable heads, allowed statuses, canonical bodies, the #175 filter stamp, the #178 sticky stamp and the #176 Location. The terminating population checked that whatever arrived started with `HTTP/1.1 `.

That is not theoretical: the #178 sticky stamp shipped 0.2.0 omitting `Secure` on terminated connections, and `zig build ci` passed identically either side of the behaviour change.

Three slices.

## 1. Describe a script's render exceptions in the table (`59db4c2`)

`sim/l7/client.zig` opens by claiming every script-specific bound lives in the `Spec` table. That was false in two places — `pageBodyFor` branched on `filter_respond`, `stickyViolation` switched on `sticky_follow` — so both move into the table as `respond_page` and `sticky_request_pinned` and the walk takes a `Spec` rather than a `Script`. No behaviour change; the sweep and its census are identical either side.

It is a precondition: `Script` cannot grow a member for the terminating population, because the plaintext one draws with `enumValue` and a new value would re-roll every seed's script.

## 2. Run the real oracle over terminated sessions (`9626303`)

`verifyTlsSessions` now walks what came back. Two things had to be true first, and the second was the finding:

- **The tls listener carried no filters at all**, so the oracle asked for a stamp the config had never ordered and failed a tenth of the first 512 seeds. It now runs the http listener's chain on the http draw (filters on an l4 listener are a config error). A listener configured with no filters cannot test the claim termination rests on — that TLS is a phase ahead of the protocol and not a protocol of its own.
- **The stamp is genuinely different there**: where zoxy terminates it knows the client-facing scheme, so the cookie carries `Secure` (#125). The walk takes a `Connection { sticky, terminated }` rather than a bare `sticky` bool.

Mutation-checked both ways. Restoring the pre-#125 stamp — no `Secure`, with the assert that shipped beside it — fails seeds 61, 129, 176, 295 and 501 of the first 512: **the 0.2.0 bug, caught**. Taking the response filters back off the tls listener fails about a tenth of them on `ResponseEditMissing`.

## 3. Let the session draw its script (`16d81d8`)

The population sent one fixed POST-then-GET pair, so the render's happy path was examined over the transform and nothing else — no request it sent could match a rule in the chain slice 2 had just attached. Each client now draws a script and is judged by that script's spec. Response classes that had never ridden the transform, in runs reaching a complete response per 4096-seed sweep:

| response class | script | runs |
| --- | --- | --- |
| 403 + static page | `filter_reject` | 66 |
| 501 | `connect_method` | 62 |
| 301 + composed Location | `filter_redirect` | 58 |
| 200 answered from memory | `filter_respond` | 54 |
| 200 owing no re-stamp | `sticky_follow` | 44 |
| 414 | `oversize_uri` | 44 |
| 400 | `malformed_head`, `post_chunked_malformed` | 74 |

The pairing rule is a table property, not a switch: a follow-up can only be judged if the drawn script's response is judged exactly as a plain GET's, which is `routed_canonical` — held to that meaning by a comptime block rather than trusted. Those draws still send the pair, so #204's keep-alive turnaround keeps its coverage. Unpaired sessions close in protocol instead, or an answered connection would sit in keep-alive holding a conn slot until the drain.

Two scripts stay out with recorded reasons (`silent` sends nothing; `keepalive_pair`'s second request is a runtime decision this client cannot make), and a comptime check means a script added to the table cannot quietly skip the population.

## What this deliberately does not do

Demand the golden *count* on clean seeds. A terminated session costs several more virtual round trips than a plaintext one and can legitimately end mid-exchange where every plaintext client finished, so that demand would fail honest runs.

`zig build ci` green; `zig build sim -- 4097 16384 keep-going` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)