### PR TITLE
io: a drain watchdog that is not a timer, so a wedged loop still reports (#226)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1527,6 +1527,39 @@ deadlines: `idle_ms` always, plus `request_ms` and `max_lifetime_ms` when
 configured, and the drain's `Connection: close` injection stops an idle
 keep-alive connection from waiting on a request that will never come.
 
+**Three layers under a drain that will not finish**, because the first two
+are ops and the failure they exist to report is a backend that has stopped
+delivering ops (#203, #226):
+
+1. `drain_deadline_ms` fires and tears down what is left. A timer.
+2. `onDrainStuck`, five seconds later, reports which plane is still
+   holding — the connection pool, the admin plane, the access log or the
+   prober — and exits **4**. Also a timer, so it is blind to exactly the
+   case where a torn-down connection's armed op never completes.
+3. The **watchdog**: `alarmStart` on the seam (§4), which is `alarm(2)`
+   and not a completion. The kernel raises SIGALRM whatever this process
+   is doing; the handler writes one line and `_exit`s **5**. Five seconds
+   past layer 2, so a loop that is alive always gets to say the useful
+   thing first.
+
+The exit codes are distinct because the two failures are: **4** means the
+drain could not finish and the process named what held it, **5** means the
+loop stopped answering and nothing could be said at all. Layer 3 arms only
+when a deadline is configured — a `drain_deadline_ms` of `0` asked for an
+uncapped drain, and killing that process after a bound it never named
+would be overruling a configuration rather than backstopping it.
+
+Layer 3's five seconds are absolute, so a deployment whose platform kills
+sooner — a `terminationGracePeriodSeconds` of 10 against a drain deadline
+of a few seconds — may never see it. That is the right trade: the layer
+worth waiting for is 2, which names the plane, and a platform that
+SIGKILLs is itself an answer. The watchdog is for the case where nothing
+else will ever come.
+
+The simulator models the alarm as a deadline its run loop checks directly
+rather than a pending op, which is what lets §9 strand every timer a
+schedule has and still demand a diagnostic instead of a hang.
+
 ## 9. Testing — required from day 0
 
 The deterministic-simulation seam is the single highest-leverage testing

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -310,17 +310,13 @@ connection teardowns never get a look in. The third strands on fewer runs
 precisely because those are gone by the time it arms, which is the point.
 It arms at both drain entries, since a seed that drains mid-scenario
 tears its connections down there.
-`timer` is the one kind still excluded, and it is the finding worth
-carrying: **`onDrainStuck` cannot catch a stranded timer, because it is
-one.** A seed that strands the drain deadline strands the thing that
-would have reported it, and the run ends in the simulator's own deadlock
-with no diagnostic at all — seed 2302, three dropped timers and nothing
-else pending. That is a true statement about the reach of #203's fix
-rather than a defect this sweep can hold the proxy to, so the kind is
-excluded and the case pinned by a directed test in `contract_test.zig`
-instead — the form that breaks loudly if it ever stops being true, where
-a comment would not. Covering it for real would need a watchdog that is
-not a timer, which is a design question and not a gate.
+`timer` was the one kind excluded, and the finding it carried —
+**`onDrainStuck` cannot catch a stranded timer, because it is one** — is
+what #226 went on to fix. A seed that stranded the drain deadline stranded
+the thing that would have reported it, and the run ended in the
+simulator's own deadlock with no diagnostic at all. It is back in the
+draw: see the watchdog section below for why, and for the two seeds per
+4096 that used to fail with `error.Deadlock` and now report.
 
 A trap worth naming while it is fresh: what a given seed strands is not
 stable across edits to this machinery. It was already true when the draw
@@ -376,6 +372,61 @@ apiece, while the verdict here is `abortedWith` and not the wording. That
 switch exists because stderr from a *passing* build step makes Zig's
 build runner print `failed command:` under a build that exited zero —
 which cost three runs to diagnose the first time.
+
+### A watchdog that is not a timer (#226)
+
+Every bound in this proxy was an op. `timerStart` submits one and the loop
+delivers it — which makes all of them blind to a backend that has stopped
+delivering, including the two the drain relies on. `onDrainStuck` is a
+timer, so the process it exists to diagnose is exactly the process that
+cannot run it.
+
+**libxev cannot answer this with a bounded wait.** Its `RunMode` is
+`no_wait | once | until_done`, and `tick(1)` blocks until at least one
+completion; there is no timeout on the wait. Adding one means changing the
+audited fork and moving the pin, which is a re-audit for a backstop — so
+the bounded-wait sketch #226 opened with is priced out rather than wrong.
+
+What ships is `alarm(2)`. The kernel raises SIGALRM whatever this process
+is doing, and the handler writes one line and `_exit`s — no loop, no
+completion, no allocation, two async-signal-safe calls. It is the second
+function in the codebase legal to call from a sigaction handler, and the
+pair differ in the one way that matters: `notifySignalFromHandler` hands
+the signal to the loop, `onAlarmFromHandler` gives up on the loop.
+
+Coarse — whole seconds — which is right for a backstop measured in them.
+The informative report still belongs to `onDrainStuck`: a handler cannot
+walk connection state safely, so all this line can honestly say is that
+nobody said anything. It waits five seconds past the point that report
+would have come, so a live loop always wins the race.
+
+**The exit codes are distinct on purpose.** `4` is "the drain could not
+finish, and here is the plane that held it". `5` is "the loop stopped
+answering". An operator reading a status with no output has only that to
+go on.
+
+**Armed at `beginDrain`, not beside `onDrainStuck`.** The stuck timer is
+started *by* the deadline timer, so arming the watchdog there would make
+it depend on the delivery it is the backstop for. And only when a deadline
+is configured, for #220's reason in the other direction: a
+`drain_deadline_ms` of `0` asked for an uncapped drain, and a watchdog
+that killed it anyway would be overruling a configuration rather than
+backstopping it.
+
+**The simulator models it as a deadline, not an op** — `alarm_at_ns`,
+checked by the run loop and folded into `earliestWakeNs`, so a schedule
+that has stranded every op still advances to it. That is the property, not
+a shortcut: a watchdog that rode the pending table would be the timer it
+replaces.
+
+Measured over a 4096-seed sweep with `.timer` back in the strand draw: 94
+runs strand a timer and still reach `onDrainStuck` (their drain deadline
+was armed after the strand landed, so it delivered), and 4 runs reach the
+watchdog instead — two seeds, 1754 and 2526, each run twice for the
+determinism check, whose mid-scenario drain had its deadline pending when
+the strand hit. Disarming the watchdog fails exactly
+those two with `error.Deadlock`, which is what the whole class looked like
+before this existed.
 
 ### Rotating from the seal (#202)
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1690,36 +1690,29 @@ fn giveUpCanExist(harness: *const Harness) bool {
     return harness.config.drain_deadline_ms != 0;
 }
 
-/// One kind out of those armed at this wind-down, or null when the
-/// wind-down holds nothing but timers — the one kind left out below.
+/// One kind out of those armed at this wind-down, or null when nothing
+/// strandable is armed at all.
 ///
-/// `timer` is left out because stranding one is the shape the §8 backstop
-/// provably cannot catch: `onDrainStuck` is itself a timer, so a seed that
-/// strands the drain deadline strands the thing that would have reported
-/// it, and the run ends in `SimIo`'s deadlock rather than in a diagnostic.
-/// Found by drawing it — seed 2302, three dropped timers and nothing else
-/// pending. That is a true statement about the backstop's reach and not a
-/// defect this sweep can hold the proxy to, so it is recorded here and
-/// pinned by a directed test (`src/io/contract_test.zig`) instead, which
-/// is the form that breaks loudly if it ever stops being true. Covering it
-/// for real needs a watchdog that is not a timer: a design question, not a
-/// gate.
+/// Nothing is excluded any more, and `timer` leaving the exclusion list is
+/// what #226 bought. Stranding one used to be the shape §8's backstop
+/// provably could not catch — `onDrainStuck` was itself a timer, so a seed
+/// that stranded the drain deadline stranded the thing that would have
+/// reported it, and the run ended in `SimIo`'s deadlock with no diagnostic
+/// at all. The watchdog under it is not an op (`alarmStart`), so it fires
+/// whether or not the backend is still delivering, and the same seeds now
+/// end in a give-up that says so.
 ///
-/// Nothing else is left out, including `close` — the one kind measured at
-/// zero wind-downs in 4096 seeds. Naming it as an exclusion would be a
-/// census baked into the code, going stale the first time the admin plane
-/// (`submitClose`, the sole `io.close` caller) is still closing its scrape
-/// when a drain begins. Asking the pending table instead spends nothing on
-/// a kind that is not there and picks one up the run it appears. Its
-/// absence is a property of the teardown path rather than an accident:
-/// `continueTeardown` waits for `armedCount()` to reach zero and closes
-/// *synchronously*, so a connection never has a close to take away — which
-/// costs this hook nothing, since every conn-armed kind it can strand
-/// already leaves a slot that cannot be released.
+/// `close` is here for a different reason and was never an exclusion: it
+/// is simply not armed at a wind-down on any measured run, and an
+/// armed-set pick spends nothing on a kind that is not there. Its absence
+/// is a property of the teardown path — `continueTeardown` waits for
+/// `armedCount()` to reach zero and closes *synchronously*, so a
+/// connection never has a close to take away — and the admin plane's
+/// `submitClose` is the only `io.close` in the proxy.
 ///
 /// Drawn from the scenario stream at the wind-down, so it consumes nothing
-/// on the fifteen in sixteen seeds that strand nothing and leaves their
-/// stream position — and with it the whole sweep's coverage — where it was.
+/// on the seeds that strand nothing and leaves their stream position — and
+/// with it the whole sweep's coverage — where it was.
 fn drawStrandKind(harness: *Harness) ?SimIo.OpKind {
     // Adding a kind here needs a matching arm in `strandCanExplainStuck`,
     // which lists `timer` and `none` as `unreachable`: without one the new
@@ -1733,6 +1726,7 @@ fn drawStrandKind(harness: *Harness) ?SimIo.OpKind {
         .send,
         .close,
         .log_write,
+        .timer,
         .timer_cancel,
         .connect_cancel,
     };
@@ -1768,7 +1762,10 @@ fn drawStrandKind(harness: *Harness) ?SimIo.OpKind {
 /// `pending_ops_live` is passed in rather than asked here because it has
 /// to be read before `verify` closes the harness's own sockets.
 fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void {
-    if (code != ServerSim.drain_stuck_exit_code) return error.UnexpectedAbort;
+    const watchdog = code == ServerSim.drain_watchdog_exit_code;
+    if (code != ServerSim.drain_stuck_exit_code and !watchdog) {
+        return error.UnexpectedAbort;
+    }
     // Only a seed that stranded something is excused. Without this, the
     // branch would accept any stuck drain as "#206 working as intended" —
     // including one a future release bug produced with every op
@@ -1782,7 +1779,29 @@ fn verifyGaveUp(harness: *const Harness, code: u8, pending_ops_live: bool) !void
     // stale-handle assert every delivered op passes through. #206 asked
     // for this oracle by name.
     if (!pending_ops_live) return error.SlotReleasedUnderPendingOp;
+    if (watchdog) return harness.verifyWatchdogGaveUp();
     if (!harness.strandCanExplainStuck()) return error.StrandCannotExplainStuck;
+}
+
+/// What the #226 watchdog owes when it is the thing that gave up.
+///
+/// Not `strandCanExplainStuck`: that oracle asks which plane the drain was
+/// waiting on, and reaching this code means nobody was in a position to
+/// ask. The loop stopped delivering, so the planes' states are whatever
+/// the schedule left them as, and demanding one be stuck would be
+/// demanding the wedged process have finished thinking.
+///
+/// What is demanded instead is that the give-up was the watchdog's — the
+/// alarm actually fired, rather than some other path exiting with its
+/// code — and that only a stranded *timer* can reach it. That second one
+/// is the layering, stated where it breaks: every other kind leaves the
+/// drain's own deadline delivering, so `onDrainStuck` fires at the grace
+/// and reports the plane, five virtual seconds before the watchdog would.
+/// A watchdog fire on any other kind means the informative layer stayed
+/// silent when it could have spoken.
+fn verifyWatchdogGaveUp(harness: *const Harness) !void {
+    if (!harness.io.alarmFired()) return error.WatchdogCodeWithoutWatchdog;
+    if (harness.strandedKind() != .timer) return error.WatchdogBeatTheReporter;
 }
 
 /// What this seed actually stranded, by whichever hook took it, or null
@@ -1849,9 +1868,10 @@ fn strandCanExplainStuck(harness: *const Harness) bool {
         .connect => conns_stuck or health_stuck,
         // A listener's accept feeds admission and the admin plane.
         .accept => conns_stuck or admin_stuck,
-        // A timer cancel belongs to a conn's deadline, the prober's own
-        // pacing timer, or the admin plane's scrape deadline.
-        .timer_cancel => conns_stuck or admin_stuck or health_stuck,
+        // Timers, and the cancels that chase them, belong to a conn's
+        // deadline, the prober's pacing or the admin plane's scrape. The
+        // access log arms none, which is why it is absent from both.
+        .timer, .timer_cancel => conns_stuck or admin_stuck or health_stuck,
         // Only the first two of those three dial, so only they can have a
         // connect to cancel.
         .connect_cancel => conns_stuck or health_stuck,
@@ -1866,7 +1886,7 @@ fn strandCanExplainStuck(harness: *const Harness) bool {
         // defaulted: adding one there without giving it an arm here panics
         // every seed that strands it, and a named arm is what makes that
         // obvious to whoever adds the next kind.
-        .none, .timer => unreachable,
+        .none => unreachable,
     };
 }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -698,6 +698,7 @@ pub fn Server(comptime IoType: type) type {
                     server,
                     onDrainDeadline,
                 );
+                server.armDrainWatchdog();
             }
             server.maybeStopAfterDrain();
         }
@@ -731,6 +732,58 @@ pub fn Server(comptime IoType: type) type {
                 onDrainStuck,
             );
         }
+
+        /// The last line of defence under the two timers above (#226).
+        ///
+        /// Both of them are ops the loop delivers, which makes them blind
+        /// to the one failure they would most like to report: a backend
+        /// that has stopped delivering has stopped delivering *them*, so
+        /// the process hangs and SIGTERM stops meaning anything — with not
+        /// even the diagnostic `onDrainStuck` exists to print. #203 was
+        /// that shape on a real runner, and #206's simulator reproduces it
+        /// on demand by stranding a timer.
+        ///
+        /// The seam's alarm is not an op. In production it is `alarm(2)`:
+        /// the kernel raises SIGALRM whatever this process is doing, and
+        /// the handler writes one line and exits without re-entering the
+        /// loop. So this fires *whether or not anything else can*.
+        ///
+        /// Armed here rather than beside `onDrainStuck`, deliberately —
+        /// that timer is started by the deadline one, so arming the
+        /// watchdog there would make it depend on the very delivery it is
+        /// the backstop for.
+        ///
+        /// Only when a deadline is configured. A zero `drain_deadline_ms`
+        /// is "no cap" (§5): the operator asked for a drain that waits for
+        /// the last connection however long it takes, and killing that
+        /// process after a bound it never named would be this proxy
+        /// overruling a configuration rather than backstopping it. Whoever
+        /// declined the cap owns the SIGKILL, which is #220's lesson in
+        /// the other direction.
+        fn armDrainWatchdog(server: *Self) void {
+            assert(server.draining);
+            assert(server.config.drain_deadline_ms != 0);
+            const deadline_ns = @as(u64, server.config.drain_deadline_ms) *
+                std.time.ns_per_ms;
+            server.io.alarmStart(
+                deadline_ns + drain_stuck_grace_ns + drain_watchdog_margin_ns,
+                drain_watchdog_exit_code,
+            );
+        }
+
+        /// How long past the point `onDrainStuck` would have reported the
+        /// watchdog waits, so a live loop always gets to say the useful
+        /// thing first. Generous because the two answers are not equal: a
+        /// named plane and its armed ops is worth waiting for, and this
+        /// line can only ever say that nobody said anything.
+        const drain_watchdog_margin_ns: u64 = 5 * std.time.ns_per_s;
+
+        /// Distinct from `drain_stuck_exit_code` because the two describe
+        /// different failures, and an operator reading a status without
+        /// output has only this to go on: 4 means the drain could not
+        /// finish and the process said which plane held it, 5 means the
+        /// loop stopped answering and nothing could be said at all.
+        pub const drain_watchdog_exit_code: u8 = 5;
 
         /// How long after the drain deadline a teardown gets to finish
         /// before it is called stuck. Generous against the work it covers —
@@ -892,6 +945,12 @@ pub fn Server(comptime IoType: type) type {
             // and every released or parked upstream let go of its head.
             assert(server.head_buffers_in_use == 0);
             assert(server.upstream_head_buffers.isFullyReleased());
+            // The drain finished, so the watchdog has nothing left to
+            // watch. Unconditional: `alarmCancel` on an unarmed alarm is
+            // a no-op on both sides of the seam, and the alternative is
+            // this line asking the same question `armDrainWatchdog` did
+            // and getting a different answer after a config reload.
+            server.io.alarmCancel();
             server.io.stop();
         }
 

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -184,6 +184,18 @@ group_in_use: u32,
 /// stranded scenario reporting *which* op it took.
 drop_next_kinds: u16,
 drop_next_taken: ?OpKind,
+/// §8's drain watchdog (#226), virtually: the instant it fires, the code
+/// it gives up with, and whether it has. `never_ns` when unarmed.
+///
+/// Not a `Completion`, and that is the whole point — in production this
+/// is `alarm(2)`, which the kernel raises whether or not the loop is
+/// still delivering. Here it is a deadline the run loop checks directly,
+/// so a schedule that strands every op still reaches it: the simulator's
+/// own `error.Deadlock` is what a wedged production process looks like
+/// from outside, and this is the thing that turns one into a diagnostic.
+alarm_at_ns: u64,
+alarm_exit_code: u8,
+alarm_fired: bool,
 
 const blackholed_addresses_max: u8 = 4;
 const connect_error_addresses_max: u8 = 4;
@@ -518,6 +530,9 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.group_in_use = 0;
     io.drop_next_kinds = 0;
     io.drop_next_taken = null;
+    io.alarm_at_ns = never_ns;
+    io.alarm_exit_code = 0;
+    io.alarm_fired = false;
     assert(io.sockets.isFullyReleased());
 }
 
@@ -1134,6 +1149,64 @@ fn kindBit(kind: OpKind) u16 {
     return @as(u16, 1) << @intCast(@intFromEnum(kind));
 }
 
+/// §8's drain watchdog (#226), the simulator's half. Production arms
+/// `alarm(2)`; here it is a deadline the run loop compares the virtual
+/// clock against, with no completion in between — which is the property
+/// being modelled, not an implementation shortcut. A watchdog that rode
+/// the pending table would be exactly the timer this exists to replace.
+pub fn alarmStart(io: *SimIo, after_ns: u64, exit_code: u8) void {
+    assert(exit_code != 0); // A give-up is never a success.
+    // The seam's floor, enforced here too: production rounds up to whole
+    // seconds, so a scenario arming a shorter one would be testing a bound
+    // no deployment can have.
+    assert(after_ns >= std.time.ns_per_s);
+    assert(io.alarm_at_ns == never_ns);
+    assert(!io.alarm_fired);
+    io.alarm_at_ns = io.now_ns_value + after_ns;
+    io.alarm_exit_code = exit_code;
+    assert(io.alarm_at_ns > io.now_ns_value);
+    // Into the trace: a run that armed a watchdog is a different run from
+    // one that did not, whether or not it ever fires.
+    io.mix(io.alarm_at_ns);
+}
+
+/// Idempotent, and tolerant of an alarm that already fired: the drain
+/// that cancels it may be finishing in the same flush the fire stopped
+/// the loop for, and a watchdog cannot be un-fired anyway.
+pub fn alarmCancel(io: *SimIo) void {
+    io.alarm_at_ns = never_ns;
+    io.alarm_exit_code = 0;
+    assert(io.alarm_at_ns == never_ns);
+    io.mix(0);
+}
+
+/// Whether the watchdog fired this run — the fact a scenario oracle asks
+/// instead of watching for a process exit it cannot survive, the same
+/// bargain `abortedWith` makes.
+pub fn alarmFired(io: *const SimIo) bool {
+    return io.alarm_fired;
+}
+
+/// The watchdog's whole behaviour: give up, with the code it was armed
+/// with. Production writes one line and `_exit`s; here it records and
+/// stops, so the scenario that provoked it can be asked what happened.
+///
+/// Called from the run loop rather than delivered, which is the modelled
+/// property: no schedule, however much of the backend it has stranded,
+/// can keep this from happening.
+fn fireAlarmIfDue(io: *SimIo) bool {
+    if (io.alarm_at_ns == never_ns) return false;
+    if (io.now_ns_value < io.alarm_at_ns) return false;
+    io.alarm_at_ns = never_ns;
+    io.alarm_fired = true;
+    // A give-up the loop was already taking is not this one's to take
+    // twice: `onDrainStuck` aborting means the loop was alive after all,
+    // and the watchdog is the layer under it.
+    if (io.aborted == null) io.abort(io.alarm_exit_code);
+    io.stop();
+    return true;
+}
+
 /// Whether any op of `kind` is pending and still deliverable — what a
 /// caller about to strand one asks first, so it picks a kind the schedule
 /// actually armed instead of spending its seed on a kind that is not
@@ -1302,6 +1375,10 @@ pub fn run(io: *SimIo) Io.RunError!void {
     // buffer need not be re-stacked (and Debug-0xAA-filled) each tick.
     var ready_buffer: [pending_ops_max]*Completion = undefined;
     while (!io.stopped) {
+        // Before anything else each turn: the watchdog is the one deadline
+        // that does not wait to be delivered, so it cannot sit behind a
+        // batch that may never come.
+        if (io.fireAlarmIfDue()) break;
         io.deliverDueSignals();
         const ready = io.collectReady(&ready_buffer);
         if (ready.len == 0) {
@@ -1783,6 +1860,10 @@ fn earliestWakeNs(io: *const SimIo) u64 {
     for (io.pending_signals[0..io.pending_signals_count]) |pending_signal| {
         earliest = @min(earliest, pending_signal.at_ns);
     }
+    // The watchdog wakes the clock like anything else: a run whose every
+    // op is stranded must still advance to it, or the deadlock this
+    // exists to report would be declared before it could fire (#226).
+    earliest = @min(earliest, io.alarm_at_ns);
     return earliest;
 }
 

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1183,9 +1183,84 @@ pub fn signalWait(
     io.notifier.wait(&io.loop, &io.notifier_completion, XevIo, io, onNotifierWake);
 }
 
-/// Async-signal-safe: an atomic bitmask store plus an eventfd write.
-/// This is the only function in the codebase legal to call from a
-/// sigaction handler (§4).
+/// The exit code the alarm handler will use, and whether `main` has
+/// installed the handler that reads it. Module-level because a signal
+/// handler takes no arguments: the whole point of this watchdog is that
+/// nothing between the kernel and the exit is the loop's (#226).
+var alarm_exit_code = std.atomic.Value(u8).init(0);
+var alarm_handler_installed = std.atomic.Value(bool).init(false);
+
+/// §8's drain watchdog (#226): a deadline that is not a completion.
+///
+/// Every other bound in this proxy is an op — `timerStart` submits one and
+/// the loop delivers it — which makes them all useless against the one
+/// failure they would most like to report. `Server.onDrainStuck` is a
+/// timer, so a backend that has stopped delivering has stopped delivering
+/// the thing that would have said so, and the process hangs with no
+/// diagnostic (#203 was the shape; #206's simulator can strand it on
+/// demand).
+///
+/// `alarm(2)` answers a different question: the kernel raises SIGALRM
+/// whatever this process is doing, and the handler exits without ever
+/// re-entering the loop. Coarse — whole seconds — which is right for a
+/// backstop measured in them, and the informative report still comes from
+/// `onDrainStuck` when the loop is alive to produce one.
+pub fn alarmStart(io: *XevIo, after_ns: u64, exit_code: u8) void {
+    _ = io;
+    assert(exit_code != 0); // A give-up is never a success.
+    assert(after_ns >= std.time.ns_per_s);
+    // Without the handler, SIGALRM's default action terminates the
+    // process silently — the hang would become a death with even less to
+    // say than before. `main` installs it before the loop ever runs; a
+    // caller arming this without one is a wiring bug, not a fallback.
+    assert(alarm_handler_installed.load(.acquire));
+    const seconds = (after_ns + std.time.ns_per_s - 1) / std.time.ns_per_s;
+    assert(seconds >= 1);
+    assert(seconds <= std.math.maxInt(c_uint));
+    alarm_exit_code.store(exit_code, .release);
+    _ = std.c.alarm(@intCast(seconds));
+}
+
+/// Disarm: the drain finished, so the watchdog has nothing left to watch.
+/// `alarm(0)` cancels whatever was pending, which is exactly the contract.
+pub fn alarmCancel(io: *XevIo) void {
+    _ = io;
+    alarm_exit_code.store(0, .release);
+    _ = std.c.alarm(0);
+}
+
+/// Called by `main` once its SIGALRM handler is installed, so `alarmStart`
+/// can refuse to arm a signal nothing is listening for.
+pub fn alarmHandlerInstalled() void {
+    alarm_handler_installed.store(true, .release);
+}
+
+/// The watchdog firing: one `write` and one `_exit`, both async-signal-
+/// safe, and deliberately nothing else. The rich report — which plane is
+/// stuck, which ops it is waiting on — belongs to `onDrainStuck`, which
+/// runs in the loop and can read the state safely; reaching *here* means
+/// the loop never got there, so all this can honestly say is that it
+/// didn't.
+///
+/// The body lives on this side of the seam because `write` and `_exit`
+/// are syscalls and those live here (§4); `main` owns only the sigaction
+/// that points at it.
+pub fn onAlarmFromHandler() noreturn {
+    const message = "zoxy: drain watchdog fired, the event loop stopped " ++
+        "delivering (DESIGN.md §8, #226)\n";
+    _ = std.c.write(2, message.ptr, message.len);
+    const code = alarm_exit_code.load(.acquire);
+    // Armed with a non-zero code, so a zero here would mean the alarm
+    // outlived its `alarmCancel` — exiting 0 on a wedged drain is the one
+    // outcome worse than exiting late.
+    std.c._exit(if (code == 0) 1 else code);
+}
+
+/// Async-signal-safe: an atomic bitmask store plus an eventfd write. One
+/// of the two functions in the codebase legal to call from a sigaction
+/// handler (§4) — `onAlarmFromHandler` is the other, and the pair differ
+/// in the one way that matters: this hands the signal to the loop, that
+/// one gives up on the loop entirely.
 pub fn notifySignalFromHandler(io: *XevIo, signal: Io.Signal) void {
     _ = io.signal_mask.fetchOr(signalBit(signal), .release);
     io.notifier.notify() catch {};

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -663,16 +663,15 @@ const StrandedTimer = struct {
     }
 };
 
-// #206: the one shape §8's drain backstop cannot catch, pinned so it
-// breaks loudly if it ever stops being true.
+// #206, and now #226's other half: what a stranded timer costs a process
+// with no watchdog under it.
 //
 // `Server.onDrainStuck` is a timer. A backend that strands timers strands
-// that one too, so the process has nothing left to notice with and the
-// run ends in the simulator's deadlock rather than in a diagnostic. The
-// sweep therefore does not draw `.timer` (see `sim/Harness.zig`), which
-// would otherwise fail honest seeds — this is where the limitation lives
-// instead of only in a comment. Covering it for real needs a watchdog
-// that is not a timer, which is a design question and not a gate.
+// that one too, so nothing is left to notice and the run ends in the
+// simulator's deadlock — a hung process, from outside — rather than in a
+// diagnostic. This is the *unwatched* case, kept because it is the
+// baseline the watchdog is measured against; the test below arms one and
+// gets an answer instead.
 test "simio: a stranded timer has nothing left to report it" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -759,6 +758,47 @@ test "simio: a latched cancel is stranded when it is finally submitted" {
     // being cancelled, which is why nothing else looks wrong.
     try std.testing.expect(!state.cancel_delivered);
     try std.testing.expect(state.timer_delivered);
+}
+
+// #226: the same stranded timer, with the watchdog armed.
+//
+// `alarmStart` is not an op. Production arms `alarm(2)` and the kernel
+// raises SIGALRM whatever the process is doing; here the run loop compares
+// the virtual clock against a deadline no completion carries. Either way
+// the property is the one the timers cannot have: it happens even when
+// nothing else can.
+//
+// So the run that deadlocked above ends in a give-up carrying the code it
+// was armed with. That is the whole of #226 in two assertions — and the
+// sweep pays for it in `sim/Harness.zig`, where `.timer` went back into
+// the strand draw and two seeds per 4096 that used to fail with
+// `error.Deadlock` now report instead.
+test "simio: an armed watchdog answers where a stranded timer cannot" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{ .seed = 17 });
+
+    var watchdog: StrandedTimer = .{ .io = &sim_io };
+    sim_io.timerStart(
+        &watchdog.completion,
+        std.time.ns_per_s,
+        StrandedTimer,
+        &watchdog,
+        StrandedTimer.onTimer,
+    );
+    try std.testing.expectEqual(@as(u32, 1), sim_io.dropPendingOps(.timer));
+    // Past the stranded timer's own deadline, so what fires is the alarm
+    // and not some artefact of the clock stopping short of it.
+    sim_io.alarmStart(2 * std.time.ns_per_s, 5);
+
+    try sim_io.run();
+    try std.testing.expect(sim_io.alarmFired());
+    try std.testing.expectEqual(@as(?u8, 5), sim_io.abortedWith());
+    // The timer it was watching still never delivered: the watchdog
+    // reports the silence, it does not break it.
+    try std.testing.expect(!watchdog.fired);
 }
 
 // #202: some bounds are measured in hours against scenarios that run for

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -34,6 +34,14 @@
 //!       file sink only — swap the sink fd between writes, never under one)
 //!   timerStart(io, c, delay_ns, U, u, cb(u, TimerError!void))
 //!   timerCancel(io, timer_c, cancel_c, U, u, cb(u))     (the one legal cancel)
+//!   alarmStart(io, after_ns, exit_code) void            (sync; §8's drain
+//!       watchdog — a deadline with no completion, so it survives a loop
+//!       that has stopped delivering. Takes the process down itself.
+//!       `after_ns` is at least a second: production is `alarm(2)`, whose
+//!       granularity is whole seconds, and both sides enforce the floor so
+//!       a caller cannot ask the simulator for a bound production would
+//!       silently round.)
+//!   alarmCancel(io) void                                (sync)
 //!   signalWait(io, U, u, cb(u, Signal))                 (persistent waiter)
 //!   setNodelay / setLingerRst (io, socket) SetOptionError!void   (sync)
 //!   shutdown(io, socket, how) void                      (sync control op)
@@ -246,6 +254,8 @@ pub fn assertIoInterface(comptime IoType: type) void {
             "logReopen",
             "timerStart",
             "timerCancel",
+            "alarmStart",
+            "alarmCancel",
             "signalWait",
             "setNodelay",
             "setLingerRst",

--- a/src/main.zig
+++ b/src/main.zig
@@ -649,6 +649,21 @@ fn installSignalHandlers() void {
     std.posix.sigaction(.INT, &action, null);
     std.posix.sigaction(.USR1, &action, null);
     std.posix.sigaction(.HUP, &action, null);
+    // §8's drain watchdog (#226). Unlike the four above, this one never
+    // reaches the loop: every other bound in the proxy is an op the loop
+    // delivers, which makes them all blind to a backend that has stopped
+    // delivering — including `onDrainStuck`, the backstop for exactly
+    // that. SIGALRM arrives from the kernel regardless, and its handler
+    // exits without asking the loop anything.
+    const alarm_action = std.posix.Sigaction{
+        .handler = .{ .handler = onAlarm },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(.ALRM, &alarm_action, null);
+    // Only now may anything arm one: the seam refuses to raise a signal
+    // whose default action would kill this process silently.
+    XevIo.alarmHandlerInstalled();
     // A proxy must not die because something downstream of it went away.
     // The access log writes to a pipe the operator owns (§8), and a `write`
     // to a pipe with no reader raises SIGPIPE, whose default action is to
@@ -664,6 +679,18 @@ fn installSignalHandlers() void {
         .flags = 0,
     };
     std.posix.sigaction(.PIPE, &ignore, null);
+}
+
+/// Async-signal-safe by delegation: the seam's handler is one `write` and
+/// one `_exit` (§4). Nothing here reads process state, because reaching
+/// this means the loop that owns it may be wedged — and nothing here
+/// asserts, for the reason `onRawSignal` does not either: `assert` panics,
+/// and the panic path locks stdio and captures a stack trace, none of
+/// which a signal handler may do. A signal this is not installed for is
+/// dropped the same way that one drops it.
+fn onAlarm(signal_number: std.posix.SIG) callconv(.c) void {
+    if (signal_number != .ALRM) return;
+    XevIo.onAlarmFromHandler();
 }
 
 /// Async-signal-safe: delegates to the seam's atomic-mask + eventfd wake


### PR DESCRIPTION
Closes #226.

Every bound in this proxy was an op. `timerStart` submits one and the loop delivers it — which makes all of them blind to a backend that has stopped delivering, including `onDrainStuck`, the backstop that exists for exactly that. A seed that stranded the drain deadline stranded the thing that would have reported it, and the process hung with no diagnostic: #203's shape on a real runner, and two seeds per 4096 in the simulator that failed with `error.Deadlock` and nothing else.

## Why not the bounded wait the issue opened with

libxev's `RunMode` is `no_wait | once | until_done`, and `tick(1)` blocks until at least one completion arrives. There is no timeout on the wait, so a bounded one means changing the audited fork and moving the pin — a re-audit for a backstop. Priced out rather than wrong, and recorded in the notes.

## What ships

The seam grows `alarmStart`/`alarmCancel`, which are not ops.

- **Production** is `alarm(2)`: the kernel raises SIGALRM whatever this process is doing, and the handler writes one line and `_exit`s. Two async-signal-safe calls, no loop in between. It is the second function in the codebase legal to call from a sigaction handler, and the pair differ in the one way that matters — `notifySignalFromHandler` hands the signal to the loop, `onAlarmFromHandler` gives up on it.
- **The simulator** models it as a deadline the run loop compares its clock against, folded into `earliestWakeNs`, so a schedule that has stranded every op still advances to it. That is the property being modelled, not a shortcut: a watchdog riding the pending table would be the timer it replaces.

Three layers now sit under a drain that will not finish:

| layer | what it is | says | exits |
| --- | --- | --- | --- |
| `drain_deadline_ms` | a timer | — | — |
| `onDrainStuck` | a timer, +5s | which plane still holds | 4 |
| the watchdog | `alarm(2)`, +5s | that nobody said anything | 5 |

The codes differ because the failures do: an operator reading a status with no output has only that to go on. It arms at `beginDrain`, not beside `onDrainStuck` — that timer is started *by* the deadline one, so arming it there would make the watchdog depend on the delivery it backstops. And only when a deadline is configured, which is #220's lesson inverted: `drain_deadline_ms = 0` asked for an uncapped drain, and killing it after a bound it never named would overrule a configuration rather than back it up.

## The acceptance test #226 named

`.timer` goes back into #206's strand draw. Over a 4096-seed sweep, 94 runs strand a timer and still reach the reporter (their drain deadline was armed *after* the strand landed, so it delivered), and 4 runs reach the watchdog instead — seeds 1754 and 2526, whose mid-scenario drain had its deadline pending when the strand hit. **Disarming the watchdog fails exactly those two with `error.Deadlock`**, which is what the whole class looked like before this existed. `contract_test.zig` pins both the unwatched and the watched case side by side.

The live gate covers the production path incidentally and usefully: it configures a 300 ms drain deadline, so every smoke run arms a real `alarm(2)` and cancels it on the clean drain.

## Recorded, not engineered around

The watchdog's five seconds are absolute, so a deployment whose platform kills sooner — a `terminationGracePeriodSeconds` of 10 against a drain deadline of a few seconds — may never see it. That is the right trade: the layer worth waiting for is the one that names the plane, and a platform that SIGKILLs is itself an answer.

`zig build ci` green; `zig build sim -- 4097 16384 keep-going` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)