### PR TITLE
proxy: a refused dial is sent to another endpoint (#181)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1003,8 +1003,55 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   kernel buffer of an already-FIN'd parked connection replays, because
   the FIN-before-checkout race is overwhelmingly the real cause. The
   replay is spent before its try begins (no loop) and always dials
-  fresh — the endpoint's whole idle list may be stale the same way. The
-  endpoint pick is per-cluster config: `p2c` (two weight-biased
+  fresh — the endpoint's whole idle list may be stale the same way.
+- **A refused dial is sent to another endpoint** (#181, settled
+  2026-08-15). `"retries": 2` beside a cluster's endpoints, 0 by
+  default and bounded by `cluster_retries_max`; without it one
+  refusing endpoint in a three-endpoint cluster fails roughly a third
+  of requests, for `fall × health_interval_ms` with checks configured
+  and **forever with them off**, which is the default.
+  This is the *safe* kind of retry, and §7 above is what settles it
+  rather than a new argument: "may have begun processing" is already
+  "a response byte arrived or relay chunks flowed", and a failed
+  connect is neither — the request reached no application, so a
+  re-send is safe for every method including `POST`, with no
+  idempotency analysis and no knob naming which methods may replay.
+  Exactly two of the four `ConnectError`s qualify. `Refused` and
+  `Unreachable` are the origin's verdict. `Unexpected` is *our* own
+  exhaustion, witnessed as kernel pressure: another dial meets the same
+  wall, and §8 says shed rather than spend more of what has run out.
+  `Canceled` is the dial deadline, and the reason it cannot retry is
+  the budget rule below.
+  **The tries share one connect deadline.** A retry chain is one client
+  waiting for one answer, so every dial in it runs under the budget the
+  first one armed rather than arming its own — the worst-case dial wait
+  stays `connect_ms` however many endpoints a request walks, and
+  `retries` never multiplies the time a client can be kept. That is
+  also why a *timed-out* dial does not retry: it has already spent the
+  budget a retry would carry, so "does a timeout retry" needs no rule
+  of its own. The cost is that a black-holed endpoint — a partitioned
+  or wedged backend, which a TCP health check cannot see either — is
+  still answered `504` rather than routed around; detecting that from
+  live traffic is passive ejection's job, not this one's.
+  The retry destination is **the cluster's own configured pick, re-run
+  over the eligible set minus what this request already tried** —
+  untried joining health and capacity as a third predicate, applied
+  before health so fail-open cannot resurrect the endpoint that just
+  refused. Each policy therefore keeps its contract, and `hash` is the
+  one that matters: rendezvous over the smaller set drops each key to
+  its own next-best score, which is precisely the redistribution
+  ejection produces later, so retry and ejection agree instead of the
+  behavior shifting when the prober catches up. Running out of untried
+  endpoints answers `502`, not a shed `503`: the origins were reachable
+  enough to refuse, which is a different sentence from "they are full".
+  `upstream_retried` and `upstream_retries_exhausted` witness both, and
+  the first has to exist — without it `upstream_connect_failed` climbs
+  while requests succeed, and an operator reads a recovery as an
+  outage. Only the L7 path spends the budget: an L4 connection dials
+  once and relays what the dial produced, with no request to send
+  somewhere else. Aggregate retry *budgets* — bounding the extra load a
+  cluster-wide failure pushes onto the survivors — stay deferred below.
+- **The endpoint pick is per-cluster config**: `p2c` (two weight-biased
   candidates from a fixed-seed PRNG — uniform at the default weights —
   the lower **in-flight total** wins: L7 leases and live L4 connections
   summed, since both are work the origin is carrying) by default, `rr`
@@ -1186,10 +1233,13 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   it. Endpoints start healthy — probing demotes, it never gates startup
   — and the pick **fails open**: a cluster with every endpoint ejected
   balances as if none were, because routing nowhere would turn a probe
-  verdict into an outage of its own. Circuit breakers, outlier ejection,
-  retry budgets stay *deferred* — the previous iteration proved them
-  buildable in this architecture; simplicity says they wait for a
-  demonstrated need.
+  verdict into an outage of its own. Circuit breakers, outlier ejection
+  and *aggregate* retry budgets stay deferred — the previous iteration
+  proved them buildable in this architecture; simplicity says they wait
+  for a demonstrated need. The per-request dial retry above is not one
+  of them: it bounds itself per request and per connect deadline, where
+  a retry budget is the cluster-wide cap that keeps a partial outage
+  from pushing its whole load onto the endpoints still answering.
 
 ## 8. Load shedding — the exhaustion ladder
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1970,6 +1970,85 @@ The two known peer-gone errnos still landing in the fallback are queued
 fork work (see "Open questions" above, "libxev fork queue"): the fix for
 a forgotten mapping is to name it, not to crash on it.
 
+## A dead endpoint is better sim coverage than a second live one (2026-08-15, #181)
+
+The dial retry had **zero** simulator reachability the moment it landed,
+and the §9 census said so in the same breath: `upstream_retried` and
+`upstream_retries_exhausted` "never fired — no scenario reaches it".
+Both sim clusters were single-endpoint (`endpoints_http: [1]`), and a
+single-endpoint cluster cannot retry by construction. The harness had
+even anticipated this — its pick-policy draw carried the comment
+"pre-wired coverage for a multi-endpoint topology" — so the topology was
+the missing half, not the draw.
+
+The obvious fix is a second live origin, and it is the expensive one:
+another `HttpOrigin` instance, another address to accept on, and every
+L7 oracle taught that a response may now come from either. The cheap fix
+turned out to be strictly better — **a second endpoint at an address
+nothing binds**, which `SimIo.finishConnect` refuses through its own
+listener lookup (`findListener(address) orelse return error.Refused`).
+Three properties fall out, and the third is the one worth remembering:
+
+- It is the issue's motivating failure *exactly* — one endpoint of a
+  cluster refusing while the rest are healthy — rather than an
+  approximation of it.
+- It refuses on **clean** seeds too, where the refusal is structural
+  rather than an adversary roll. So the retry is exercised by the seeds
+  whose oracles demand exact golden outcomes, not only by the
+  adversarial ones that tolerate a cut. That is what made the mutation
+  test bite: deleting `error.Refused` from the retry-eligible set failed
+  seed 38 with `GoldenOutcomeMissed` inside 38 seeds.
+- **A dead endpoint cannot change any successful response**, so not one
+  oracle needed touching — including #178's sticky tag, which is pinned
+  to `endpoints_http[0]`'s address and stays pinned because nothing at
+  index 1 can ever serve. A second live origin would have put that
+  assertion, and every golden body, into play for no coverage gain.
+
+Black-holing the address instead would have been the wrong instrument
+and is worth stating: a black-holed dial *times out*, and a timed-out
+dial does not retry (it has spent the budget a retry carries), so the
+scenario would have proven the opposite of what it was for.
+
+The retry budget is drawn across its whole legal range rather than fixed
+at 1, because which of the two endings a request reaches depends on
+whether the *budget* or the *endpoint set* runs out first: at
+`retries: 1` a second failure answers 502 with the budget spent, while
+at 2 or more the exclusion set empties first and the answer comes from
+the exhaustion rung. One draw, both rungs.
+
+### The second endpoint was also a pool-sizing scenario (seed 4316)
+
+The 4096-seed gate passed; a 16384-seed sweep did not, and what it caught
+was not a retry bug. `l7_shed_upstream_slots` fired once against a census
+allowance of `0` — on a seed whose counters showed `upstream_retried = 0`
+and `upstream_connect_failed = 0`, so **no dial had failed at all**. The
+second endpoint alone did it.
+
+That counter's exemption reads: the only pool-starved seeds set
+`relay_buffers` and `upstream_slots` both to 1, and the L7 path takes the
+relay buffer first, so the relay rung answers everything that would reach
+the slot rung. The unstated premise was **single-endpoint clusters**.
+With two endpoints and one slot, that slot can be *parked* on endpoint 0
+while the next request picks endpoint 1 — which cannot reuse it and must
+dial, so it sheds. A single-endpoint cluster never produces this, because
+the parked connection is always the one wanted.
+
+The shed is correct §8 behavior, not a defect, and it is covered directly
+by `src/http_proxy_test.zig`. What did not belong was a pool-sizing
+scenario arriving as a side effect of a *retry* draw, so `deriveRetries`
+suppresses its second endpoint on starved seeds, and the exemption now
+states the premise it was silently relying on rather than leaving the
+next multi-endpoint feature to rediscover it. The draw still happens on
+those seeds and only its effect is dropped, so stream positions stay
+where an unstarved seed's are.
+
+Worth separating out as a live question rather than buried here: **an
+idle parked connection can shed a request bound for another endpoint.**
+Evicting the parked one instead of shedding is a real option the design
+has not taken; today the ladder says shed, and at production pool sizes
+it is unreachable. It becomes interesting the moment a deployment runs
+many endpoints against a tight upstream pool.
+
 ## The nightly's second rare event: `tls_handshake_failed` (2026-08-11)
 
 Run 31457966341 failed every shard on the census: `tls_handshake_failed`

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -107,11 +107,15 @@ comptime {
 io: SimIo,
 server: ServerSim,
 endpoints_l4: [1]std.Io.net.IpAddress,
-endpoints_http: [1]std.Io.net.IpAddress,
-/// The #174 weight tables the clusters may reference; single-entry like
-/// the endpoint lists they parallel.
+/// The http cluster's endpoints: the origin at index 0 always, and on a
+/// #181 retry seed a second one nothing is listening on (`deriveRetries`).
+/// How many are configured is `endpoints_http_count`.
+endpoints_http: [2]std.Io.net.IpAddress,
+endpoints_http_count: u16,
+/// The #174 weight tables the clusters may reference, each as long as
+/// the endpoint list it parallels.
 weights_l4: [1]u16,
-weights_http: [1]u16,
+weights_http: [2]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
@@ -191,6 +195,9 @@ clean: bool,
 /// runs the stamp oracle, and `verify` holds the sticky counters to
 /// the responses they annotate.
 sticky_http: bool,
+/// The #181 dial-retry budget on the http cluster; zero on the seeds
+/// that carry no second endpoint, which is most of them.
+retries_http: u16,
 /// Decided before `io.init` (the ring the sim registers must equal the
 /// limit the server accounts against — Server.init asserts the match),
 /// consumed by `startServerAndOrigins` for the rest of the pool shape.
@@ -270,6 +277,24 @@ fn originAddress() std.Io.net.IpAddress {
 
 fn httpOriginAddress() std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9001") catch unreachable;
+}
+
+/// The #181 second endpoint: an address no origin ever binds, so every
+/// dial to it is refused by `SimIo.finishConnect`'s own listener lookup
+/// rather than by an adversary roll. That is the issue's motivating
+/// failure modelled exactly — one endpoint of a cluster refusing while
+/// the others are healthy — and it is refused on *clean* seeds too, so
+/// the retry path is reached by the seeds whose oracles demand exact
+/// outcomes rather than only by the ones that tolerate a cut.
+///
+/// Dead rather than merely slow on purpose: a black-holed endpoint would
+/// time out, and a timed-out dial does not retry (it has spent the
+/// budget a retry carries). Dead rather than a second live origin also
+/// keeps every oracle untouched — nothing here can serve, so every
+/// response the clients check still came from the one origin at index 0,
+/// including the #178 sticky tag pinned to its address.
+fn refusingEndpointAddress() std.Io.net.IpAddress {
+    return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9002") catch unreachable;
 }
 
 pub fn setUp(harness: *Harness, arena: std.mem.Allocator, seed: u64) !void {
@@ -532,9 +557,55 @@ fn randomPick(random: std.Random) zoxy.config.Config.Cluster.Pick {
     return random.enumValue(zoxy.config.Config.Cluster.Pick);
 }
 
+/// The #181 draw: a third of seeds give the http cluster a retry budget
+/// and, with it, the refusing second endpoint the budget exists to get
+/// past. The two ride together deliberately — a dead endpoint without
+/// retries would answer half the requests `502`, which a clean seed's
+/// golden outcomes forbid, while retries without one would be a budget
+/// nothing ever spends.
+///
+/// Drawn across the whole legal range rather than fixed at 1, because
+/// the two ways a retry can end are decided by which of the budget and
+/// the endpoint set runs out first: at 1 retry a second failure answers
+/// `502` with the budget spent, while at 2 or more it is the *endpoints*
+/// that run out and the answer comes from the exhaustion rung instead.
+/// Both are reachable here only because the range is.
+/// A pool-starved seed keeps the single-endpoint topology whatever it
+/// drew, and the reason is a shadow the §9 census depends on. Those seeds
+/// set `relay_buffers` and `upstream_slots` both to 1, and the exemption
+/// for `l7_shed_upstream_slots` rests on the L7 path taking the relay
+/// buffer first, so the relay rung answers everything that would reach
+/// the slot rung. A *second endpoint* breaks that: the one slot can be
+/// parked on endpoint 0 while a request picks endpoint 1, which cannot
+/// reuse it and must dial — a correct shed, and one no single-endpoint
+/// cluster can produce, because there the parked connection is always the
+/// one wanted. Found on seed 4316 of a 16384-seed sweep. The behavior
+/// itself is covered directly by `src/http_proxy_test.zig`, which
+/// exhausts the upstream pool on purpose; what does not belong here is a
+/// pool-sizing scenario arriving as a side effect of a retry draw.
+fn deriveRetries(harness: *Harness, random: std.Random) void {
+    // Drawn either way, so a starved seed's stream position stays where
+    // an unstarved one's is and the suppression costs no other coverage.
+    const budget: u16 = if (random.uintLessThan(u8, 3) == 0)
+        1 + random.uintAtMost(u16, zoxy.constants.cluster_retries_max - 1)
+    else
+        0;
+    if (budget == 0 or harness.force_exhaustion) {
+        harness.retries_http = 0;
+        harness.endpoints_http_count = 1;
+        return;
+    }
+    harness.retries_http = budget;
+    harness.endpoints_http_count = 2;
+    harness.endpoints_http[1] = refusingEndpointAddress();
+    assert(harness.retries_http >= 1);
+    assert(harness.retries_http <= zoxy.constants.cluster_retries_max);
+}
+
 fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.endpoints_l4 = .{originAddress()};
-    harness.endpoints_http = .{httpOriginAddress()};
+    harness.endpoints_http = .{ httpOriginAddress(), httpOriginAddress() };
+    deriveRetries(harness, random);
     // Each cluster draws its pick policy independently so mixed configs
     // (one cluster each way) flow through the balancer under the schedule
     // fuzz, not just the uniform pairings. Single-endpoint clusters
@@ -568,33 +639,73 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     // properties are pinned by balancer.zig's own tests, exactly like
     // `hash`'s stickiness above.
     harness.weights_l4 = .{1 + random.uintAtMost(u16, 255)};
-    harness.weights_http = .{1 + random.uintAtMost(u16, 255)};
-    harness.clusters = .{
-        .{
-            .name = "origin-l4",
-            .endpoints = &harness.endpoints_l4,
-            .weights = if (random.boolean()) &harness.weights_l4 else null,
-            .pick = pick_l4,
-            .check = health.check_l4,
-            .max_inflight = deriveMaxInflight(harness.clean, random),
-            .proxy_protocol_send = harness.proxy_protocol_send_l4,
-        },
-        .{
-            .name = "origin-http",
-            .endpoints = &harness.endpoints_http,
-            .weights = if (random.boolean()) &harness.weights_http else null,
-            .pick = pick_http,
-            .hash_key = http_hash_key,
-            .check = health.check_http,
-            .max_inflight = deriveMaxInflight(harness.clean, random),
-        },
+    harness.weights_http = .{
+        1 + random.uintAtMost(u16, 255),
+        1 + random.uintAtMost(u16, 255),
     };
+    wireClusters(harness, random, .{
+        .l4 = pick_l4,
+        .http = pick_http,
+        .http_hash_key = http_hash_key,
+    }, health);
     harness.routes_l4 = .{.{ .prefix = "/", .cluster_index = 0 }};
     harness.routes_http = .{.{ .prefix = "/", .cluster_index = 1 }};
     harness.proxy_protocol_l4 = deriveProxyProtocol(random);
     harness.deriveTerminatingDraws(random);
     harness.wireListeners(deriveForwarded(random));
     harness.deriveServerConfig(random, connect_timeout_ms, health.interval_ms);
+}
+
+/// The picks the two clusters were drawn with, bundled so `wireClusters`
+/// takes one argument for them rather than three positional ones that
+/// read alike at the call site.
+const ClusterPicks = struct {
+    l4: zoxy.config.Config.Cluster.Pick,
+    http: zoxy.config.Config.Cluster.Pick,
+    http_hash_key: zoxy.config.Config.Cluster.HashKey,
+};
+
+/// The two cluster records, split from `deriveTopology` for exactly the
+/// reason `deriveTerminatingDraws` below was: the #181 second endpoint
+/// pushed that function past the length limit again. Nothing moved but
+/// the braces — the literal is still evaluated where it was, so the four
+/// draws inside it (a weights coin and a `max_inflight` per cluster) keep
+/// their stream positions.
+fn wireClusters(
+    harness: *Harness,
+    random: std.Random,
+    picks: ClusterPicks,
+    health: HealthDraw,
+) void {
+    assert(harness.endpoints_http_count >= 1);
+    assert(harness.endpoints_http_count <= harness.endpoints_http.len);
+    harness.clusters = .{
+        .{
+            .name = "origin-l4",
+            .endpoints = &harness.endpoints_l4,
+            .weights = if (random.boolean()) &harness.weights_l4 else null,
+            .pick = picks.l4,
+            .check = health.check_l4,
+            .max_inflight = deriveMaxInflight(harness.clean, random),
+            .proxy_protocol_send = harness.proxy_protocol_send_l4,
+        },
+        .{
+            .name = "origin-http",
+            .endpoints = harness.endpoints_http[0..harness.endpoints_http_count],
+            .weights = if (random.boolean())
+                harness.weights_http[0..harness.endpoints_http_count]
+            else
+                null,
+            .pick = picks.http,
+            .hash_key = picks.http_hash_key,
+            .check = health.check_http,
+            .max_inflight = deriveMaxInflight(harness.clean, random),
+            .retries = harness.retries_http,
+        },
+    };
+    // The retry budget and the endpoint that makes it spendable ride
+    // together (`deriveRetries`), so neither is ever configured alone.
+    assert((harness.retries_http == 0) == (harness.endpoints_http_count == 1));
 }
 
 /// The §4 terminating draws, split from `deriveTopology` when the #202

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -247,8 +247,13 @@ const uncovered = [_]Uncovered{
         .reason = "the only seeds that starve a pool set relay_buffers and " ++
             "upstream_slots both to 1, and the L7 path takes the relay " ++
             "buffer first, so the relay rung answers every request that " ++
-            "would have reached this one; src/http_proxy_test.zig " ++
-            "exhausts the upstream pool directly",
+            "would have reached this one. That shadow needs the starved " ++
+            "seeds to stay single-endpoint, which is why the #181 retry " ++
+            "draw suppresses its second endpoint on them: one slot parked " ++
+            "on endpoint 0 cannot serve a request picking endpoint 1, and " ++
+            "the resulting shed is legal but reaches this rung (seed 4316 " ++
+            "of 4097..20480, before `deriveRetries` accounted for it); " ++
+            "src/http_proxy_test.zig exhausts the upstream pool directly",
     },
     .{
         .name = "l7_shed_upstream_head_buffers",

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2204,35 +2204,46 @@ pub fn Server(comptime IoType: type) type {
                 // off l4 listeners (#178), so `.none` is exact, not a
                 // shrug.
                 .none,
-            ) orelse {
-                // Every endpoint is at its §8 cap. An L4 listener has no
-                // way to say so — it relays bytes, and there is no
-                // protocol to answer in — so the ladder's L4 answer
-                // applies: close. Counted outside the gate identity,
-                // because this connection was admitted before an endpoint
-                // was ever picked (§8) — which is also why the labeled
-                // twin carries only the cluster: no endpoint was full,
-                // all of them were.
-                server.counters.increment("l4_shed_endpoint_inflight");
-                server.labeled.incrementCluster(.l4_shed_inflight, cluster_index);
-                // Nothing was armed for this dial yet — the arm below is
-                // the first — so teardown here cancels only the deadline
-                // admission left running (§5).
-                assert(!conn.armed.connect);
-                server.beginTeardown(conn);
-                return;
+                // An L4 connection dials once and relays whatever the
+                // dial produced, so there is nothing tried to exclude
+                // (#181): a failed L4 dial has no request to re-send.
+                &.{},
+            );
+            const dial = switch (pick) {
+                .dial => |chosen| chosen,
+                // Unreachable with nothing tried: only a retry can run
+                // the routable set empty.
+                .exhausted => unreachable,
+                .capped => {
+                    // Every endpoint is at its §8 cap. An L4 listener has no
+                    // way to say so — it relays bytes, and there is no
+                    // protocol to answer in — so the ladder's L4 answer
+                    // applies: close. Counted outside the gate identity,
+                    // because this connection was admitted before an
+                    // endpoint was ever picked (§8) — which is also why
+                    // the labeled twin carries only the cluster: no
+                    // endpoint was full, all of them were.
+                    server.counters.increment("l4_shed_endpoint_inflight");
+                    server.labeled.incrementCluster(.l4_shed_inflight, cluster_index);
+                    // Nothing was armed for this dial yet — the arm below
+                    // is the first — so teardown here cancels only the
+                    // deadline admission left running (§5).
+                    assert(!conn.armed.connect);
+                    server.beginTeardown(conn);
+                    return;
+                },
             };
             conn.arm(&conn.op_connect, "connect");
             // An L4 dial holds no slot to record the endpoint on, so the
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
-            conn.log.endpoint_index = pick.endpoint_index;
-            server.chargeL4(conn, cluster_index, pick.endpoint_index);
+            conn.log.endpoint_index = dial.endpoint_index;
+            server.chargeL4(conn, cluster_index, dial.endpoint_index);
             if (server.config.clusters[cluster_index].proxy_protocol_send) |version| {
                 server.stageProxySendHeader(conn, version);
             }
             server.io.connect(
-                pick.address,
+                dial.address,
                 &conn.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -51,6 +51,20 @@
 //! feature), and a keyless header population has no identity to be
 //! sticky on in the first place.
 //!
+//! **Untried endpoints (#181).** A pick takes the set of endpoints this
+//! request has already dialed and failed, and excludes them. It is a
+//! filter on the routable set, applied *before* health — not after, or a
+//! two-endpoint cluster with one ejected would have its only untried
+//! candidate removed by health and then resurrected by fail-open, handing
+//! the retry straight back to the endpoint that just refused. Excluding
+//! first and re-running the cluster's configured policy over what remains
+//! is also what keeps each policy's contract: `rr` gives the next in
+//! rotation, `p2c` still compares load across a smaller set, and `hash`
+//! redistributes by rendezvous — each key falling to its own next-best
+//! score, which is exactly where health-check ejection would send it a few
+//! seconds later. A "take the next endpoint" rule would instead stampede
+//! every sticky client of the failed backend onto the same neighbor.
+//!
 //! **Why rendezvous rather than a ring or Maglev.** Both of those answer
 //! a lookup from a precomputed table, and a table has to be *rebuilt*
 //! whenever membership changes — which here is every health-check
@@ -379,6 +393,23 @@ pub const Balancer = struct {
         endpoint_index: u16,
     };
 
+    /// What a pick concluded. The two empty answers are different rungs
+    /// and the caller must not collapse them: `capped` is §8's
+    /// origin-capacity shed — every candidate is already carrying its
+    /// `max_inflight`, so this proxy refuses rather than dialing — while
+    /// `exhausted` is #181's retry budget running out, every routable
+    /// endpoint having been dialed and failed by this one request. One
+    /// answers 503 and the other 502, and an operator reading either
+    /// counter is asking a different question.
+    pub const Outcome = union(enum) {
+        dial: Pick,
+        capped,
+        /// Only reachable from a retry: with nothing tried, the drain
+        /// filter alone can never empty the routable set (`init` proves
+        /// at least one endpoint holds weight).
+        exhausted,
+    };
+
     /// Choose the endpoint to dial for `cluster_index` under the
     /// cluster's configured policy. `load` is the per-endpoint in-flight
     /// view (indexed by `upstream.endpointKey`), consulted by p2c —
@@ -387,7 +418,9 @@ pub const Balancer = struct {
     /// index) — the prober owns that truth the way the pool and the
     /// server own the load. `request_key` is what the serving path read
     /// off the parsed head for a request-keyed cluster, `.none`
-    /// everywhere else. Bounded work, no allocation, and a validated
+    /// everywhere else. `tried` names the endpoints this request already
+    /// dialed and failed (#181) — empty on a first try — and they are
+    /// excluded outright. Bounded work, no allocation, and a validated
     /// config guarantees at least one endpoint.
     pub fn pick(
         balancer: *Balancer,
@@ -396,28 +429,45 @@ pub const Balancer = struct {
         healthy: []const bool,
         client_address: *const std.Io.net.IpAddress,
         request_key: RequestKey,
-    ) ?Pick {
+        tried: []const u16,
+    ) Outcome {
         assert(cluster_index < balancer.config.clusters.len);
         const cluster = &balancer.config.clusters[cluster_index];
         assert(cluster.endpoints.len >= 1);
         assert(cluster.endpoints.len <= balancer.keys.stride);
-        if (cluster.endpoints.len == 1 and cluster.max_inflight == null) {
+        assert(tried.len <= cluster.endpoints.len);
+        // The exclusion set is the caller's to build, so its entries are
+        // checked here rather than trusted: an index past this cluster
+        // would exclude nothing and read as a retry that had somewhere
+        // left to go, which is the quiet direction to be wrong in.
+        for (tried) |index| assert(index < cluster.endpoints.len);
+        if (tried.len == 0 and cluster.endpoints.len == 1 and cluster.max_inflight == null) {
             // Neither a rotation nor a draw: uncapped single-endpoint
             // clusters stay branch-cheap and policy state is untouched.
             // The mask is moot too — one endpoint ejected is the
             // fail-open case. A cap has to be read, so it takes the
-            // general path below.
-            return .{ .address = cluster.endpoints[0], .endpoint_index = 0 };
+            // general path below — and so does a retry, which must see
+            // its own exclusion rather than this endpoint again.
+            return .{ .dial = .{ .address = cluster.endpoints[0], .endpoint_index = 0 } };
         }
         const eligible = balancer.eligible_scratch;
-        const count = eligibleEndpoints(balancer.keys, cluster_index, cluster, load, healthy, eligible);
+        const candidates = candidateEndpoints(balancer.keys, cluster_index, cluster, healthy, tried, eligible);
+        if (candidates == 0) {
+            // A single-endpoint cluster cannot retry, and neither can one
+            // whose every routable endpoint this request has already
+            // dialed. Health does not fail open past this: the endpoints
+            // it would resurrect are the ones that just failed.
+            assert(tried.len >= 1);
+            return .exhausted;
+        }
+        const count = underCapacity(balancer.keys, cluster_index, cluster, load, eligible[0..candidates]);
         if (count == 0) {
-            // Every endpoint is at its §8 cap. Unlike the health mask
+            // Every candidate is at its §8 cap. Unlike the health mask
             // this does *not* fail open: an ejected cluster means "we do
             // not know, try anyway", while a capped one means "we know
             // they are full", and dialing anyway is the exact thing the
             // cap exists to stop.
-            return null;
+            return .capped;
         }
         const chosen = switch (cluster.pick) {
             .rr => balancer.pickRoundRobin(cluster_index, eligible[0..count]),
@@ -431,13 +481,15 @@ pub const Balancer = struct {
             ),
         };
         assert(chosen < cluster.endpoints.len);
-        return .{
+        assert(!alreadyTried(tried, chosen)); // The exclusion is not advisory.
+        return .{ .dial = .{
             .address = cluster.endpoints[chosen],
             .endpoint_index = chosen,
-        };
+        } };
     }
 
-    /// The endpoints a pick may choose between, in three passes.
+    /// The endpoints a pick may choose between before capacity is read,
+    /// in three passes.
     ///
     /// First the #174 drain: a weight-0 endpoint never enters the set.
     /// Unlike the health mask this is not a verdict to fail open past —
@@ -445,25 +497,27 @@ pub const Balancer = struct {
     /// point of the spelling is that it holds while everything else
     /// flaps.
     ///
-    /// Then §7 health over the routable set: the healthy ones — or, the
-    /// fail-open rule, every routable endpoint when all of them are
-    /// ejected. Dialing a maybe-dead endpoint reports the outage the way
-    /// it always did; routing nowhere would turn a probe verdict into an
-    /// outage of its own, and a same-port TCP probe cannot know better
-    /// than the dial.
+    /// Then #181's exclusion: an endpoint this request already dialed and
+    /// failed is out, and health does not fail open past this one either.
+    /// Both filters run before health for the same reason — they say
+    /// *not here*, where health only says *we suspect*.
     ///
-    /// Then §8 capacity, over whatever survived: an endpoint already
-    /// carrying its `max_inflight` is dropped. This pass **may return
-    /// zero**, and that is the difference from the health pass — the
-    /// caller sheds rather than dialing. The order matters too: capacity
-    /// is judged over the endpoints health would have used, so a cluster
-    /// that fails open still respects its caps.
-    fn eligibleEndpoints(
+    /// Then §7 health over what remains: the healthy ones — or, the
+    /// fail-open rule, all of them when every one is ejected. Dialing a
+    /// maybe-dead endpoint reports the outage the way it always did;
+    /// routing nowhere would turn a probe verdict into an outage of its
+    /// own, and a same-port TCP probe cannot know better than the dial.
+    ///
+    /// **May return zero**, but only for a request that has tried
+    /// something: at least one endpoint holds weight (the loader rejects
+    /// an all-zero cluster and `init` re-proves it), so the drain filter
+    /// alone can never empty the set.
+    fn candidateEndpoints(
         keys: upstream.EndpointKeys,
         cluster_index: u16,
         cluster: *const config_module.Config.Cluster,
-        load: *const upstream.Load,
         healthy: []const bool,
+        tried: []const u16,
         eligible: []u16,
     ) u16 {
         assert(cluster.endpoints.len >= 1);
@@ -472,6 +526,7 @@ pub const Balancer = struct {
         for (0..cluster.endpoints.len) |endpoint_index| {
             const index: u16 = @intCast(endpoint_index);
             if (weightOf(cluster, index) == 0) continue;
+            if (alreadyTried(tried, index)) continue;
             if (healthy[keys.key(cluster_index, index)]) {
                 eligible[count] = index;
                 count += 1;
@@ -481,27 +536,55 @@ pub const Balancer = struct {
             for (0..cluster.endpoints.len) |endpoint_index| {
                 const index: u16 = @intCast(endpoint_index);
                 if (weightOf(cluster, index) == 0) continue;
+                if (alreadyTried(tried, index)) continue;
                 eligible[count] = index;
                 count += 1;
             }
         }
-        // At least one endpoint holds weight — the loader rejects an
-        // all-zero cluster and `init` re-proves it — so the drain filter
-        // alone can never empty the set.
-        assert(count >= 1);
-        if (cluster.max_inflight) |cap| {
-            assert(cap >= 1);
-            var under: u16 = 0;
-            for (eligible[0..count]) |index| {
-                if (load.inFlight(keys.key(cluster_index, index)) < cap) {
-                    eligible[under] = index;
-                    under += 1;
-                }
-            }
-            count = under;
-        }
+        assert(count >= 1 or tried.len >= 1);
         assert(count <= cluster.endpoints.len);
         return count;
+    }
+
+    /// §8 capacity over the candidates: an endpoint already carrying its
+    /// `max_inflight` is dropped. This pass may empty a non-empty set,
+    /// and that is the difference from the health pass — the caller sheds
+    /// rather than dialing. The order matters too: capacity is judged
+    /// over the endpoints health would have used, so a cluster that fails
+    /// open still respects its caps.
+    fn underCapacity(
+        keys: upstream.EndpointKeys,
+        cluster_index: u16,
+        cluster: *const config_module.Config.Cluster,
+        load: *const upstream.Load,
+        eligible: []u16,
+    ) u16 {
+        assert(eligible.len >= 1);
+        assert(eligible.len <= cluster.endpoints.len);
+        const cap = cluster.max_inflight orelse return @intCast(eligible.len);
+        assert(cap >= 1);
+        var under: u16 = 0;
+        for (eligible) |index| {
+            if (load.inFlight(keys.key(cluster_index, index)) < cap) {
+                eligible[under] = index;
+                under += 1;
+            }
+        }
+        assert(under <= eligible.len);
+        return under;
+    }
+
+    /// Whether this request has already dialed `endpoint_index` and had
+    /// the dial fail (#181). A linear scan because the set is bounded by
+    /// `constants.cluster_retries_max` and never sorted — the order it
+    /// was filled in is the order the tries happened, which is what the
+    /// access log and the counters describe.
+    fn alreadyTried(tried: []const u16, endpoint_index: u16) bool {
+        assert(tried.len <= constants.cluster_retries_max + 1);
+        for (tried) |index| {
+            if (index == endpoint_index) return true;
+        }
+        return false;
     }
 
     /// Smooth weighted rotation over the eligible set (nginx's SWRR):
@@ -838,6 +921,10 @@ fn testLoad(l7: *const [test_keys.count]u16) upstream.Load {
 /// reads it.
 const test_client = std.Io.net.IpAddress.parseLiteral("198.51.100.7:40000") catch unreachable;
 
+/// A first try, which is every scenario that is not about #181: nothing
+/// has been dialed yet, so nothing is excluded.
+const test_untried: []const u16 = &.{};
+
 fn testAddress(comptime literal: []const u8) std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parseLiteral(literal) catch unreachable;
 }
@@ -874,7 +961,7 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
     counts[test_keys.key(0, 0)] = 100;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
         try std.testing.expectEqual(trio[want_index], picked.address);
     }
@@ -897,7 +984,7 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(solo, picked.address);
         try std.testing.expectEqual(@as(u16, 0), picked.endpoint_index);
     }
@@ -927,7 +1014,7 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
     counts[test_keys.key(0, 1)] = 100;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -953,7 +1040,7 @@ test "balancer: p2c spreads across endpoints under equal load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 300) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         hits[picked.endpoint_index] += 1;
     }
     for (hits) |hit_count| {
@@ -985,8 +1072,8 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
-            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
+            left.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
+            right.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
         );
     }
 }
@@ -1013,7 +1100,7 @@ test "balancer: rr rotates over the healthy endpoints only" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -1040,7 +1127,7 @@ test "balancer: rr honors weights, and the schedule is smooth" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 0, 1, 0 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -1066,7 +1153,7 @@ test "balancer: rr weight zero drains an endpoint, past fail-open" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 2, 0, 2 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
     // Fail-open re-admits the ejected, never the drained: a weight of 0
@@ -1075,7 +1162,7 @@ test "balancer: rr weight zero drains an endpoint, past fail-open" {
     const none_healthy = [_]bool{false} ** test_keys.count;
     var round: u32 = 0;
     while (round < 20) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &none_healthy, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &none_healthy, &test_client, .none, test_untried).dial;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -1104,7 +1191,7 @@ test "balancer: p2c candidacy follows weight" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 400) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial;
         hits[picked.endpoint_index] += 1;
     }
     try std.testing.expect(hits[0] > hits[1] + hits[2]);
@@ -1144,8 +1231,8 @@ test "balancer: p2c at unit weights draws exactly as the unweighted form" {
     var round: u32 = 0;
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
-            bare.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
-            spelled.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index,
+            bare.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
+            spelled.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
         );
     }
     try std.testing.expectEqual(bare.pick_state, spelled.pick_state);
@@ -1175,7 +1262,7 @@ test "balancer: p2c never picks an ejected endpoint" {
     counts[test_keys.key(0, 2)] = 50;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none, test_untried).dial;
         try std.testing.expect(picked.endpoint_index != 1);
     }
 }
@@ -1202,7 +1289,7 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
     const counts = [_]u16{0} ** test_counts_len;
     var round: u32 = 0;
     while (round < 10) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(@as(u16, 1), picked.endpoint_index);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
@@ -1232,7 +1319,7 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 2, 0, 1 };
     for (expected) |want_index| {
-        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none, test_untried).dial;
         try std.testing.expectEqual(want_index, picked.endpoint_index);
     }
 }
@@ -1257,8 +1344,8 @@ test "balancer: policies keep independent state across clusters" {
     const counts = [_]u16{0} ** test_counts_len;
     const expected = [_]u16{ 0, 1, 0, 1, 0 };
     for (expected) |want_index| {
-        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none).?.endpoint_index);
-        _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client, .none);
+        try std.testing.expectEqual(want_index, balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index);
+        _ = balancer.pick(1, &testLoad(&counts), &test_healthy_all, &test_client, .none, test_untried);
     }
 }
 
@@ -1295,10 +1382,10 @@ test "balancer: hash sends one client to one endpoint, every time" {
 
     const counts = [_]u16{0} ** test_counts_len;
     const client = testAddress("203.0.113.9:51000");
-    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
+        const again = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial;
         try std.testing.expectEqual(first, again.endpoint_index);
         try std.testing.expectEqual(endpoints[first], again.address);
     }
@@ -1308,7 +1395,7 @@ test "balancer: hash sends one client to one endpoint, every time" {
     loaded[test_keys.key(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client, .none).?.endpoint_index,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index,
     );
 }
 
@@ -1329,7 +1416,7 @@ test "balancer: hash spends no PRNG state and needs none" {
     const counts = [_]u16{0} ** test_counts_len;
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
-        _ = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none);
+        _ = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none, test_untried);
     }
     try std.testing.expectEqual(state_before, balancer.pick_state);
 }
@@ -1350,7 +1437,7 @@ test "balancer: hash spreads distinct clients across every endpoint" {
     var hits = [_]u32{0} ** 8;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none, test_untried).dial.endpoint_index] += 1;
     }
     // Rendezvous gives each client an independent uniform choice, so the
     // spread is a balls-in-bins one: loose bounds, but every endpoint must
@@ -1384,7 +1471,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var before: [clients]u16 = undefined;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index;
+        before[index] = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none, test_untried).dial.endpoint_index;
     }
 
     const ejected: u16 = 3;
@@ -1394,7 +1481,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     var moved: u32 = 0;
     index = 0;
     while (index < clients) : (index += 1) {
-        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index), .none).?.endpoint_index;
+        const after = balancer.pick(0, &testLoad(&counts), &healthy, &testClientAt(index), .none, test_untried).dial.endpoint_index;
         try std.testing.expect(after != ejected);
         if (before[index] == ejected) {
             moved += 1;
@@ -1415,7 +1502,7 @@ test "balancer: ejecting an endpoint moves its clients and nobody else's" {
     while (index < clients) : (index += 1) {
         try std.testing.expectEqual(
             before[index],
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none, test_untried).dial.endpoint_index,
         );
     }
 }
@@ -1448,7 +1535,7 @@ test "balancer: hash spreads clients in proportion to weight" {
     var hits = [_]u32{0} ** 2;
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none).?.endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &testClientAt(index), .none, test_untried).dial.endpoint_index] += 1;
     }
     const expected_heavy = clients * 3 / 4;
     try std.testing.expect(hits[0] > expected_heavy - 400);
@@ -1489,8 +1576,8 @@ test "balancer: re-weighting an endpoint disrupts only the clients it gains" {
     var index: u16 = 0;
     while (index < clients) : (index += 1) {
         const client = testClientAt(index);
-        const before = flat.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
-        const after = weighted.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
+        const before = flat.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index;
+        const after = weighted.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index;
         if (after != before) {
             try std.testing.expectEqual(@as(u16, 3), after);
             moved += 1;
@@ -1535,15 +1622,15 @@ test "balancer: hash weight zero drains an endpoint, past fail-open" {
     var index: u16 = 0;
     while (index < 500) : (index += 1) {
         const client = testClientAt(index);
-        const after = drained.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index;
+        const after = drained.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index;
         try std.testing.expect(after != 3);
         try std.testing.expectEqual(
-            flat.pick(0, &testLoad(&counts), &ejected_mask, &client, .none).?.endpoint_index,
+            flat.pick(0, &testLoad(&counts), &ejected_mask, &client, .none, test_untried).dial.endpoint_index,
             after,
         );
         // Fail-open re-admits the ejected, never the drained.
         try std.testing.expect(
-            drained.pick(0, &testLoad(&counts), &none_healthy, &client, .none).?.endpoint_index != 3,
+            drained.pick(0, &testLoad(&counts), &none_healthy, &client, .none, test_untried).dial.endpoint_index != 3,
         );
     }
 }
@@ -1582,8 +1669,8 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     var index: u16 = 0;
     while (index < 1000) : (index += 1) {
         const client = testClientAt(index);
-        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
-        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?;
+        const left_pick = left.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial;
+        const right_pick = right.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial;
         // The *address* must match; the index deliberately need not, the
         // lists being permutations of each other.
         try std.testing.expectEqual(left_pick.address, right_pick.address);
@@ -1608,8 +1695,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     const first = testAddress("[2001:db8:1:2:aaaa:bbbb:cccc:dddd]:51000");
     const rotated = testAddress("[2001:db8:1:2:1111:2222:3333:4444]:52000");
     try std.testing.expectEqual(
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none).?.endpoint_index,
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated, .none).?.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none, test_untried).dial.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &rotated, .none, test_untried).dial.endpoint_index,
     );
 
     // A different /64 is a different client and must be free to land
@@ -1620,8 +1707,8 @@ test "balancer: an IPv6 client keeps its endpoint when its /64 does" {
     while (prefix < 64) : (prefix += 1) {
         var other = first;
         other.ip6.bytes[7] = @intCast(prefix);
-        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other, .none).?.endpoint_index !=
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none).?.endpoint_index)
+        if (balancer.pick(0, &testLoad(&counts), &test_healthy_all, &other, .none, test_untried).dial.endpoint_index !=
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &first, .none, test_untried).dial.endpoint_index)
         {
             differs = true;
             break;
@@ -1694,8 +1781,8 @@ test "balancer: a fully ejected hash cluster still answers, deterministically" {
         // Fail-open restores the full set, so the answer is the same one
         // the healthy cluster gives.
         try std.testing.expectEqual(
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none).?.endpoint_index,
-            balancer.pick(0, &testLoad(&counts), &none_healthy, &client, .none).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &none_healthy, &client, .none, test_untried).dial.endpoint_index,
         );
     }
 }
@@ -1732,13 +1819,13 @@ test "balancer: hash on a header keys on the value, not the client" {
 
     const counts = [_]u16{0} ** test_counts_len;
     const key: Balancer.RequestKey = .{ .key = Balancer.bytesKey("tenant-a") };
-    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, key).?.endpoint_index;
+    const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, key, test_untried).dial.endpoint_index;
     // A different client with the same header value is the same tenant:
     // the address must contribute nothing to a header-keyed pick.
     const roaming = testAddress("198.51.100.200:41000");
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &roaming, key).?.endpoint_index,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &roaming, key, test_untried).dial.endpoint_index,
     );
     // Load on the winner must not move the tenant, and no PRNG state may
     // be spent: a keyed pick is a pure function, like source_ip's.
@@ -1746,7 +1833,7 @@ test "balancer: hash on a header keys on the value, not the client" {
     loaded[test_keys.key(0, first)] = 10_000;
     try std.testing.expectEqual(
         first,
-        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, key).?.endpoint_index,
+        balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, key, test_untried).dial.endpoint_index,
     );
     try std.testing.expectEqual(state_before, balancer.pick_state);
 
@@ -1758,7 +1845,7 @@ test "balancer: hash on a header keys on the value, not the client" {
         var name_buffer: [16]u8 = undefined;
         const name = std.fmt.bufPrint(&name_buffer, "tenant-{d}", .{tenant}) catch unreachable;
         const tenant_key: Balancer.RequestKey = .{ .key = Balancer.bytesKey(name) };
-        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, tenant_key).?.endpoint_index] += 1;
+        hits[balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, tenant_key, test_untried).dial.endpoint_index] += 1;
     }
     var reached: u32 = 0;
     for (hits) |hit_count| {
@@ -1792,7 +1879,7 @@ test "balancer: a request without its keyed material places by load" {
     var hits = [_]u32{0} ** 3;
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .absent).?;
+        const picked = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .absent, test_untried).dial;
         hits[picked.endpoint_index] += 1;
     }
     try std.testing.expectEqual(@as(u32, 0), hits[1]);
@@ -1826,7 +1913,7 @@ test "balancer: a cookie tag names its endpoint through any load" {
     loaded[test_keys.key(0, wanted)] = 10_000;
     var round: u32 = 0;
     while (round < 50) : (round += 1) {
-        const picked = balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, tagged).?;
+        const picked = balancer.pick(0, &testLoad(&loaded), &test_healthy_all, &test_client, tagged, test_untried).dial;
         try std.testing.expectEqual(wanted, picked.endpoint_index);
         try std.testing.expectEqual(endpoints[wanted], picked.address);
     }
@@ -1866,13 +1953,13 @@ test "balancer: a tag naming nothing eligible re-homes by load" {
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 1),
-            balancer.pick(0, &testLoad(&counts), &ejected_mask, &test_client, ejected_tag).?.endpoint_index,
+            balancer.pick(0, &testLoad(&counts), &ejected_mask, &test_client, ejected_tag, test_untried).dial.endpoint_index,
         );
         try std.testing.expect(
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, drained_tag).?.endpoint_index != 2,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, drained_tag, test_untried).dial.endpoint_index != 2,
         );
         try std.testing.expect(
-            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, forged_tag).?.endpoint_index != 2,
+            balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, forged_tag, test_untried).dial.endpoint_index != 2,
         );
     }
 }
@@ -1937,7 +2024,7 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
     const load: upstream.Load = .{ .l7 = &l7_idle, .l4 = &l4 };
     var round: u32 = 0;
     while (round < 200) : (round += 1) {
-        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index != 1);
+        try std.testing.expect(balancer.pick(0, &load, &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index != 1);
     }
 }
 
@@ -1971,7 +2058,7 @@ test "balancer: p2c compares the sum of both protocols" {
     while (round < 100) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 0),
-            balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index,
+            balancer.pick(0, &load, &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
         );
     }
 }
@@ -2000,7 +2087,7 @@ test "balancer: a capped endpoint is skipped while another has room" {
     while (round < 8) : (round += 1) {
         try std.testing.expectEqual(
             @as(u16, 1),
-            balancer.pick(0, &load, &test_healthy_all, &test_client, .none).?.endpoint_index,
+            balancer.pick(0, &load, &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
         );
     }
 }
@@ -2027,14 +2114,14 @@ test "balancer: a fully capped cluster refuses rather than failing open" {
     l7[test_keys.key(0, 0)] = 3;
     l7[test_keys.key(0, 1)] = 3;
     try std.testing.expectEqual(
-        @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none),
+        Balancer.Outcome.capped,
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none, test_untried),
     );
     // One request completes on endpoint 1 and the cluster serves again.
     l7[test_keys.key(0, 1)] = 2;
     try std.testing.expectEqual(
         @as(u16, 1),
-        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none).?.endpoint_index,
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none, test_untried).dial.endpoint_index,
     );
 }
 
@@ -2060,8 +2147,8 @@ test "balancer: the cap counts both protocols, and covers one endpoint" {
     l4[test_keys.key(0, 0)] = 1;
     const load: upstream.Load = .{ .l7 = &l7, .l4 = &l4 };
     try std.testing.expectEqual(
-        @as(?Balancer.Pick, null),
-        balancer.pick(0, &load, &test_healthy_all, &test_client, .none),
+        Balancer.Outcome.capped,
+        balancer.pick(0, &load, &test_healthy_all, &test_client, .none, test_untried),
     );
     // Reading either table alone would leave room and dial anyway.
     try std.testing.expect(l7[test_keys.key(0, 0)] < 4);
@@ -2090,15 +2177,206 @@ test "balancer: capacity is judged over the endpoints health left" {
     var l7 = [_]u16{0} ** test_counts_len;
     l7[test_keys.key(0, 1)] = 1;
     try std.testing.expectEqual(
-        @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none),
+        Balancer.Outcome.capped,
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none, test_untried),
     );
     // And when health fails open — every endpoint ejected — the caps
     // still apply to the whole set rather than being bypassed with it.
     healthy[test_keys.key(0, 1)] = false;
     l7[test_keys.key(0, 0)] = 1;
     try std.testing.expectEqual(
-        @as(?Balancer.Pick, null),
-        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none),
+        Balancer.Outcome.capped,
+        balancer.pick(0, &testLoad(&l7), &healthy, &test_client, .none, test_untried),
     );
+}
+
+test "balancer: a tried endpoint is excluded from the retry" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    const counts = [_]u16{0} ** test_counts_len;
+    // Whatever the rotation would have handed back, the endpoint this
+    // request already dialed is not it — and the retry after that skips
+    // both. Every remaining pick is still a real rotation over what is
+    // left, not a fixed "next endpoint" rule.
+    const first = [_]u16{0};
+    const second = [_]u16{ 0, 2 };
+    var round: u32 = 0;
+    while (round < 6) : (round += 1) {
+        const retry = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, &first).dial;
+        try std.testing.expect(retry.endpoint_index != 0);
+        const last = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, &second).dial;
+        try std.testing.expectEqual(@as(u16, 1), last.endpoint_index);
+        try std.testing.expectEqual(b, last.address);
+    }
+}
+
+test "balancer: fail-open cannot resurrect the endpoint that just failed" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Endpoint 1 is ejected, endpoint 0 was just dialed and refused. Run
+    // the exclusion after health and the sequence is: health keeps {0},
+    // untried removes it, the empty set fails open, and the retry goes
+    // straight back to the endpoint that refused. Running it first — as
+    // `candidateEndpoints` does — leaves {1}, which health then fails
+    // open over, and the maybe-dead endpoint is dialed rather than none.
+    var healthy = test_healthy_all;
+    healthy[test_keys.key(0, 1)] = false;
+    const counts = [_]u16{0} ** test_counts_len;
+    const tried = [_]u16{0};
+    const retry = balancer.pick(0, &testLoad(&counts), &healthy, &test_client, .none, &tried).dial;
+    try std.testing.expectEqual(@as(u16, 1), retry.endpoint_index);
+    try std.testing.expectEqual(b, retry.address);
+}
+
+test "balancer: every routable endpoint tried is exhausted, never capped" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
+    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    // Endpoint 2 is drained (#174), so the routable set is {0, 1} and
+    // trying both exhausts the cluster even though an endpoint remains.
+    const weights = [_]u16{ 1, 1, 0 };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "trio", .endpoints = &trio, .weights = &weights, .pick = .rr },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    const counts = [_]u16{0} ** test_counts_len;
+    const one_left = [_]u16{0};
+    try std.testing.expectEqual(
+        @as(u16, 1),
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, &one_left).dial.endpoint_index,
+    );
+    // A drain is the operator's statement and outranks the retry's need
+    // for somewhere to go: endpoint 2 is not a candidate at any point.
+    const both = [_]u16{ 0, 1 };
+    try std.testing.expectEqual(
+        Balancer.Outcome.exhausted,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, &both),
+    );
+}
+
+test "balancer: a single-endpoint cluster cannot retry" {
+    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
+    const one = [_]std.Io.net.IpAddress{solo};
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "one", .endpoints = &one },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // The uncapped single-endpoint fast path must not answer a retry with
+    // the endpoint the retry exists to avoid — it is the one short-circuit
+    // that returns before the eligible set is ever built.
+    const counts = [_]u16{0} ** test_counts_len;
+    const tried = [_]u16{0};
+    try std.testing.expectEqual(
+        Balancer.Outcome.exhausted,
+        balancer.pick(0, &testLoad(&counts), &test_healthy_all, &test_client, .none, &tried),
+    );
+}
+
+test "balancer: a retry whose survivors are all full is capped, not exhausted" {
+    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
+    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
+    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 2 },
+    };
+    const config = testConfig(&clusters);
+
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    // Endpoint 0 refused; endpoint 1 is untried but at its §8 cap. The
+    // two empty answers must stay apart: this is the origin carrying all
+    // it agreed to (503), not the request running out of places to go.
+    var l7 = [_]u16{0} ** test_counts_len;
+    l7[test_keys.key(0, 1)] = 2;
+    const tried = [_]u16{0};
+    try std.testing.expectEqual(
+        Balancer.Outcome.capped,
+        balancer.pick(0, &testLoad(&l7), &test_healthy_all, &test_client, .none, &tried),
+    );
+}
+
+test "balancer: a hash retry lands where ejection would send the key" {
+    // The property the retry design turns on (#181): re-running the
+    // configured pick over the set minus what was tried gives each key
+    // its own next-best score — the same redistribution health-check
+    // ejection produces a few seconds later. Retry and ejection therefore
+    // agree, and behavior does not shift under the operator when the
+    // prober catches up. A "take the next endpoint" rule would instead
+    // pile every client of the failed backend onto one neighbor.
+    const endpoints = testHashEndpoints(8);
+    const clusters = [_]config_module.Config.Cluster{
+        .{ .name = "sticky", .endpoints = &endpoints, .pick = .hash },
+    };
+    const config = testConfig(&clusters);
+    var balancer_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer balancer_arena.deinit();
+    var balancer: Balancer = undefined;
+    try balancer.init(balancer_arena.allocator(), &config, testKeysFor(&config));
+
+    const counts = [_]u16{0} ** test_counts_len;
+    const failed: u16 = 3;
+    var healthy = test_healthy_all;
+    healthy[test_keys.key(0, failed)] = false;
+    const tried = [_]u16{failed};
+
+    var spread = [_]u32{0} ** 8;
+    var retried: u32 = 0;
+    var index: u16 = 0;
+    while (index < 4000) : (index += 1) {
+        const client = testClientAt(index);
+        const first = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, test_untried).dial;
+        if (first.endpoint_index != failed) continue;
+        retried += 1;
+        const retry = balancer.pick(0, &testLoad(&counts), &test_healthy_all, &client, .none, &tried).dial;
+        const ejected = balancer.pick(0, &testLoad(&counts), &healthy, &client, .none, test_untried).dial;
+        try std.testing.expectEqual(ejected.endpoint_index, retry.endpoint_index);
+        spread[retry.endpoint_index] += 1;
+    }
+    try std.testing.expect(retried > 0);
+    // And the population really is redistributed rather than moved: the
+    // failed endpoint's clients reach more than one survivor.
+    var reached: u32 = 0;
+    for (spread) |hits| {
+        if (hits > 0) reached += 1;
+    }
+    try std.testing.expect(reached > 1);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -311,6 +311,14 @@ pub const Config = struct {
         /// L7 requests and live L4 connections alike (§7).
         max_inflight: ?u32 = null,
 
+        /// How many further endpoints one request may dial after a
+        /// refused or unreachable first try (#181), 0 for none — the
+        /// default, and what every config predating this key keeps
+        /// doing. Bounded by `cluster_retries_max`. Only the L7 path
+        /// spends it: an L4 connection dials once and relays whatever
+        /// the dial produced, with no request to send somewhere else.
+        retries: u16 = 0,
+
         /// What a `hash` cluster keys its endpoint choice on (§7, #178).
         /// Read only when `pick == .hash`; the loader rejects key
         /// settings beside any other policy rather than leaving them
@@ -443,6 +451,7 @@ pub const ValidationError = error{
     ClusterCheckHostInvalid,
     ClusterCheckStatusInvalid,
     ClusterMaxInflightOutOfRange,
+    ClusterRetriesOutOfRange,
     ClusterPickKeyMissing,
     ClusterPickKeyUnknown,
     ClusterPickKeyWithoutHash,
@@ -1876,6 +1885,10 @@ pub const ClusterJson = struct {
     check: ?CheckJson = null,
     /// Optional §8 per-endpoint concurrency cap; absent means uncapped.
     max_inflight: ?u32 = null,
+    /// Optional #181 dial retries across this cluster's endpoints;
+    /// absent means none, which is what every config written before the
+    /// key existed asked for.
+    retries: u16 = 0,
     /// Optional PROXY protocol announcement on upstream connections
     /// (#142); absent sends none. Only valid on clusters no http
     /// listener routes to.
@@ -1900,6 +1913,13 @@ pub const ClusterJson = struct {
             .desc = "Cap on concurrent in-flight work per endpoint; absent leaves the cluster uncapped.",
             .minimum = 1,
             .maximum = constants.endpoint_inflight_max,
+        },
+        .retries = .{
+            .desc = "Further endpoints one request may dial after a refused or " ++
+                "unreachable first try; 0 (the default) answers 502 on the first " ++
+                "failure. All tries share the one connect timeout.",
+            .minimum = 0,
+            .maximum = constants.cluster_retries_max,
         },
         .proxy_protocol = .{
             .desc = "Announce each client to this cluster's origins with a PROXY " ++
@@ -2507,6 +2527,7 @@ fn resolveClusters(
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
             .hash_key = picked.hash_key,
             .max_inflight = try resolveMaxInflight(entry.cluster.max_inflight),
+            .retries = try resolveRetries(entry.cluster.retries),
             .proxy_protocol_send = try resolveClusterProxyProtocol(entry.cluster.proxy_protocol),
         };
     }
@@ -3520,6 +3541,19 @@ fn resolveMaxInflight(max_inflight: ?u32) ParseError!?u32 {
         return error.ClusterMaxInflightOutOfRange;
     }
     return cap;
+}
+
+/// Resolve the #181 dial-retry budget. Zero is the default and means
+/// "answer the first failure", so it needs no rejection; past the
+/// ceiling is refused rather than clamped, because every try this
+/// permits is load the surviving endpoints absorb, and an operator who
+/// wrote a number the proxy will not honor should hear about it at load
+/// rather than infer it from a counter.
+fn resolveRetries(retries: u16) ParseError!u16 {
+    if (retries > constants.cluster_retries_max) {
+        return error.ClusterRetriesOutOfRange;
+    }
+    return retries;
 }
 
 /// Resolve a listener's §7 client-address forwarding: absent is off, and
@@ -6404,5 +6438,60 @@ test "config: a filter may not name the header zoxy manages" {
         const parsed = try expectParseOk(&arena_state, head ++
             "{\"actions\":[{\"header_set\":{\"name\":\"X-Forwarded-Proto\",\"value\":\"https\"}}]}" ++ tail);
         try std.testing.expectEqual(@as(usize, 1), parsed.listeners[0].request_filters.len);
+    }
+}
+
+test "config: retries resolves, defaults to none, rejects past the ceiling" {
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state,
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:2","127.0.0.1:3"],"retries":2},
+            \\   "b":{"endpoints":["127.0.0.1:4"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(@as(u16, 2), parsed.clusters[0].retries);
+        // Absent is no retry, which is what every config written before
+        // the key existed asked for and must keep getting (#181).
+        try std.testing.expectEqual(@as(u16, 0), parsed.clusters[1].retries);
+    }
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"retries":
+    ;
+    const tail =
+        \\}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    // Zero is the default rather than a typo, so it loads; past the
+    // ceiling is refused rather than clamped, because a number the proxy
+    // will not honor should be heard about at load.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ "0" ++ tail);
+        try std.testing.expectEqual(@as(u16, 0), parsed.clusters[0].retries);
+    }
+    {
+        var buffer: [512]u8 = undefined;
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const json = try std.fmt.bufPrint(
+            &buffer,
+            "{s}{d}{s}",
+            .{ head, constants.cluster_retries_max, tail },
+        );
+        const parsed = try expectParseOk(&arena_state, json);
+        try std.testing.expectEqual(constants.cluster_retries_max, parsed.clusters[0].retries);
+    }
+    {
+        var buffer: [512]u8 = undefined;
+        const json = try std.fmt.bufPrint(
+            &buffer,
+            "{s}{d}{s}",
+            .{ head, constants.cluster_retries_max + 1, tail },
+        );
+        try expectParseError(error.ClusterRetriesOutOfRange, json);
     }
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -495,6 +495,16 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// not a share.
 pub const endpoint_weight_max: u16 = 256;
 
+/// Upper bound on a cluster's configured `retries` (#181) — the extra
+/// dials one request may spend after a refused or unreachable first try.
+/// HAProxy's own default, and a ceiling rather than a taste: every try
+/// this permits is load moved onto the endpoints that are still answering,
+/// so a generous bound would make a partial outage worse at the moment the
+/// cluster is least able to absorb it. It also sizes the per-connection
+/// tried-endpoint set, which is why it is a constant and not open-ended:
+/// the set holds the first try plus this many retries.
+pub const cluster_retries_max: u16 = 3;
+
 /// Lower bound on configured clusters: a config with no cluster can route
 /// nowhere, so the loader rejects an empty map and the config JSON Schema
 /// emits it as `minProperties`.
@@ -1153,6 +1163,11 @@ comptime {
     // A weight ceiling of zero would make every cluster all-drained and
     // unloadable; one weight step is the degenerate-but-legal minimum.
     assert(endpoint_weight_max >= 1);
+    // A retry cap of zero would make the config key unspellable; one
+    // retry is the degenerate-but-legal minimum. The set it sizes must
+    // still fit the u16 count the balancer scans it with.
+    assert(cluster_retries_max >= 1);
+    assert(cluster_retries_max < std.math.maxInt(u16));
     // The health prober's reservations and thresholds (§7): the op budget
     // covers dial + deadline + one cancel, a threshold of zero would eject
     // or restore on no evidence, and the default probe interval is a legal

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -185,6 +185,19 @@ pub const Counters = struct {
     /// and its request took the one free §7 replay on a fresh dial.
     /// Every replay rides a reuse — an inequality `reconcile` asserts.
     upstream_replayed: Value = Value.init(0),
+    /// Dials taken as a #181 retry: a previous endpoint refused or was
+    /// unreachable and the request was sent to an untried one. Every
+    /// retry rides a connect failure — an inequality `reconcile` asserts
+    /// — which is also why this counter has to exist: without it
+    /// `upstream_connect_failed` climbs while requests succeed, and an
+    /// operator reads a recovery as an outage.
+    upstream_retried: Value = Value.init(0),
+    /// Requests allowed to retry that found no untried endpoint left and
+    /// answered 502. Separate from the shed counters on purpose: this is
+    /// "none of them would talk to us", not "all of them are full". On a
+    /// single-endpoint cluster it fires on every dial failure, which is
+    /// the honest reading — a retry budget there can never be spent.
+    upstream_retries_exhausted: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
     /// §7 active health probes dispatched — one per checked endpoint per
@@ -661,6 +674,11 @@ pub const Counters = struct {
         // Every §7 replay rides a checkout: only a reused connection's
         // early failure is blamed on staleness.
         assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));
+        // Every #181 retry rides a connect failure, and so does every
+        // exhaustion: both are answers to a dial the origin refused.
+        assert(counters.get("upstream_retried") <= counters.get("upstream_connect_failed"));
+        assert(counters.get("upstream_retries_exhausted") <=
+            counters.get("upstream_connect_failed"));
         // A resumed session is a completed handshake that skipped the
         // certificate, not a separate kind of event — so it can never
         // outrun the handshakes it is a subset of. Worth stating because

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -859,21 +859,28 @@ pub fn Proxy(comptime IoType: type) type {
             conn: *ConnType,
             request_key: Balancer.RequestKey,
         ) ?Balancer.Pick {
-            return server.balancer.pick(
+            const outcome = server.balancer.pick(
                 conn.cluster_index,
                 &server.endpointLoad(),
                 server.health.healthy,
                 &conn.client_address,
                 request_key,
-            ) orelse {
-                // The labeled twin (#179) carries only the cluster: this
-                // fires precisely because no endpoint could be picked —
-                // all of them were full, so an endpoint label would be
-                // an invention.
-                server.labeled.incrementCluster(.l7_shed_inflight, conn.cluster_index);
-                respond(server, conn, 503, "l7_shed_endpoint_inflight");
-                return null;
-            };
+                &.{},
+            );
+            switch (outcome) {
+                .dial => |chosen| return chosen,
+                // Nothing was tried, so the routable set cannot be empty.
+                .exhausted => unreachable,
+                .capped => {
+                    // The labeled twin (#179) carries only the cluster:
+                    // this fires precisely because no endpoint could be
+                    // picked — all of them were full, so an endpoint
+                    // label would be an invention.
+                    server.labeled.incrementCluster(.l7_shed_inflight, conn.cluster_index);
+                    respond(server, conn, 503, "l7_shed_endpoint_inflight");
+                    return null;
+                },
+            }
         }
 
         /// Route resolved and a relay buffer held: choose an endpoint and

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -850,10 +850,16 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
-        /// Picks a live endpoint under the §8 per-endpoint inflight cap, or
-        /// sheds 503 and returns null when every endpoint of this cluster
-        /// is already at it. Shared by the first-try and replay dial paths
-        /// so the cap and its shed counter cannot drift between them.
+        /// Picks a live endpoint under the §8 per-endpoint inflight cap
+        /// and outside what this request has already tried (#181), or
+        /// answers and returns null. Shared by all three dial paths — the
+        /// first try, the §7 replay and the retry — so neither the cap's
+        /// shed nor the exhaustion 502 can drift between them.
+        ///
+        /// The two null answers are different rungs and are counted apart:
+        /// every candidate at its cap sheds 503, while every routable
+        /// endpoint already tried answers 502. Only a retry can reach the
+        /// second, since the exclusion set is empty until a dial fails.
         fn pickEndpointOrShed(
             server: *ServerType,
             conn: *ConnType,
@@ -865,12 +871,22 @@ pub fn Proxy(comptime IoType: type) type {
                 server.health.healthy,
                 &conn.client_address,
                 request_key,
-                &.{},
+                conn.l7.tried[0..conn.l7.tried_count],
             );
             switch (outcome) {
                 .dial => |chosen| return chosen,
-                // Nothing was tried, so the routable set cannot be empty.
-                .exhausted => unreachable,
+                .exhausted => {
+                    // Every routable endpoint refused this request (#181).
+                    // 502 rather than 503: the origins were reachable
+                    // enough to say no, which is a different sentence from
+                    // "they are full", and the shed rungs must not absorb
+                    // it. A first try cannot land here — the routable set
+                    // is non-empty until something has been tried.
+                    assert(conn.l7.tried_count >= 1);
+                    server.counters.increment("upstream_retries_exhausted");
+                    respond(server, conn, 502, "l7_bad_gateway");
+                    return null;
+                },
                 .capped => {
                     // The labeled twin (#179) carries only the cluster:
                     // this fires precisely because no endpoint could be
@@ -941,7 +957,7 @@ pub fn Proxy(comptime IoType: type) type {
                 renderRequestAndStartLegs(server, conn, request, views);
                 return;
             }
-            dialUpstream(server, conn, pick);
+            dialUpstream(server, conn, pick, .fresh);
         }
 
         /// Acquire the exchange's upstream head buffer (§5) — the render
@@ -964,12 +980,37 @@ pub fn Proxy(comptime IoType: type) type {
             return true;
         }
 
-        /// Acquire a fresh slot and dial `pick` under the per-try connect
-        /// deadline (§8) — shared by the first try (`routeRequest`) and
-        /// the §7 stale replay (`beginReplay`), so both tries dial
-        /// identically.
-        fn dialUpstream(server: *ServerType, conn: *ConnType, pick: Balancer.Pick) void {
-            assert(conn.state == .l7_reading_head or conn.state == .l7_exchanging);
+        /// Whether a dial opens its own connect budget or continues one
+        /// already running.
+        ///
+        /// `fresh` is the §7 rule — each try, the first and the stale
+        /// replay's, runs under its own `connect_ms`. `carried` is
+        /// #181's: a retry chain is one client waiting for one answer, so
+        /// every dial in it shares the budget the first one armed. That
+        /// keeps the worst-case dial wait at `connect_ms` however many
+        /// endpoints the request walks, and it is why a *timed-out* dial
+        /// does not retry — the budget it would retry under is the budget
+        /// it just spent, so there is nothing left to try with. The two
+        /// answers to the "does a retry multiply the client's wait"
+        /// question, and this picks the one that says no.
+        const DialBudget = enum { fresh, carried };
+
+        /// Acquire a fresh slot and dial `pick` under the connect deadline
+        /// (§8) — shared by the first try (`routeRequest`), the §7 stale
+        /// replay (`beginReplay`) and the #181 retry (`beginRetry`), so
+        /// every try dials identically but for its budget.
+        fn dialUpstream(
+            server: *ServerType,
+            conn: *ConnType,
+            pick: Balancer.Pick,
+            budget: DialBudget,
+        ) void {
+            // `.l7_dialing` is a retry re-entering: the state never left
+            // the dial, because nothing about this request reached an
+            // origin and there is no exchange to be in.
+            assert(conn.state == .l7_reading_head or conn.state == .l7_dialing or
+                conn.state == .l7_exchanging);
+            if (conn.state == .l7_dialing) assert(budget == .carried);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
             conn.upstream = server.acquireUpstream(conn.cluster_index, pick.endpoint_index) orelse {
@@ -984,9 +1025,22 @@ pub fn Proxy(comptime IoType: type) type {
             // The head-read/idle timer is already armed; re-base it to the
             // tighter per-try connect budget so a hung origin fires the §8
             // 504 at connect_timeout, not idle_timeout (§4: the lazy timer
-            // never moves earlier on its own).
-            server.storeDeadline(conn, server.config.connect_timeout_ms);
-            server.rebaseDeadline(conn);
+            // never moves earlier on its own). A carried budget leaves the
+            // running deadline exactly where the first dial put it, so the
+            // expiry still fires on time and still finds this connection
+            // dialing — whichever endpoint it is dialing by then.
+            if (budget == .fresh) {
+                server.storeDeadline(conn, server.config.connect_timeout_ms);
+                server.rebaseDeadline(conn);
+            } else {
+                // Stated rather than assumed: the budget being carried is
+                // only a budget if it is still running. It must be, since
+                // a fired deadline reaches `onUpstreamConnect` as a
+                // pending verdict and answers 504 before any failure could
+                // ask to retry — but a future path that disarmed it would
+                // otherwise leave this dial with no clock at all.
+                assert(conn.armed.deadline);
+            }
             conn.arm(&conn.op_connect, "connect");
             server.io.connect(
                 pick.address,
@@ -1040,6 +1094,10 @@ pub fn Proxy(comptime IoType: type) type {
                 // Same split as the L4 dial: the origin's verdict arrives
                 // typed, our own resource exhaustion does not (§8).
                 server.witnessKernelPressure(.connect, err);
+                if (retryEligible(server, conn, err)) {
+                    beginRetry(server, conn);
+                    return;
+                }
                 respond(server, conn, 502, "l7_bad_gateway");
                 return;
             };
@@ -1049,6 +1107,88 @@ pub fn Proxy(comptime IoType: type) type {
                 server.witnessKernelPressure(.set_option, err);
             };
             renderAndStartLegs(server, conn);
+        }
+
+        /// Whether a failed dial may be sent to another endpoint (#181).
+        ///
+        /// Two of the four `ConnectError`s qualify, and the split is the
+        /// feature's whole safety argument. `Refused` and `Unreachable`
+        /// are the *origin's* verdict: the request reached no application,
+        /// nothing was processed, nothing was observed — so §7's settled
+        /// reading of "may have begun processing" ("a response byte
+        /// arrived or relay chunks flowed") is unambiguously not met, and
+        /// re-sending is safe for every method including POST, with no
+        /// idempotency analysis and no knob about which methods may
+        /// replay. `Unexpected` is *our* resource exhaustion, already
+        /// witnessed as kernel pressure by the caller: another dial would
+        /// meet the same wall and §8 says shed rather than retry.
+        /// `Canceled` is the dial deadline, which arrives through
+        /// `pending_verdict` above and never reaches here — and could not
+        /// retry anyway, having spent the budget a retry would carry.
+        fn retryEligible(
+            server: *const ServerType,
+            conn: *const ConnType,
+            err: Io.ConnectError,
+        ) bool {
+            assert(conn.state == .l7_dialing);
+            assert(conn.upstream != null);
+            // Exhaustive rather than an `else`, so a fifth connect error
+            // is a compile error here — a decision to make once, not a
+            // default to inherit silently.
+            switch (err) {
+                error.Refused, error.Unreachable => {},
+                error.Canceled, error.Unexpected => return false,
+            }
+            const budget = server.config.clusters[conn.cluster_index].retries;
+            assert(budget <= constants.cluster_retries_max);
+            assert(conn.l7.retries_used <= budget);
+            return conn.l7.retries_used < budget;
+        }
+
+        /// Spend one retry: record the endpoint that refused, give its
+        /// slot back, and dial an untried one from the same client bytes.
+        ///
+        /// Cheaper than the §7 replay, and for a structural reason — a
+        /// dial that never connected sent nothing, so there is no stale
+        /// socket to shut down, no framing to rebuild and no per-try state
+        /// to reset. The head still holds the request exactly as it
+        /// arrived (the render happens after the connect completes), so
+        /// the re-parse here is the same one the replay does, for the same
+        /// reason: only the bytes survive an await, and they are unchanged.
+        fn beginRetry(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_dialing);
+            assert(conn.upstream_socket == null); // A failed dial produced none.
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            const failed = conn.upstream.?;
+            assert(conn.l7.tried_count < conn.l7.tried.len);
+            conn.l7.tried[conn.l7.tried_count] = failed.endpoint_index;
+            conn.l7.tried_count += 1;
+            // Released before the re-pick, not after: the endpoint's
+            // in-flight total is what `p2c` and the §8 cap read, and
+            // leaving a dead dial counted there would make the retry
+            // avoid a busy endpoint on the strength of work nobody is
+            // doing. The slot is re-acquired in the same callback, so the
+            // pool cannot have been emptied in between.
+            server.releaseUpstream(failed);
+            conn.upstream = null;
+            var storage: parser.HeaderStorage = undefined;
+            const request = parser.parseRequestHead(
+                headBytes(server, conn)[0..conn.head_len],
+                false,
+                &storage,
+            ) catch unreachable;
+            // Re-derived rather than remembered, like the replay's
+            // framing: same bytes, same key. A cookie cluster's #178
+            // announcement still names whichever endpoint finally serves,
+            // because `sticky_cookie` records what the *client* asked for
+            // and that has not changed.
+            const request_key = requestKeyFor(server, conn, &request);
+            const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
+            assert(pick.endpoint_index != conn.l7.tried[conn.l7.tried_count - 1]);
+            conn.l7.retries_used += 1;
+            server.counters.increment("upstream_retried");
+            dialUpstream(server, conn, pick, .carried);
         }
 
         /// The fresh-dial completion path: the head bytes are re-parsed —
@@ -2543,6 +2683,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.pending_verdict == .none);
             assert(conn.l7.replay_used); // Spent before the try began.
+            // A replay always precedes any #181 retry, never follows one:
+            // it needs a *reused* checkout, and a retry only ever dials
+            // fresh. So the rebuild below defaulting the tried set to
+            // empty is the truth, not a reset.
+            assert(conn.l7.tried_count == 0);
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
@@ -2597,7 +2742,7 @@ pub fn Proxy(comptime IoType: type) type {
                 else => null,
             };
             const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
-            dialUpstream(server, conn, pick);
+            dialUpstream(server, conn, pick, .fresh);
         }
 
         /// The upstream leg failed. A stale checkout takes its one free

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -446,7 +446,8 @@ const HttpOrigin = struct {
 const Http1Bed = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
-    endpoints: [1]std.Io.net.IpAddress,
+    endpoints: [2]std.Io.net.IpAddress,
+    endpoints_count: u16,
     clusters: [1]config_module.Config.Cluster,
     routes: [1]router.Route,
     listeners: [1]config_module.Config.Listener,
@@ -473,6 +474,13 @@ const Http1Bed = struct {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
     }
 
+    /// An address no origin binds, so `SimIo` refuses every dial to it
+    /// through its own listener lookup — the same answer a kernel gives
+    /// for a port nothing is on, and the failure #181 exists to survive.
+    fn refusingEndpointAddress() std.Io.net.IpAddress {
+        return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9002") catch unreachable;
+    }
+
     const Options = struct {
         seed: u64,
         partial_io: bool = false,
@@ -488,6 +496,12 @@ const Http1Bed = struct {
         /// ring was willing to carry.
         inbox_bytes: ?u32 = null,
         origin_response: []const u8 = "",
+        /// The #181 dial-retry budget on the bed's one cluster.
+        retries: u16 = 0,
+        /// Put an endpoint nothing listens on *ahead* of the origin, so
+        /// the first pick of an `rr` cluster is always the one that
+        /// refuses and the retry is the only way to reach the origin.
+        refusing_endpoint_first: bool = false,
         origin_listens: bool = true,
         origin_closes: bool = false,
         /// The origin reads the whole request and never answers (§8 504).
@@ -588,8 +602,12 @@ const Http1Bed = struct {
             .buffer_group_count = head_buffers,
             .buffer_group_bytes = options.head_buffer_bytes,
         });
-        bed.endpoints = .{originAddress()};
-        bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints, .check = options.check, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key }};
+        bed.endpoints = if (options.refusing_endpoint_first)
+            .{ refusingEndpointAddress(), originAddress() }
+        else
+            .{ originAddress(), originAddress() };
+        bed.endpoints_count = if (options.refusing_endpoint_first) 2 else 1;
+        bed.clusters = .{.{ .name = "origin", .endpoints = bed.endpoints[0..bed.endpoints_count], .check = options.check, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key, .retries = options.retries }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -4533,5 +4551,147 @@ test "l7: a terminated listener honours the configured head limit" {
         client.app_received[0..client.app_received_len],
         "HTTP/1.1 431 ",
     ));
+    try bed.expectDrained();
+}
+
+test "l7: a refused endpoint is retried onto another and the client sees the origin" {
+    // #181's motivating case, end to end: one endpoint of a cluster
+    // refuses while another is healthy. Without a retry every request
+    // the pick sends to the refusing one is a 502, and with health
+    // checks off — the default — that lasts forever rather than for a
+    // detection window.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 190,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .refusing_endpoint_first = true,
+        .retries = 1,
+        // Strict rotation puts the refusing endpoint first, so the retry
+        // is the only path to the origin rather than a coin flip.
+        .pick = .rr,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // The origin's own answer, not a gateway error: the client cannot
+    // tell that its request took two dials, which is the whole point.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_retried"));
+    // The recovery must be visible as a recovery. Without the retry
+    // counter an operator sees `upstream_connect_failed` climbing while
+    // requests succeed, and reads it as an outage.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_retries_exhausted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: a retry runs out of endpoints before its budget and answers 502" {
+    // Both endpoints refuse and the budget still has a try left, so it
+    // is the *endpoint set* that ends the request, not the count. That
+    // is the exhaustion rung, and it answers 502 rather than a shed 503:
+    // the origins were reachable enough to say no, which is a different
+    // sentence from "all of them are full".
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 191,
+        .refusing_endpoint_first = true,
+        .origin_listens = false,
+        .retries = 2,
+        .pick = .rr,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    // Two dials, one retry between them, and no third: the exclusion
+    // set emptied the cluster before the budget's second retry was
+    // reached, so the request stopped without dialing anything twice.
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_retried"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_retries_exhausted"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_endpoint_inflight"));
+    try bed.expectDrained();
+}
+
+test "l7: our own dial exhaustion is not retried onto another endpoint" {
+    // The split that makes the retry safe (#181): a refused or
+    // unreachable dial is the *origin's* verdict, while kernel pressure
+    // is ours. Another dial would meet the same wall, and §8 says shed
+    // rather than spend more of a resource we have already run out of.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 192,
+        .refusing_endpoint_first = true,
+        .retries = 2,
+        .pick = .rr,
+    });
+    defer bed.tearDown();
+
+    bed.sim_io.setPressureCause(.address_unavailable);
+    bed.sim_io.injectConnectError(Http1Bed.refusingEndpointAddress());
+
+    try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    // The healthy origin sat there untried, and that is correct: the
+    // dial never reached the network to have an opinion about it.
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("kernel_pressure_connect"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_retried"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try bed.expectDrained();
+}
+
+test "l7: a dial that times out does not retry, because it spent the budget" {
+    // The retry chain carries one connect deadline rather than arming a
+    // fresh one per try, so the worst-case dial wait stays `connect_ms`
+    // however many endpoints a request walks. A timed-out dial has
+    // therefore already spent the budget a retry would run under, and
+    // the §8 answer is the 504 the deadline decided — not a second dial
+    // the client would wait through all over again.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 193,
+        .refusing_endpoint_first = true,
+        .retries = 2,
+        .pick = .rr,
+    });
+    defer bed.tearDown();
+
+    bed.sim_io.blackholeAddress(Http1Bed.refusingEndpointAddress());
+
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\n\r\n");
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    // One budget, not one per endpoint: three tries at a fresh deadline
+    // each would have kept the client waiting three times as long.
+    try std.testing.expect(elapsed_ms < 2 * Http1Bed.connect_timeout_ms);
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_retried"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
     try bed.expectDrained();
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -589,6 +589,24 @@ pub fn Conn(comptime IoType: type) type {
             /// The one free replay is spent (§7): a failure on the replay
             /// try answers 502 like any other, never a second replay.
             replay_used: bool = false,
+            /// The endpoints this request dialed and had refused or found
+            /// unreachable (#181), in the order it tried them — the
+            /// exclusion set the next pick runs over. Sized for the first
+            /// try plus every retry the largest configured budget allows,
+            /// so it is a fixed field like everything else on this
+            /// connection and never grows.
+            tried: [constants.cluster_retries_max + 1]u16 = @splat(0),
+            /// How many of `tried` are written. Every entry past it is
+            /// stale from an earlier request on this connection and must
+            /// not be read.
+            tried_count: u16 = 0,
+            /// Retries spent against the cluster's budget. Equal to
+            /// `tried_count` between hops, since a retry records the
+            /// endpoint that failed and spends a retry to leave it in the
+            /// same step — and one *behind* it in the terminal state where
+            /// the endpoint set ran out first, because that last failure
+            /// is recorded and then answered rather than retried.
+            retries_used: u16 = 0,
 
             pub const Leg = enum(u8) {
                 idle,


### PR DESCRIPTION
Closes #181.

A failed dial ended the exchange with a `502`, whatever else the cluster had healthy and idle. One refusing endpoint in a three-endpoint cluster therefore failed roughly a third of requests — for `fall × health_interval_ms` with health checks configured, and **forever with them off, which is the default**.

`"retries": N` beside a cluster's endpoints now sends such a request to an untried endpoint. 0 by default, bounded by `cluster_retries_max` (3, HAProxy's own default), rejected past it at load rather than clamped.

## The decisions the issue left open

**Which failures retry** — refusals and unreachable only. The `switch` over `ConnectError` is exhaustive, so a fifth variant is a compile error rather than an inherited default: `Refused`/`Unreachable` are the origin's verdict, `Unexpected` is our own exhaustion (already witnessed as kernel pressure, where another dial meets the same wall and §8 says shed), `Canceled` is the deadline. This leaves black-holed endpoints uncovered — they still cost a `connect_ms` and a `504` — which is passive ejection's job rather than this one's.

**The safety argument is §7's, not a new one.** "May have begun processing" is already settled as *a response byte arrived or relay chunks flowed*, and a failed connect is neither. So re-sending is safe for every method including `POST`, with no idempotency analysis and no knob about which methods may replay.

**Deadline composition** — the issue called this the sharpest decision and offered two options; this takes a third. A retry chain is one client waiting for one answer, so every dial in it **carries** the budget the first one armed instead of arming its own. Worst-case dial wait stays `connect_ms` however many endpoints a request walks, and `retries` never multiplies the time a client can be kept. That also dissolves "does a timeout retry?" — a timed-out dial has already spent the budget a retry would run under, so it needs no rule of its own.

**Which endpoint** — the cluster's configured pick, re-run over the eligible set minus what was tried, with untried joining health and capacity as a third predicate. Applied *before* health, or a two-endpoint cluster with one ejected would have its only untried candidate removed by health and then resurrected by fail-open, handing the retry straight back to the endpoint that just refused. For `hash` this means each key falls to its own next-best rendezvous score — precisely the redistribution ejection produces later, so retry and ejection agree instead of behaviour shifting when the prober catches up. A test verifies that per-client across 4000 keys.

**Running out of endpoints answers `502`, not a shed `503`.** The origins were reachable enough to refuse, which is a different sentence from "they are full", so `Balancer.pick` returns an `Outcome` (`dial`/`capped`/`exhausted`) rather than `?Pick` and the two rungs stay counted apart.

## Coverage

The simulator could not reach any of this: both clusters were single-endpoint, and a single-endpoint cluster cannot retry by construction. The §9 census said so immediately. A third of seeds now draw a budget together with a second endpoint at an address nothing binds, which `SimIo` refuses through its own listener lookup — cheaper than a second live origin and strictly better, since it refuses on **clean** seeds too and a dead endpoint cannot change any successful response, leaving every oracle untouched including #178's sticky tag pinned to `endpoints_http[0]`.

Mutation-tested rather than trusted: deleting `error.Refused` from the eligible set fails **seed 38 with `GoldenOutcomeMissed`**.

Four proxy tests pin what the sweep cannot isolate — a refused endpoint retried onto a live one with the client seeing the origin's own `200`; endpoints running out before the budget; kernel pressure *not* retried, with the healthy origin left untried; and a timed-out dial answering `504` in under `2 × connect_ms`.

## A regression the gate did not reach

A 16384-seed sweep failed where the 4096-seed gate passed: `l7_shed_upstream_slots` fired once against a census allowance of 0, on **seed 4316**, where no dial had failed at all. That counter's exemption assumed single-endpoint clusters — with two endpoints and `upstream_slots = 1`, the one slot can be parked on endpoint 0 while a request picks endpoint 1, which cannot reuse it and must dial. The shed is correct §8 behaviour and is covered directly by `http_proxy_test.zig`; what did not belong was a pool-sizing scenario arriving as a side effect of a retry draw. Starved seeds now keep the single-endpoint topology (the draw still happens, only its effect is dropped, so stream positions hold) and the exemption states the premise it had been relying on silently.

It also surfaced an open question, written up in IMPLEMENTATION_NOTES rather than acted on here: **an idle parked connection can shed a request bound for another endpoint.** Evicting the parked one instead is a design option zoxy has not taken; unreachable at production pool sizes, but real for many endpoints against a tight upstream pool.

## Gates

- `zig build ci` green — 4096 seeds, census ok (61 counters fired), live smoke gate clean
- `zig build sim -- 4097 16384` green including census
- `zig fmt --check` clean
- `tiger-style-reviewer` run on both slices; every finding fixed (an orphaned word in the §7 prose, a stale docstring, a missing `assert(conn.armed.deadline)` on the carried-budget arm, `tried_len` → `tried_count`, an inaccurate comment about how the two counters relate, and `deriveTopology` split once it passed the length limit)

Aggregate retry *budgets* — the cluster-wide cap that keeps a partial outage from pushing its whole load onto the survivors — stay deferred, and §7's deferral line now distinguishes them from the per-request retry that landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)