### PR TITLE
http: WebSocket support as tunnelled upgrades on a bounded pool (#180)

### DIFF
--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -56,9 +56,9 @@ pub fn main() void {
         // address forwarding is opt-in per listener, so the case that must
         // not regress is the one where it is off and the render's
         // suppression test is pure overhead.
-        const upstream = render.renderRequestHead(&request, target, no_edits, false, null, &upstream_head) catch unreachable;
+        const upstream = render.renderRequestHead(&request, target, no_edits, false, null, false, &upstream_head) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
-        const downstream = render.renderResponseHead(&response, true, no_edits, &downstream_head) catch unreachable;
+        const downstream = render.renderResponseHead(&response, true, no_edits, false, &downstream_head) catch unreachable;
 
         // Consume the outputs so nothing is dead-code-eliminated.
         checksum +%= upstream[upstream.len - 1];

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1758,6 +1758,27 @@ state that landed outside it would be a counter bug wearing a feature's
 clothes. What the tunnel-only bound needs is a name and a value in
 `constants.zig`, not a place in that sum.
 
+Two consequences worth stating, because the machinery above does not
+cover them and silence would read as an oversight. The gate **refuses a
+new upgrade once the drain has begun** — a proxy on its way out does not
+open the longest-lived thing it has, and the refusal is the pool rung's
+`503` rather than a `501`, since the listener does allow the token and
+there is simply nowhere to put it. And a handshake admitted just before
+the drain that completes *during* it takes the drain's bound rather than
+`tunnel_ms`, because the timer above is a single shot that may already
+have passed; without that, the sessions established late would be
+exactly the ones nothing bounded.
+
+**Layers 2 and 3 stay unarmed here, and that is deliberate.** Cutting a
+tunnel forces a teardown, and a teardown whose ops a wedged backend never
+delivers is the failure those layers exist to report — so it is fair to
+ask why this path does not arm them. Because a `drain_deadline_ms` of `0`
+still means the supervisor owns the upper bound, and it would be an odd
+contract that declined to kill the process for an uncapped drain but
+exited 4 for one. The tunnel bound makes the common case fast; the
+pathological one falls back to precisely the behaviour a zero deadline
+already asks for.
+
 Cutting rather than waiting is also the honest reading of what a tunnel
 is. The replacement instance has already bound the port, every WebSocket
 client reconnects — it is the protocol's expected failure mode — and

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -942,8 +942,18 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   decision from carrying a protocol upgrade to a *routed* cluster.
   **The upgraded upstream connection leaves the pool and never returns
   to it** (§5): it is no longer an interchangeable origin connection but
-  one client's session. `max_inflight` counts a tunnel for its whole
-  life, which is correct — the backend really is carrying it.
+  one client's session. It leaves by *releasing its upstream slot while
+  keeping its socket* — the two are separable, and separating them is
+  what lets §5's claim and the next sentence both be true. Holding the
+  slot would mean tunnels drawing on the pool ordinary exchanges shed
+  against, which is exactly what the tunnel pool exists to prevent.
+  And `max_inflight` still counts a tunnel for its whole life, which is
+  correct — the backend really is carrying it — because the endpoint is
+  charged the way an **L4 connection** is charged: a per-endpoint count
+  held by a live connection rather than by a pool lease. That is not a
+  special case invented for this. After 101 a tunnel *is* an L4 relay,
+  and §7's in-flight total already sums L7 leases and live L4
+  connections precisely because both are work the origin is carrying.
   The access log writes one line at close, carrying the request facts
   that opened the tunnel plus the byte counts each way, because a line
   written at 101 would name a transfer that had not happened yet.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -44,7 +44,12 @@ Goals, in priority order:
 
 Non-goals (deliberate, recorded so they are decisions rather than drift):
 
-- HTTP/2, HTTP/3, gRPC, WebSocket — deferred until the L4/L7 core is proven.
+- HTTP/2, HTTP/3, gRPC — deferred until the L4/L7 core is proven. WebSocket
+  was deferred on the same line and is not any more (#180, §7): the
+  condition was met, and carrying it needs no new I/O machinery — a
+  tunnel is the L4 relay this proxy already runs, entered from an L7
+  exchange. What it does need is its own resource model, which is why it
+  is a §5 pool rather than a §7 detail.
 - Feature parity with Envoy/NGINX. Pingora's lesson is that a small, sharp
   proxy core beats a configurable monolith.
 - Caching, compression, request transformation.
@@ -482,7 +487,8 @@ a raised `RLIMIT_NOFILE`:
 | head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
 | upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | tls engines | 0, or min(conn slots, 1024) | 1024 | ~132 KiB + plaintext |
-| **pool memory** | **~34 MiB** | **~294 MiB** | |
+| tunnels | 0 (off) | 11466 | 2 × 4 KiB + ~64 B state |
+| **pool memory** | **~34 MiB** | **~384 MiB** | |
 
 `head_buffer_bytes` defaults to 8 KiB and is the largest head accepted
 (oversize → 414/431, §7), with a 1 KiB floor and a 1 MiB ceiling: a size
@@ -490,6 +496,57 @@ knob is operator-visible behaviour, not only memory. Three head-sized
 side buffers ride the same knob — the serving path's two
 canonicalization scratches and the health prober's response buffer — and
 appear in the banner as their own term.
+
+The **tunnel pool** (§7, #180) is the one that exists because a tunnel
+has the opposite shape to everything else here. Every pool above is
+sized for concurrent *activity*: a keep-alive connection holds no head
+buffer, a parked upstream holds no head, and that is the whole reason
+these numbers look the way they do. A tunnel inverts it — it pins its
+buffers for the connection's entire life and can never return to the
+keep-alive pool, so thousands of mostly-idle long-lived connections is
+the pathological case for the model. Drawing them from the shared pools
+would cap tunnels at the upstream-slot count *and starve ordinary HTTP
+on the way there*: not a tuning problem, but two workloads with opposite
+shapes sharing one budget.
+
+So a tunnel draws its relay buffer and its upstream socket from a pool
+of its own, and the request is refused **up front** when that pool is
+full rather than admitted and torn down later (§8). Three properties
+follow, and they are why the pool is worth the extra concept: tunnels
+cannot starve HTTP, because they never touch its pools; the cost stays
+closed-form and printable in the startup banner like every other row;
+and "unbounded long-lived connections", which §1 rules out, becomes "a
+bounded number of long-lived connections an operator explicitly paid
+for".
+
+`limits.tunnels` is zero — the feature entirely free — unless some
+listener allows an upgrade token, and it has **no derived default** when
+one does. Every other optional pool resolves an omitted field to
+something (head buffers to conn slots, engines to conn slots capped);
+this one is rejected at load instead, because the others' derived value
+is a worst case that *cannot shed*, while a tunnel count is a capacity
+decision with no honest guess available — how many long-lived sessions
+an origin fleet should carry is not something this proxy can infer from
+a connection count. The one bound it does carry is `≤ conn_slots`: a
+tunnel is still an accepted client connection occupying a slot, so
+sizing tunnels above the connections that could hold them describes a
+proxy that cannot exist.
+
+That bound is also what keeps the **fd and ring budgets unchanged**,
+which is worth stating rather than leaving a reader to verify: a tunnel
+pool costs ~90 MiB at the ceiling and nothing else. `fdsRequired`
+already charges `2 × conn_slots` — a client socket and an upstream one
+for every connection — and a tunnel holds exactly that pair, so its
+upstream socket is an fd the budget has always reserved; the separate
+`upstream_slots` term covers *parked* pooled connections, which have no
+connection of their own and which a tunnel by definition is not.
+`inFlightOps` needs nothing either: `conn_ops_max` is 4 precisely
+because one of its two tying peaks is "a relay teardown holds both data
+ops, the deadline and the deadline-cancel", which is a tunnel's steady
+state and its teardown exactly. So this pool costs memory, and the two
+budgets that would otherwise have to grow beside it do not — but only
+while `tunnels ≤ conn_slots` holds, which is why that is a rejection at
+load rather than advice.
 
 The **TLS engine pool** (§4) is the one whose default is not "one per
 connection", and the row above says so: an engine is ~132 KiB of ztls
@@ -786,7 +843,8 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   dependency's.
 - **Both directions framed** (RFC 9112 §6.3). Smuggling shapes (TE+CL,
   duplicate/garbage Content-Length) → 400 before any byte reaches an
-  upstream. `Upgrade` → 501 (non-goal). Hop-by-hop headers stripped both
+  upstream. An `Upgrade` this listener does not allow → 501 (below).
+  Hop-by-hop headers stripped both
   ways; `Connection: close` injected when the proxy will close — announced,
   not silent, or a client pipelines into the close and reads the reset as
   an error instead of a clean end.
@@ -834,6 +892,57 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   one matches only the any-host routes; config hosts must themselves be
   canonical (rejected at load otherwise), so a request host compares
   byte-for-byte against them.
+- **An allowed upgrade becomes a tunnel** (#180). The proxy does not
+  speak WebSocket and will not: it forwards the handshake, recognises
+  `101 Switching Protocols`, and relays bytes both ways for the rest of
+  the connection's life — which is the L4 relay of §6, entered from an
+  L7 exchange. So this is a **state transition, not new I/O machinery**:
+  the exchange ends in `.relaying`, the state a `l4` listener's
+  connections already live in, half-close and all.
+  Three things make that transition correct, and each is a rule the
+  ordinary path would otherwise get wrong. **101 is terminal, not
+  interim.** The parser already frames a `< 200` status as bodiless, so
+  a 101 *parses* today — but the state machine would treat the exchange
+  as complete and go read the next request, which is precisely the
+  desynchronisation §7 exists to prevent. 100 continues an exchange; 101
+  ends the HTTP conversation on that connection forever, and that
+  distinction is the actual change. **A participating `Upgrade` survives
+  hop-by-hop stripping.** `Connection` and `Upgrade` are hop-by-hop by
+  definition and are stripped both ways today; a handshake this proxy is
+  choosing to forward is the one case where they name *this* hop's
+  intent and must travel. **The bytes past the boundary are relayed, not
+  dropped.** A client may pipeline its first frame straight behind the
+  handshake, and the origin's 101 may arrive with frame bytes behind it
+  in the same read; the head buffer already holds "parsed head plus
+  possibly more", so the remainder is handed to the relay rather than
+  discarded with the head.
+  **The allowed tokens are an allowlist, defaulting to `websocket`
+  alone**, per listener. After 101 the connection is opaque bytes:
+  filters, routing, header rules and canonicalisation no longer apply to
+  anything on it, so "tunnel any upgrade token" is a policy escape
+  hatch, not a convenience. `h2c` is the sharp case — it would tunnel
+  HTTP/2 to an origin this proxy cannot parse, past every rule the
+  config expresses. Same instinct as `proxy_protocol`'s single `require`
+  mode: the permissive reading is the one that hands control to the
+  caller. An `Upgrade` naming a token the listener does not allow keeps
+  today's answer, `501` counted as `l7_not_implemented`, which fails at
+  the proxy with a status that means what happened rather than failing
+  confusingly at an origin that never saw the handshake. `CONNECT` is
+  unchanged and stays a 501: it asks this proxy to open an arbitrary
+  destination, which is a forward-proxy behaviour and a different
+  decision from carrying a protocol upgrade to a *routed* cluster.
+  **The upgraded upstream connection leaves the pool and never returns
+  to it** (§5): it is no longer an interchangeable origin connection but
+  one client's session. `max_inflight` counts a tunnel for its whole
+  life, which is correct — the backend really is carrying it.
+  The access log writes one line at close, carrying the request facts
+  that opened the tunnel plus the byte counts each way, because a line
+  written at 101 would name a transfer that had not happened yet.
+  Tunnels established, the live gauge, and upgrades refused for want of
+  capacity are each counted — and the §9 census is what makes that a
+  requirement rather than an intention: a counter no scenario reaches
+  fails the sweep, so the simulator has to carry the L7→L4 transition
+  and the trailing-bytes case before any of this can land.
 - **Early responses are legal.** An origin may answer before the request
   body finishes (RFC 9110 — e.g. 413 mid-upload): the response head is
   forwarded when it arrives, and the remaining request body is drained or
@@ -1257,6 +1366,7 @@ the loop thread.
 | upstream slots / dial concurrency | upstream checkout | static `503` (L7), then keep or close per pressure / close (L4) |
 | upstream head buffers | beside the slot, as it is obtained | static `503`, then keep or close per pressure |
 | **origin capacity** — every endpoint at its `max_inflight` | endpoint pick | static `503` (L7) / close (L4) |
+| tunnels | the upgrade request, **before** it is forwarded | static `503`, then keep or close per pressure |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
@@ -1275,6 +1385,24 @@ caps the work one endpoint may carry, counted across both protocols
 upstream slots says *widen the pool*, while a capped endpoint says *the
 backend is full*, and the two have their own counters so an operator
 cannot read one as the other.
+
+The tunnel rung is the one that refuses **before** doing the work rather
+than after: the check runs on the upgrade request, before the handshake
+is forwarded, so a client that cannot be carried learns it from a `503`
+instead of from a live tunnel torn down seconds later. That ordering is
+the rung — admitting first and shedding after would spend an origin
+handshake to produce a worse answer.
+
+**Tunnels need their own timeout class**, and it is the same reasoning
+that gives them their own pool. `idle_ms` defaults to 60 s and would
+reap an idle WebSocket; `request_ms` and `max_lifetime_ms` would cut a
+healthy one mid-session. A WebSocket may be legitimately idle for hours,
+and its keepalive is application-layer ping/pong — bytes this proxy
+cannot see, because after 101 they are opaque by construction. So
+`timeouts.tunnel_ms` replaces all three for a connection that has
+become a tunnel, exactly as HAProxy's `timeout tunnel` does, and the
+substitution happens at the transition rather than being a fourth clock
+running beside them.
 
 The rung that answers on **time** rather than on exhaustion is the
 request deadline, and `timeouts.request_ms` is what arms it: an absolute
@@ -1576,6 +1704,49 @@ What still bounds a straggler either way is its own per-connection
 deadlines: `idle_ms` always, plus `request_ms` and `max_lifetime_ms` when
 configured, and the drain's `Connection: close` injection stops an idle
 keep-alive connection from waiting on a request that will never come.
+
+**A tunnel is the straggler none of that reaches** (#180), and it is
+sharp enough to state as its own rule. A tunnel has no message boundary
+to finish at, so "let admitted work finish" has no meaning for one; its
+`tunnel_ms` is measured in hours by design; and `Connection: close`
+announces nothing to a connection that stopped speaking HTTP at 101. So
+one idle WebSocket would hold a `drain_deadline_ms: 0` drain open
+forever. That does not breach the contract above — a zero deadline says
+the supervisor owns the upper bound, and it still would — but it
+converts "the drain ends in milliseconds" into "every rolling restart
+waits out `TimeoutStopSec` and dies by `SIGKILL`", which is a real
+regression in the documented replacement procedure even though no
+invariant broke. Worth being precise about, because the machinery built
+for a drain that will not finish does not cover this either: layer 3
+arms only when a deadline is configured, so the watchdog would not fire.
+
+The rule: **a drain cuts tunnels at `drain_deadline_ms`, and at a finite
+tunnel-only bound when that is `0`.** The first half is not a special
+case at all — the deadline already tears down what is left, and a tunnel
+is simply always left. The second half is, and it is the smaller of two
+evils: a constant rather than a config key, because the alternative is
+asking every operator to answer a question created entirely by a feature
+they may not use, and because a tunnel is the one connection kind where
+"no cap" cannot mean what it means everywhere else. `drain_deadline_ms`
+keeps its exact present meaning for every other connection.
+
+A tunnel cut either way is a **teardown, not a shed**: it was admitted,
+it carried bytes, and it ends because the process is going away. So it
+settles into the same accounting every drained straggler does rather
+than earning a rung of its own — `admitted = completed + shed +
+in-flight` is the identity §9 reconciles against, and a new terminal
+state that landed outside it would be a counter bug wearing a feature's
+clothes. What the tunnel-only bound needs is a name and a value in
+`constants.zig`, not a place in that sum.
+
+Cutting rather than waiting is also the honest reading of what a tunnel
+is. The replacement instance has already bound the port, every WebSocket
+client reconnects — it is the protocol's expected failure mode — and
+holding the old process open longer delays the disconnect without
+preventing it. That is more aggressive than HAProxy or nginx, which let
+tunnels run to their tunnel timeout across a reload; the difference is
+deliberate, and it is §8's posture everywhere else: shed rather than
+heroics.
 
 **Three layers under a drain that will not finish**, because the first two
 are ops and the failure they exist to report is a backend that has stopped

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -916,8 +916,13 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   in the same read; the head buffer already holds "parsed head plus
   possibly more", so the remainder is handed to the relay rather than
   discarded with the head.
-  **The allowed tokens are an allowlist, defaulting to `websocket`
-  alone**, per listener. After 101 the connection is opaque bytes:
+  **The allowed tokens are a per-listener allowlist, empty unless the
+  config names one**, over a closed vocabulary whose only member today is
+  `websocket`. Two separate statements, and worth keeping apart because
+  reading them as one lands the opposite, security-relevant behavior: no
+  listener carries an upgrade it was not told to carry, exactly as
+  `proxy_protocol` defaults off per listener despite `require` being its
+  only mode. After 101 the connection is opaque bytes:
   filters, routing, header rules and canonicalisation no longer apply to
   anything on it, so "tunnel any upgrade token" is a policy escape
   hatch, not a convenience. `h2c` is the sharp case — it would tunnel

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -487,7 +487,7 @@ a raised `RLIMIT_NOFILE`:
 | head buffers (ring) | = conn slots | 11466 | `head_buffer_bytes` + 1 B |
 | upstream head buffers | = upstream slots | 11466 | `head_buffer_bytes` + 24 B |
 | tls engines | 0, or min(conn slots, 1024) | 1024 | ~132 KiB + plaintext |
-| tunnels | 0 (off) | 11466 | 2 × 4 KiB + ~64 B state |
+| tunnels | 0 (off) | 11466 | 2 × 4 KiB |
 | **pool memory** | **~34 MiB** | **~384 MiB** | |
 
 `head_buffer_bytes` defaults to 8 KiB and is the largest head accepted
@@ -509,9 +509,13 @@ would cap tunnels at the upstream-slot count *and starve ordinary HTTP
 on the way there*: not a tuning problem, but two workloads with opposite
 shapes sharing one budget.
 
-So a tunnel draws its relay buffer and its upstream socket from a pool
-of its own, and the request is refused **up front** when that pool is
-full rather than admitted and torn down later (§8). Three properties
+So a tunnel draws its relay buffer from a pool of its own — the same
+element the shared pool holds, reserved apart from it, which is the
+point rather than an accident of it — and the request is refused **up
+front** when that pool is full rather than admitted and torn down later
+(§8). Its upstream socket needs no pool: a tunnel is an accepted client
+connection, and `fdsRequired` already charges every connection the pair
+it holds. Three properties
 follow, and they are why the pool is worth the extra concept: tunnels
 cannot starve HTTP, because they never touch its pools; the cost stays
 closed-form and printable in the startup banner like every other row;

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,14 @@ How long the old process lingers is `timeouts.drain_deadline_ms`; with the
 default `0` it waits for its last connection to finish. Its exit prints the
 final counters, so the run it just ended is still accountable.
 
+[Tunnels](#tunnelled-upgrades-websocket) are the exception, and they have to
+be: a WebSocket has no message boundary to finish at, so "wait for the last
+connection" would mean waiting for a client that may never disconnect. A
+draining process refuses new upgrades with `503` and cuts the live ones — at
+`drain_deadline_ms` where you set one, and five seconds in where you did not.
+Without that, one idle session would hold every rolling restart open until
+your supervisor's `SIGKILL`. `zoxy_tunnels_drained` counts the ones cut.
+
 The same two commands are how you *add* capacity rather than replace it —
 start N processes on the same port and signal none of them. That is the
 supported way to use more than one core, and a replacement is just the case
@@ -234,6 +242,72 @@ full handshake.
 > parity, ~20k req/s at a p50 within a few µs of each other. Bulk
 > transfer is the one band zoxy trails on, by a third to two-fifths:
 > 507–542 µs against 383–385 µs at the same 100 MiB/s.
+
+#### Tunnelled upgrades (WebSocket)
+
+By default any request carrying `Upgrade` is answered `501` — the same as
+`CONNECT`, and what every config that does not name an allowlist keeps
+getting. An `http` listener opts in by naming the tokens it will carry:
+
+```json
+"listeners": [
+    { "bind": "0.0.0.0:80", "protocol": "http", "cluster": "web",
+      "upgrades": ["websocket"] }
+],
+"limits": { "tunnels": 512 }
+```
+
+zoxy does not speak WebSocket. It forwards the handshake, recognises the
+origin's `101 Switching Protocols`, and from that point relays bytes both
+ways until one side closes — the same byte relay an `l4` listener runs,
+entered from an HTTP exchange. Routing, filters and health checks apply to
+the handshake exactly as they do to any request.
+
+> [!IMPORTANT]
+> **After `101` the connection is opaque.** Filters, routes, header rules
+> and canonicalisation stop applying to every byte that follows, because
+> there are no more HTTP messages to apply them to. That is why the token
+> list is an allowlist and not a switch: `websocket` is the only token
+> zoxy accepts, and anything else — `h2c` in particular, which would carry
+> HTTP/2 to an origin zoxy cannot parse — is refused by name at load.
+
+**`limits.tunnels` is required, and has no default.** Every other pool
+derives one, because their fallbacks can only be too generous; how many
+long-lived sessions your origins should carry is a capacity decision zoxy
+cannot infer from a connection count, so a listener that allows an upgrade
+without one is refused at startup rather than shedding later. It may not
+exceed `conn_slots`.
+
+The pool is separate from the buffers ordinary traffic uses, and that is
+the point. Every other pool is sized for concurrent *activity* — an idle
+keep-alive connection holds no head buffer — while a tunnel pins its relay
+buffer for its whole life and never returns it. Sharing one pool would let
+idle WebSockets consume what live requests need; a separate one means
+tunnels cannot starve HTTP, and costs 8200 bytes each, printed in the
+startup banner.
+
+When the pool is full the upgrade is refused with `503` **before** the
+handshake reaches your origin, so a refusal costs no backend connection.
+`zoxy_l7_shed_tunnels` counts those; `zoxy_tunnels_established` counts the
+ones that became sessions.
+
+Two further consequences worth knowing:
+
+- **`timeouts.tunnel_ms` replaces the other deadlines** once a connection
+  becomes a tunnel. It has to: `idle_ms` defaults to 60 s and a WebSocket
+  is legitimately idle for hours, its keepalive being application-level
+  ping/pong zoxy cannot see through opaque bytes. Default one hour, floor
+  one second, ceiling one day — and unlike `request_ms` there is no `0`
+  for "no cap", because a tunnel holds a pool slot for its whole life.
+- **The upgraded upstream connection leaves the keep-alive pool** and is
+  never reused for another client. It still counts against the cluster's
+  `max_inflight` for as long as the tunnel lives, which is honest: your
+  backend really is carrying it.
+
+The access log writes one line when the tunnel closes — `kind` `http`,
+`status` `101`, the request facts that opened it, and `bytes_in`/`bytes_out`
+for the whole session. A line at the handshake would name a transfer that
+had not happened yet.
 
 ### Routing
 
@@ -744,6 +818,7 @@ the other. Statuses are `200` plus the error set.
     "drain_deadline_ms": 10000,
     "max_lifetime_ms": 0,
     "request_ms": 0,
+    "tunnel_ms": 3600000,
     "health_interval_ms": 2000
 }
 ```
@@ -769,6 +844,7 @@ dial or idle budget is a mistake rather than a policy.
 | `drain_deadline_ms` | `0` | how long a `SIGTERM` drain waits before reaping stragglers; `0` waits for the last connection |
 | `max_lifetime_ms` | `0` | absolute connection-age cap regardless of activity; `0` disables |
 | `request_ms` | `0` | cap on one L7 exchange, **not** refreshed by activity — bounds a request that is merely slow, where `idle_ms` only bounds one that has stalled; `0` disables |
+| `tunnel_ms` | `3600000` | whole life of a [tunnelled upgrade](#tunnelled-upgrades-websocket), replacing the three above once one is established; 1 s to 1 day, and `0` is **not** legal |
 | `health_interval_ms` | `2000` | pause between health-probe sweeps |
 
 `drain_deadline_ms` defaults to waiting indefinitely because there is no
@@ -791,7 +867,8 @@ reserves nor demands the ceiling's resources.
     "upstream_slots": 4096,
     "head_buffers": 1024,
     "upstream_head_buffers": 512,
-    "head_buffer_bytes": 16384
+    "head_buffer_bytes": 16384,
+    "tunnels": 512
 }
 ```
 
@@ -817,6 +894,13 @@ per-connection object zoxy holds, about 132 KiB plus a 32 KiB plaintext
 buffer, so 1024 of them is roughly 170 MiB. It defaults to your connection
 slots capped at 1024, and the startup banner prints the total either way —
 lower it if that is more concurrent TLS than you serve.
+
+`tunnels` bounds concurrent [tunnelled upgrades](#tunnelled-upgrades-websocket)
+and is zero unless some listener names an `upgrades` allowlist — in which case
+it is **required**, since no default can be derived for it. Each costs one
+relay-buffer pair (8200 bytes), held for the tunnel's whole life rather than
+for the duration of a request, which is why they are reserved apart from
+`relay_buffers` instead of drawn from it.
 
 `cq_fill_eighths` trades connection ceiling for `io_uring` completion-queue
 burst headroom; `access_log_buffer_bytes` sizes the access log's staging
@@ -879,7 +963,9 @@ timeouts included) and one per L4 connection:
 `outcome` is what `status` cannot tell you: an origin answering `503` and
 zoxy shedding a request with `503` are the same three digits and opposite
 events. It reads `ok`, `rejected`, `shed`, `timed_out`, `upstream_failed`,
-`aborted`, or — for L4 — `closed`.
+`aborted`, or `closed` — the last for L4 connections and for
+[tunnels](#tunnelled-upgrades-websocket), which end the way a relay ends
+rather than the way an exchange does.
 
 Logging never blocks the event loop, so a sink that stalls costs dropped
 lines rather than latency; `zoxy_access_log_dropped` counts them exactly.
@@ -959,6 +1045,10 @@ dies.** Every limit has a defined answer rather than an unbounded queue.
   constant memory, and the connection is *kept* when the client's byte stream
   is still on a message boundary, because closing costs more than the work
   being shed.
+- **A tunnel is refused before it costs anything.** No tunnel slot → the
+  upgrade is answered `503` *before* the handshake is forwarded, so a
+  refusal never spends an origin connection to produce a worse answer once
+  the session is already live.
 - **Watermarks before walls.** Each pool raises a pressure flag at 3/4
   occupancy and lowers it again only once it has drained back to 1/2 — the gap
   is what stops the flag flapping around a single threshold. While it is

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -198,6 +198,11 @@ sticky_http: bool,
 /// The #181 dial-retry budget on the http cluster; zero on the seeds
 /// that carry no second endpoint, which is most of them.
 retries_http: u16,
+/// The seed allows the #180 upgrade token on its http listener, and has
+/// a tunnel pool to carry it. Off on most seeds, so the handshake script
+/// keeps proving the `501` every config had before the feature.
+upgrades_http: bool,
+tunnels: u32,
 /// Decided before `io.init` (the ring the sim registers must equal the
 /// limit the server accounts against — Server.init asserts the match),
 /// consumed by `startServerAndOrigins` for the rest of the pool shape.
@@ -602,10 +607,38 @@ fn deriveRetries(harness: *Harness, random: std.Random) void {
     assert(harness.retries_http <= zoxy.constants.cluster_retries_max);
 }
 
+/// The #180 draw: a third of seeds allow the WebSocket token and size a
+/// tunnel pool for it. The rest keep the `501` — which is not merely the
+/// absence of coverage but the other half of the gate, and the shape
+/// every config written before the feature still has.
+///
+/// A clean seed's pool is wide enough that no handshake can be shed,
+/// because its oracle demands an exact transcript and a `503` is not the
+/// answer its script asked for — the same reason `deriveMaxInflight`
+/// caps only under the adversary. An adversarial seed draws a pool small
+/// enough to run out, which is what reaches the §8 tunnel rung.
+fn deriveUpgrades(harness: *Harness, random: std.Random) void {
+    if (random.uintLessThan(u8, 3) != 0) {
+        harness.upgrades_http = false;
+        harness.tunnels = 0;
+        return;
+    }
+    harness.upgrades_http = true;
+    // One tunnel under the adversary, so two concurrent handshakes
+    // collide and the §8 rung is reached by ordinary scheduling rather
+    // than by a rare coincidence. A clean seed gets room for every
+    // client instead: its oracle demands an exact transcript, and a
+    // `503` is not the answer its script asked for.
+    harness.tunnels = if (harness.clean) clients_max else 1;
+    assert(harness.tunnels >= 1);
+    assert(harness.tunnels <= clients_max);
+}
+
 fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.endpoints_l4 = .{originAddress()};
     harness.endpoints_http = .{ httpOriginAddress(), httpOriginAddress() };
     deriveRetries(harness, random);
+    deriveUpgrades(harness, random);
     // Each cluster draws its pick policy independently so mixed configs
     // (one cluster each way) flow through the balancer under the schedule
     // fuzz, not just the uniform pairings. Single-endpoint clusters
@@ -1176,6 +1209,7 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .response_filters = &harness.response_filters_http,
             .protocol = .http,
             .forwarded = forwarded,
+            .upgrades = .{ .websocket = harness.upgrades_http },
         },
         .{
             .bind_address = tlsBindAddress(),
@@ -1262,6 +1296,14 @@ fn deriveInitOptions(harness: *const Harness, random: std.Random) ServerSim.Init
             .relay_buffers = 1,
             .upstream_slots = 1,
             .head_buffers = harness.head_buffers,
+            // Clamped, because a starved seed's slot count is drawn from
+            // the ring and can sit below the pool the upgrade draw asked
+            // for — and a tunnel is an accepted connection, so a pool
+            // wider than the slots that hold one cannot exist (§5). A
+            // clamp to zero is legal here and means every handshake on
+            // this seed meets the tunnel rung, which is coverage rather
+            // than a loss.
+            .tunnels = @min(harness.tunnels, harness.head_buffers),
             // Capacity 1: the first render engages the pressure flag, so
             // the engage counter stays reachable even though the shed
             // rung itself is relay-shadowed (see sim/main.zig uncovered).
@@ -1271,6 +1313,7 @@ fn deriveInitOptions(harness: *const Harness, random: std.Random) ServerSim.Init
         }
     else
         .{
+            .tunnels = harness.tunnels,
             .access_log_buffer_bytes = access_log_buffer_bytes,
             // Clean seeds size every pool so its §8 pressure
             // watermark (ceil of 3/4 capacity: 9 of 12) sits above
@@ -1378,11 +1421,22 @@ fn populateClients(harness: *Harness, random: std.Random) void {
         if (random.boolean()) {
             const client = &harness.l7_clients[harness.l7_count];
             harness.l7_count += 1;
+            // A seed that enables upgrades puts its first two http
+            // clients on the handshake, rather than waiting for a
+            // uniform draw over every script to produce one. It raises
+            // the odds rather than guaranteeing them — the client count
+            // and the per-slot coin still decide how many http clients a
+            // seed has — but it is what makes two concurrent handshakes,
+            // and so the §8 tunnel rung, ordinary across a sweep instead
+            // of a coincidence. Every other client still draws freely,
+            // so the population keeps its shape.
+            const forced_upgrade = harness.upgrades_http and harness.l7_count < 2;
             client.prepare(
                 &harness.io,
                 httpBindAddress(),
-                random.enumValue(l7.Script),
+                if (forced_upgrade) .upgrade_request else random.enumValue(l7.Script),
                 harness.clean,
+                harness.upgrades_http,
                 harness.sticky_http,
             );
             client.on_ended = clientEndedHook;
@@ -2468,6 +2522,19 @@ fn tallyAccessLog(sink: []const u8) !LineTally {
             continue;
         }
         tally.http += 1;
+        // A tunnel's line is already explained by `tunnels_established`
+        // (#180), so it must not also be counted as an unexplained
+        // abort. Its outcome legitimately goes both ways — `closed` when
+        // both halves said goodbye, `aborted` when a drain or a peer cut
+        // it — because after `101` this connection ends the way an L4
+        // relay ends, not the way an exchange does. Never `ok`: only
+        // `finishExchange` sets that, and a tunnel never returns there.
+        // The status is what identifies it: `101` is the one status no
+        // ordinary exchange can carry, since the proxy answers it only
+        // for a tunnel that its client provably received.
+        if (std.mem.indexOf(u8, line, "\"status\":101") != null) {
+            continue;
+        }
         if (std.mem.indexOf(u8, line, "\"outcome\":\"aborted\"") != null) {
             tally.http_aborted += 1;
         }
@@ -2497,6 +2564,15 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_responded",
         "l7_shed_relay_buffers",
         "l7_shed_tunnels",
+        // A tunnel is an *answered* exchange like any other here (#180):
+        // the client asked for an upgrade and got its `101`. It is the
+        // one member that reaches neither `respond` nor `finishExchange`
+        // — its line is written at close by the ordinary teardown path —
+        // which is why the sum's own description above names two paths
+        // and this needs a third. Leaving it out makes the line
+        // unexplained, exactly what this identity caught on the first
+        // seed to carry one.
+        "tunnels_established",
         "l7_shed_upstream_slots",
         "l7_shed_endpoint_inflight",
         "l7_bad_gateway",

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -2496,6 +2496,7 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_redirected",
         "l7_responded",
         "l7_shed_relay_buffers",
+        "l7_shed_tunnels",
         "l7_shed_upstream_slots",
         "l7_shed_endpoint_inflight",
         "l7_bad_gateway",

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -775,6 +775,11 @@ fn deriveServerConfig(
         // The §8 per-exchange deadline: measured from routing instead, so
         // the same range lands on a different clock.
         .request_timeout_ms = deriveOptionalDeadlineMs(random),
+        // Stated, not drawn: no seed allows an upgrade yet, so this clock
+        // is inert and drawing it would move every seed's stream position
+        // for coverage that does not exist. The draw arrives with the
+        // tunnels themselves (#180).
+        .tunnel_timeout_ms = zoxy.constants.tunnel_ms_default,
         // Three seeds in four run with the access log on, so the sink,
         // its staging swap, and the per-request captures all take the
         // schedule fuzz; the fourth leaves it off, which is the shape

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -86,10 +86,21 @@ pub const page_content_type = "text/plain";
 /// 502 or teardown, never a crash.
 pub const oversize_head = "HTTP/1.1 200 OK\r\nx-pad: " ++ ("p" ** 8162) ++ "\r\n\r\n";
 
+/// The `101` a WebSocket origin answers an upgrade request with (#180).
+/// Carries the participating pair the proxy must let travel: strip
+/// either and the client is told it succeeded without being told to
+/// what, which is exactly what §7's hop-by-hop exemption exists to stop.
+pub const switching_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
+    "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
+
 comptime {
     assert(sticky_tag.len == 16);
     assert(sized_body.len == 32);
     assert(chunked_wire[0] == '1' and chunked_wire[1] == '0');
     assert(chunked_wire.len == 4 + 16 + 2 + 5);
     assert(oversize_head.len == 8190);
+    // The handshake answer must carry both halves of the pair, or the
+    // scenario would pass while proving nothing about the exemption.
+    assert(std.mem.indexOf(u8, switching_response, "Upgrade: websocket") != null);
+    assert(std.mem.indexOf(u8, switching_response, "Connection: Upgrade") != null);
 }

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -35,6 +35,9 @@ pub const ClientError = error{
     ResponseCorrupted,
     /// A complete response carried a status outside the script's set.
     ResponseStatusUnexpected,
+    /// A `101` reached the client without the participating
+    /// `Upgrade`/`Connection` pair §7 exists to let through (#180).
+    UpgradePairMissing,
     /// A 200 body diverged from every canonical origin body.
     ResponseBodyCorrupted,
     /// More response bytes than any legal transcript contains.
@@ -86,6 +89,12 @@ pub fn Client(comptime IoType: type) type {
         /// Clean seeds harden the prefix oracle to the exact golden
         /// outcome — nothing may be cut, shed, or silently torn down.
         clean: bool = false,
+        /// This client's listener allows the #180 upgrade token, which
+        /// decides what its handshake script is *entitled* to: the `101`
+        /// and a tunnel, or the `501` every config had before the
+        /// feature. A property of the listener rather than the script,
+        /// which is why it rides the client and not the spec.
+        upgrades: bool = false,
         /// The seed drew the #178 cookie-keyed http cluster, so the
         /// stamp oracle runs over every parsed response head.
         sticky: bool = false,
@@ -141,12 +150,14 @@ pub fn Client(comptime IoType: type) type {
             address: std.Io.net.IpAddress,
             script: Script,
             clean: bool,
+            upgrades: bool,
             sticky: bool,
         ) void {
             client.io = io;
             client.address = address;
             client.script = script;
             client.clean = clean;
+            client.upgrades = upgrades;
             client.sticky = sticky;
             const bytes = scripts.spec(script).request;
             assert(bytes.len <= client.request.len);
@@ -364,8 +375,16 @@ pub fn Client(comptime IoType: type) type {
                 if (walk.offset != client.received_len) {
                     return ClientError.GoldenOutcomeMissed;
                 }
+                // A handshake earns the `101` only where the listener
+                // allows the token; everywhere else it earns the refusal
+                // the spec's own golden cannot name, because which of the
+                // two is right is the listener's fact (#180).
+                const golden: u16 = if (client.script == .upgrade_request and !client.upgrades)
+                    501
+                else
+                    entry.golden_status;
                 for (walk.statuses[0..walk.complete_count]) |status| {
-                    if (status != entry.golden_status) {
+                    if (status != golden) {
                         return ClientError.GoldenOutcomeMissed;
                     }
                 }
@@ -436,6 +455,23 @@ pub fn Client(comptime IoType: type) type {
                 if (response.status == 301) {
                     if (!headerEquals(response.headers, "Location", canon.redirect_location)) {
                         walk.violation = ClientError.RedirectLocationWrong;
+                        return walk;
+                    }
+                }
+                // The #180 oracle, and the mirror of the redirect check
+                // above: §7 lets the participating `Upgrade` survive
+                // hop-by-hop stripping precisely so the client is told
+                // *what* it was upgraded to, and the proxy writes its own
+                // `Connection: upgrade` rather than echoing whatever
+                // arrived. A status check alone cannot see either — a
+                // render that dropped or corrupted the pair would still
+                // produce a `101` and pass — so the headers are demanded
+                // by name, byte for byte.
+                if (response.status == 101) {
+                    if (!headerEquals(response.headers, "upgrade", "websocket") or
+                        !headerEquals(response.headers, "connection", "upgrade"))
+                    {
+                        walk.violation = ClientError.UpgradePairMissing;
                         return walk;
                     }
                 }
@@ -630,6 +666,15 @@ pub fn Client(comptime IoType: type) type {
         /// every legal non-200 is a static with Content-Length 0 — so a
         /// corrupted length fails even before its body arrives.
         fn walkBody(response: parser.ResponseHead, body: []const u8, entry: Spec) ?BodyVerdict {
+            // A `101` is bodiless by status, not by header (#180): the
+            // bytes after it are the tunnel's, and belong to no response
+            // at all. The framing arm below reads `.none` as corruption
+            // because until upgrades existed nothing legal could carry
+            // it — every canonical 200 has a body and every static an
+            // explicit `Content-Length: 0`.
+            if (response.status == 101) {
+                return .{ .body_len = 0, .violation = null };
+            }
             const page_body = pageBodyFor(entry, response.status);
             switch (response.framing) {
                 .content_length => |length| {

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -257,6 +257,20 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     conn.close();
                     return false;
                 };
+                // A forwarded `Upgrade` means the proxy agreed to carry a
+                // handshake (#180), so answer it the way an origin that
+                // speaks the protocol would: `101`, and then the bytes
+                // are opaque — no further request will ever parse out of
+                // this connection, so it drains from here.
+                //
+                // Decided from the request rather than from a drawn mode,
+                // because that is what a real origin does and because it
+                // keeps a clean seed deterministic: the same request gets
+                // the same answer whatever the schedule.
+                if (parser.headerValue(request.headers, "upgrade") != null) {
+                    conn.response_bytes = canon.switching_response;
+                    conn.drain_only = true;
+                }
                 // §7 canonical forwarding: the proxy sends the canonical
                 // path the router matched on, so what the origin receives
                 // must already be canonical — re-canonicalizing is a no-op.

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -44,6 +44,12 @@ pub const Script = enum(u8) {
     oversize_uri,
     /// CONNECT is a §1 non-goal; 501.
     connect_method,
+    /// A WebSocket handshake (#180). What it earns depends on the
+    /// listener: `101` and a tunnel where the config allows the token,
+    /// the unchanged `501` where it does not — so one script covers both
+    /// halves of the gate, and the seeds that never enable upgrades keep
+    /// proving the refusal that every config had before the feature.
+    upgrade_request,
     /// Two sequential GETs on one connection: the §5 parking/checkout
     /// path — the second is sent only after the first 200 settles
     /// reusable.
@@ -356,6 +362,30 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         // Only the §5 head ring's 503 precedes the parse the 501 rides on.
         .allowed_statuses = &.{ 501, 503 },
     },
+    .upgrade_request = .{
+        .request = "GET /ws HTTP/1.1\r\nHost: origin\r\n" ++
+            "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        // The allowed answer, which a seed that enables upgrades demands.
+        // A seed that does not is held to `501` instead — the client
+        // carries that fact, because it is the *listener's* config and
+        // not the script's (`Client.upgrades`).
+        .golden_status = 101,
+        .method = .get,
+        // 101 where carried, 501 where the token is not allowed, 503
+        // where the tunnel pool or a pool before it had nothing left —
+        // and 502/504 because a handshake is forwarded like any request
+        // and meets the same origin fates on the way.
+        //
+        // 200 because an origin may *decline*, which is legal and which
+        // the adversary reaches through the instant modes: those answer
+        // at accept, before reading, so they refuse an upgrade they never
+        // saw. A clean seed's origin always reads first and always
+        // answers `101`, which is why the golden above can still be
+        // exact.
+        .allowed_statuses = &.{ 101, 200, 501, 502, 503, 504 },
+    },
     .keepalive_pair = .{
         // The second GET is appended at run time, only after the first
         // 200 settles reusable.
@@ -590,11 +620,19 @@ pub const terminating_scripts = [_]Script{
 };
 
 comptime {
-    // Every script is either drawable there or one of the two named
+    // Every script is either drawable there or one of the three named
     // exceptions, so a script added to the table cannot quietly skip the
     // terminating population — someone has to decide which it is.
+    //
+    // `upgrade_request` is excepted because the terminating listener
+    // allows no upgrade token, so drawing it there could only ever prove
+    // the `501` a second time. Both halves of that gate are already
+    // covered on the plaintext listener, which is the one the #180 draw
+    // configures — and an upgrade over a terminated connection is its
+    // own feature, not this script run through a different socket.
     for (std.enums.values(Script)) |script| {
-        const excepted = script == .silent or script == .keepalive_pair;
+        const excepted = script == .silent or script == .keepalive_pair or
+            script == .upgrade_request;
         var drawable = false;
         for (terminating_scripts) |candidate| {
             if (candidate == script) drawable = true;

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -256,33 +256,15 @@ const uncovered = [_]Uncovered{
             "src/http_proxy_test.zig exhausts the upstream pool directly",
     },
     .{
-        .name = "l7_shed_tunnels",
-        .why = .unreached,
-        .reason = "no seed configures an `upgrades` allowlist, so no scenario " ++
-            "can request the tunnel this rung refuses. Teaching the harness " ++
-            "to script an upgrade — an origin that answers 101 and then " ++
-            "echoes, and a client that expects it — is #180's next slice; " ++
-            "src/http_proxy_test.zig exhausts the tunnel pool directly in " ++
-            "the meantime",
-    },
-    .{
-        .name = "tunnels_established",
-        .why = .unreached,
-        .reason = "same gap as l7_shed_tunnels above, and the same remedy: " ++
-            "until a seed can allow an upgrade, no scenario reaches 101 at " ++
-            "all. src/http_proxy_test.zig carries a tunnel end to end, " ++
-            "including the participating Upgrade pair and the relay after " ++
-            "the handshake",
-    },
-    .{
         .name = "tunnels_drained",
         .why = .unreached,
-        .reason = "the third of #180's counters, unreachable for the same one " ++
-            "reason as the two above: no seed allows an upgrade, so no " ++
-            "scenario has a tunnel for a drain to cut. All three retire " ++
-            "together when the harness learns to script one; " ++
+        .reason = "structural rather than a gap in ambition: the production " ++
+            "bound is `tunnel_drain_ms` (5 s) and a whole scenario is 2 s of " ++
+            "virtual time, so no schedule this sweep can produce reaches it. " ++
+            "Seeds do establish tunnels and do drain with them live — the " ++
+            "tunnel dies with its client rather than at the bound. " ++
             "src/http_proxy_test.zig drains a live tunnel under a zero " ++
-            "drain_deadline_ms directly",
+            "drain_deadline_ms directly, and asserts the loop reached idle",
     },
     .{
         .name = "l7_shed_upstream_head_buffers",

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -256,6 +256,25 @@ const uncovered = [_]Uncovered{
             "src/http_proxy_test.zig exhausts the upstream pool directly",
     },
     .{
+        .name = "l7_shed_tunnels",
+        .why = .unreached,
+        .reason = "no seed configures an `upgrades` allowlist, so no scenario " ++
+            "can request the tunnel this rung refuses. Teaching the harness " ++
+            "to script an upgrade — an origin that answers 101 and then " ++
+            "echoes, and a client that expects it — is #180's next slice; " ++
+            "src/http_proxy_test.zig exhausts the tunnel pool directly in " ++
+            "the meantime",
+    },
+    .{
+        .name = "tunnels_established",
+        .why = .unreached,
+        .reason = "same gap as l7_shed_tunnels above, and the same remedy: " ++
+            "until a seed can allow an upgrade, no scenario reaches 101 at " ++
+            "all. src/http_proxy_test.zig carries a tunnel end to end, " ++
+            "including the participating Upgrade pair and the relay after " ++
+            "the handshake",
+    },
+    .{
         .name = "l7_shed_upstream_head_buffers",
         .why = .unreached,
         .reason = "same shadow as l7_shed_upstream_slots: the relay rung " ++

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -275,6 +275,16 @@ const uncovered = [_]Uncovered{
             "the handshake",
     },
     .{
+        .name = "tunnels_drained",
+        .why = .unreached,
+        .reason = "the third of #180's counters, unreachable for the same one " ++
+            "reason as the two above: no seed allows an upgrade, so no " ++
+            "scenario has a tunnel for a drain to cut. All three retire " ++
+            "together when the harness learns to script one; " ++
+            "src/http_proxy_test.zig drains a live tunnel under a zero " ++
+            "drain_deadline_ms directly",
+    },
+    .{
         .name = "l7_shed_upstream_head_buffers",
         .why = .unreached,
         .reason = "same shadow as l7_shed_upstream_slots: the relay rung " ++

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -747,6 +747,64 @@ pub fn Server(comptime IoType: type) type {
                     onDrainDeadline,
                 );
                 server.armDrainWatchdog();
+            } else {
+                if (server.tunnel_buffers.slots.len >= 1) {
+                    // A zero deadline says "wait for the last connection",
+                    // and a tunnel has no message boundary to be the last
+                    // thing it does — so one idle session would hold the
+                    // drain open until the supervisor's SIGKILL, turning a
+                    // millisecond drain into every rolling restart waiting
+                    // out `TimeoutStopSec` (§8, #180). Tunnels alone are
+                    // bounded here; `drain_deadline_ms` keeps its exact
+                    // present meaning for every other connection, which is
+                    // why this arms only when the branch above did not.
+                    //
+                    // The same completion the configured deadline would have
+                    // used, so the ring budget is unchanged: the two are
+                    // mutually exclusive by construction.
+                    // Mutually exclusive with the branch above by
+                    // construction, and stated so: both arm the same
+                    // completion, and arming it twice would double-arm a
+                    // ring op the drain then has to account for.
+                    assert(server.config.drain_deadline_ms == 0);
+                    server.io.timerStart(
+                        &server.drain_deadline_completion,
+                        @as(u64, constants.tunnel_drain_ms) * std.time.ns_per_ms,
+                        Self,
+                        server,
+                        onTunnelDrainDeadline,
+                    );
+                }
+            }
+            server.maybeStopAfterDrain();
+        }
+
+        /// The #180 tunnel-only drain bound fired: cut the tunnels and
+        /// leave everything else alone.
+        ///
+        /// The difference from `onDrainDeadline` is the whole point of
+        /// having a second handler. That one tears down every live
+        /// connection because the operator named a deadline for the
+        /// drain; this one fires when they named *none*, so it may only
+        /// end the connections that can never end themselves. An ordinary
+        /// exchange still finishes on its own terms, and a zero
+        /// `drain_deadline_ms` still means what it has always meant for
+        /// it.
+        fn onTunnelDrainDeadline(server: *Self, result: Io.TimerError!void) void {
+            assert(server.draining);
+            assert(server.config.drain_deadline_ms == 0);
+            // Nothing ever cancels this timer, the same as its sibling.
+            result catch unreachable;
+            for (server.conns.slots) |*conn| {
+                if (!server.conns.isAcquired(conn)) continue;
+                if (conn.state != .relaying) continue;
+                // Relaying and holding a tunnel: an L4 connection is also
+                // `.relaying` and is deliberately untouched, because it
+                // *can* end on its own when its peers do.
+                if (conn.tunnel_buffer == null) continue;
+                if (conn.isTearingDown()) continue;
+                server.counters.increment("tunnels_drained");
+                server.beginTeardown(conn);
             }
             server.maybeStopAfterDrain();
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -44,6 +44,21 @@ pub fn Server(comptime IoType: type) type {
         config: *const config_module.Config,
         conns: Pool(ConnType),
         relay_buffers: Pool(relay.RelayBuffer),
+        /// The §5 tunnel pool (#180): relay buffers for upgraded
+        /// connections, deliberately *not* the pool above.
+        ///
+        /// Same element, separate reservation, and the separation is the
+        /// whole feature. Every other pool here is sized for concurrent
+        /// activity — a keep-alive connection holds no head buffer, a
+        /// parked upstream holds no head — while a tunnel pins its buffer
+        /// for the connection's entire life and can never return to
+        /// keep-alive. Sharing one pool between the two shapes would let
+        /// long-lived sessions consume the buffers ordinary traffic sheds
+        /// on, so tunnels cannot starve HTTP because they never touch
+        /// what HTTP draws from. Zero exactly when no listener allows an
+        /// upgrade, which is what makes the feature free to a deployment
+        /// that did not ask for it.
+        tunnel_buffers: Pool(relay.RelayBuffer),
         /// The shared upstream connection pool (§3, §5): leased per L7
         /// exchange today; parking joins with keep-alive.
         upstreams: upstream_module.UpstreamPool(IoType),
@@ -373,6 +388,7 @@ pub fn Server(comptime IoType: type) type {
             server.config = config;
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
+            try server.initTunnelBuffers(arena, &options);
             // One index space, derived once and shared by every
             // endpoint-keyed table so they cannot disagree about a key.
             const keys = endpointKeysFor(config);
@@ -442,6 +458,33 @@ pub fn Server(comptime IoType: type) type {
         /// The §4 engine pool and the one slab its plaintext destinations
         /// carve out of. Both are empty on a deployment where no listener
         /// terminates TLS — the whole feature reserving nothing, which is
+        /// The §5 tunnel pool (#180), split from `init` for the length
+        /// limit like `initHeadBuffers` beside it.
+        ///
+        /// A second pool of the *same element* as `relay_buffers`, and the
+        /// separation is the feature rather than an implementation
+        /// detail: a tunnel holds its buffer for the connection's whole
+        /// life, so sharing one reservation with traffic sized for
+        /// concurrent activity would let long-lived sessions consume what
+        /// ordinary requests shed against. Zero slots is a deployment
+        /// that allows no upgrade, which is what `Pool`'s zero-slot
+        /// support is for.
+        fn initTunnelBuffers(
+            server: *Self,
+            arena: std.mem.Allocator,
+            options: *const InitOptions,
+        ) error{OutOfMemory}!void {
+            // A tunnel is an accepted client connection holding one of
+            // these, so a pool past the connections that could hold one is
+            // unreachable capacity — and the fd and ring budgets are
+            // derived from `conn_slots` on the strength of that bound
+            // (§5), so this is the assert those budgets rest on. The
+            // loader refuses the config-level version of the same rule.
+            assert(options.tunnels <= options.conn_slots);
+            try server.tunnel_buffers.init(arena, options.tunnels);
+            assert(server.tunnel_buffers.slots.len == options.tunnels);
+        }
+
         /// what `limits.tls_engines == 0` means and what `Pool`'s
         /// zero-slot support is for.
         fn initTlsEngines(
@@ -937,6 +980,11 @@ pub fn Server(comptime IoType: type) type {
             // Same rule for the prober's armed ops (§8).
             if (!server.health.isQuiescent()) return;
             assert(server.relay_buffers.isFullyReleased());
+            // Trivially true until a tunnel can exist, and stated now for
+            // exactly that reason: the §9 leak invariant is cheapest to
+            // extend while it cannot fail, and a pool added to the server
+            // but not to this enumeration is a leak nothing would report.
+            assert(server.tunnel_buffers.isFullyReleased());
             // beginDrain reaped every parked slot synchronously and no
             // conn is left to lease one, so the pool must be empty.
             assert(server.upstreams.isFullyReleased());
@@ -1020,6 +1068,7 @@ pub fn Server(comptime IoType: type) type {
             return server.l4Released() and
                 server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
+                server.tunnel_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
                 server.upstream_head_buffers.isFullyReleased() and
                 server.head_buffers_in_use == 0 and
@@ -1376,6 +1425,38 @@ pub fn Server(comptime IoType: type) type {
             const buffer = server.relay_buffers.acquire() orelse return null;
             server.updateRelayPressure();
             return buffer;
+        }
+
+        /// Take a tunnel's relay buffer, or null when the pool is full
+        /// (§8: the upgrade is refused up front with a `503`, before the
+        /// handshake is forwarded, rather than admitted and torn down
+        /// once it is live).
+        ///
+        /// No pressure recompute, unlike its sibling above, and that is
+        /// the difference between a watermark and a wall. The shared
+        /// pools bias idle deadlines as they fill, so ordinary traffic
+        /// returns buffers sooner; there is nothing equivalent to ask of
+        /// a tunnel, whose whole contract is to hold its buffer until the
+        /// session ends. The pool's ceiling is the only answer it has.
+        pub fn acquireTunnelBuffer(server: *Self) ?*relay.RelayBuffer {
+            return server.tunnel_buffers.acquire();
+        }
+
+        /// Give one back when the tunnel closes — to the pool it came
+        /// from, never the shared one.
+        ///
+        /// Worth being exact about what enforces that, because it is less
+        /// than it looks: the two pools hold the *same* element type, so
+        /// a buffer from either type-checks at either release site.
+        /// `Pool.indexOf`'s bounds assert does catch a crossed release
+        /// today, but only because the two reservations occupy disjoint
+        /// arena ranges — a property of allocation order, not of the type
+        /// system. So this is a discipline the caller keeps, backed by a
+        /// check that happens to hold, rather than a guarantee. Naming it
+        /// here because the slice that gives tunnels a lifecycle is the
+        /// one that could get it wrong.
+        pub fn releaseTunnelBuffer(server: *Self, buffer: *relay.RelayBuffer) void {
+            server.tunnel_buffers.release(buffer);
         }
 
         /// The release pair: an L7 connection going idle on keep-alive

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -260,6 +260,10 @@ pub fn Server(comptime IoType: type) type {
             /// The listener's #175 response filter rules, handed over the
             /// same way so the response re-render can apply its edits.
             response_filters: []const filter.ResponseRule,
+            /// The listener's #180 upgrade allowlist, carried for the same
+            /// reason as the tables above: an admitted connection asks its
+            /// own socket what it may carry.
+            upgrades: config_module.Config.Listener.Upgrades,
             /// The listener's §7 client-address forwarding mode (null = off),
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
@@ -683,6 +687,7 @@ pub fn Server(comptime IoType: type) type {
                     // path's route once the head parses (§7).
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
+                    .upgrades = listener_config.upgrades,
                     .request_filters = listener_config.request_filters,
                     .response_filters = listener_config.response_filters,
                     .forwarded = listener_config.forwarded,
@@ -1403,6 +1408,7 @@ pub fn Server(comptime IoType: type) type {
             conn.routes = listener.routes;
             conn.request_filters = listener.request_filters;
             conn.response_filters = listener.response_filters;
+            conn.upgrades = listener.upgrades;
             conn.forwarded = listener.forwarded;
             // The #140 captures live in a side table addressed by pool
             // slot, so a slot's bytes outlive the connection that wrote
@@ -2319,7 +2325,7 @@ pub fn Server(comptime IoType: type) type {
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
             conn.log.endpoint_index = dial.endpoint_index;
-            server.chargeL4(conn, cluster_index, dial.endpoint_index);
+            server.chargeEndpoint(conn, cluster_index, dial.endpoint_index);
             if (server.config.clusters[cluster_index].proxy_protocol_send) |version| {
                 server.stageProxySendHeader(conn, version);
             }
@@ -2349,7 +2355,7 @@ pub fn Server(comptime IoType: type) type {
             const socket = result catch |err| {
                 server.counters.increment("upstream_connect_failed");
                 // The labeled twin (#179): the pick did not survive the
-                // await, but the L4 charge did — `chargeL4` recorded the
+                // await, but the charge did — `chargeEndpoint` recorded the
                 // endpoint this dial was for, and the charge is released
                 // only at teardown, after this line.
                 assert(conn.charged_endpoint != conn_module.LogState.endpoint_none);
@@ -2428,6 +2434,26 @@ pub fn Server(comptime IoType: type) type {
             if (conn.upstream_socket) |socket| {
                 server.io.closeNow(socket);
                 conn.upstream_socket = null;
+            }
+            // The §5 tunnel buffer first, and the order matters: a live
+            // tunnel's `relay_buffer` *aliases* its `tunnel_buffer`
+            // (#180), so releasing the shared way would hand one pool's
+            // slot to the other — which `Pool.indexOf` catches, but only
+            // after the accounting is already wrong. One owner, checked
+            // before the alias is read.
+            if (conn.tunnel_buffer) |buffer| {
+                // The alias holds only once `beginTunnel` swapped this
+                // buffer in (#180). *Before* `101` the two fields are
+                // distinct buffers from distinct pools — the claim, and
+                // the ordinary relay buffer the exchange is still using —
+                // so clearing the second on the strength of the first
+                // would drop a live pool slot without releasing it. The
+                // pointer compare says exactly which case this is.
+                if (conn.relay_buffer == buffer) {
+                    conn.relay_buffer = null;
+                }
+                server.releaseTunnelBuffer(buffer);
+                conn.tunnel_buffer = null;
             }
             // An idle L7 connection holds no relay buffer (§5); only
             // release one that was actually acquired.
@@ -2764,8 +2790,14 @@ pub fn Server(comptime IoType: type) type {
         /// out counts against its endpoint. The endpoint is recorded on
         /// the connection so the release cannot guess, and so a slot
         /// that never dialed releases nothing.
-        fn chargeL4(server: *Self, conn: *ConnType, cluster_index: u16, endpoint_index: u16) void {
-            assert(conn.protocol == .l4);
+        /// Charge one endpoint for a connection this proxy is carrying
+        /// that holds no upstream *slot* — an L4 relay, or a #180 tunnel,
+        /// which after `101` is the same thing. The `max_inflight` view
+        /// sums this beside the pool's L7 leases precisely because both
+        /// are work the origin is carrying (§7), so a tunnel keeps being
+        /// counted for its whole life without pinning a shared slot.
+        pub fn chargeEndpoint(server: *Self, conn: *ConnType, cluster_index: u16, endpoint_index: u16) void {
+            assert(conn.protocol == .l4 or conn.state == .l7_exchanging);
             assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
             const key = server.upstreams.keys.key(cluster_index, endpoint_index);
             server.l4_inflight[key] += 1;

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -81,7 +81,12 @@ pub const Outcome = enum(u8) {
     /// straggler. The default outcome, so any teardown path that skips
     /// setting a more specific one lands here too.
     aborted,
-    /// L4 only: both directions drained and the connection closed cleanly.
+    /// Both directions drained and the connection closed cleanly. L4 —
+    /// and, since #180, a tunnel: after `101` the connection ends the way
+    /// a relay ends rather than the way an exchange does, so a graceful
+    /// tunnel's line carries this on a `"kind":"http"` record. `ok` is
+    /// unreachable for one, because only `finishExchange` sets it and a
+    /// tunnel never returns there.
     closed,
 };
 

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -91,6 +91,7 @@ const Harness = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
             .access_log_sink = if (buffer_bytes == 0) null else sink,
         };
         try harness.server.init(arena, &harness.sim_io, &harness.config, .{

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -75,6 +75,7 @@ const Harness = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
         };
         try harness.server.init(arena, &harness.sim_io, &harness.config, .{
             .conn_slots = 4,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -938,6 +938,7 @@ fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Conf
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,
+        .tunnel_timeout_ms = constants.tunnel_ms_default,
     };
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -43,6 +43,23 @@ pub const Config = struct {
     /// otherwise. `0` disables it, so it is optional in the JSON and
     /// defaults off. L4 connections never set it.
     request_timeout_ms: u32,
+    /// Bound on one tunnel's whole life (§8, #180), replacing `idle_ms`,
+    /// `request_ms` and `max_lifetime_ms` from the moment a connection
+    /// becomes one. Not a fourth clock running beside them: each of those
+    /// would cut a healthy session — `idle_ms` defaults to 60 s, and a
+    /// WebSocket's keepalive is application-layer ping/pong this proxy
+    /// cannot see, because after `101` the bytes are opaque by
+    /// construction. Unlike `max_lifetime_ms` and `request_ms`, zero is
+    /// **not** legal: a tunnel holds a dedicated pool slot for its whole
+    /// life, and an unbounded hold on a bounded pool is the one thing
+    /// that model cannot absorb. Inert when no listener allows upgrades.
+    ///
+    /// No struct default, deliberately, on the same terms as
+    /// `request_timeout_ms`: a hand-built config that forgot this would
+    /// otherwise run a real one-hour deadline nobody asked for, and a
+    /// silently-inherited deadline is exactly what the absent defaults
+    /// on the other caps exist to prevent.
+    tunnel_timeout_ms: u32,
     /// Pause between §7 health-probe sweeps over every `check` cluster's
     /// endpoints. Probing itself is enabled per cluster (`Cluster.check`);
     /// this only paces it, so it is optional in the JSON and defaults to
@@ -160,6 +177,22 @@ pub const Config = struct {
         /// terminates TLS, and the struct default is the off state on the
         /// same terms as `head_buffers`.
         tls_engines: u32 = 0,
+        /// The §5 tunnel pool (#180): how many upgraded connections may be
+        /// carried at once, each holding its own relay buffer and upstream
+        /// socket for its whole life rather than drawing from the shared
+        /// pools — which is the point, since a tunnel has the opposite
+        /// shape to everything those pools are sized for.
+        ///
+        /// Alone among the optional pools it has **no derived default**.
+        /// The others resolve to a worst case that cannot shed — every
+        /// connection mid-head, every leased slot holding one head — and
+        /// a count derived that way is safe because it can only be too
+        /// generous. There is no such number here: how many long-lived
+        /// sessions an origin fleet should carry is a capacity decision
+        /// with no honest guess available from a connection count, so a
+        /// listener that allows upgrades without one is rejected at load.
+        /// Zero exactly when no listener allows any upgrade.
+        tunnels: u32 = 0,
         /// How many eighths of the io_uring completion queue the worst-case
         /// in-flight ops may fill (§8). Unlike the pool sizes this is not a
         /// shrink: ⅞ (the compiled default, the fill the ceiling is derived
@@ -223,6 +256,37 @@ pub const Config = struct {
         /// says; originating TLS to a backend is a separate decision with
         /// its own trust store, and #125 is termination.
         tls: ?Tls = null,
+        /// Which protocol upgrades this listener will carry as tunnels
+        /// (§7, #180). Empty by default — an `Upgrade` naming nothing
+        /// here is `501`, which is what every config predating this
+        /// keeps getting. Per listener, like `forwarded` and `tls`, and
+        /// for the stronger version of the same reason: after `101` the
+        /// stream is opaque and no filter, route or header rule on this
+        /// listener applies to another byte of it, so which sockets may
+        /// hand out that exemption is a property of the socket.
+        upgrades: Upgrades = .{},
+
+        /// The upgrade tokens a listener may allow, as a set rather than
+        /// a list: the vocabulary is closed, so membership is a field
+        /// and not an arena slice to bound.
+        ///
+        /// Closed deliberately, and it is the §7 "closed action enum"
+        /// instinct rather than a shortcut. A token this proxy does not
+        /// name is one it cannot reason about: `h2c` would tunnel HTTP/2
+        /// to an origin it cannot parse, past every rule the config
+        /// expresses. Adding a token is therefore a code decision, made
+        /// once with its consequences understood, not a string an
+        /// operator can invent.
+        pub const Upgrades = struct {
+            websocket: bool = false,
+
+            /// Whether this listener allows any upgrade at all — what
+            /// decides whether a `limits.tunnels` is required (§5) and
+            /// whether the §7 gate has anything to consult.
+            pub fn any(upgrades: Upgrades) bool {
+                return upgrades.websocket;
+            }
+        };
 
         /// What the listener speaks (§6, §7): `l4` relays bytes blindly,
         /// `http` runs the HTTP/1.1 reverse-proxy state machine. The
@@ -490,6 +554,9 @@ pub const ValidationError = error{
     ListenerL4RequestFilters,
     ListenerL4ResponseFilters,
     ListenerL4Forwarded,
+    ListenerL4Upgrades,
+    ListenerUpgradesEmpty,
+    ListenerUpgradeTokenUnknown,
     ListenerForwardedModeUnknown,
     ListenerHttpProxyProtocol,
     ListenerProxyProtocolModeUnknown,
@@ -533,6 +600,7 @@ pub const ValidationError = error{
     TimeoutZero,
     TimeoutOverLimit,
     TimeoutOrderInvalid,
+    TimeoutTunnelOutOfRange,
     LimitConnSlotsOutOfRange,
     LimitRelayBuffersOutOfRange,
     LimitRelayBuffersOverConnSlots,
@@ -547,6 +615,10 @@ pub const ValidationError = error{
     LimitTlsEnginesOutOfRange,
     LimitTlsEnginesOverConnSlots,
     LimitTlsEnginesWithoutTlsListener,
+    LimitTunnelsRequired,
+    LimitTunnelsOutOfRange,
+    LimitTunnelsOverConnSlots,
+    LimitTunnelsWithoutUpgrades,
     LimitCqFillOutOfRange,
     LimitConnSlotsOverCqFill,
     LimitAccessLogBufferOutOfRange,
@@ -627,6 +699,7 @@ pub fn parseWithFiles(
     }
     var http_listeners_count: u32 = 0;
     var tls_listeners_count: u32 = 0;
+    var upgrade_listeners_count: u32 = 0;
     for (parsed.listeners) |listener_json| {
         if (try protocolOf(listener_json.protocol) == .http) http_listeners_count += 1;
         // Presence only: whether the block is *usable* is `resolveTls`'s
@@ -635,6 +708,12 @@ pub fn parseWithFiles(
         // be refused, and reporting a limit error for a config whose real
         // fault is a missing path.
         if (listener_json.tls != null) tls_listeners_count += 1;
+        // Presence only, like `tls` above and for the same reason: what
+        // the tokens *say* is `resolveUpgrades`'s to judge per listener,
+        // and sizing the tunnel pool against a list that might yet be
+        // refused would report a limits error for a config whose real
+        // fault is a token nobody recognises.
+        if (listener_json.upgrades != null) upgrade_listeners_count += 1;
     }
     const access_log_sink = try resolveAccessLogSink(parsed.access_log);
     // Before the limits, because the named headers widen the line the
@@ -645,6 +724,7 @@ pub fn parseWithFiles(
         @intCast(parsed.listeners.len),
         http_listeners_count,
         tls_listeners_count,
+        upgrade_listeners_count,
         access_log_sink != null,
         log_headers.count(),
     );
@@ -675,6 +755,7 @@ pub fn parseWithFiles(
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
         .request_timeout_ms = parsed.timeouts.request_ms,
+        .tunnel_timeout_ms = parsed.timeouts.tunnel_ms,
         .health_interval_ms = parsed.timeouts.health_interval_ms,
         .limits = limits,
         .admin_bind = admin_bind,
@@ -1045,17 +1126,38 @@ fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddres
 /// relay-buffer count derives from the effective conn slots (a buffer
 /// beyond the slot count could never be acquired); a *specified* count
 /// above them is a contradiction and fails loudly.
+/// The §5 relation every per-connection pool shares: none of them may
+/// out-size the connections that draw on it. Stated once, after the
+/// resolvers have each enforced their own half, because a pool past this
+/// is not merely wasteful — the fd and ring budgets are derived from
+/// `conn_slots` on the strength of it (`fdsRequired`, `inFlightOps`), so
+/// a breach here is an under-provisioned ring rather than spare memory.
+fn assertPoolsFitConnSlots(
+    conn_slots: u32,
+    relay_buffers: u32,
+    head_buffers: u32,
+    tls_engines: u32,
+    tunnels: u32,
+) void {
+    assert(relay_buffers <= conn_slots);
+    assert(head_buffers <= conn_slots);
+    assert(tls_engines <= conn_slots);
+    assert(tunnels <= conn_slots);
+}
+
 fn resolveLimits(
     limits_json: *const LimitsJson,
     listeners_count: u32,
     http_listeners_count: u32,
     tls_listeners_count: u32,
+    upgrade_listeners_count: u32,
     access_log_on: bool,
     log_header_count: u32,
 ) ValidationError!Config.Limits {
     assert(listeners_count >= 1);
     assert(http_listeners_count <= listeners_count);
     assert(tls_listeners_count <= listeners_count);
+    assert(upgrade_listeners_count <= listeners_count);
     const slots = try resolveSlotCounts(limits_json);
     const conn_slots = slots.conn_slots;
     const relay_buffers = slots.relay_buffers;
@@ -1076,6 +1178,11 @@ fn resolveLimits(
         conn_slots,
         tls_listeners_count,
     );
+    const tunnels = try resolveTunnels(
+        limits_json.tunnels,
+        conn_slots,
+        upgrade_listeners_count,
+    );
     const cq_fill_eighths = try resolveCqFill(
         limits_json.cq_fill_eighths,
         conn_slots,
@@ -1092,9 +1199,7 @@ fn resolveLimits(
         access_log_on,
         log_header_count,
     );
-    assert(relay_buffers <= conn_slots);
-    assert(head_buffers <= conn_slots);
-    assert(tls_engines <= conn_slots);
+    assertPoolsFitConnSlots(conn_slots, relay_buffers, head_buffers, tls_engines, tunnels);
     return .{
         .conn_slots = conn_slots,
         .relay_buffers = relay_buffers,
@@ -1103,6 +1208,7 @@ fn resolveLimits(
         .upstream_head_buffers = upstream_head_buffers,
         .head_buffer_bytes = head_buffer_bytes,
         .tls_engines = tls_engines,
+        .tunnels = tunnels,
         .cq_fill_eighths = cq_fill_eighths,
         .access_log_buffer_bytes = access_log_buffer_bytes,
     };
@@ -1203,6 +1309,56 @@ fn resolveTlsEngines(
     }
     assert(tls_engines <= conn_slots);
     return tls_engines;
+}
+
+/// The §5 tunnel pool (#180). Shaped like `resolveTlsEngines` in every
+/// respect but the one that matters: **there is no derived default**.
+///
+/// Every other optional pool falls back to a worst case that cannot shed
+/// — head buffers to conn slots because every connection could be
+/// mid-head at once, engines to conn slots capped — and such a fallback
+/// is safe precisely because it can only be too generous. A tunnel count
+/// has no such number behind it. How many long-lived sessions an origin
+/// fleet should carry is a capacity decision, and deriving it from a
+/// connection count would silently promise a pool nobody sized: the
+/// failure would arrive as tunnels refused under load, far from the
+/// config that caused it. So a listener that allows upgrades without a
+/// `limits.tunnels` is refused at load, where the operator is looking.
+///
+/// The `≤ conn_slots` bound is not arithmetic hygiene either — it is
+/// what leaves the fd and ring budgets untouched (§5): `fdsRequired`
+/// already charges two sockets per connection, which is exactly what a
+/// tunnel holds, and `conn_ops_max` is 4 because one of its tying peaks
+/// is a relay teardown, which is a tunnel's steady state.
+fn resolveTunnels(
+    requested: ?u32,
+    conn_slots: u32,
+    upgrade_listeners_count: u32,
+) ValidationError!u32 {
+    assert(conn_slots >= 1);
+    const tunnels = requested orelse {
+        if (upgrade_listeners_count >= 1) {
+            return error.LimitTunnelsRequired;
+        }
+        return 0;
+    };
+    if (tunnels > constants.tunnels_max) {
+        return error.LimitTunnelsOutOfRange;
+    }
+    if (tunnels > conn_slots) {
+        return error.LimitTunnelsOverConnSlots;
+    }
+    if (upgrade_listeners_count == 0 and tunnels >= 1) {
+        return error.LimitTunnelsWithoutUpgrades;
+    }
+    // A pool of zero beside a listener that allows upgrades would refuse
+    // every one of them: the same contradiction as sizing the head ring
+    // to zero on an http deployment, and rejected on the same terms.
+    if (upgrade_listeners_count >= 1 and tunnels == 0) {
+        return error.LimitTunnelsOutOfRange;
+    }
+    assert(tunnels <= conn_slots);
+    return tunnels;
 }
 
 /// The §5 head-buffer ring follows conn slots when omitted (every
@@ -1431,6 +1587,7 @@ pub const LimitsJson = struct {
     upstream_head_buffers: ?u32 = null,
     head_buffer_bytes: ?u32 = null,
     tls_engines: ?u32 = null,
+    tunnels: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
     access_log_buffer_bytes: ?u32 = null,
 
@@ -1485,6 +1642,16 @@ pub const LimitsJson = struct {
             .minimum = 1,
             .maximum = constants.tls_engines_max,
         },
+        .tunnels = .{
+            .desc = "Concurrent tunnelled upgrades (#180). Each holds its own relay " ++
+                "buffer and upstream socket for its whole life, so tunnels never " ++
+                "draw on the pools ordinary traffic shares. Required — and only " ++
+                "legal — when some listener allows an upgrade; no default is " ++
+                "derived, because a count of long-lived sessions is a capacity " ++
+                "decision rather than something a connection count implies.",
+            .minimum = 1,
+            .maximum = constants.tunnels_max,
+        },
         .cq_fill_eighths = .{
             .desc = "Eighths of the io_uring completion queue the worst-case " ++
                 "in-flight ops may fill; lower reserves more burst headroom " ++
@@ -1523,6 +1690,10 @@ pub const ListenerJson = struct {
     proxy_protocol: ?ProxyProtocolJson = null,
     /// Optional TLS termination (#125); absent is a plaintext socket.
     tls: ?TlsJson = null,
+    /// Optional #180 upgrade allowlist; absent allows none, so an
+    /// `Upgrade` stays the 501 it has always been. HTTP-only — an l4
+    /// relay parses no handshake to recognise.
+    upgrades: ?[]const []const u8 = null,
 
     pub const schema_doc =
         "One accepting socket. Exactly one of `cluster` or `routes` selects " ++
@@ -1558,6 +1729,13 @@ pub const ListenerJson = struct {
             .desc = "Terminate TLS on this listener with the given certificate " ++
                 "and key; absent is a plaintext socket. Inbound only — the " ++
                 "upstream leg stays plaintext.",
+        },
+        .upgrades = .{
+            .desc = "Protocol upgrades this listener will carry as tunnels (http " ++
+                "listeners only); absent allows none and an Upgrade stays 501. " ++
+                "Requires limits.tunnels.",
+            .min_items = 1,
+            .items = SchemaItems.upgrade_token,
         },
     };
 };
@@ -2318,6 +2496,10 @@ pub const TimeoutsJson = struct {
     /// because a request deadline is a policy an operator sets against
     /// their own origin's latency, not a value zoxy can pick for them.
     request_ms: u32 = 0,
+    /// Optional #180 tunnel lifetime; absent means an hour. Unlike the
+    /// two caps above, zero is rejected — a tunnel pins a dedicated pool
+    /// slot, so "no cap" is the one answer §5 cannot carry.
+    tunnel_ms: u32 = constants.tunnel_ms_default,
     /// Optional §7 health-probe pacing; absent means HAProxy's `inter`
     /// default. Unlike the two caps above, zero is rejected: probing is
     /// switched per cluster (`check`), never by zeroing its interval.
@@ -2344,6 +2526,13 @@ pub const TimeoutsJson = struct {
             .desc = "Absolute connection-age cap; 0 disables it.",
             .minimum = 0,
             .maximum = constants.timeout_ms_max,
+        },
+        .tunnel_ms = .{
+            .desc = "Cap on one tunnelled upgrade's whole life, replacing the idle, " ++
+                "request and lifetime deadlines once a connection becomes one. " ++
+                "Zero is rejected: a tunnel holds a dedicated pool slot.",
+            .minimum = constants.tunnel_ms_min,
+            .maximum = constants.tunnel_ms_max,
         },
         .request_ms = .{
             .desc = "Cap on one L7 exchange, not refreshed by activity; 0 disables it.",
@@ -2414,8 +2603,9 @@ pub const ClustersJson = struct {
 
 /// Marker for array-item vocabularies reflection can't infer from the
 /// element type alone. `http_method` means "the items are the registered
-/// HTTP method tokens", which `config_schema.zig` emits as a token enum.
-pub const SchemaItems = enum { http_method };
+/// HTTP method tokens" and `upgrade_token` "the #180 upgrade set's field
+/// names", each of which `config_schema.zig` emits as a token enum.
+pub const SchemaItems = enum { http_method, upgrade_token };
 
 /// The attribute keys a `schema_fields` entry may carry beyond `.desc`.
 /// `assert_meta_matches` rejects any other key at comptime, so a typo'd
@@ -2719,6 +2909,7 @@ fn resolveListener(
         .forwarded = try resolveForwarded(listener_json.forwarded, protocol),
         .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
         .tls = try resolveTls(listener_json.tls, protocol),
+        .upgrades = try resolveUpgrades(listener_json.upgrades, protocol),
     };
     if (protocol == .http) {
         try rejectHttpClusterSend(listener.routes, clusters);
@@ -3556,6 +3747,53 @@ fn resolveRetries(retries: u16) ParseError!u16 {
     return retries;
 }
 
+/// Resolve a listener's #180 upgrade allowlist. Absent allows none, so
+/// an `Upgrade` keeps the `501` it has always got.
+///
+/// The vocabulary is the `Upgrades` set's own field names, which *are*
+/// the JSON tokens — the same one-source-of-truth the `protocol` and
+/// `pick` matches use, so a token the proxy can carry and a token an
+/// operator may write cannot drift apart. Anything else is refused by
+/// name rather than ignored: a config that asked to tunnel `h2c` and got
+/// silence would believe it had, and after `101` there is no rule left
+/// to catch what came through.
+///
+/// An empty list is refused too. It reads as "allow nothing", which
+/// already has a spelling — omit the field — and configured this way it
+/// would demand a `limits.tunnels` for a listener that can never use
+/// one.
+fn resolveUpgrades(
+    upgrades_json: ?[]const []const u8,
+    protocol: Config.Listener.Protocol,
+) ValidationError!Config.Listener.Upgrades {
+    const tokens = upgrades_json orelse return .{};
+    if (protocol == .l4) {
+        // A byte relay parses no handshake to recognise, so there is
+        // nothing here for it to allow — the same refusal `forwarded`
+        // and `routes` get on an l4 listener, for the same reason.
+        return error.ListenerL4Upgrades;
+    }
+    if (tokens.len == 0) {
+        return error.ListenerUpgradesEmpty;
+    }
+    assert(tokens.len >= 1);
+    var upgrades: Config.Listener.Upgrades = .{};
+    for (tokens) |token| {
+        var matched = false;
+        inline for (@typeInfo(Config.Listener.Upgrades).@"struct".fields) |field| {
+            if (std.mem.eql(u8, token, field.name)) {
+                @field(upgrades, field.name) = true;
+                matched = true;
+            }
+        }
+        if (!matched) {
+            return error.ListenerUpgradeTokenUnknown;
+        }
+    }
+    assert(upgrades.any()); // A non-empty list of known tokens sets one.
+    return upgrades;
+}
+
 /// Resolve a listener's §7 client-address forwarding: absent is off, and
 /// a `forwarded` block on an `l4` listener is rejected rather than
 /// ignored — a byte relay has no header to carry an address, so asking
@@ -3756,6 +3994,29 @@ fn clusterIndexOf(
     return error.ClusterUnknown;
 }
 
+/// The #180 tunnel lifetime, which is neither of the two shapes
+/// `validateTimeouts` handles in bulk.
+///
+/// It has no "off": a tunnel holds a dedicated pool slot for its whole
+/// life, so an unbounded one is the single hold §5's model cannot
+/// absorb, and `0` is therefore a value rather than a switch. It carries
+/// a *floor* rather than a nonzero check, because a sub-second lifetime
+/// would reap every session the instant it opened — a typo that presents
+/// as the feature not working. And its ceiling is its own, above
+/// `timeout_ms_max`: that bound calls an hour suspicious, which is right
+/// for every other timeout and wrong for this one, where an hour is the
+/// routine case and must leave somewhere to go.
+fn validateTunnelTimeout(tunnel_ms: u32) ValidationError!void {
+    if (tunnel_ms < constants.tunnel_ms_min) {
+        return error.TimeoutTunnelOutOfRange;
+    }
+    if (tunnel_ms > constants.tunnel_ms_max) {
+        return error.TimeoutTunnelOutOfRange;
+    }
+    assert(tunnel_ms >= constants.tunnel_ms_min);
+    assert(tunnel_ms <= constants.tunnel_ms_max);
+}
+
 fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
     // Deadlines a zero would break rather than disable: a 0 ms connect or
     // idle budget reaps on arrival, and a 0 ms probe interval would probe
@@ -3805,6 +4066,7 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
     if (timeouts.connect_ms >= timeouts.idle_ms) {
         return error.TimeoutOrderInvalid;
     }
+    try validateTunnelTimeout(timeouts.tunnel_ms);
     // Postconditions: reaching here means every bound a consumer reads
     // without checking is in range, and every optional one is at most the
     // ceiling — zero included, which each consumer reads as "off" — and the
@@ -3818,6 +4080,8 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
         assert(value <= constants.timeout_ms_max);
     }
     assert(timeouts.connect_ms < timeouts.idle_ms);
+    assert(timeouts.tunnel_ms >= constants.tunnel_ms_min);
+    assert(timeouts.tunnel_ms <= constants.tunnel_ms_max);
 }
 
 const example_json = @embedFile("example_config");
@@ -6493,5 +6757,150 @@ test "config: retries resolves, defaults to none, rejects past the ceiling" {
             .{ head, constants.cluster_retries_max + 1, tail },
         );
         try expectParseError(error.ClusterRetriesOutOfRange, json);
+    }
+}
+
+test "config: the upgrade allowlist is closed, http-only, and never empty" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http",
+        \\ "upgrades":
+    ;
+    const tail =
+        \\},{"bind":"127.0.0.1:2","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "limits":{"tunnels":16},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ "[\"websocket\"]" ++ tail);
+        try std.testing.expect(parsed.listeners[0].upgrades.websocket);
+        try std.testing.expect(parsed.listeners[0].upgrades.any());
+        // Per listener, and the l4 one beside it allows nothing — which is
+        // what every config predating the key keeps getting.
+        try std.testing.expect(!parsed.listeners[1].upgrades.any());
+        try std.testing.expectEqual(@as(u32, 16), parsed.limits.tunnels);
+    }
+    // A token this proxy cannot reason about is refused by name, never
+    // ignored: `h2c` would tunnel HTTP/2 to an origin it cannot parse,
+    // and a config that asked for it and got silence would believe it
+    // had — with no rule left after 101 to catch what came through.
+    try expectParseError(error.ListenerUpgradeTokenUnknown, head ++ "[\"h2c\"]" ++ tail);
+    try expectParseError(error.ListenerUpgradeTokenUnknown, head ++ "[\"websocket\",\"h2c\"]" ++ tail);
+    // "Allow nothing" already has a spelling — omit the field — and this
+    // one would demand a tunnel pool for a listener that can never use it.
+    try expectParseError(error.ListenerUpgradesEmpty, head ++ "[]" ++ tail);
+}
+
+test "config: upgrades are refused on an l4 listener" {
+    // A byte relay parses no handshake to recognise, so there is nothing
+    // here for it to allow — the same refusal `forwarded` and `routes`
+    // get on an l4 listener, rather than a block that quietly does
+    // nothing.
+    try expectParseError(error.ListenerL4Upgrades,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","upgrades":["websocket"]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "limits":{"tunnels":4},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+}
+
+test "config: the tunnel pool has no derived default, and binds to the allowlist" {
+    const with_upgrades =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http",
+        \\ "upgrades":["websocket"]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}
+    ;
+    // Every other optional pool derives a fallback that can only be too
+    // generous; a count of long-lived sessions has no such number behind
+    // it, so the omission is refused where the operator is looking rather
+    // than surfacing later as tunnels shed under load.
+    try expectParseError(error.LimitTunnelsRequired, with_upgrades ++ "}");
+    // A pool of zero beside a listener that allows upgrades would refuse
+    // every one of them — the same contradiction as a zero head ring on
+    // an http deployment.
+    try expectParseError(
+        error.LimitTunnelsOutOfRange,
+        with_upgrades ++ ",\"limits\":{\"tunnels\":0}}",
+    );
+    // And a pool nothing can draw on is the mirror image: asked for, and
+    // unusable.
+    try expectParseError(error.LimitTunnelsWithoutUpgrades,
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "limits":{"tunnels":8},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    // Zero exactly when no listener allows an upgrade, so one number says
+    // both how many tunnels there may be and whether the feature is on.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state,
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+        );
+        try std.testing.expectEqual(@as(u32, 0), parsed.limits.tunnels);
+    }
+}
+
+test "config: the tunnel pool may not exceed the connections that hold one" {
+    // Not arithmetic hygiene: this bound is what leaves the fd and ring
+    // budgets untouched by the feature (§5). A tunnel is an accepted
+    // client connection, so `fdsRequired`'s two-sockets-per-connection
+    // already covers its pair — but only while every tunnel has a
+    // connection to be.
+    var buffer: [512]u8 = undefined;
+    const json = try std.fmt.bufPrint(
+        &buffer,
+        "{s}{d}{s}",
+        .{
+            \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http",
+            \\ "upgrades":["websocket"]}],
+            \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+            \\ "limits":{"conn_slots":8,"tunnels":
+            ,
+            @as(u32, 9),
+            \\},
+            \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+            ,
+        },
+    );
+    try expectParseError(error.LimitTunnelsOverConnSlots, json);
+}
+
+test "config: tunnel_ms defaults to an hour and has no off switch" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http",
+        \\ "upgrades":["websocket"]}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "limits":{"tunnels":4},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1
+    ;
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ "}}");
+        try std.testing.expectEqual(
+            constants.tunnel_ms_default,
+            parsed.tunnel_timeout_ms,
+        );
+    }
+    // Zero is legal for `max_lifetime_ms` and `request_ms` and means "no
+    // cap". It cannot mean that here: a tunnel pins a dedicated pool slot
+    // for its whole life, and an unbounded hold on a bounded pool is the
+    // one thing that model cannot absorb.
+    try expectParseError(error.TimeoutTunnelOutOfRange, head ++ ",\"tunnel_ms\":0}}");
+    // The floor is a floor, not a nonzero check: a sub-second lifetime
+    // would reap every session on arrival, which reads as a typo.
+    try expectParseError(error.TimeoutTunnelOutOfRange, head ++ ",\"tunnel_ms\":999}}");
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ ",\"tunnel_ms\":1000}}");
+        try std.testing.expectEqual(constants.tunnel_ms_min, parsed.tunnel_timeout_ms);
     }
 }

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -242,8 +242,10 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
         .pointer => |ptr| {
             comptime assert(ptr.child == u8);
             if (comptime @hasField(@TypeOf(meta), "items")) {
-                comptime assert(meta.items == .http_method); // the only marker we define
-                try writeMethodEnum(out);
+                switch (meta.items) {
+                    .http_method => try writeMethodEnum(out),
+                    .upgrade_token => try writeUpgradeEnum(out),
+                }
             } else {
                 try out.objectField("type");
                 try out.write("string");
@@ -319,6 +321,22 @@ fn writePickField(out: *Stringify) Writer.Error!void {
 /// (`protocol` via a literal match, `pick` via `std.meta.stringToEnum`).
 fn writeEnum(out: *Stringify, comptime Enum: type) Writer.Error!void {
     const fields = @typeInfo(Enum).@"enum".fields;
+    comptime assert(fields.len >= 1);
+    try out.objectField("enum");
+    try out.beginArray();
+    inline for (fields) |field| try out.write(field.name);
+    try out.endArray();
+}
+
+/// The #180 upgrade vocabulary as an `"enum"` array, read off the
+/// `Upgrades` set's own field names — which *are* the JSON tokens, the
+/// same one-source-of-truth `protocol` and `pick` get from their enums.
+/// The set is a struct rather than an enum because membership is what
+/// the config expresses, so this walks fields where `writeEnum` walks
+/// variants; the closedness it publishes is the same, and it is the
+/// point: a token absent from here is one no rule could catch after 101.
+fn writeUpgradeEnum(out: *Stringify) Writer.Error!void {
+    const fields = @typeInfo(config.Config.Listener.Upgrades).@"struct".fields;
     comptime assert(fields.len >= 1);
     try out.objectField("enum");
     try out.beginArray();

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -251,6 +251,15 @@ pub const tls_engine_bytes_max: u32 = 160 * 1024;
 /// completion, so it costs memory and nothing else.
 pub const tls_engines_max: u32 = 1024;
 
+/// Ceiling on the §5 tunnel pool (#180): the same c10k ceiling conn slots
+/// carry, and necessarily so — a tunnel is an accepted client connection
+/// occupying a slot, so a pool larger than the connections that could
+/// hold one describes a proxy that cannot exist. The loader rejects past
+/// the *effective* `conn_slots` too; this is the comptime half, and the
+/// pair is what leaves the fd and ring budgets untouched by the feature
+/// (§5): `fdsRequired` already charges two sockets per connection.
+pub const tunnels_max: u32 = conn_slots_max;
+
 /// The default when a listener terminates TLS and the operator did not
 /// say. Follows conn slots like the head-buffer ring does — every
 /// connection could be mid-handshake at once — but capped, because
@@ -621,6 +630,33 @@ pub const body_name_bytes_max: u16 = 64;
 /// Upper bound on every configured timeout — one hour. A timeout above
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
+
+/// Ceiling on `timeouts.tunnel_ms` (#180) — the one timeout allowed past
+/// `timeout_ms_max`, and deliberately. That bound exists because an
+/// ordinary timeout above an hour is almost certainly a units mistake;
+/// for a tunnel an hour is not a suspicious number but a routine one, so
+/// reusing it would leave the default sitting *on* the ceiling with no
+/// way to ask for longer. A day is the units-mistake bound for a clock
+/// whose job is to outlive a working session.
+pub const tunnel_ms_max: u32 = 24 * 60 * 60 * 1000;
+
+/// Default bound on one tunnel's whole life (#180), replacing `idle_ms`,
+/// `request_ms` and `max_lifetime_ms` once a connection has become one —
+/// HAProxy's `timeout tunnel` in everything but spelling. An hour,
+/// because what is being bounded is a session whose keepalive is
+/// application-layer ping/pong this proxy cannot see: after `101` the
+/// bytes are opaque by construction, so a legitimately idle WebSocket is
+/// indistinguishable from an abandoned one and the only honest bound is
+/// a generous one.
+pub const tunnel_ms_default: u32 = 60 * 60 * 1000;
+
+/// Floor on `timeouts.tunnel_ms`. A sub-second lifetime would reap every
+/// session the instant it opened — a typo that presents as the feature
+/// not working. "No cap" deliberately has no spelling here at all,
+/// unlike `request_ms`: a tunnel holds a dedicated pool slot for its
+/// whole life (§5), and an unbounded hold on a bounded pool is the one
+/// thing that model cannot absorb.
+pub const tunnel_ms_min: u32 = 1000;
 
 /// Default `timeouts.connect_ms`: the per-try upstream dial budget when
 /// the config omits it (§5). Five seconds is the conventional figure — an
@@ -1166,6 +1202,14 @@ comptime {
     // A retry cap of zero would make the config key unspellable; one
     // retry is the degenerate-but-legal minimum. The set it sizes must
     // still fit the u16 count the balancer scans it with.
+    // A tunnel's clock must be a real duration, must leave headroom above
+    // its default, and must outrank the ordinary ceiling it deliberately
+    // escapes; the pool cannot exceed the connections that hold it.
+    assert(tunnels_max <= conn_slots_max);
+    assert(tunnel_ms_min >= 1);
+    assert(tunnel_ms_default >= tunnel_ms_min);
+    assert(tunnel_ms_max > tunnel_ms_default);
+    assert(tunnel_ms_max >= timeout_ms_max);
     assert(cluster_retries_max >= 1);
     assert(cluster_retries_max < std.math.maxInt(u16));
     // The health prober's reservations and thresholds (§7): the op budget

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -658,6 +658,21 @@ pub const tunnel_ms_default: u32 = 60 * 60 * 1000;
 /// thing that model cannot absorb.
 pub const tunnel_ms_min: u32 = 1000;
 
+/// How long a drain carries live tunnels when `drain_deadline_ms` is `0`
+/// (#180, §8). Five seconds, matching the drain ladder's other steps.
+///
+/// It exists because a zero deadline means "wait for the last
+/// connection", and a tunnel has no message boundary to finish at — one
+/// idle WebSocket would hold the drain open until the supervisor's
+/// SIGKILL, turning a millisecond drain into every rolling restart
+/// waiting out `TimeoutStopSec`. A constant rather than a config key
+/// deliberately: the alternative asks every operator to answer a
+/// question raised entirely by a feature they may not use, and
+/// `drain_deadline_ms` keeps its exact present meaning for every other
+/// connection. When a deadline *is* configured it governs tunnels like
+/// anything else and this is never armed.
+pub const tunnel_drain_ms: u32 = 5000;
+
 /// Default `timeouts.connect_ms`: the per-try upstream dial budget when
 /// the config omits it (§5). Five seconds is the conventional figure — an
 /// order below nginx's 60 s `proxy_connect_timeout`, which is a read
@@ -1210,6 +1225,10 @@ comptime {
     assert(tunnel_ms_default >= tunnel_ms_min);
     assert(tunnel_ms_max > tunnel_ms_default);
     assert(tunnel_ms_max >= timeout_ms_max);
+    // The tunnel drain bound must be a real wait and must not itself be
+    // the thing that makes a drain slow.
+    assert(tunnel_drain_ms >= 1);
+    assert(tunnel_drain_ms <= timeout_ms_max);
     assert(cluster_retries_max >= 1);
     assert(cluster_retries_max < std.math.maxInt(u16));
     // The health prober's reservations and thresholds (§7): the op budget

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1310,6 +1310,16 @@ pub const PoolSizes = struct {
     /// reservation like the access log's, in the total on the same
     /// promise; `main.zig` composes it to mirror `Server.init` exactly.
     head_scratch_bytes: u64,
+    /// The §5 tunnel pool (`limits.tunnels`; zero when no listener
+    /// allows an upgrade) and its unit size — the same `RelayBuffer` the
+    /// shared pool holds, reserved apart from it (§5, #180). Its own
+    /// term rather than folded into `relay_buffers` precisely because
+    /// the two are sized for opposite shapes: that pool for concurrent
+    /// activity, this one for connections that hold a buffer until they
+    /// close. A reader comparing the banner's two lines is reading the
+    /// trade the feature makes.
+    tunnels: u32 = 0,
+    tunnel_buffer_pair_bytes: u64 = 0,
     /// The §4 TLS engine pool (`limits.tls_engines`; zero when no
     /// listener terminates TLS) and its unit size — `@sizeOf(Engine)`,
     /// so the pool's own free-list header rides along like every other
@@ -1382,6 +1392,18 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     // A config has at least one cluster with one endpoint, so the
     // labeled tables and their buffers can never price at zero.
     assert(sizes.metrics_bytes > 0);
+    // All-or-nothing together, like the TLS terms below and for the same
+    // reason: a pool with no tunnels is a deployment that allows no
+    // upgrade, and any mixture is a composition mistake rather than a
+    // configuration one — `limits.tunnels` already refuses the
+    // config-level version of it.
+    assert(sizes.tunnels <= tunnels_max);
+    assert(sizes.tunnels <= sizes.conn_slots);
+    if (sizes.tunnels == 0) {
+        assert(sizes.tunnel_buffer_pair_bytes == 0);
+    } else {
+        assert(sizes.tunnel_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes));
+    }
     // The TLS terms are all-or-nothing together: a pool with no engines
     // is a plaintext deployment, which reserves no heap and no plaintext
     // buffers either. Any mixture is a composition mistake, not a
@@ -1403,6 +1425,7 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
         sizes.access_log_bytes + sizes.log_header_bytes +
         sizes.endpoint_table_bytes + sizes.metrics_bytes +
+        @as(u64, sizes.tunnels) * sizes.tunnel_buffer_pair_bytes +
         @as(u64, sizes.head_buffers) * (sizes.head_buffer_bytes + 1) +
         bufferGroupDescriptorBytes(sizes.head_buffers) +
         @as(u64, sizes.upstream_head_buffers) * sizes.upstream_head_buffer_bytes +
@@ -1512,6 +1535,39 @@ test "budgets: memory total matches the closed form" {
         .upstream_head_buffer_bytes = head_buffer_bytes_default,
         .head_scratch_bytes = head_buffer_bytes_default,
     }));
+    // Tunnels are priced only when a listener allows an upgrade, and the
+    // term is the pool's own — same shape as the L4 case above plus a
+    // tunnel pool, so the difference between the two totals is exactly
+    // what tunnels cost and nothing else. That separability is the
+    // budget half of §5's argument: a reader can see what the feature
+    // costs without unpicking it from the buffers HTTP shares.
+    const tunnels: u32 = 16;
+    const expected_tunnels = expected_small + @as(u64, tunnels) * pair_bytes;
+    try std.testing.expectEqual(expected_tunnels, memoryBytesTotal(&.{
+        .conn_slots = 64,
+        .conn_bytes = conn_bytes,
+        .relay_buffers = 8,
+        .relay_buffer_pair_bytes = pair_bytes,
+        .upstream_slots = 8,
+        .upstream_bytes = upstream_bytes,
+        .access_log_bytes = accessLogBytes(0),
+        .endpoint_table_bytes = 0,
+        .metrics_bytes = metrics,
+        .head_buffers = 0,
+        .head_buffer_bytes = head_buffer_bytes_default,
+        .upstream_head_buffers = 0,
+        .upstream_head_buffer_bytes = head_buffer_bytes_default,
+        .head_scratch_bytes = head_buffer_bytes_default,
+        .tunnels = tunnels,
+        .tunnel_buffer_pair_bytes = pair_bytes,
+    }));
+    // And the term really is what separates them: the difference between
+    // the two totals is the pool and nothing else, which is the claim a
+    // reader of the banner's tunnel line is entitled to make.
+    try std.testing.expectEqual(
+        @as(u64, tunnels) * pair_bytes,
+        expected_tunnels - expected_small,
+    );
     // TLS is priced only when a listener terminates it, and then by three
     // terms that move together: the engines, their plaintext buffers, and
     // the one process-wide libcrypto heap. Same shape as the L4 case above

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -208,6 +208,12 @@ pub const Counters = struct {
     /// is how many sessions were *established*, which is the number that
     /// answers "is the feature being used" long after they closed.
     tunnels_established: Value = Value.init(0),
+    /// Tunnels cut by the #180 drain bound — the connections a zero
+    /// `drain_deadline_ms` could otherwise wait on forever. Its own
+    /// counter rather than a share of `drained_at_deadline`: that one
+    /// says an operator's deadline expired, this one says a deadline
+    /// they never named was supplied for them (§8).
+    tunnels_drained: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
     /// §7 active health probes dispatched — one per checked endpoint per

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -198,6 +198,16 @@ pub const Counters = struct {
     /// single-endpoint cluster it fires on every dial failure, which is
     /// the honest reading — a retry budget there can never be spent.
     upstream_retries_exhausted: Value = Value.init(0),
+    /// Upgrade requests refused for want of a §5 tunnel (#180). Its own
+    /// rung rather than a share of the other sheds: each of those says
+    /// "widen this pool", and they name different pools. Counted before
+    /// the handshake is forwarded, so a refusal here contacted no origin.
+    l7_shed_tunnels: Value = Value.init(0),
+    /// Upgrades carried through to `101` and handed to the relay (#180).
+    /// The live count is a gauge read off the pool, not a counter: this
+    /// is how many sessions were *established*, which is the number that
+    /// answers "is the feature being used" long after they closed.
+    tunnels_established: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
     /// §7 active health probes dispatched — one per checked endpoint per

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -1449,6 +1449,7 @@ fn labeledTestConfig(clusters: []const config_module.Config.Cluster) config_modu
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,
+        .tunnel_timeout_ms = constants.tunnel_ms_default,
     };
 }
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -879,6 +879,15 @@ pub fn Proxy(comptime IoType: type) type {
                 respond(server, conn, 501, "l7_not_implemented");
                 return false;
             }
+            // A draining proxy does not open new sessions, and a tunnel is
+            // the longest-lived thing it could open (§8). Refused as a
+            // shed rather than a 501: the listener does allow this token,
+            // there is simply nowhere to put it — the same sentence the
+            // pool rung says, for the same reason.
+            if (server.draining) {
+                respond(server, conn, 503, "l7_shed_tunnels");
+                return false;
+            }
             conn.tunnel_buffer = server.acquireTunnelBuffer() orelse {
                 respond(server, conn, 503, "l7_shed_tunnels");
                 return false;
@@ -2160,7 +2169,20 @@ pub fn Proxy(comptime IoType: type) type {
             // and this one moves the other way — the armed timer fires at
             // the exchange's old target, reads the later stored one and
             // re-arms, which is how the L4 relay start hands over too.
-            server.storeDeadline(conn, server.config.tunnel_timeout_ms);
+            //
+            // A tunnel that completes its handshake *during* a drain takes
+            // the drain's bound instead, and it has to: the gate refuses
+            // new upgrades once draining, but one admitted just before it
+            // began is still in flight, and the drain's own timer is a
+            // single shot that may already have passed. Without this the
+            // failure #180 exists to close reopens for exactly the
+            // sessions that established late — an hour-long deadline on a
+            // process trying to exit.
+            const draining_bound = server.draining and server.config.drain_deadline_ms == 0;
+            server.storeDeadline(conn, if (draining_bound)
+                constants.tunnel_drain_ms
+            else
+                server.config.tunnel_timeout_ms);
             relay.Relay(IoType).start(server, conn);
         }
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -2087,7 +2087,10 @@ pub fn Proxy(comptime IoType: type) type {
             const head_write_len: u32 = @intCast(rendered.len + trailing.len);
             conn.l7.response_leg = .sending_head;
             conn.l7.response_started = true;
-            conn.log.status = response.status;
+            // The status is recorded at `beginTunnel`, not here: a `101`
+            // in the log means a tunnel the client actually got, so a
+            // handshake whose write never landed reports the teardown it
+            // really was rather than a session that never existed.
             server.captureResponseLogHeaders(conn, response.headers);
             armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .tunnel_start);
         }
@@ -2163,6 +2166,10 @@ pub fn Proxy(comptime IoType: type) type {
                 direction.owe(pipelined);
             }
             server.counters.increment("tunnels_established");
+            // Recorded here, where the client provably has the handshake
+            // (§8): the one line this connection writes at close is the
+            // tunnel's, and `101` is what identifies it as one.
+            conn.log.status = 101;
             // The tunnel's own clock replaces the three that would each
             // cut a healthy session (§8). Stored, not re-based: a rebase
             // exists to pull a deadline *earlier* than the armed timer,
@@ -2968,6 +2975,15 @@ pub fn Proxy(comptime IoType: type) type {
                 // Dropping it here would silently uncap the rest of the
                 // exchange, since `storeDeadline` stops clamping at zero.
                 .request_deadline_ns = conn.l7.request_deadline_ns,
+                // The #180 claim rides across, and must: the tunnel
+                // buffer is held on the connection, so a rebuild that
+                // dropped this flag would re-render the head *without*
+                // its participating `Upgrade` — the origin would answer
+                // an ordinary request, the client would get a `200` it
+                // never asked for, and the claim would sit unspent until
+                // the connection closed. Found by the simulator, on a
+                // seed where a stale checkout replayed a handshake.
+                .upgrade_requested = conn.l7.upgrade_requested,
                 // upstream_was_reused stays default-false: the replay try
                 // is a fresh dial, and a second early failure answers 502.
             };

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -39,6 +39,7 @@ const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
 const pump = @import("../net/pump.zig");
+const relay = @import("../net/relay.zig");
 const Io = @import("../io/io.zig");
 const parser = @import("parser.zig");
 const render = @import("render.zig");
@@ -765,8 +766,8 @@ pub fn Proxy(comptime IoType: type) type {
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");
             }
-            if (parser.headerValue(request.headers, "upgrade") != null) {
-                return respond(server, conn, 501, "l7_not_implemented");
+            if (parser.headerValue(request.headers, "upgrade")) |token| {
+                if (!admitUpgrade(server, conn, token)) return;
             }
 
             // §7: canonicalize the host and path once, then apply filters
@@ -848,6 +849,42 @@ pub fn Proxy(comptime IoType: type) type {
                     return .{ .endpoint = identity };
                 },
             }
+        }
+
+        /// Decide an `Upgrade` request's fate before a byte of it is
+        /// forwarded (#180). True means it may proceed as a would-be
+        /// tunnel; false means this function already answered.
+        ///
+        /// Two refusals saying different things. A token the listener
+        /// does not allow is `501` — the answer every `Upgrade` got
+        /// before this existed, and the honest one: it fails *here*, with
+        /// a status meaning what happened, rather than at an origin that
+        /// never saw a handshake. A token it does allow but no capacity
+        /// to carry is `503`, and the ordering *is* the §8 rung: checking
+        /// before the handshake is forwarded is what makes a refusal cost
+        /// nothing, where admitting first and shedding later would spend
+        /// an origin connection to produce a worse answer.
+        ///
+        /// The token must match whole and alone. RFC 9110 lets `Upgrade`
+        /// carry a comma-separated list with versions; anything but a
+        /// single token this proxy knows is refused rather than parsed
+        /// generously, because after `101` no rule of ours applies to
+        /// another byte and a loose reading here is the one thing that
+        /// cannot be taken back.
+        fn admitUpgrade(server: *ServerType, conn: *ConnType, token: []const u8) bool {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.tunnel_buffer == null);
+            assert(!conn.l7.upgrade_requested);
+            if (!conn.upgrades.websocket or !std.ascii.eqlIgnoreCase(token, "websocket")) {
+                respond(server, conn, 501, "l7_not_implemented");
+                return false;
+            }
+            conn.tunnel_buffer = server.acquireTunnelBuffer() orelse {
+                respond(server, conn, 503, "l7_shed_tunnels");
+                return false;
+            };
+            conn.l7.upgrade_requested = true;
+            return true;
         }
 
         /// Picks a live endpoint under the §8 per-endpoint inflight cap
@@ -1270,7 +1307,18 @@ pub fn Proxy(comptime IoType: type) type {
             // connection is a parking candidate (§5), and stripping the
             // client's Connection header already made persistence the wire
             // default.
-            const rendered = render.renderRequestHead(request, plan.target, plan.edits, false, forwarded, upstreamHeadBytes(upstream)) catch {
+            const rendered = render.renderRequestHead(
+                request,
+                plan.target,
+                plan.edits,
+                false,
+                forwarded,
+                // The participating `Upgrade` travels only when this
+                // listener agreed to carry it (#180); the gate already
+                // refused every other spelling.
+                conn.l7.upgrade_requested,
+                upstreamHeadBytes(upstream),
+            ) catch {
                 // Valid on arrival but no longer fits after edits: the §7
                 // oversize-after-edits verdict.
                 return respond(server, conn, 431, "l7_headers_too_large");
@@ -1982,6 +2030,140 @@ pub fn Proxy(comptime IoType: type) type {
             }
         }
 
+        /// The origin agreed: render its `101` to the client, with every
+        /// trailing byte it arrived with, and hand the connection to the
+        /// relay once the client has it (#180).
+        ///
+        /// The trailing bytes are why this cannot reuse the response
+        /// machinery. There, excess past the head is fed through the
+        /// framing tracker and forwarded as *body*; here the response is
+        /// bodiless by status and the bytes past the head are the origin's
+        /// first frames — payload of a protocol this proxy does not read.
+        /// So they are copied verbatim behind the rendered head, and the
+        /// head buffer is what bounds them: an origin that sent more than
+        /// fits is not a client error but an origin this proxy cannot
+        /// carry, answered like any other unrenderable head.
+        fn renderUpgradeAccepted(
+            server: *ServerType,
+            conn: *ConnType,
+            response: *const parser.ResponseHead,
+        ) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.upgrade_requested);
+            assert(response.status == 101);
+            assert(conn.tunnel_buffer != null);
+            const upstream = conn.upstream.?;
+            // No edits and no sticky stamp: #175 and #178 both describe a
+            // response an origin *served*, and this one only announces
+            // that serving has stopped being HTTP. A `Set-Cookie` naming
+            // the endpoint of a session about to become opaque would be a
+            // statement about a request that no longer exists.
+            const rendered = render.renderResponseHead(
+                response,
+                false,
+                &.{},
+                true,
+                headBytes(server, conn),
+            ) catch {
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(rendered.len >= 1);
+            const trailing = upstreamHeadBytes(upstream)[response.head_len..upstream.head_len];
+            if (rendered.len + trailing.len > headBytes(server, conn).len) {
+                upstreamFailed(server, conn);
+                return;
+            }
+            @memcpy(headBytes(server, conn)[rendered.len..][0..trailing.len], trailing);
+            const head_write_len: u32 = @intCast(rendered.len + trailing.len);
+            conn.l7.response_leg = .sending_head;
+            conn.l7.response_started = true;
+            conn.log.status = response.status;
+            server.captureResponseLogHeaders(conn, response.headers);
+            armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .tunnel_start);
+        }
+
+        /// The handshake reached the client, so this connection stops
+        /// speaking HTTP and starts relaying (#180).
+        ///
+        /// What changes hands here is the whole point of the feature. The
+        /// shared relay buffer, the head buffer and the *upstream slot*
+        /// all go back to the pools ordinary traffic draws on — a tunnel
+        /// that kept them would be the starvation §5 refuses — while the
+        /// origin socket stays open and the endpoint stays charged, now
+        /// the way an L4 connection charges it (`chargeEndpoint`). Slot
+        /// and socket are separable, and separating them is what lets a
+        /// tunnel be counted against `max_inflight` for its whole life
+        /// without pinning capacity ordinary exchanges shed against.
+        ///
+        /// Client bytes that arrived behind the handshake are staged into
+        /// the tunnel buffer and framed as this direction's debt, exactly
+        /// as a payload behind a PROXY header is (#142) — so `Relay.start`
+        /// sends them before it reads another byte, and a client that
+        /// pipelined its first frame is not left waiting for an echo of
+        /// something this proxy dropped.
+        fn beginTunnel(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.upgrade_requested);
+            assert(conn.upstream_socket != null);
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(conn.l7.request_head_len <= conn.head_len);
+            const pipelined = conn.head_len - conn.l7.request_head_len;
+            // `tunnel_buffer` stays set: it is what marks which pool this
+            // buffer belongs to. `relay_buffer` only *aliases* it, so the
+            // relay reads one field like every other connection while the
+            // release paths still know where to give it back — the two
+            // pools hold the same element type, so nothing but this marker
+            // could tell them apart.
+            const buffer = conn.tunnel_buffer.?;
+            // Staged before the head buffer goes back, since that is where
+            // the client's own trailing bytes still live.
+            if (pipelined >= 1) {
+                assert(pipelined <= buffer.client_to_upstream.len);
+                @memcpy(
+                    buffer.client_to_upstream[0..pipelined],
+                    headBytes(server, conn)[conn.l7.request_head_len..conn.head_len],
+                );
+            }
+            const leased = conn.upstream.?;
+            const cluster_index = leased.cluster_index;
+            const endpoint_index = leased.endpoint_index;
+            server.releaseUpstream(leased);
+            conn.upstream = null;
+            // Both held for certain here, unlike at the static-response
+            // rungs where either may never have been acquired: this runs
+            // only after a rendered head went out, which needed the head
+            // buffer, and every routed exchange holds a relay buffer.
+            assert(conn.relay_buffer != null);
+            assert(conn.head_buffer_id != ConnType.head_buffer_none);
+            server.releaseRelayBuffer(conn.relay_buffer.?);
+            server.returnHeadBuffer(conn);
+            conn.head_len = 0;
+            conn.relay_buffer = buffer;
+            conn.directions = .{ .{}, .{} };
+            // Charged while this is still an exchange, so the charge and
+            // the slot it replaces never both count the same work: the
+            // release above gave the lease back, and this takes its place
+            // in the same view (§7) before anything can read it.
+            server.chargeEndpoint(conn, cluster_index, endpoint_index);
+            conn.state = .relaying;
+            if (pipelined >= 1) {
+                const direction = &conn.directions[0];
+                direction.phase = .receiving;
+                direction.owe(pipelined);
+            }
+            server.counters.increment("tunnels_established");
+            // The tunnel's own clock replaces the three that would each
+            // cut a healthy session (§8). Stored, not re-based: a rebase
+            // exists to pull a deadline *earlier* than the armed timer,
+            // and this one moves the other way — the armed timer fires at
+            // the exchange's old target, reads the later stored one and
+            // re-arms, which is how the L4 relay start hands over too.
+            server.storeDeadline(conn, server.config.tunnel_timeout_ms);
+            relay.Relay(IoType).start(server, conn);
+        }
+
         fn renderResponse(
             server: *ServerType,
             conn: *ConnType,
@@ -1991,6 +2173,33 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_leg == .awaiting_head);
             assert(conn.l7.request_head_vacated);
             const upstream = conn.upstream.?;
+            // `101` on a carried upgrade is terminal, not interim (#180),
+            // and diverts before any of the ordinary response machinery
+            // below. Two reasons it cannot share that path: the framing
+            // tracker reads a sub-200 status as bodiless and would consume
+            // none of the trailing bytes, when for a tunnel every trailing
+            // byte is payload; and the state machine would treat the
+            // exchange as complete and go read another request, which is
+            // the desynchronisation §7 exists to prevent. An unrequested
+            // `101` is *not* diverted — an origin cannot upgrade a
+            // connection this proxy never asked to upgrade.
+            if (conn.l7.upgrade_requested and response.status == 101) {
+                return renderUpgradeAccepted(server, conn, response);
+            }
+            // The origin declined. Answering an upgrade request with an
+            // ordinary response is legal and common — an origin that does
+            // not speak WebSocket just serves the request — and the
+            // exchange from here is an ordinary one, so the tunnel claimed
+            // at the gate goes back *now* rather than at teardown. This
+            // connection is very likely kept: `conn.l7` resets at the
+            // turnaround while the claim lives on the connection, so
+            // holding it would pin a pool slot nothing is using for as
+            // long as the client stays, and a second `Upgrade` over the
+            // same connection would find one already held.
+            if (conn.l7.upgrade_requested) {
+                conn.l7.upgrade_requested = false;
+                releaseTunnelClaim(server, conn);
+            }
 
             const keep_downstream = downstreamKeepAlive(server, conn, response);
             conn.l7.downstream_close_announced = !keep_downstream;
@@ -2002,6 +2211,7 @@ pub fn Proxy(comptime IoType: type) type {
                 response,
                 !keep_downstream,
                 responseEditsWithStamp(server, conn, response, verdict, &edit_buffer, &cookie_scratch),
+                false,
                 headBytes(server, conn),
             ) catch {
                 // The head no longer fits — after the #175 edits or the
@@ -2113,6 +2323,15 @@ pub fn Proxy(comptime IoType: type) type {
             then: conn_module.ClientWrite.Then,
         ) void {
             switch (then) {
+                // The handshake is out and nothing has been relayed yet:
+                // still the exchange, still no verdict, and the tunnel
+                // buffer claimed at the gate is still in hand (#180).
+                .tunnel_start => {
+                    assert(conn.state == .l7_exchanging);
+                    assert(conn.l7.pending_verdict == .none);
+                    assert(conn.l7.upgrade_requested);
+                    assert(conn.tunnel_buffer != null);
+                },
                 .response_excess, .response_body => {
                     // `response_started` blocks a verdict, so none can be
                     // pending once response bytes are flowing (negative
@@ -2225,6 +2444,9 @@ pub fn Proxy(comptime IoType: type) type {
             }
             assertWriteContinuation(conn, write.then);
             switch (write.then) {
+                // The origin's `101` has reached the client, so the HTTP
+                // conversation on this connection is over (#180).
+                .tunnel_start => beginTunnel(server, conn),
                 .response_excess => sendResponseExcess(server, conn),
                 .response_body => {
                     assert(conn.l7.response_leg == .sending_body_excess);
@@ -2846,6 +3068,11 @@ pub fn Proxy(comptime IoType: type) type {
                 server.releaseRelayBuffer(buffer);
                 conn.relay_buffer = null;
             }
+            // The tunnel this request asked for and did not get (#180).
+            // A live tunnel never reaches here — it answers no static
+            // response — so this is always an unspent claim.
+            assert(conn.state != .relaying);
+            releaseTunnelClaim(server, conn);
             if (conn.upstream) |leased| {
                 if (conn.upstream_socket) |socket| {
                     server.io.closeNow(socket);
@@ -2857,6 +3084,24 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
+        }
+
+        /// Undo an unspent tunnel claim (#180): the gate takes a buffer
+        /// before the handshake is forwarded, and every ending other than
+        /// the origin's `101` has to give it back.
+        ///
+        /// One chokepoint because the claim outlives `conn.l7`. The
+        /// per-exchange state resets at every keep-alive turnaround, but
+        /// this lives on the connection, so a path that forgot would pin a
+        /// pool slot no session is using for as long as the client stays —
+        /// and the next `Upgrade` on that connection would meet a claim
+        /// already held. A no-op when nothing is claimed, so callers do
+        /// not each re-test it.
+        fn releaseTunnelClaim(server: *ServerType, conn: *ConnType) void {
+            const buffer = conn.tunnel_buffer orelse return;
+            assert(conn.relay_buffer != buffer); // Not yet swapped in: no live tunnel here.
+            server.releaseTunnelBuffer(buffer);
+            conn.tunnel_buffer = null;
         }
 
         /// Answer a comptime static error response, then keep the
@@ -3199,6 +3444,11 @@ pub fn Proxy(comptime IoType: type) type {
             // origin, and the line should read the same as the rungs
             // that refuse to protect this proxy (§8).
             if (std.mem.eql(u8, counter, "l7_shed_endpoint_inflight")) return .shed;
+            // A refused tunnel reads to a client like any other shed
+            // (#180): admitted, answered, refused for a resource. Which
+            // resource changes what an operator widens, not what the line
+            // says happened.
+            if (std.mem.eql(u8, counter, "l7_shed_tunnels")) return .shed;
             if (std.mem.eql(u8, counter, "l7_bad_gateway")) return .upstream_failed;
             if (std.mem.eql(u8, counter, "l7_gateway_timeout")) return .timed_out;
             @compileError("static-response counter with no access-log outcome: " ++ counter);

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -104,6 +104,10 @@ pub fn renderRequestHead(
     /// deliberate: the trust rule is a security decision with a counter
     /// attached, and a byte-assembler should have access to neither.
     forwarded_for: ?[]const u8,
+    /// True when this request is a protocol upgrade this listener has
+    /// agreed to carry (#180): the participating `Upgrade` travels and
+    /// the proxy writes its own `Connection: upgrade`.
+    keep_upgrade: bool,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     // The proxy answers CONNECT with 501 itself, never forwards it (§7).
@@ -130,10 +134,21 @@ pub fn renderRequestHead(
         request.connection_nominates_header,
         edits,
         forwarded_for != null,
+        keep_upgrade,
     );
     if (forwarded_for) |value| {
         assert(value.len >= 1);
         try staging.appendHeaderLine(forwarded_for_name, value);
+    }
+    // A carried upgrade announces the opposite of a close: this hop is
+    // continuing, in a different protocol. The two are mutually exclusive
+    // by construction — an exchange that becomes a tunnel is never the
+    // last one on a connection about to end — and the proxy writes this
+    // line itself rather than forwarding whichever spelling arrived, so
+    // what the next hop reads is exactly what this hop decided (#180).
+    if (keep_upgrade) {
+        assert(!inject_close);
+        try staging.append("Connection: upgrade\r\n");
     }
     if (inject_close) {
         try staging.append("Connection: close\r\n");
@@ -158,6 +173,9 @@ pub fn renderResponseHead(
     response: *const parser.ResponseHead,
     inject_close: bool,
     edits: []const filter.AppliedHeaderEdit,
+    /// True when this response is the `101` completing an upgrade this
+    /// proxy is carrying (#180), the mirror of the request-side flag.
+    keep_upgrade: bool,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     assert(response.status >= 100);
@@ -182,7 +200,18 @@ pub fn renderResponseHead(
         response.connection_nominates_header,
         edits,
         false,
+        keep_upgrade,
     );
+    // A carried upgrade announces the opposite of a close: this hop is
+    // continuing, in a different protocol. The two are mutually exclusive
+    // by construction — an exchange that becomes a tunnel is never the
+    // last one on a connection about to end — and the proxy writes this
+    // line itself rather than forwarding whichever spelling arrived, so
+    // what the next hop reads is exactly what this hop decided (#180).
+    if (keep_upgrade) {
+        assert(!inject_close);
+        try staging.append("Connection: upgrade\r\n");
+    }
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }
@@ -305,6 +334,21 @@ fn appendEndToEndHeaders(
     /// because the caller already folded it into the line it will write.
     /// Either way the header must appear exactly once downstream.
     suppress_forwarded_for: bool,
+    /// True when this hop is *participating* in a protocol upgrade
+    /// (#180), which is the one case where `Upgrade` must travel.
+    ///
+    /// It is hop-by-hop by definition, and stripping it is right for
+    /// every message this proxy merely forwards — the header names what
+    /// *this* connection could become, not what the next one should. A
+    /// handshake the proxy has decided to carry inverts that: here the
+    /// header names exactly this hop's intent, and removing it would
+    /// leave an origin asked to upgrade to nothing, or a client told it
+    /// succeeded without being told to what. Only the `Upgrade` header
+    /// itself is exempted — a `Connection` value's other nominations
+    /// still strip what they name, and the caller writes its own
+    /// `Connection: upgrade` line rather than forwarding whatever
+    /// spelling arrived.
+    keep_upgrade: bool,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
     // One slot past the filter budget: the #178 Set-Cookie stamp.
@@ -333,7 +377,12 @@ fn appendEndToEndHeaders(
     for (headers) |*header| {
         assert(header.name.len >= 1);
         if (isHopByHop(header, active_nominations)) {
-            continue;
+            // The one exemption (#180): a participating `Upgrade` on a
+            // hop this proxy has agreed to carry. Everything else the
+            // hop-by-hop rule names, including whatever a `Connection`
+            // value nominates beside it, still goes.
+            const participating = keep_upgrade and header.tag == .upgrade;
+            if (!participating) continue;
         }
         if (suppress_forwarded_for and header.tag == .x_forwarded_for) {
             continue;
@@ -461,13 +510,13 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
@@ -488,7 +537,7 @@ test "render: filter edits set, add, and remove headers" {
         .{ .kind = .remove, .name = "cookie", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, false, &buffer);
     // Surviving source headers first (Host, kept X-Trace, X-Keep), then the
     // injected set/add lines; the source X-Env and Cookie are gone.
     try testing.expectEqualStrings(
@@ -518,7 +567,7 @@ test "render: an edit that overflows the buffer is Oversize" {
     var tight: [34]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, &tight),
+        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, false, &tight),
     );
 }
 
@@ -551,7 +600,7 @@ test "render: the edited oracle skips a head that grows past head_buffer_bytes_d
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var render_buf: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, &render_buf);
+    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, false, &render_buf);
     try testing.expect(rendered.len > constants.head_buffer_bytes_default);
     // Must return cleanly instead of panicking in the reparse precondition.
     checkRequestRenderEdited(&source);
@@ -565,7 +614,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -583,7 +632,7 @@ test "render: a nomination on a second Connection line still strips" {
     const request = try parser.parseRequestHead(head, false, &storage);
     try testing.expect(request.connection_nominates_header);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
     // Both Connection lines are hop-by-hop; X-Nominated goes because the
     // second line named it; X-Keep is untouched.
     try testing.expectEqualStrings(
@@ -603,7 +652,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -618,7 +667,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, false, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -629,7 +678,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -640,13 +689,13 @@ test "render: response preserves status line and strips hop-by-hop" {
     const response = try parser.parseResponseHead(head, false, &storage, .get);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderResponseHead(&response, false, &.{}, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, false, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderResponseHead(&response, true, &.{}, &buffer);
+    const closed = try renderResponseHead(&response, true, &.{}, false, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n" ++
             "Connection: close\r\n\r\n",
@@ -669,7 +718,7 @@ test "render: response edits suppress, replace and append (#175)" {
         .{ .kind = .set, .name = "X-Keep", .value = "edited" },
         .{ .kind = .add, .name = "Strict-Transport-Security", .value = "max-age=63072000" },
     };
-    const rendered = try renderResponseHead(&response, false, &edits, &buffer);
+    const rendered = try renderResponseHead(&response, false, &edits, false, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
             "X-Keep: edited\r\n" ++
@@ -679,7 +728,7 @@ test "render: response edits suppress, replace and append (#175)" {
 
     // The close injection lands after the edits, exactly as it lands
     // after the origin's own headers.
-    const closed = try renderResponseHead(&response, true, &edits, &buffer);
+    const closed = try renderResponseHead(&response, true, &edits, false, &buffer);
     try testing.expect(std.mem.endsWith(u8, closed, "Connection: close\r\n\r\n"));
 
     // Growth from edits is a real overflow: the same head with an added
@@ -687,7 +736,7 @@ test "render: response edits suppress, replace and append (#175)" {
     var tight: [head.len - 1]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderResponseHead(&response, false, &edits, &tight),
+        renderResponseHead(&response, false, &edits, false, &tight),
     );
 }
 
@@ -696,7 +745,7 @@ test "render: bare status line without a reason phrase round-trips" {
     const response = try parser.parseResponseHead("HTTP/1.0 204\r\n\r\n", false, &storage, .get);
     try testing.expectEqual(@as(?[]const u8, null), response.status_message);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderResponseHead(&response, false, &.{}, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, false, &buffer);
     try testing.expectEqualStrings("HTTP/1.0 204\r\n\r\n", rendered);
 }
 
@@ -706,7 +755,7 @@ test "render: a head that no longer fits is Oversize" {
     const request = try parser.parseRequestHead(head, false, &storage);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, false, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -729,7 +778,7 @@ fn checkRequestRender(input: []const u8) void {
         .{ .path = request.target, .query = "" };
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &.{}, false, null, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, &.{}, false, null, false, &buffer) catch unreachable;
 
     // The oracle buffer carries slack past `head_buffer_bytes_default` so normalization
     // growth never truncates the comparison; production renders into an
@@ -786,7 +835,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &edits, false, null, &buffer) catch return;
+    const rendered = renderRequestHead(&request, target, &edits, false, null, false, &buffer) catch return;
 
     // The appended edits can push an already-large head past `head_buffer_bytes_default`
     // — the oversize-after-edits verdict (431 in production, which renders
@@ -813,7 +862,7 @@ fn checkResponseRender(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
     const response = parser.parseResponseHead(input, false, &storage, .get) catch return;
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderResponseHead(&response, false, &.{}, &buffer) catch unreachable;
+    const rendered = renderResponseHead(&response, false, &.{}, false, &buffer) catch unreachable;
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = parser.parseResponseHead(rendered, false, &reparse_storage, .get) catch unreachable;
@@ -881,6 +930,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
         &.{},
         false,
         forwarded_for,
+        false,
         &buffer,
     ) catch return;
     if (rendered.len > constants.head_buffer_bytes_default) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -631,6 +631,7 @@ const Http1Bed = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
             .access_log_sink = if (options.access_log) .stdout else null,
             .health_interval_ms = options.health_interval_ms,
             .error_pages = options.error_pages,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -498,6 +498,10 @@ const Http1Bed = struct {
         origin_response: []const u8 = "",
         /// The #181 dial-retry budget on the bed's one cluster.
         retries: u16 = 0,
+        /// The #180 upgrade allowlist and tunnel pool. Both off by
+        /// default, which is the shape every pre-#180 config has.
+        upgrades: config_module.Config.Listener.Upgrades = .{},
+        tunnels: u32 = 0,
         /// Put an endpoint nothing listens on *ahead* of the origin, so
         /// the first pick of an `rr` cluster is always the one that
         /// refuses and the retry is the only way to reach the origin.
@@ -615,6 +619,7 @@ const Http1Bed = struct {
             .request_filters = options.request_filters,
             .response_filters = options.response_filters,
             .protocol = .http,
+            .upgrades = options.upgrades,
             .forwarded = options.forwarded,
             // Paths nothing reads: the bed embeds the PEMs, so what this
             // states is only that the listener terminates.
@@ -650,6 +655,7 @@ const Http1Bed = struct {
             else
                 0,
             .tls_engines = if (options.tls) options.conn_slots else 0,
+            .tunnels = options.tunnels,
         });
         try bed.loadTlsCredentials(arena, options.tls);
         try bed.server.start();
@@ -4694,5 +4700,155 @@ test "l7: a dial that times out does not retry, because it spent the budget" {
     try std.testing.expect(elapsed_ms < 2 * Http1Bed.connect_timeout_ms);
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_retried"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try bed.expectDrained();
+}
+
+test "l7: an allowed upgrade becomes a tunnel and relays both ways" {
+    // #180 end to end: the handshake reaches the origin, its 101 reaches
+    // the client, and the connection then carries opaque bytes in both
+    // directions — the L4 relay of §6 entered from an L7 exchange.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 200,
+        .origin_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        .upgrades = .{ .websocket = true },
+        .tunnels = 2,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n");
+
+    // The client sees the origin's own 101, with the participating pair
+    // intact: stripping either would leave it told it succeeded without
+    // being told to what.
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 101 Switching Protocols\r\n",
+    ));
+    try std.testing.expect(std.mem.indexOf(u8, bed.client.response(), "Upgrade: websocket") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bed.client.response(), "Connection: upgrade") != null);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("tunnels_established"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_tunnels"));
+    try bed.expectDrained();
+}
+
+test "l7: an upgrade this listener does not allow keeps its 501" {
+    // The default, and what every config predating #180 keeps getting.
+    // Refused here rather than at an origin that never saw a handshake.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 201,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 501 Not Implemented\r\n",
+    ));
+    // No origin was contacted: the refusal is this proxy's own.
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tunnels_established"));
+    try bed.expectDrained();
+}
+
+test "l7: a token the allowlist does not name is refused by name" {
+    // `h2c` is the sharp case: tunnelling it would carry HTTP/2 to an
+    // origin this proxy cannot parse, past every rule the config
+    // expresses — and after 101 no rule of ours applies to another byte.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 202,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .upgrades = .{ .websocket = true },
+        .tunnels = 2,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: h2c\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 501 Not Implemented\r\n",
+    ));
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    // The pool is untouched: a token refused at the gate claims nothing.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_tunnels"));
+    try bed.expectDrained();
+}
+
+test "l7: an upgrade with no tunnel capacity is shed before the handshake" {
+    // The §8 rung, and the ordering is the rung: refused up front, so no
+    // origin connection is spent to produce a worse answer later.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 203,
+        .origin_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        .upgrades = .{ .websocket = true },
+        .tunnels = 1,
+    });
+    defer bed.tearDown();
+
+    // The first upgrade takes the only tunnel and holds it for the rest
+    // of the run; the second arrives once it is held and finds the pool
+    // empty, which is the whole point — a tunnel does not give its buffer
+    // back at the end of an exchange, because it has no end of exchange.
+    bed.client.drain_on_finish = false;
+    bed.client2.send_delay_ms = 100;
+    bed.client2.request = "GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\nConnection: close\r\n\r\n";
+    bed.client2.start(&bed.sim_io, &bed.server, Http1Bed.bindAddress());
+    try bed.exchange("GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("tunnels_established"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_shed_tunnels"));
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client2.response(),
+        "HTTP/1.1 503 Service Unavailable\r\n",
+    ));
+}
+
+test "l7: an origin that declines an upgrade gives the tunnel back" {
+    // Answering an `Upgrade` with an ordinary response is legal and
+    // common — an origin that does not speak WebSocket just serves the
+    // request. The claim taken at the gate has to come back at that
+    // moment, not at teardown: this connection is kept, and a claim left
+    // held would pin a pool slot nothing is using for as long as the
+    // client stays. `tunnels: 1` is what makes the leak visible — the
+    // second upgrade can only be served if the first gave its slot back.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 204,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .upgrades = .{ .websocket = true },
+        .tunnels = 1,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n");
+
+    // Both requests were served by the origin, and neither was shed: the
+    // second proves the first released its claim, since one tunnel is all
+    // the pool has. A leak here would answer the second with a 503.
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_tunnels"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tunnels_established"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_responses"));
     try bed.expectDrained();
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -502,6 +502,10 @@ const Http1Bed = struct {
         /// default, which is the shape every pre-#180 config has.
         upgrades: config_module.Config.Listener.Upgrades = .{},
         tunnels: u32 = 0,
+        /// The §8 drain deadline. The bed's default is a real one; a
+        /// tunnel scenario needs the zero case, which is production's
+        /// default and the one #180 had to answer for.
+        drain_deadline_ms: u32 = 1000,
         /// Put an endpoint nothing listens on *ahead* of the origin, so
         /// the first pick of an `rr` cluster is always the one that
         /// refuses and the retry is the only way to reach the origin.
@@ -633,7 +637,7 @@ const Http1Bed = struct {
             .clusters = &bed.clusters,
             .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
-            .drain_deadline_ms = 1000,
+            .drain_deadline_ms = options.drain_deadline_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
             .tunnel_timeout_ms = constants.tunnel_ms_default,
@@ -4850,5 +4854,40 @@ test "l7: an origin that declines an upgrade gives the tunnel back" {
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_tunnels"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tunnels_established"));
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: a drain with no deadline still ends, because tunnels are cut" {
+    // The trap #180 had to answer (§8). `drain_deadline_ms: 0` means
+    // "wait for the last connection", and a tunnel has no message
+    // boundary to be the last thing it does — so without this bound one
+    // idle session holds the process open until the supervisor's SIGKILL,
+    // turning a millisecond drain into every rolling restart waiting out
+    // TimeoutStopSec. Not an invariant breach, which is why it needed
+    // stating: a zero deadline always said the supervisor owns the upper
+    // bound, and it still does for every other connection.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 205,
+        .origin_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        .upgrades = .{ .websocket = true },
+        .tunnels = 1,
+        .drain_deadline_ms = 0,
+    });
+    defer bed.tearDown();
+
+    // The tunnel is established and then simply sits there, exactly as an
+    // idle WebSocket does; the drain arrives with it live.
+    bed.client.drain_on_finish = false;
+    bed.armDrainTimer(50);
+    try bed.exchange("GET /ws HTTP/1.1\r\nHost: o\r\n" ++
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("tunnels_established"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("tunnels_drained"));
+    // The line the drain's own counter cannot say: the loop actually
+    // stopped, with every pool given back (§9's leak invariant).
+    try std.testing.expect(bed.server.isIdle());
     try bed.expectDrained();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -496,6 +496,15 @@ fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
         // its share of the slab itself.
         .upstream_head_buffer_bytes = @sizeOf(zoxy.UpstreamHeadBuffer) + limits.head_buffer_bytes,
         .head_scratch_bytes = head_scratch_bytes,
+        // Zero unless a listener allows an upgrade, on the same terms as
+        // the TLS terms below: a feature nobody asked for costs nothing.
+        // Same element as a shared relay buffer, reserved apart from it
+        // (§5) — the point of the pool, not an accident of it.
+        .tunnels = limits.tunnels,
+        .tunnel_buffer_pair_bytes = if (limits.tunnels == 0)
+            0
+        else
+            @sizeOf(zoxy.RelayBuffer),
         // Zero unless a listener terminates TLS, which is what makes the
         // whole feature free to a deployment that did not ask for it. The
         // three terms move together: `limits.tls_engines` is zero exactly
@@ -601,6 +610,7 @@ fn printMemoryBanner(
         \\          + access log {d} KiB (+ logged headers {d} B)
         \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
         \\          + labeled metrics {d} B (tables, labels and render buffers)
+        \\          + tunnels {d} x {d} B (their own relay buffers, never HTTP's)
         \\          + tls engines {d} x {d} B (+ plaintext {d} B each, libcrypto heap {d} KiB)
         \\          + config arena {d} KiB (measured, not closed-form)
         \\
@@ -628,6 +638,10 @@ fn printMemoryBanner(
         config.clusters.len,
         ServerXev.endpointKeysFor(config).stride,
         ServerXev.metricsBytes(config),
+        // Both read zero unless a listener allows an upgrade — printed
+        // rather than omitted, on the same terms as the TLS line below.
+        limits.tunnels,
+        sizes.tunnel_buffer_pair_bytes,
         // All four read zero on a plaintext deployment, which is the line
         // saying "you are not paying for this" rather than omitting itself
         // and leaving the reader to wonder.

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -136,6 +136,13 @@ pub const ClientWrite = struct {
         response_body,
         /// A static response is out: the lingering close (§7, §8).
         lingering_close,
+        /// The origin's `101` is out and the client has it, so the HTTP
+        /// conversation on this connection is over (#180): hand the
+        /// connection to the relay. Deliberately *after* the head reaches
+        /// the client rather than at the parse — a tunnel that started
+        /// relaying before its handshake landed would interleave frame
+        /// bytes with the head that announces them.
+        tunnel_start,
         /// A static response is out and the client's byte stream is still
         /// synchronized: serve the next request on this connection (§7,
         /// §8). The keep half of the ladder's "then keep or close per
@@ -274,6 +281,19 @@ pub fn Conn(comptime IoType: type) type {
         /// idle on keep-alive — an idle L7 connection costs a slot and
         /// head buffer only (§5).
         relay_buffer: ?*relay.RelayBuffer,
+        /// The §5 tunnel buffer this connection has claimed (#180), held
+        /// from the moment its upgrade request is admitted until the
+        /// tunnel closes — or until the exchange fails before `101`, in
+        /// which case the disposal paths give it back like any other
+        /// resource.
+        ///
+        /// A field of its own rather than an early swap into
+        /// `relay_buffer`, because the exchange carrying the handshake is
+        /// still an ordinary L7 exchange that may need an ordinary relay
+        /// buffer. The two coexist for exactly the window between the
+        /// upgrade being admitted and the origin answering; at `101` the
+        /// shared one goes back and this one takes its place.
+        tunnel_buffer: ?*relay.RelayBuffer,
         /// Absolute deadline; state transitions only store a new value —
         /// the armed timer op is never touched (§4).
         deadline_ns: u64,
@@ -352,6 +372,10 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's §7 request filter rules, same lifetime as
         /// `routes` (empty on L4 and when no request filters are
         /// configured).
+        /// The listener's #180 upgrade allowlist, handed over at
+        /// admission like the filter tables beside it, so the gate asks
+        /// what *this* socket allows rather than consulting the config.
+        upgrades: config_module.Config.Listener.Upgrades,
         request_filters: []const filter.Rule,
         /// The listener's #175 response filter rules, same lifetime:
         /// matched against the origin's parsed response head at the
@@ -589,6 +613,12 @@ pub fn Conn(comptime IoType: type) type {
             /// The one free replay is spent (§7): a failure on the replay
             /// try answers 502 like any other, never a second replay.
             replay_used: bool = false,
+            /// This request asked for an upgrade the listener allows, and
+            /// a tunnel buffer is held for it (#180). What makes `101`
+            /// terminal rather than interim on the response path, and what
+            /// tells the render to let the participating
+            /// `Connection`/`Upgrade` pair travel.
+            upgrade_requested: bool = false,
             /// The endpoints this request dialed and had refused or found
             /// unreachable (#181), in the order it tried them — the
             /// exclusion set the next pick runs over. Sized for the first
@@ -674,6 +704,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.client_socket = client_socket;
             conn.upstream_socket = null;
             conn.relay_buffer = buffer;
+            conn.tunnel_buffer = null;
             conn.deadline_ns = 0;
             conn.birth_ns = server.io.nowNs();
             conn.armed = .{};
@@ -694,6 +725,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.routes = &.{};
             conn.request_filters = &.{};
             conn.response_filters = &.{};
+            conn.upgrades = .{};
             conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -36,6 +36,7 @@
 const std = @import("std");
 
 const config_module = @import("../config.zig");
+const constants = @import("../constants.zig");
 const conn_module = @import("Conn.zig");
 const pump = @import("pump.zig");
 const router = @import("../http/router.zig");
@@ -630,6 +631,7 @@ const Harness = struct {
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
         };
         // The Server owns the pools, the clock and teardown. Its own
         // listeners stay unbound: this scenario drives the pump directly, so

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -356,6 +356,7 @@ pub const TestBed = struct {
             // L4 only: the §8 request deadline is an L7 exchange bound and
             // this bed never routes one.
             .request_timeout_ms = 0,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
             .access_log_sink = if (options.access_log) .stdout else null,
             .health_interval_ms = options.health_interval_ms,
         };


### PR DESCRIPTION
Closes #180.

Any request carrying `Upgrade` was answered `501`. It now becomes a tunnel where the listener allows the token: the handshake reaches the origin, its `101` reaches the client, and the connection relays opaque bytes both ways for the rest of its life. Everything else keeps the `501` — which is every config that does not name an allowlist.

Six commits, design first. The order was deliberate: what #180 needed decided is operator-visible policy that the implementation would otherwise hard-code assumptions about, and that is cheaper to argue with on paper than to unpick from a slice.

| | |
|---|---|
| `ba1c763` | the settled design (§1/§5/§7/§8) |
| `eca0423` | config surface — allowlist, pool, timeout class |
| `b71c046` | the tunnel pool, reserved apart from HTTP's |
| `e1d0c5b` | the mechanism — `101` terminal, the transition |
| `d067f16` | the drain rule |
| `0175bf7` | simulator coverage |

## The mechanism is small; the resource model is the work

A tunnel is the L4 relay of §6 entered from an L7 exchange — `Conn.State.relaying` already existed, half-close and all. Three rules the ordinary path would otherwise get wrong:

- **`101` is terminal, not interim.** The parser already frames a sub-200 status as bodiless, so a `101` *parses* today. The bug is that the state machine would treat the exchange as complete and go read another request — the desynchronisation §7 exists to prevent. It also cannot share the ordinary response path, because the framing tracker consumes no trailing bytes for a bodiless status, and for a tunnel every byte past the head is payload.
- **A participating `Upgrade` survives hop-by-hop stripping** — the one case where that header names *this* hop's intent rather than something to forward. The proxy writes its own `Connection: upgrade` instead of echoing whatever arrived.
- **Bytes past the boundary are relayed.** A client may pipeline its first frame behind the handshake; those are staged as owed debt exactly as a payload behind a PROXY header is (#142), so `Relay.start` sends them before reading another byte.

An **unrequested** `101` is deliberately not diverted: an origin cannot upgrade a connection this proxy never asked to upgrade.

## Why tunnels get their own pool

Every pool in §5 is sized for concurrent *activity* — a keep-alive connection holds no head buffer, a parked upstream holds no head. A tunnel inverts that: it pins its buffer for the connection's whole life and can never return to keep-alive. Sharing one reservation would let long-lived sessions consume exactly what ordinary requests shed against, so `limits.tunnels` is reserved apart and tunnels cannot starve HTTP because they never touch what HTTP draws from.

It is the one optional pool with **no derived default**. The others fall back to a worst case that cannot shed, which is safe because it can only be too generous; a count of long-lived sessions has no such number behind it, so a listener allowing upgrades without one is refused at load rather than surfacing later as tunnels shed under load. Its `≤ conn_slots` bound is not arithmetic hygiene — it is what leaves the fd and ring budgets untouched, since `fdsRequired` already charges two sockets per connection and `conn_ops_max` is 4 because one of its tying peaks is a relay teardown.

Cost: **~90 MiB at the ceiling and nothing else.** The §5 total moves ~294 → ~384 MiB, and the banner prints `+ tunnels N x 8200 B`.

## Two design contradictions found while building, both corrected

**§5 said tunnels never touch shared pools; §7 said `max_inflight` counts them.** Both cannot hold if a tunnel keeps its upstream slot. It releases the slot and keeps the *socket* — separable, and separating them is what makes both true — and charges the endpoint the way an L4 connection is charged, which is what a tunnel is after `101`.

**The drain trap is real but not the contract breach the issue describes.** A `drain_deadline_ms` of `0` already means the supervisor owns the upper bound. What an idle tunnel does is turn "the drain ends in milliseconds" into "every rolling restart waits out `TimeoutStopSec`". A configured deadline already cut tunnels; only the zero case needed code, and it arms a tunnel-only bound on the very completion the configured deadline would have used — mutually exclusive, so no ring-budget change. Review caught that a single shot was not enough: a handshake admitted before the drain can reach `101` after the timer fires, so the gate now refuses new upgrades while draining and a tunnel establishing mid-drain takes the drain's bound.

## Security

The token allowlist is closed and empty by default, per listener. After `101` the stream is opaque and no filter, route or header rule applies to another byte, so a token this proxy cannot reason about is refused **by name**, never ignored — `h2c` would tunnel HTTP/2 to an origin it cannot parse, past everything the config expresses, and a config that asked for it and got silence would believe it had.

## What the gates caught

Worth reading as the argument for having them, since none of this was found by inspection:

- `Pool.indexOf` caught a **crossed release** between the two same-element pools — the exact check the pool slice's review had flagged as only incidentally protective.
- Review caught two leaks reachable by ordinary traffic: an origin may simply **decline** an upgrade with a normal response (the claim must come back then, or a second `Upgrade` over that kept connection trips a live assert), and teardown must not read the buffer alias **before** `101`, when the two fields are distinct buffers from distinct pools.
- The simulator found `beginReplay` was not carrying `upgrade_requested`, so a handshake hitting a stale pooled connection was re-rendered with `Upgrade` stripped; and that `101` was logged before the client had the bytes.
- The access-log identity fired on the first seed to carry a tunnel, exactly as its comment promises.
- Review found the sim oracle was **silent on the participating pair** — a response-side render regression would have produced a `101` and passed. It now demands both headers by name; dropping the exemption fails seed 24 with `UpgradePairMissing`, where before it failed nothing.

## Gates

- `zig build ci` green — 4096 seeds, census ok (63 counters fired, up from 61), live smoke gate clean
- `zig build sim -- 4097 16384` green including census
- `zig fmt --check` clean
- `tiger-style-reviewer` on every slice; every finding fixed

One census exemption remains, structural rather than a shortfall: `tunnels_drained` needs the five-second production drain bound and a whole scenario is two seconds of virtual time. Seeds do establish tunnels and do drain with them live — the tunnel dies with its client instead. `src/http_proxy_test.zig` drains a live tunnel under a zero `drain_deadline_ms` and asserts the loop reached idle.

Not in scope: WebSocket over HTTP/2 (RFC 8441 Extended CONNECT) is a different mechanism — see #173. `CONNECT` stays `501`: it asks this proxy to open an arbitrary destination, which is a forward-proxy behaviour and a different decision from carrying an upgrade to a routed cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)