### PR TITLE
http: a 1xx is interim — relay it, and let the exchange go on (#232)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -962,6 +962,32 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   requirement rather than an intention: a counter no scenario reaches
   fails the sweep, so the simulator has to carry the L7→L4 transition
   and the trailing-bytes case before any of this can land.
+- **A `1xx` is interim: it is relayed, and the exchange goes on** (#232).
+  The state machine had no status branch at all on the response path, so a
+  `100 Continue` parsed as a complete bodiless keep-alive response and the
+  exchange *settled* on it. Which way that broke depended only on whether
+  the request body had finished. Mid-body — `Expect: 100-continue`, which
+  curl sends automatically for any body over 1 KiB and nginx honours — the
+  client got the interim and then a close. Body already sent, the interim
+  was rendered as the answer and the upstream **parked with the real
+  response still unread in its socket**, so the next checkout read one
+  client's answer as another's. The stale check at checkout detects a FIN,
+  not pending data, so nothing caught it.
+  Relayed rather than absorbed, which is what nginx and HAProxy both do
+  and the only useful half to copy: a `103 Early Hints` is worthless to a
+  client that never sees it, and a `100` is precisely what a client
+  blocked on `Expect` is waiting for. `Expect` itself needs no handling —
+  it travels to the origin like any other header and the origin decides.
+  Answering `100` locally would commit this proxy to admitting a body the
+  origin may be about to refuse, which is the worse trade.
+  **Bounded, which neither reference is.** An origin streaming `103`s
+  forever is an unbounded loop on the one thread (§3), so
+  `interim_responses_max` caps them per exchange and the overrun takes the
+  same path an unparseable origin head does. `101` is the exception at
+  both ends: a protocol switch rather than a continuation, terminal when
+  this proxy asked for it (#180) and a failed exchange when it did not,
+  because relaying it as interim would carry on reading bytes that are no
+  longer HTTP.
 - **Early responses are legal.** An origin may answer before the request
   body finishes (RFC 9110 — e.g. 413 mid-upload): the response head is
   forwarded when it arrives, and the remaining request body is drained or

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -202,6 +202,12 @@ retries_http: u16,
 /// a tunnel pool to carry it. Off on most seeds, so the handshake script
 /// keeps proving the `501` every config had before the feature.
 upgrades_http: bool,
+/// The seed's http origin prefixes an interim `100 Continue` to every
+/// answer (#232). Drawn once per seed rather than per accept, so a clean
+/// seed's transcript stays exact — which is the point: the golden oracle
+/// is what has teeth over the interim path, and it only runs on clean
+/// seeds.
+interim_http: bool,
 tunnels: u32,
 /// Decided before `io.init` (the ring the sim registers must equal the
 /// limit the server accounts against — Server.init asserts the match),
@@ -639,6 +645,11 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.endpoints_http = .{ httpOriginAddress(), httpOriginAddress() };
     deriveRetries(harness, random);
     deriveUpgrades(harness, random);
+    // A quarter of seeds. Clean ones included, deliberately: an
+    // adversarial seed only holds the transcript to a legal *prefix*, so
+    // a proxy that settled on the interim and dropped the real answer
+    // would pass there. The exact-outcome oracle is the one that notices.
+    harness.interim_http = random.uintLessThan(u8, 4) == 0;
     // Each cluster draws its pick policy independently so mixed configs
     // (one cluster each way) flow through the balancer under the schedule
     // fuzz, not just the uniform pairings. Single-endpoint clusters
@@ -2685,6 +2696,9 @@ fn pickOriginMode(context: ?*anyopaque) zoxy.testing.Mode {
 /// outcomes stay exact.
 fn pickHttpOriginMode(context: ?*anyopaque) l7.OriginMode {
     const harness: *Harness = @ptrCast(@alignCast(context.?));
-    if (harness.clean) return .sized;
+    if (harness.clean) {
+        return if (harness.interim_http) .interim_then_sized else .sized;
+    }
+    if (harness.interim_http) return .interim_then_sized;
     return harness.scenario_prng.random().enumValue(l7.OriginMode);
 }

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -93,6 +93,18 @@ pub const oversize_head = "HTTP/1.1 200 OK\r\nx-pad: " ++ ("p" ** 8162) ++ "\r\n
 pub const switching_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
     "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
 
+/// The `100 Continue` an Expect-honouring origin answers with (#232),
+/// ahead of the response it was going to send anyway. Interim: the
+/// exchange is not over, and a proxy that settles on it either closes on
+/// a client mid-body or parks an upstream whose real answer is still
+/// unread.
+pub const interim_continue = "HTTP/1.1 100 Continue\r\n\r\n";
+
+/// `103 Early Hints` with a preload link — what Cloudflare, Fastly and
+/// `res.writeEarlyHints` emit. Repeated past `interim_responses_max` it is
+/// also the flood the bound exists to cut.
+pub const interim_hints = "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n";
+
 comptime {
     assert(sticky_tag.len == 16);
     assert(sized_body.len == 32);

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -398,6 +398,10 @@ pub fn Client(comptime IoType: type) type {
 
         pub const Walk = struct {
             complete_count: u8,
+            /// Interim `1xx` heads walked past (#232). Kept apart from
+            /// `complete_count` because they are not responses — an
+            /// exchange that carried three of them still answered once.
+            interim_count: u8,
             offset: u32,
             statuses: [responses_max]u16,
             /// Per-response persistence verdicts (§7): version defaults
@@ -415,6 +419,7 @@ pub fn Client(comptime IoType: type) type {
         pub fn walkResponses(bytes: []const u8, entry: Spec, connection: Connection) Walk {
             var walk = Walk{
                 .complete_count = 0,
+                .interim_count = 0,
                 .offset = 0,
                 .statuses = @splat(0),
                 .keep_alives = @splat(false),
@@ -436,6 +441,23 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = ClientError.ResponseCorrupted;
                     return walk;
                 };
+                // An interim `1xx` is not the response (#232): the origin
+                // has not answered yet, so it advances the walk without
+                // counting toward the transcript or its allowed set. That
+                // is what lets every existing script stay exactly as it
+                // was while an origin drawn into an interim mode prefixes
+                // one — and it is the oracle half of the bug, since a
+                // proxy that *settled* on the interim would leave the
+                // real answer unwalked and the count short.
+                // `101` is excluded on the same grounds the proxy excludes
+                // it: a protocol switch, not a continuation. It *is* the
+                // answer to an upgrade (#180), and walking past it would
+                // leave that transcript looking like no response at all.
+                if (response.status >= 100 and response.status < 200 and response.status != 101) {
+                    walk.interim_count +|= 1;
+                    walk.offset += response.head_len;
+                    continue;
+                }
                 if (std.mem.indexOfScalar(u16, entry.allowed_statuses, response.status) == null) {
                     walk.violation = ClientError.ResponseStatusUnexpected;
                     return walk;

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -47,6 +47,15 @@ pub const OriginMode = enum(u8) {
     /// Send the oversize-after-edits head at accept time, then drain:
     /// the render-failure race into the deferred-render path.
     instant_oversize,
+    /// Answer `100 Continue` and then the canonical sized 200 (#232).
+    /// An interim is not the answer: a proxy that settles on one closes
+    /// on a client still sending its body, or parks an upstream with the
+    /// real response unread and hands it to the next client.
+    interim_then_sized,
+    /// Answer `103 Early Hints` past the proxy's own bound and never
+    /// answer at all — the unbounded-`1xx` origin neither nginx nor
+    /// HAProxy bounds, which the one-thread design has to.
+    interim_flood,
     /// Answer the sized keep-alive 200, then close: the proxy parks on
     /// the head's promise, the FIN lands while parked, and the next
     /// checkout meets the §5 stale connection — the §7 replay's shape.
@@ -438,6 +447,18 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 assert(conn.phase == .head);
                 switch (conn.mode) {
                     .sized, .reset => conn.armRecv(),
+                    .interim_then_sized => {
+                        conn.response_bytes = canon.interim_continue ++ canon.sized_response;
+                        conn.armRecv();
+                    },
+                    .interim_flood => {
+                        // Never answers: the proxy's own bound is what
+                        // ends this, which is the whole point of the mode.
+                        conn.response_bytes = canon.interim_hints **
+                            (zoxy.constants.interim_responses_max + 2);
+                        conn.drain_only = true;
+                        conn.armRecv();
+                    },
                     .stale_reuse => {
                         // The keep-alive head parks the proxy's side; the
                         // close after responding is the staleness itself.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -504,6 +504,16 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// not a share.
 pub const endpoint_weight_max: u16 = 256;
 
+/// Interim (`1xx`) responses one exchange may carry before the origin's
+/// final answer (#232). RFC 9110 puts no cap on them, and neither nginx
+/// nor HAProxy does — both loop while the status is `1xx` — but an origin
+/// streaming `103 Early Hints` forever is an unbounded loop on the one
+/// thread (§3), which §1 rules out. Eight is well past what a real origin
+/// sends (a `100`, or a handful of `103`s naming preload targets) and far
+/// short of a stall; the overrun takes the `upstreamFailed` path, the same
+/// verdict an unparseable origin head earns.
+pub const interim_responses_max: u8 = 8;
+
 /// Upper bound on a cluster's configured `retries` (#181) — the extra
 /// dials one request may spend after a refused or unreachable first try.
 /// HAProxy's own default, and a ceiling rather than a taste: every try
@@ -1229,6 +1239,9 @@ comptime {
     // the thing that makes a drain slow.
     assert(tunnel_drain_ms >= 1);
     assert(tunnel_drain_ms <= timeout_ms_max);
+    // An exchange must be allowed at least one interim, or the bound
+    // would forbid the `100 Continue` the feature exists to carry.
+    assert(interim_responses_max >= 1);
     assert(cluster_retries_max >= 1);
     assert(cluster_retries_max < std.math.maxInt(u16));
     // The health prober's reservations and thresholds (§7): the op budget

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -214,6 +214,17 @@ pub const Counters = struct {
     /// says an operator's deadline expired, this one says a deadline
     /// they never named was supplied for them (§8).
     tunnels_drained: Value = Value.init(0),
+    /// Interim `1xx` responses relayed to the client (#232). Forwarded
+    /// rather than absorbed, which is what both references do: a `103` is
+    /// worthless to a client that never sees it, and a `100` the client is
+    /// blocked waiting for is the whole point of `Expect`. Counted per
+    /// interim, so an exchange carrying several moves it several times.
+    l7_interim_forwarded: Value = Value.init(0),
+    /// Exchanges torn down for exceeding `interim_responses_max` (#232) —
+    /// an origin that kept sending `1xx` and never answered. Its own
+    /// counter because it is a *bound* being hit rather than an origin
+    /// speaking badly: the head parsed fine every time.
+    l7_interim_overrun: Value = Value.init(0),
     /// Parked upstream connections reaped by the idle sweep (§5).
     upstream_idle_reaped: Value = Value.init(0),
     /// §7 active health probes dispatched — one per checked endpoint per

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -2193,6 +2193,159 @@ pub fn Proxy(comptime IoType: type) type {
             relay.Relay(IoType).start(server, conn);
         }
 
+        /// Relay an interim `1xx` to the client and leave the exchange
+        /// exactly where it was (#232).
+        ///
+        /// Forwarded rather than absorbed, which is both references'
+        /// behaviour and the only useful one: a `103 Early Hints` is
+        /// worthless to a client that never sees it, and a `100 Continue`
+        /// is precisely what a client sending `Expect: 100-continue` is
+        /// blocked waiting for. `Expect` itself needs no handling — it
+        /// travels to the origin like any other header, and the origin
+        /// decides. Answering `100` locally would commit this proxy to a
+        /// body the origin may be about to refuse.
+        ///
+        /// Nothing about the exchange is committed here: no edits, no
+        /// #178 stamp, no `response_started`, no logged status. An
+        /// interim is not the answer, and every one of those would
+        /// describe the answer.
+        fn forwardInterim(
+            server: *ServerType,
+            conn: *ConnType,
+            response: *const parser.ResponseHead,
+        ) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            assert(response.status >= 100);
+            assert(response.status < 200);
+            assert(response.status != 101); // The caller diverts both 101 cases.
+            if (conn.l7.interims_seen >= constants.interim_responses_max) {
+                // An origin that keeps promising and never answers is an
+                // unbounded loop on the one thread (§3), which no legal
+                // response justifies. Counted apart from a malformed head
+                // because nothing was malformed — the bound is what ran
+                // out.
+                server.counters.increment("l7_interim_overrun");
+                upstreamFailed(server, conn);
+                return;
+            }
+            conn.l7.interims_seen += 1;
+            const upstream = conn.upstream.?;
+            const rendered = render.renderResponseHead(
+                response,
+                false,
+                &.{},
+                false,
+                headBytes(server, conn),
+            ) catch {
+                upstreamFailed(server, conn);
+                return;
+            };
+            assert(rendered.len >= 1);
+            // Drop the interim from the origin's buffer and keep whatever
+            // followed it: the final response's head may already be
+            // sitting behind this one in the same read, and discarding it
+            // would strand the exchange waiting for bytes it already has.
+            const consumed = response.head_len;
+            assert(consumed <= upstream.head_len);
+            const rest = upstream.head_len - consumed;
+            if (rest >= 1) {
+                std.mem.copyForwards(
+                    u8,
+                    upstreamHeadBytes(upstream)[0..rest],
+                    upstreamHeadBytes(upstream)[consumed..upstream.head_len],
+                );
+            }
+            upstream.head_len = rest;
+            conn.l7.response_head_len_marker = 0;
+            server.counters.increment("l7_interim_forwarded");
+            armClientWrite(server, conn, headBytes(server, conn)[0..rendered.len], .interim_sent);
+        }
+
+        /// The interim reached the client; carry on waiting for the real
+        /// answer (#232). Either it is already buffered — an origin that
+        /// sent `100` and its `200` in one write — or the socket owes it.
+        fn resumeAfterInterim(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_exchanging);
+            assert(conn.l7.response_leg == .awaiting_head);
+            assert(!conn.l7.response_started);
+            assert(conn.l7.interims_seen >= 1);
+            const upstream = conn.upstream.?;
+            if (upstream.head_len >= 1) {
+                parseResponseAndDispatch(server, conn);
+                return;
+            }
+            armResponseHeadRecv(server, conn);
+        }
+
+        /// What kind of response this is, before any of the machinery
+        /// that assumes it is *the* response runs. Returns false when it
+        /// has taken the exchange somewhere else.
+        ///
+        /// Three answers hide behind a status here, and each breaks the
+        /// ordinary path differently. A requested `101` is terminal and
+        /// becomes a tunnel (#180). Any other `1xx` is interim: relayed,
+        /// with the exchange left exactly where it was (#232) — settling
+        /// on one either closes on a client still sending its body, or
+        /// parks an upstream whose real answer is still unread. And a
+        /// `101` nobody asked for is an origin switching a protocol it
+        /// was not invited to switch, which cannot be relayed as interim
+        /// because what follows it is no longer HTTP.
+        fn dispatchByStatus(
+            server: *ServerType,
+            conn: *ConnType,
+            response: *const parser.ResponseHead,
+        ) bool {
+            assert(conn.state == .l7_exchanging);
+            assert(response.status >= 100);
+            if (conn.l7.upgrade_requested and response.status == 101) {
+                renderUpgradeAccepted(server, conn, response);
+                return false;
+            }
+            if (response.status >= 200) {
+                // The origin declined an upgrade it was offered, which is
+                // legal and ordinary — hand the claim back before the
+                // exchange carries on as any other (#180).
+                if (conn.l7.upgrade_requested) {
+                    conn.l7.upgrade_requested = false;
+                    releaseTunnelClaim(server, conn);
+                }
+                return true;
+            }
+            if (response.status == 101) {
+                upstreamFailed(server, conn);
+                return false;
+            }
+            forwardInterim(server, conn, response);
+            return false;
+        }
+
+        /// Append the origin's coalesced body excess to the rendered head
+        /// when both fit, and return how many bytes the head write covers.
+        ///
+        /// The common small response arrives from the origin in one piece;
+        /// forwarding it in one piece trades a bounded memcpy for a whole
+        /// ring round trip per response. When it does not fit, the excess
+        /// stays in the upstream head and leaves as the channel's next
+        /// write instead.
+        fn coalesceResponseExcess(
+            server: *ServerType,
+            conn: *ConnType,
+            rendered_len: u32,
+            excess: []const u8,
+        ) u32 {
+            assert(rendered_len >= 1);
+            const head = headBytes(server, conn);
+            assert(rendered_len <= head.len);
+            if (rendered_len + excess.len > head.len) {
+                conn.l7.response_excess_len = @intCast(excess.len);
+                return rendered_len;
+            }
+            @memcpy(head[rendered_len..][0..excess.len], excess);
+            conn.l7.response_excess_len = 0; // It rides the head write.
+            return rendered_len + @as(u32, @intCast(excess.len));
+        }
+
         fn renderResponse(
             server: *ServerType,
             conn: *ConnType,
@@ -2202,33 +2355,9 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_leg == .awaiting_head);
             assert(conn.l7.request_head_vacated);
             const upstream = conn.upstream.?;
-            // `101` on a carried upgrade is terminal, not interim (#180),
-            // and diverts before any of the ordinary response machinery
-            // below. Two reasons it cannot share that path: the framing
-            // tracker reads a sub-200 status as bodiless and would consume
-            // none of the trailing bytes, when for a tunnel every trailing
-            // byte is payload; and the state machine would treat the
-            // exchange as complete and go read another request, which is
-            // the desynchronisation §7 exists to prevent. An unrequested
-            // `101` is *not* diverted — an origin cannot upgrade a
-            // connection this proxy never asked to upgrade.
-            if (conn.l7.upgrade_requested and response.status == 101) {
-                return renderUpgradeAccepted(server, conn, response);
-            }
-            // The origin declined. Answering an upgrade request with an
-            // ordinary response is legal and common — an origin that does
-            // not speak WebSocket just serves the request — and the
-            // exchange from here is an ordinary one, so the tunnel claimed
-            // at the gate goes back *now* rather than at teardown. This
-            // connection is very likely kept: `conn.l7` resets at the
-            // turnaround while the claim lives on the connection, so
-            // holding it would pin a pool slot nothing is using for as
-            // long as the client stays, and a second `Upgrade` over the
-            // same connection would find one already held.
-            if (conn.l7.upgrade_requested) {
-                conn.l7.upgrade_requested = false;
-                releaseTunnelClaim(server, conn);
-            }
+            // Not every status reaching here is *the* response: a tunnel,
+            // an interim and an uninvited switch all divert first.
+            if (!dispatchByStatus(server, conn, response)) return;
 
             const keep_downstream = downstreamKeepAlive(server, conn, response);
             conn.l7.downstream_close_announced = !keep_downstream;
@@ -2261,22 +2390,12 @@ pub fn Proxy(comptime IoType: type) type {
                 upstreamFailed(server, conn);
                 return;
             }
-            // The common small response arrives from the origin in one
-            // piece; forward it in one piece too. Appending the excess to
-            // the rendered head trades a bounded memcpy for a whole ring
-            // round trip per response. The fallback writes the head, then
-            // the excess from upstream.head as the channel's next write.
-            var head_write_len: u32 = @intCast(rendered.len);
-            if (rendered.len + feed.consumed <= headBytes(server, conn).len) {
-                @memcpy(
-                    headBytes(server, conn)[rendered.len..][0..feed.consumed],
-                    excess[0..feed.consumed],
-                );
-                head_write_len = @intCast(rendered.len + feed.consumed);
-                conn.l7.response_excess_len = 0; // It rides the head write.
-            } else {
-                conn.l7.response_excess_len = feed.consumed;
-            }
+            const head_write_len = coalesceResponseExcess(
+                server,
+                conn,
+                @intCast(rendered.len),
+                excess[0..feed.consumed],
+            );
 
             conn.l7.response_leg = .sending_head;
             // Committed to answering: no verdict may intervene from here (§7).
@@ -2352,6 +2471,15 @@ pub fn Proxy(comptime IoType: type) type {
             then: conn_module.ClientWrite.Then,
         ) void {
             switch (then) {
+                // An interim is out and the origin still owes an answer:
+                // the exchange is untouched, nothing has been committed to
+                // as the response, and no verdict can be pending (#232).
+                .interim_sent => {
+                    assert(conn.state == .l7_exchanging);
+                    assert(conn.l7.pending_verdict == .none);
+                    assert(!conn.l7.response_started);
+                    assert(conn.l7.response_leg == .awaiting_head);
+                },
                 // The handshake is out and nothing has been relayed yet:
                 // still the exchange, still no verdict, and the tunnel
                 // buffer claimed at the gate is still in hand (#180).
@@ -2476,6 +2604,8 @@ pub fn Proxy(comptime IoType: type) type {
                 // The origin's `101` has reached the client, so the HTTP
                 // conversation on this connection is over (#180).
                 .tunnel_start => beginTunnel(server, conn),
+                // The interim is out and the exchange continues (#232).
+                .interim_sent => resumeAfterInterim(server, conn),
                 .response_excess => sendResponseExcess(server, conn),
                 .response_body => {
                     assert(conn.l7.response_leg == .sending_body_excess);
@@ -2919,6 +3049,18 @@ pub fn Proxy(comptime IoType: type) type {
             if (conn.upstream.?.head_len != 0) {
                 return false; // A response byte arrived: the origin spoke.
             }
+            // And an interim means it spoke *and the client heard it*
+            // (#232). The check above cannot see that: `forwardInterim`
+            // compacts the interim out of the head buffer, so `head_len`
+            // is commonly back at zero by the time a later failure asks.
+            // Replaying here would re-send a request the origin may
+            // already have begun processing — the exact reading §7
+            // settles "may have begun processing" against — to a second
+            // origin, after this proxy has already told the client to go
+            // ahead.
+            if (conn.l7.interims_seen != 0) {
+                return false;
+            }
             if (conn.l7.request_body_pumped) {
                 return false; // Relay chunks flowed; not reconstructible.
             }
@@ -2939,6 +3081,12 @@ pub fn Proxy(comptime IoType: type) type {
             // fresh. So the rebuild below defaulting the tried set to
             // empty is the truth, not a reset.
             assert(conn.l7.tried_count == 0);
+            // No interim was relayed, so the rebuild below defaulting
+            // `interims_seen` to zero is the truth rather than a reset —
+            // `replayEligible` refuses a replay once one has gone out
+            // (#232), and this is what would trip if that ever stopped
+            // being true.
+            assert(conn.l7.interims_seen == 0);
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -253,6 +253,12 @@ const HttpOrigin = struct {
     /// later. The only way to reach the *reuse* path with a stalled
     /// exchange — a parked upstream exists only after one was served.
     mute_after_served: u32 = std.math.maxInt(u32),
+    /// From the Nth request on, answer with a bare `100 Continue` and
+    /// close (#232). The sibling of `mute_after_served`, and for the same
+    /// reason: it is the only way to park an upstream on a served
+    /// exchange and then have the *reused* one relay an interim and die,
+    /// which is the shape that decides whether a replay is legal.
+    interim_then_close_after_served: u32 = std.math.maxInt(u32),
     /// Close the second accepted connection immediately: the replayed
     /// try fails too, pinning the one-replay budget (§7).
     close_second_at_accept: bool = false,
@@ -279,6 +285,8 @@ const HttpOrigin = struct {
         /// stay captured in the buffer for the tests' assertions.
         request_offset: u32 = 0,
         request_complete: bool = false,
+        /// This connection answers a bare interim and dies (#232).
+        interim_then_close: bool = false,
         closed: bool = false,
         /// Total bytes expected for the current request (head + framed
         /// body), known once its head parses. 0 means not parsed yet.
@@ -348,14 +356,22 @@ const HttpOrigin = struct {
                 // then stall the *reused* one.
                 return;
             }
+            if (oconn.origin.requests_served >= oconn.origin.interim_then_close_after_served) {
+                oconn.interim_then_close = true;
+            }
             oconn.armSend();
         }
 
+        fn responseBytes(oconn: *const OConn) []const u8 {
+            if (oconn.interim_then_close) return "HTTP/1.1 100 Continue\r\n\r\n";
+            return oconn.origin.response;
+        }
+
         fn armSend(oconn: *OConn) void {
-            assert(oconn.response_sent < oconn.origin.response.len);
+            assert(oconn.response_sent < oconn.responseBytes().len);
             oconn.origin.io.send(
                 oconn.socket,
-                oconn.origin.response[oconn.response_sent..],
+                oconn.responseBytes()[oconn.response_sent..],
                 &oconn.send_completion,
                 OConn,
                 oconn,
@@ -370,8 +386,16 @@ const HttpOrigin = struct {
                 return;
             };
             oconn.response_sent += sent;
-            if (oconn.response_sent < oconn.origin.response.len) {
+            if (oconn.response_sent < oconn.responseBytes().len) {
                 oconn.armSend();
+                return;
+            }
+            if (oconn.interim_then_close) {
+                // The interim went out and the origin dies on it: the
+                // client has been told to go ahead by an origin that then
+                // stopped answering.
+                oconn.origin.io.closeNow(oconn.socket);
+                oconn.closed = true;
                 return;
             }
             oconn.origin.requests_served += 1;
@@ -518,6 +542,9 @@ const Http1Bed = struct {
         /// so a test can stall a *reused* upstream rather than a fresh
         /// dial. Default never stalls.
         origin_mute_after_served: u32 = std.math.maxInt(u32),
+        /// From the Nth request on, the origin answers `100 Continue` and
+        /// closes — the reused-upstream-dies-after-an-interim shape.
+        origin_interim_then_close_after_served: u32 = std.math.maxInt(u32),
         /// The origin closes the second accepted connection at accept —
         /// the replayed try fails too, pinning the one-replay budget.
         close_second_at_accept: bool = false,
@@ -668,6 +695,7 @@ const Http1Bed = struct {
             .close_after_response = options.origin_closes,
             .mute = options.origin_mute,
             .mute_after_served = options.origin_mute_after_served,
+            .interim_then_close_after_served = options.origin_interim_then_close_after_served,
             .close_second_at_accept = options.close_second_at_accept,
         };
         if (options.origin_listens) {
@@ -4889,5 +4917,156 @@ test "l7: a drain with no deadline still ends, because tunnels are cut" {
     // The line the drain's own counter cannot say: the loop actually
     // stopped, with every pool given back (§9's leak invariant).
     try std.testing.expect(bed.server.isIdle());
+    try bed.expectDrained();
+}
+
+test "l7: a 100 Continue reaches the client and the exchange goes on" {
+    // The `curl -d @file` case (#232). curl sends `Expect: 100-continue`
+    // for any body over 1 KiB and nginx honours it, so before this the
+    // client got `100 Continue` followed by a close — the body had not
+    // been pumped, so nothing could park and nothing could keep.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 300,
+        .origin_response = "HTTP/1.1 100 Continue\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("POST /upload HTTP/1.1\r\nHost: o\r\n" ++
+        "Expect: 100-continue\r\nContent-Length: 4\r\nConnection: close\r\n\r\nbody");
+
+    // Both, in order: the interim the client was waiting for, then the
+    // answer. An interim is relayed rather than absorbed because a `100`
+    // a client never sees is the whole point of `Expect` withheld.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 100 Continue\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_interim_forwarded"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_interim_overrun"));
+    try bed.expectDrained();
+}
+
+test "l7: a 103 does not settle the exchange, so no answer is left unread" {
+    // The sharper half of #232. With the body already sent,
+    // `request_leg == .done` and the origin's keep-alive verdict is
+    // honoured — so the interim was rendered as the answer and the
+    // upstream parked with the *real* response still unread in its
+    // socket. The next checkout would read it as its own: one client's
+    // answer delivered to another.
+    //
+    // Two requests over one connection is what makes that visible. If
+    // the 103 settled the first exchange, the second would be served the
+    // first's leftover `200` — here both must get their own.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 301,
+        .origin_response = "HTTP/1.1 103 Early Hints\r\n" ++
+            "Link: </s.css>; rel=preload\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /second HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /first HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" ++
+            "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    // Two exchanges, two answers, two interims — and the origin served
+    // both requests rather than one of them reading the other's reply.
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_responses"));
+    try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_interim_forwarded"));
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: an origin that only ever sends interims is cut at the bound" {
+    // Neither nginx nor HAProxy bounds this; zoxy must, because an
+    // unbounded loop on the one thread is what §1 rules out (#232). The
+    // overrun is counted apart from a malformed head: nothing was
+    // malformed, the bound is what ran out.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 302,
+        .origin_response = "HTTP/1.1 103 Early Hints\r\n\r\n" ** 12,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(
+        @as(u64, constants.interim_responses_max),
+        bed.server.counters.get("l7_interim_forwarded"),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_interim_overrun"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
+    try bed.expectDrained();
+}
+
+test "l7: a 101 nobody asked for fails the exchange" {
+    // `101` is a protocol switch, not a continuation, so it cannot be
+    // relayed as interim — carrying on to read the next head would meet
+    // bytes that are no longer HTTP. An origin sending one to a request
+    // that carried no `Upgrade` is doing something it was not invited to
+    // (#232, #180).
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 303,
+        .origin_response = "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_interim_forwarded"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("tunnels_established"));
+    try bed.expectDrained();
+}
+
+test "l7: an interim spends the free replay — the origin already spoke" {
+    // The §7 replay is for a *stale* checkout: a parked connection the
+    // origin closed while nobody was looking, where nothing reached an
+    // application. An interim proves the opposite — the origin answered,
+    // and this proxy already relayed that answer to the client (#232).
+    //
+    // `replayEligible`'s "a response byte arrived" test reads
+    // `upstream.head_len`, which `forwardInterim` compacts back to zero,
+    // so without an explicit check the guard is blind exactly here and
+    // the request would be re-sent to a second origin after the first had
+    // begun processing it.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 304,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        // The first request parks a reusable upstream; the second checks
+        // it out, gets an interim, and loses the origin on it.
+        .origin_interim_then_close_after_served = 1,
+    });
+    defer bed.tearDown();
+
+    bed.client.next = &bed.client2;
+    bed.client2.request = "GET /b HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    // The reuse happened and the interim reached the second client —
+    // and then the exchange failed honestly instead of being replayed.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_reused"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_interim_forwarded"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_replayed"));
+    // One origin connection per client: the request was never sent twice.
+    try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
     try bed.expectDrained();
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -136,6 +136,10 @@ pub const ClientWrite = struct {
         response_body,
         /// A static response is out: the lingering close (§7, §8).
         lingering_close,
+        /// An interim `1xx` reached the client and the exchange is
+        /// *not* over (#232): go back to reading the origin's next
+        /// response head, which may already be buffered behind it.
+        interim_sent,
         /// The origin's `101` is out and the client has it, so the HTTP
         /// conversation on this connection is over (#180): hand the
         /// connection to the relay. Deliberately *after* the head reaches
@@ -619,6 +623,12 @@ pub fn Conn(comptime IoType: type) type {
             /// tells the render to let the participating
             /// `Connection`/`Upgrade` pair travel.
             upgrade_requested: bool = false,
+            /// Interim `1xx` responses this exchange has already relayed
+            /// (#232). Per exchange, not per connection: the bound is
+            /// about one origin answering one request, and a keep-alive
+            /// turnaround clears `l7` wholesale, so it cannot leak into
+            /// the next request even if a path forgets to reset it.
+            interims_seen: u8 = 0,
             /// The endpoints this request dialed and had refused or found
             /// unreachable (#181), in the order it tried them — the
             /// exclusion set the next pick runs over. Sized for the first

--- a/src/tls/TestClient.zig
+++ b/src/tls/TestClient.zig
@@ -700,6 +700,15 @@ fn completeResponses(bytes: []const u8) u32 {
             .chunked, .until_close => break,
         };
         if (rest.len - head.head_len < body_len) break;
+        // An interim `1xx` is not an answer (#232): the origin still owes
+        // one, so counting it here would read as a response this session
+        // never earned — which is exactly what the caller's
+        // responses-vs-requests bound exists to catch. `101` is excluded
+        // on the proxy's own grounds: a protocol switch *is* the answer.
+        if (head.status >= 100 and head.status < 200 and head.status != 101) {
+            rest = rest[head.head_len..];
+            continue;
+        }
         count += 1;
         rest = rest[head.head_len + body_len ..];
     }


### PR DESCRIPTION
Closes #232.

The L7 state machine had **no status branch on the response path at all**, so `HTTP/1.1 100 Continue` parsed as a complete, bodiless, keep-alive response and the exchange settled on it. Which way that broke depended only on whether the request body had finished.

- **Mid-body** — `Expect: 100-continue`, which curl sends automatically for any body over 1 KiB and nginx honours — the client got the interim and then a close. `curl -d @file` through zoxy to an nginx origin failed.
- **Body already sent** — the interim was rendered as *the answer*, and the upstream **parked with the real `200` still unread in its socket**. The next checkout read one client's response as its own. The stale check at checkout looks for a FIN, not for pending data, so nothing caught it. `103 Early Hints` is not exotic: Cloudflare and Fastly emit it, and `res.writeEarlyHints` is a one-liner.

## The fix

Relayed rather than absorbed, which is what nginx and HAProxy both do and the only useful half to copy: a `103` is worthless to a client that never sees it, and a `100` is exactly what a client blocked on `Expect` is waiting for. `Expect` itself needs nothing — it travels to the origin and the origin decides. Answering `100` locally would commit this proxy to admitting a body the origin may be about to refuse.

**Bounded, which neither reference is.** An origin streaming `103`s forever is an unbounded loop on the one thread (§3), so `interim_responses_max` (8) caps them per exchange and the overrun takes the `upstreamFailed` path — counted apart from a malformed head, because nothing was malformed; the bound is what ran out.

**`101` is excluded at both ends**, and this is a behaviour change the issue does not call for. It is terminal when this proxy asked for it (#180's upgrade), and a **failed exchange** when it did not — relaying an uninvited protocol switch as interim would carry on reading bytes that are no longer HTTP. The alternative is the same park-with-unread-response bug wearing a different status.

## The fix broke §7's replay invariant, and review caught it

Worth calling out, because it is the sharpest thing in the diff and it was mine.

`replayEligible` reads `upstream.head_len != 0` as its "a response byte arrived" signal. `forwardInterim` compacts the interim out of that buffer, so once one had been relayed the guard went **blind** — and a reused upstream failing afterwards would re-send the whole request to a second origin *after the first had begun processing it, and after this proxy had already told the client to go ahead*. That is precisely the reading §7 settles "may have begun processing" against.

An interim is a response byte, and `replayEligible` now says so. `beginReplay` asserts the same from the other side, so a future path that reopened the hole trips loudly rather than silently double-sending.

Reproducing it needed a new test-bed knob (`origin_interim_then_close_after_served`) — an origin that serves one request normally, then relays an interim on the *reused* connection and dies. It is the sibling of the existing `mute_after_served`, which exists for the same reason.

## Three places count responses

Each had to learn that an interim is not one: the proxy, `sim/l7/client.zig`'s `walkResponses`, and `src/tls/TestClient.zig`'s `completeResponses`. The last two surfaced as failing seeds (`GoldenOutcomeMissed`, `TlsResponseCountDiverged`) rather than as review findings.

## Simulator coverage, and why clean seeds take the draw

Two origin modes (`interim_then_sized`, `interim_flood`) plus a per-seed `interim_http` draw that **clean seeds also take**. That is the whole point of it: an adversarial seed holds a transcript only to a legal *prefix*, so a proxy that settled on the interim and dropped the real answer passes there. The exact-outcome oracle is what notices.

My first version got this wrong — it passed all 1024 seeds under mutation and only the census failed, which catches "the feature is gone" rather than "the feature is wrong". Letting clean seeds draw it is what gave the sweep teeth.

## Verification

- Removing the interim divert fails **all four** directed tests, and fails the sweep at **seed 64** (`GoldenOutcomeMissed`).
- Removing the replay guard fails the replay regression test on `beginReplay`'s assert.
- `zig build ci` green — 4096 seeds, census ok, **65 counters fired and no new exemptions**.
- `zig fmt --check` clean.
- `tiger-style-reviewer` run on the diff; the replay finding above and a pre-existing length violation both fixed — `renderResponse` was already over the 70-line limit before this diff and this grew it to 129, so `dispatchByStatus` and `coalesceResponseExcess` are extracted and it sits at 70.

DESIGN.md §7 records the settled behaviour beside the "early responses are legal" bullet, which already covered the case where an origin answers *finally* before the body finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)