### PR TITLE
timeouts: the head read gets its own budget, not the idle window's (#235)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -454,9 +454,25 @@ that sent the signal keeps the upper bound it already enforces with
 `SIGKILL`. Where a zero would break rather than disable — a 0 ms dial,
 idle, or probe interval — it stays rejected.
 
-One *ordering* is enforced alongside those zeroes, and it is the only
-cross-check between two configured values in the loader: `connect_ms`
-must sit strictly below `idle_ms`. A connection's first deadline is
+`head_ms` (#235) is the one field whose default is *derived* rather than
+borrowed or refused, and the reason is that its neighbours already fix
+the band it may sit in. Ten seconds is the figure — a head read is a
+client mid-sentence, where nothing legitimate is slow, and the window is
+exactly a slowloris's budget — but a flat ten seconds would break two
+shapes of existing config: one whose whole `idle_ms` is smaller, and one
+whose `connect_ms` is *larger*, whose dial budget would then be quietly
+cut to the head budget at the re-base. So the default is that figure
+clamped between the two, which is what lets the field arrive without
+changing any config that predates it. Splitting it out at all is the
+point: one value served both the head read and the keep-alive idle
+window, they want opposite figures, and the one an operator tunes is the
+idle window — so the slowloris budget silently inherited it, and the
+conservative choice was the insecure one.
+
+*Orderings* are enforced alongside those zeroes, and they are the only
+cross-checks between configured values in the loader: `connect_ms` must
+sit strictly below `head_ms`, which must sit at or below `idle_ms` — and
+so, transitively, strictly below `idle_ms` as before. A connection's first deadline is
 armed at the dial budget and the dial's completion re-stores it to the
 idle one, but the single lazy timer never moves *earlier* once armed
 (§4) — only the stored target does. So the reverse order does not

--- a/docs/README.md
+++ b/docs/README.md
@@ -814,6 +814,7 @@ the other. Statuses are `200` plus the error set.
 ```json
 "timeouts": {
     "connect_ms": 5000,
+    "head_ms": 10000,
     "idle_ms": 60000,
     "drain_deadline_ms": 10000,
     "max_lifetime_ms": 0,
@@ -829,18 +830,23 @@ caps; for `connect_ms` and `idle_ms` it is rejected, since a zero-length
 dial or idle budget is a mistake rather than a policy.
 
 > [!WARNING]
-> `connect_ms` must be **strictly below** `idle_ms`, or the config is
-> rejected at load. A connection's first deadline is the dial budget and the
+> `connect_ms` must be **strictly below** `head_ms`, which must be at or
+> below `idle_ms`, or the config is rejected at load. A connection's first deadline is the dial budget and the
 > dial's completion re-stores it to the idle one, but zoxy's single timer per
 > connection never moves earlier once armed — so an idle budget that does not
 > exceed the dial budget would not take effect at the handoff and would reap
 > late instead. This bites when only *one* field is tuned: raising
 > `connect_ms` past the default 60 s `idle_ms` is rejected just the same.
+> The same reasoning is why `head_ms` sits between them rather than
+> beside them: it is re-based *down* from the idle deadline when the
+> client's first byte lands, and *down* again to `connect_ms` at the
+> dial.
 
 | field | default | meaning |
 |---|---|---|
 | `connect_ms` | `5000` | per-try upstream connect budget |
-| `idle_ms` | `60000` | idle and head-read deadline — what a slowloris meets |
+| `head_ms` | derived | budget for reading one request head — what a slowloris meets. 10 s, clamped between `connect_ms` and `idle_ms` so it never changes a config that predates it |
+| `idle_ms` | `60000` | how long a connection may stay quiet — between requests, or before its first byte |
 | `drain_deadline_ms` | `0` | how long a `SIGTERM` drain waits before reaping stragglers; `0` waits for the last connection |
 | `max_lifetime_ms` | `0` | absolute connection-age cap regardless of activity; `0` disables |
 | `request_ms` | `0` | cap on one L7 exchange, **not** refreshed by activity — bounds a request that is merely slow, where `idle_ms` only bounds one that has stalled; `0` disables |

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -799,6 +799,7 @@ fn deriveServerConfig(
 ) void {
     assert(connect_timeout_ms >= 1);
     assert(health_interval_ms >= 1);
+    const idle_timeout_ms = connect_timeout_ms + 10 + random.uintAtMost(u32, 70);
     harness.config = .{
         // The terminating listener is the third, and only a seed that drew
         // TLS clients binds it. Sliced rather than left inert so a
@@ -811,7 +812,20 @@ fn deriveServerConfig(
         // Drawn *above* the dial budget rather than independently: the
         // loader rejects the other order (§5), so an independent draw would
         // spend seeds on a config production cannot load.
-        .idle_timeout_ms = connect_timeout_ms + 10 + random.uintAtMost(u32, 70),
+        .idle_timeout_ms = idle_timeout_ms,
+        // Mirrors the idle window (#235), which is also what the loader
+        // would derive at this scale: the sim draws its timeouts in tens
+        // of milliseconds, and `defaultHeadMs` clamps its ten seconds down
+        // to `idle_ms` for exactly such a config.
+        //
+        // A known gap, stated rather than left implicit: equal values mean
+        // no seed exercises the first-byte re-base under a *tighter* head
+        // budget, so that call site's randomized coverage is deferred to
+        // the two scripted tests in `src/http_proxy_test.zig`. Drawing the
+        // two apart is a scenario for the split, and wants the head budget
+        // to be a drawn value the response oracles can still live with —
+        // more than this line.
+        .head_timeout_ms = idle_timeout_ms,
         .drain_deadline_ms = deriveDrainDeadlineMs(harness.drain_at_ns, random),
         // The §6 age cap: measured from the connection's birth, so the
         // clamp sometimes reaps an actively-relaying connection.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -370,6 +370,14 @@ pub fn Server(comptime IoType: type) type {
             // directly and would otherwise be measuring a config production
             // cannot load.
             assert(config.connect_timeout_ms < config.idle_timeout_ms);
+            // The #235 head budget sits between the two, and its relations
+            // matter here more than the pair above rather than less: every
+            // hand-built config now states this field, so a test or a seed
+            // that inverted it would silently reproduce the failure the
+            // split exists to prevent — a head read left running under the
+            // wider window — with no loader in the way to say so.
+            assert(config.connect_timeout_ms < config.head_timeout_ms);
+            assert(config.head_timeout_ms <= config.idle_timeout_ms);
             // `Pool` permits an empty pool — that is how an unconfigured
             // feature reserves nothing (§5) — so the requirement that these
             // three are non-empty lives here, where it is true: a proxy with
@@ -1304,8 +1312,15 @@ pub fn Server(comptime IoType: type) type {
         }
 
         /// The first deadline that connection runs under: an L4 connection
-        /// is dialing, so it gets the connect budget (§8); an L7 one is
-        /// reading a head, so a slowloris meets the clock or
+        /// is dialing, so it gets the connect budget (§8); an L7 one has
+        /// said nothing yet, so it gets the *idle* window.
+        ///
+        /// Not the head budget, and the distinction is #235's: a connection
+        /// that has connected and not spoken is quiet, not slow, and
+        /// bounding it as a slowloris would reap the honest client that
+        /// opened early. The slowloris clock starts at its first byte,
+        /// where `onHeadGroupRecv` re-bases this down to
+        /// `head_timeout_ms` — a client mid-sentence meets that or
         /// `limits.head_buffer_bytes`, whichever comes first (§7).
         fn entryTimeoutMs(
             server: *const Self,
@@ -3018,11 +3033,14 @@ pub fn Server(comptime IoType: type) type {
         /// (so the cancel cannot match the fresh timer). A path that already
         /// delivered the timer has no armed op to re-base, so it arms fresh.
         pub fn rebaseDeadline(server: *Self, conn: *ConnType) void {
-            // Two callers, both storing a target earlier than the armed
-            // timer: the dial's per-try connect budget (`.l7_dialing`) and
-            // the request deadline installed at routing (`.l7_reading_head`,
-            // §8) — which must re-base here because the reuse path never
-            // reaches the dial.
+            // Three callers, all storing a target earlier than the armed
+            // timer. The dial's per-try connect budget (`.l7_dialing`); the
+            // request deadline installed at routing (`.l7_reading_head`,
+            // §8), which must re-base here because the reuse path never
+            // reaches the dial; and the #235 head budget, installed at the
+            // client's first byte — also from `.l7_reading_head`, but a
+            // different narrowing: routing tightens to the *exchange* cap,
+            // this one tightens the idle window to the head read.
             assert(conn.state == .l7_dialing or conn.state == .l7_reading_head);
             // A prior dial's rebase cancel can still be draining if the
             // exchange outran it across a keep-alive turnaround. It re-arms

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -88,6 +88,7 @@ const Harness = struct {
             .clusters = &harness.clusters,
             .connect_timeout_ms = 50,
             .idle_timeout_ms = 1000,
+            .head_timeout_ms = 1000,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -72,6 +72,7 @@ const Harness = struct {
             .clusters = &harness.clusters,
             .connect_timeout_ms = 50,
             .idle_timeout_ms = 1000,
+            .head_timeout_ms = 1000,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -935,6 +935,7 @@ fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Conf
         .clusters = clusters,
         .connect_timeout_ms = 1,
         .idle_timeout_ms = 1,
+        .head_timeout_ms = 1,
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,

--- a/src/config.zig
+++ b/src/config.zig
@@ -32,6 +32,20 @@ pub const Config = struct {
     /// where zero is legal (an unbounded connection age), so it is optional
     /// in the JSON and defaults off.
     max_lifetime_ms: u32,
+    /// Budget for reading one request head (§8, #235): from the client's
+    /// first byte to a complete head, which is a slowloris's whole window.
+    /// Distinct from `idle_timeout_ms`, which bounds a *quiet* connection
+    /// — the two want opposite values, and one number serving both meant
+    /// the head-read budget inherited whatever the keep-alive window was
+    /// tuned to. Rebased down from the idle deadline at the first byte,
+    /// and down again to `connect_timeout_ms` at the dial.
+    ///
+    /// No struct default, on the same terms as `request_timeout_ms`: the
+    /// loader *derives* one from this config's own neighbours, and a flat
+    /// fallback here would hand a hand-built config a ten-second head
+    /// budget beside a millisecond idle window — the very inversion the
+    /// loader refuses, and one nothing else would notice.
+    head_timeout_ms: u32,
     /// Cap on one L7 exchange, from the moment a request head is routed to
     /// the last response byte (§8). Unlike the idle timeout it is *not*
     /// refreshed by activity, so it bounds a request that is progressing
@@ -754,6 +768,7 @@ pub fn parseWithFiles(
         .idle_timeout_ms = parsed.timeouts.idle_ms,
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
+        .head_timeout_ms = resolveHeadTimeout(&parsed.timeouts),
         .request_timeout_ms = parsed.timeouts.request_ms,
         .tunnel_timeout_ms = parsed.timeouts.tunnel_ms,
         .health_interval_ms = parsed.timeouts.health_interval_ms,
@@ -2496,6 +2511,10 @@ pub const TimeoutsJson = struct {
     /// because a request deadline is a policy an operator sets against
     /// their own origin's latency, not a value zoxy can pick for them.
     request_ms: u32 = 0,
+    /// Optional #235 head-read budget. Absent is *derived* rather than
+    /// fixed — see `resolveHeadTimeout`, which is what keeps every config
+    /// written before this field behaving exactly as it did.
+    head_ms: ?u32 = null,
     /// Optional #180 tunnel lifetime; absent means an hour. Unlike the
     /// two caps above, zero is rejected — a tunnel pins a dedicated pool
     /// slot, so "no cap" is the one answer §5 cannot carry.
@@ -2525,6 +2544,12 @@ pub const TimeoutsJson = struct {
         .max_lifetime_ms = .{
             .desc = "Absolute connection-age cap; 0 disables it.",
             .minimum = 0,
+            .maximum = constants.timeout_ms_max,
+        },
+        .head_ms = .{
+            .desc = "Budget for reading one request head — a slowloris's window. " ++
+                "Must exceed connect_ms and not exceed idle_ms.",
+            .minimum = 1,
             .maximum = constants.timeout_ms_max,
         },
         .tunnel_ms = .{
@@ -4017,6 +4042,66 @@ fn validateTunnelTimeout(tunnel_ms: u32) ValidationError!void {
     assert(tunnel_ms <= constants.tunnel_ms_max);
 }
 
+/// The #235 head-read budget when the config names none.
+///
+/// Derived rather than fixed, and that is what keeps every config written
+/// before this field existed behaving exactly as it did. A flat ten
+/// seconds would break two shapes: a config whose whole `idle_ms` is
+/// smaller than the default (the head budget must never exceed the idle
+/// window it tightens), and — the one that would have been a silent
+/// regression rather than a load error — a config with a `connect_ms`
+/// *above* ten seconds, whose dial budget would quietly have been cut to
+/// the head budget, since the lazy timer cannot move later at the
+/// re-base. So the default is the ten seconds clamped into the band the
+/// two neighbours leave: strictly above the dial, at or below the idle.
+/// `connect_ms < idle_ms` is already enforced, so that band is never
+/// empty.
+fn defaultHeadMs(timeouts: *const TimeoutsJson) u32 {
+    assert(timeouts.connect_ms < timeouts.idle_ms);
+    const floored = @max(constants.head_ms_default, timeouts.connect_ms + 1);
+    const derived = @min(floored, timeouts.idle_ms);
+    assert(derived > timeouts.connect_ms);
+    assert(derived <= timeouts.idle_ms);
+    return derived;
+}
+
+/// The resolved head budget: what the config named, or the derived
+/// default. Plain `u32` rather than the usual resolver error union,
+/// because `validateHeadOrder` has already held both spellings to the
+/// same relations — there is no failure left for this to report, and a
+/// return type that claimed one would be the wider of two that fit.
+fn resolveHeadTimeout(timeouts: *const TimeoutsJson) u32 {
+    const head_ms = timeouts.head_ms orelse defaultHeadMs(timeouts);
+    assert(timeouts.connect_ms < head_ms);
+    assert(head_ms <= timeouts.idle_ms);
+    return head_ms;
+}
+
+/// The #235 head-read budget's two orderings, extracted for the length
+/// limit the way `validateTunnelTimeout` was.
+///
+/// Both exist for the reason `connect_ms < idle_ms` does: the single lazy
+/// timer only ever moves *earlier* once armed (§4). The first byte
+/// re-bases the idle deadline down to the head budget, and the dial
+/// re-bases the head budget down to the connect one — so a head budget
+/// above `idle_ms` would never take effect, and one at or below
+/// `connect_ms` would make the dial's re-base a lengthening the timer
+/// cannot honour, silently cutting the dial short. Rejected rather than
+/// clamped, like its sibling: a config that reads one way and behaves
+/// another is what these checks exist to prevent.
+fn validateHeadOrder(timeouts: *const TimeoutsJson) ValidationError!void {
+    const head_ms = timeouts.head_ms orelse defaultHeadMs(timeouts);
+    if (head_ms == 0 or head_ms > constants.timeout_ms_max) {
+        return error.TimeoutOverLimit;
+    }
+    if (timeouts.connect_ms >= head_ms) {
+        return error.TimeoutOrderInvalid;
+    }
+    if (head_ms > timeouts.idle_ms) {
+        return error.TimeoutOrderInvalid;
+    }
+}
+
 fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
     // Deadlines a zero would break rather than disable: a 0 ms connect or
     // idle budget reaps on arrival, and a 0 ms probe interval would probe
@@ -4066,12 +4151,33 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
     if (timeouts.connect_ms >= timeouts.idle_ms) {
         return error.TimeoutOrderInvalid;
     }
+    // The #235 head-read budget sits between the two, and both relations
+    // exist for the same reason as the one above: the single lazy timer
+    // never moves *later* once armed, only earlier. The first byte
+    // re-bases the idle deadline down to the head budget, and the dial
+    // re-bases the head budget down to the connect one — so a head budget
+    // above `idle_ms` would never take effect, and one at or below
+    // `connect_ms` would make the dial's re-base a lengthening the timer
+    // cannot honour. Rejected rather than clamped, like its sibling: a
+    // config that reads one way and behaves another is the failure this
+    // check exists to prevent.
+    try validateHeadOrder(timeouts);
     try validateTunnelTimeout(timeouts.tunnel_ms);
-    // Postconditions: reaching here means every bound a consumer reads
-    // without checking is in range, and every optional one is at most the
-    // ceiling — zero included, which each consumer reads as "off" — and the
-    // pair the deadline handoff depends on is ordered, which is what
-    // `Server.init` asserts of any config however it was built.
+    assertTimeoutsBounded(timeouts, &nonzero, &optional);
+}
+
+/// What reaching the end of `validateTimeouts` means, restated: every
+/// bound a consumer reads without checking is in range, every optional
+/// one is at most the ceiling — zero included, which each consumer reads
+/// as "off" — and the three relations the deadline handoff depends on are
+/// ordered. `Server.init` asserts those same relations of any config
+/// however it was built, which is what covers the configs the simulator
+/// and the tests hand-build past this loader entirely.
+fn assertTimeoutsBounded(
+    timeouts: *const TimeoutsJson,
+    nonzero: []const u32,
+    optional: []const u32,
+) void {
     for (nonzero) |value| {
         assert(value >= 1);
         assert(value <= constants.timeout_ms_max);
@@ -4080,6 +4186,9 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
         assert(value <= constants.timeout_ms_max);
     }
     assert(timeouts.connect_ms < timeouts.idle_ms);
+    const head_ms = resolveHeadTimeout(timeouts);
+    assert(timeouts.connect_ms < head_ms);
+    assert(head_ms <= timeouts.idle_ms);
     assert(timeouts.tunnel_ms >= constants.tunnel_ms_min);
     assert(timeouts.tunnel_ms <= constants.tunnel_ms_max);
 }
@@ -6903,4 +7012,73 @@ test "config: tunnel_ms defaults to an hour and has no off switch" {
         const parsed = try expectParseOk(&arena_state, head ++ ",\"tunnel_ms\":1000}}");
         try std.testing.expectEqual(constants.tunnel_ms_min, parsed.tunnel_timeout_ms);
     }
+}
+
+test "config: the head budget is derived from its neighbours, never fixed" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "timeouts":{"drain_deadline_ms":1,
+    ;
+    const tail = "}}";
+    // The ordinary shape: the default lands as itself, an order of
+    // magnitude under the idle window it tightens (#235).
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"connect_ms\":5000,\"idle_ms\":60000" ++ tail,
+        );
+        try std.testing.expectEqual(constants.head_ms_default, parsed.head_timeout_ms);
+    }
+    // A config whose whole idle window is under the default keeps it: the
+    // head budget tightens the idle one, so it can never exceed it. This
+    // is most hand-written test configs, and every one of them predates
+    // the field.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"connect_ms\":1,\"idle_ms\":2" ++ tail,
+        );
+        try std.testing.expectEqual(@as(u32, 2), parsed.head_timeout_ms);
+    }
+    // The shape a flat default would have broken *silently*: a dial budget
+    // above the default. The head budget would have sat below it, and the
+    // lazy timer cannot lengthen at the re-base — so the dial would have
+    // been cut to ten seconds by a field the operator never set.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"connect_ms\":20000,\"idle_ms\":60000" ++ tail,
+        );
+        try std.testing.expect(parsed.head_timeout_ms > 20000);
+    }
+}
+
+test "config: head_ms must sit strictly above the dial and at or below the idle" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a","protocol":"http"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "timeouts":{"drain_deadline_ms":1,"connect_ms":5000,"idle_ms":60000,"head_ms":
+    ;
+    const tail = "}}";
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ "9000" ++ tail);
+        try std.testing.expectEqual(@as(u32, 9000), parsed.head_timeout_ms);
+    }
+    // Both inversions are rejected rather than clamped, on the same
+    // grounds as `connect_ms < idle_ms`: the single lazy timer only ever
+    // moves earlier, so either one would leave the wider value quietly in
+    // force and the config would behave differently than it reads.
+    try expectParseError(error.TimeoutOrderInvalid, head ++ "5000" ++ tail);
+    try expectParseError(error.TimeoutOrderInvalid, head ++ "4000" ++ tail);
+    try expectParseError(error.TimeoutOrderInvalid, head ++ "60001" ++ tail);
+    try expectParseError(error.TimeoutOverLimit, head ++ "0" ++ tail);
 }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -504,6 +504,23 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// not a share.
 pub const endpoint_weight_max: u16 = 256;
 
+/// Default budget for reading one request head (#235) — from the
+/// client's first byte to a complete head, which is exactly a slowloris's
+/// window (§7: "a slowloris meets the clock or `head_buffer_bytes`,
+/// whichever comes first").
+///
+/// Ten seconds, an order of magnitude under `idle_ms`, and the split is
+/// the point rather than the number. One value used to serve both this
+/// and the keep-alive idle window, and they want opposite things: a head
+/// read is a client mid-sentence, where nothing legitimate is slow, while
+/// an idle window is a healthy connection between requests, where short
+/// values churn the population into reconnects. With one knob an operator
+/// tunes the one whose cost is visible — the idle window — and the
+/// head-read budget silently inherits it. The conservative choice was the
+/// insecure one, which is the signature of a knob that should have been
+/// two.
+pub const head_ms_default: u32 = 10_000;
+
 /// Interim (`1xx`) responses one exchange may carry before the origin's
 /// final answer (#232). RFC 9110 puts no cap on them, and neither nginx
 /// nor HAProxy does — both loop while the status is `1xx` — but an origin
@@ -1242,6 +1259,14 @@ comptime {
     // An exchange must be allowed at least one interim, or the bound
     // would forbid the `100 Continue` the feature exists to carry.
     assert(interim_responses_max >= 1);
+    // The head-read budget sits between the dial budget and the idle
+    // window, and both relations are what the single lazy timer needs
+    // (§4): the dial re-bases the head deadline *down* to `connect_ms`,
+    // and the first byte re-bases the idle deadline *down* to this — a
+    // timer never moves later once armed, so an inversion either way
+    // would silently leave the wider value in force.
+    assert(connect_ms_default < head_ms_default);
+    assert(head_ms_default <= idle_ms_default);
     assert(cluster_retries_max >= 1);
     assert(cluster_retries_max < std.math.maxInt(u16));
     // The health prober's reservations and thresholds (§7): the op budget

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -1473,6 +1473,7 @@ fn labeledTestConfig(clusters: []const config_module.Config.Cluster) config_modu
         .clusters = clusters,
         .connect_timeout_ms = 1,
         .idle_timeout_ms = 1,
+        .head_timeout_ms = 1,
         .drain_deadline_ms = 1,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -459,6 +459,13 @@ pub fn Proxy(comptime IoType: type) type {
             // the parse: a slowloris that dribbles for the whole head-read
             // deadline must report the time it spent doing it (§8).
             server.beginLogRequest(conn);
+            // The idle window ends where the head read begins (#235). Until
+            // this byte the connection was quiet and bounded by `idle_ms`;
+            // from here it is a client mid-sentence, bounded by the much
+            // tighter head budget — which is the slowloris's whole window,
+            // and the reason the two stopped being one number.
+            server.storeDeadline(conn, server.config.head_timeout_ms);
+            server.rebaseDeadline(conn);
             conn.log.bytes_in += bound.len;
             fillHead(conn, bound.len, headBytes(server, conn).len);
             parseAndDispatch(server, conn);

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -530,6 +530,8 @@ const Http1Bed = struct {
         /// tunnel scenario needs the zero case, which is production's
         /// default and the one #180 had to answer for.
         drain_deadline_ms: u32 = 1000,
+        /// The #235 head-read budget; absent mirrors the bed's idle window.
+        head_timeout_ms: ?u32 = null,
         /// Put an endpoint nothing listens on *ahead* of the origin, so
         /// the first pick of an `rr` cluster is always the one that
         /// refuses and the retry is the only way to reach the origin.
@@ -664,6 +666,10 @@ const Http1Bed = struct {
             .clusters = &bed.clusters,
             .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
+            // Mirrors the idle window unless a test is about the split
+            // (#235): the bed's timeouts are milliseconds, so a flat
+            // default would sit far above the window it must tighten.
+            .head_timeout_ms = options.head_timeout_ms orelse idle_timeout_ms,
             .drain_deadline_ms = options.drain_deadline_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
@@ -5068,5 +5074,62 @@ test "l7: an interim spends the free replay — the origin already spoke" {
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_replayed"));
     // One origin connection per client: the request was never sent twice.
     try std.testing.expectEqual(@as(u32, 1), bed.origin.accepted_count);
+    try bed.expectDrained();
+}
+
+test "l7: a partial head is reaped at the head budget, not the idle window" {
+    // #235's whole point. One number used to serve both, and the one an
+    // operator tunes is the keep-alive window — its cost is the visible
+    // one — so the slowloris budget silently inherited it. Here the two
+    // are an order of magnitude apart, and the connection that goes quiet
+    // *mid-head* must meet the tighter of them.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 310,
+        .head_timeout_ms = 100,
+    });
+    defer bed.tearDown();
+
+    // A head that never finishes: the client sends a request line and a
+    // header, then nothing — no blank line, so the parse never completes.
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /slow HTTP/1.1\r\nHost: o\r\n");
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    // Reaped on the head budget. The idle window is 1000 ms, so anything
+    // near it would mean the split is not in force — which is exactly the
+    // state this fix found.
+    try std.testing.expect(elapsed_ms >= 100);
+    try std.testing.expect(elapsed_ms < 500);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try bed.expectDrained();
+}
+
+test "l7: an idle kept connection still gets the whole idle window" {
+    // The other half of the split, and the reason it is a split rather
+    // than a tightening: between requests a connection is quiet and
+    // healthy, and short values there churn the population into
+    // reconnects. The head budget must not reach it.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 311,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .head_timeout_ms = 100,
+    });
+    defer bed.tearDown();
+
+    // One exchange, then the client holds the connection open saying
+    // nothing. The turnaround stores the idle window, and no head byte
+    // has arrived to replace it with the tighter budget.
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    // Past the head budget by a wide margin, and bounded above by the
+    // idle window it should actually meet: an idle connection is not a
+    // slowloris, and treating it as one is the churn the split avoids.
+    try std.testing.expect(elapsed_ms > 500);
+    try std.testing.expect(elapsed_ms < 2000);
     try bed.expectDrained();
 }

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -628,6 +628,7 @@ const Harness = struct {
             .clusters = &bed.clusters,
             .connect_timeout_ms = 1000,
             .idle_timeout_ms = 5000,
+            .head_timeout_ms = 5000,
             .drain_deadline_ms = 1000,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -351,6 +351,7 @@ pub const TestBed = struct {
             .clusters = &bed.clusters,
             .connect_timeout_ms = options.connect_timeout_ms,
             .idle_timeout_ms = options.idle_timeout_ms,
+            .head_timeout_ms = options.idle_timeout_ms,
             .drain_deadline_ms = options.drain_deadline_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
             // L4 only: the §8 request deadline is an L7 exchange bound and


### PR DESCRIPTION
Refs #235. First of a three-PR stack bounding what one client connection can cost:

1. **this** — `timeouts.head_ms` (#235)
2. `request-body-cap` — a request body cap (#236)
3. `keepalive-request-cap` — a keep-alive request cap (#237)

## The problem

`idle_ms` was three timeouts wearing one name, and the head read was the one that lost.

A **head read** is a client mid-sentence: nothing legitimate is slow there, and the window is exactly a slowloris's budget. An **idle window** is a healthy connection between requests, where short values churn the population into reconnects. They want opposite figures — and the one an operator tunes is the idle window, because its cost is the visible one. So the slowloris budget silently inherited it. The conservative choice was the insecure one, which is the signature of a knob that should have been two.

`request_ms` does not close this: it is off by default and caps the whole exchange, not the pre-routing head.

## The fix

`timeouts.head_ms`, with the idle deadline re-based down to it at the client's **first byte** — beside `beginLogRequest`, which already marks where a request begins. Before that byte a connection is quiet, not slow, and bounding it as a slowloris would reap the honest client that opened early.

**The default is derived, not flat**, and that is what lets the field arrive without touching a single config that predates it. Ten seconds is the figure, but a flat ten seconds would have broken two shapes:

- one whose whole `idle_ms` is smaller than the default — the head budget tightens the idle window, so it can never exceed it;
- one whose `connect_ms` is **larger** — whose dial budget would then have been cut to the head budget at the re-base, since the lazy timer cannot lengthen. That one would have been a silent behaviour change rather than a load error.

So the default is ten seconds clamped between its two neighbours, with a test for each band. Two loader orderings enforce it: `connect_ms < head_ms <= idle_ms`.

`Config.head_timeout_ms` carries no struct default, on the same terms as `request_timeout_ms` — the loader derives one from a config's own neighbours, and a flat fallback would hand a hand-built config a ten-second head budget beside a millisecond idle window.

## What review caught

§5 claimed `Server.init` asserts the ordering, and it did not. That matters here **more** than for the sibling `connect_ms < idle_ms` relation, not less: every hand-built config now states `head_timeout_ms` explicitly, so a test or a seed that inverted it would silently reproduce the very failure the split exists to prevent, with no loader in the way to say so. It asserts it now, and the sentence is true.

Also fixed: `validateTimeouts` had grown from 66 to 88 lines (extracted `validateHeadOrder` and `assertTimeoutsBounded`, now 63); two docstrings this change had made stale (`rebaseDeadline` undercounted its callers, `entryTimeoutMs` claimed the slowloris clock starts at admission when it now starts at the first byte); a resolver returning an error union for a failure that cannot occur; and a lower-bound-only assertion in the second test.

## Deliberately not here: the `408` half

The issue also asks for `408 Request Timeout` instead of the silent teardown. That cannot be built as described. Answering means forcing an in-flight head recv so a response can be written, and the seam's `ShutdownHow` offers only `write` and `both` — no `read`. `Conn.zig` already records the consequence: such an op *"cannot be forced without closing the client the verdict would answer"*.

It needs a §4 seam change (a `.read` shutdown, both backends, the contract suite), which is a different decision from adding a timeout knob. Worth its own issue. The issue's own "Scope" section calls the split the minimum, which is what this is.

## Verification

- Two proxy tests: a partial head reaped on the head budget (≥100 ms, <500 ms against a 1000 ms idle window), and an idle kept connection still getting the whole idle window.
- Mutation-verified: deleting the first-byte re-base fails the slowloris test.
- Three config tests, one per band of the derived default.
- `zig build ci` green — 4096 seeds, census ok, smoke clean. `zig fmt --check` clean.

## Known gap, recorded rather than narrowed

The simulator does not exercise the first-byte re-base under a genuinely *tighter* head budget: its timeouts are drawn in tens of milliseconds, so mirroring `idle_ms` is exactly what the loader would derive at that scale. That call site's randomized coverage sits with the two scripted tests. A comment in the harness names what a real scenario for it would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)