### PR TITLE
http: bound a request body, per listener, on by default (#236)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1004,6 +1004,28 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   this proxy asked for it (#180) and a failed exchange when it did not,
   because relaying it as interim would carry on reading bytes that are no
   longer HTTP.
+- **A request body is bounded, and the bound is the origin's** (#236).
+  Nothing here needs it: §6's strict recv → send → recv relay keeps
+  per-connection memory constant whatever the stream size, so an
+  unbounded upload costs one relay buffer and no more. What it protects
+  is the backend, and "the proxy in front bounds it" is what most
+  application stacks assume — which is why the default is borrowed from
+  the reference that also ships one on (nginx's `client_max_body_size`,
+  one MiB) rather than derived from anything in this process. It is a
+  *listener* field, not a `limits` one: §5's line is that `limits` sizes
+  what the process reserves, and this reserves nothing.
+  Two paths, one cap, and the difference is what the head declared. A
+  `Content-Length` over the cap is knowable before the dial and refused
+  there — the §8 tunnel rung's reasoning, that admitting first and
+  shedding after spends an origin connection to produce a worse answer —
+  and the connection closes, because the declared body is unread in the
+  socket and draining it only to reject it is the wrong trade at this
+  size. A chunked body declares nothing, so it is measured as it
+  arrives: over the cap before the response leg is armed it still earns
+  the `413`, and over it later it can only be a teardown, since §7 has
+  no status left to send. Catching only the declared case would leave a
+  limit any client bypasses by choosing an encoding, which reads as
+  protection and is not.
 - **Early responses are legal.** An origin may answer before the request
   body finishes (RFC 9110 — e.g. 413 mid-upload): the response head is
   forwarded when it arrives, and the remaining request body is drained or

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,6 +309,45 @@ The access log writes one line when the tunnel closes — `kind` `http`,
 for the whole session. A line at the handshake would name a transfer that
 had not happened yet.
 
+#### Bounding a request body
+
+An `http` listener caps how large a request body it will carry. **One MiB
+by default** — nginx's `client_max_body_size`, which also ships on — and
+`0` accepts any size:
+
+```json
+{ "bind": "0.0.0.0:80", "protocol": "http", "cluster": "api",
+  "max_body_bytes": 5242880 }
+```
+
+zoxy itself is unharmed by a large upload: the strict recv → send → recv
+relay means per-connection memory is constant whatever the stream size, so
+an unbounded body costs one relay buffer and no more. **The exposure this
+bounds is your origin's** — and "the proxy in front bounds it" is the
+assumption most application stacks are deployed under.
+
+Per listener rather than in `limits`, because `limits` sizes what the
+process *reserves* and a body cap reserves nothing: it states policy, the
+same footing `forwarded` and `upgrades` stand on. One listener fronting an
+upload endpoint and another fronting an API want different numbers.
+
+Where the body's length is **declared**, the refusal costs nothing: a
+`Content-Length` over the cap is answered `413` before your origin is
+dialed, and the connection closes — the declared body is still unread in
+the socket, and draining it only to reject it is the wrong trade at the
+size this triggers on. A **chunked** body announces no size, so it is
+measured as it arrives: caught before the response leg is armed it earns
+the same `413`, and caught later it can only be a teardown, since by then
+no status can be sent. Both are counted —
+`zoxy_l7_body_over_limit` and `zoxy_l7_body_cut_mid_stream` — and the
+split matters when reading them: the first is a client told why, the
+second a client that just lost its connection.
+
+> [!IMPORTANT]
+> This is a change in behaviour from 0.3.0, which bounded nothing. A
+> deployment proxying uploads larger than 1 MiB needs `max_body_bytes`
+> raised, or set to `0`, before upgrading.
+
 ### Routing
 
 `"cluster"` is sugar for a single catch-all route. An `http` listener can

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -202,6 +202,10 @@ retries_http: u16,
 /// a tunnel pool to carry it. Off on most seeds, so the handshake script
 /// keeps proving the `501` every config had before the feature.
 upgrades_http: bool,
+/// The seed's #236 request-body cap on the plaintext http listener; `0`
+/// on every clean seed, since a `413` is a status its scripts did not ask
+/// for.
+max_body_bytes: u64,
 /// The seed's http origin prefixes an interim `100 Continue` to every
 /// answer (#232). Drawn once per seed rather than per accept, so a clean
 /// seed's transcript stays exact — which is the point: the golden oracle
@@ -645,6 +649,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     harness.endpoints_http = .{ httpOriginAddress(), httpOriginAddress() };
     deriveRetries(harness, random);
     deriveUpgrades(harness, random);
+    harness.max_body_bytes = deriveMaxBodyBytes(harness.clean, random);
     // A quarter of seeds. Clean ones included, deliberately: an
     // adversarial seed only holds the transcript to a legal *prefix*, so
     // a proxy that settled on the interim and dropped the real answer
@@ -901,6 +906,22 @@ fn deriveSticky(harness: *Harness, random: std.Random) zoxy.config.Config.Cluste
 /// at one or two against up to six clients, both refusal paths run
 /// against real contention, and every seed still crosses back under the
 /// cap as connections finish — so the recovery side runs too.
+/// The #236 body cap, drawn only under the adversary and for the same
+/// reason `deriveMaxInflight` caps only there: a `413` is a status an L7
+/// script did not ask for, and a clean seed's golden outcomes forbid it.
+/// Drawn in the single-byte range so the rung is reached by ordinary
+/// scheduling rather than a coincidence of sizes: `post_big`'s few
+/// thousand bytes and `post_sized`'s twenty-four are over it on every
+/// draw. `post_chunked`'s eight-byte payload is the one that is not —
+/// roughly half the range leaves it under the cap — which is legal and
+/// which the directed tests cover regardless; the claim here is that the
+/// cap *bites*, not that it bites everything.
+fn deriveMaxBodyBytes(clean: bool, random: std.Random) u64 {
+    if (clean) return 0;
+    if (random.uintLessThan(u8, 3) != 0) return 0;
+    return 1 + random.uintLessThan(u64, 16);
+}
+
 fn deriveMaxInflight(clean: bool, random: std.Random) ?u32 {
     if (clean) return null;
     if (random.uintLessThan(u8, 3) != 0) return null;
@@ -1235,9 +1256,20 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .protocol = .http,
             .forwarded = forwarded,
             .upgrades = .{ .websocket = harness.upgrades_http },
+            .max_body_bytes = harness.max_body_bytes,
         },
         .{
             .bind_address = tlsBindAddress(),
+            // No #236 body cap, stated rather than inherited. The draw is
+            // a *plaintext-leg* one, and that is exactly what makes
+            // `routed_canonical`'s per-leg argument in `scripts.zig`
+            // exact: a terminated run of a body-carrying script is judged
+            // by `terminating_pair`'s spec, whose legal set omits `413`.
+            // Left to the struct default this listener would silently
+            // carry the one-MiB production cap — never firing today, and
+            // turning the first script whose body outgrew it into an
+            // oracle failure that looked unrelated to its cause.
+            .max_body_bytes = 0,
             // Its own route, so a terminated connection's origin conn is
             // one `verifyUpstreamIdentities` can tell from a plaintext
             // client's. Which cluster it points at follows the protocol:
@@ -2582,6 +2614,11 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         // in the same sum — added while it is free rather than on the
         // first seed that reaches it.
         "l7_body_too_large",
+        // The #236 cap's answered half. Its sibling
+        // `l7_body_cut_mid_stream` is deliberately absent: that one tears
+        // the exchange down without a status, so its line is an abort and
+        // counting it here would explain the same line twice.
+        "l7_body_over_limit",
         "l7_not_implemented",
         "l7_no_route",
         "l7_filtered",

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -162,6 +162,12 @@ pub const Spec = struct {
     /// Every other routed request is assigned or repicked and owes the
     /// pinned cookie.
     sticky_request_pinned: bool = false,
+    /// This script sends a request body, so the #236 cap can refuse it
+    /// where a listener draws one. Stated rather than sniffed out of the
+    /// request bytes: the property decides which oracle the script is
+    /// entitled to, and a table that inferred it would let a bodyless
+    /// script widen its own legal set by accident.
+    carries_body: bool = false,
     /// This script routes to an origin and its 200 is the canonical body
     /// with the standard stamps — nothing about the response tells it
     /// apart from a plain `get`'s. That is what lets the terminating
@@ -268,6 +274,12 @@ comptime {
 /// response byte sent. Clean seeds pin the origin to `sized` and never
 /// stall, so `golden_status` still demands exact outcomes there.
 const statuses_routed: []const u16 = &.{ 200, 502, 503, 504 };
+/// The routed set plus the #236 body cap's `413`, for the scripts that
+/// carry a body. Only an adversarial seed draws a cap — a clean seed's
+/// script asked for a `200` and a refusal is not it — so the golden
+/// outcome is unchanged and this only widens what a cut seed may legally
+/// show.
+const statuses_routed_body: []const u16 = &.{ 200, 413, 502, 503, 504 };
 /// The head routes and forwards before its body is validated, so several
 /// outcomes can precede the 400: the §8 rungs, a killed dial, and — the
 /// subtlety — an early origin response. An instant origin answers 200
@@ -291,7 +303,8 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 200,
         .method = .post,
-        .allowed_statuses = statuses_routed,
+        .allowed_statuses = statuses_routed_body,
+        .carries_body = true,
         .routed_canonical = true,
     },
     .post_big = .{
@@ -301,7 +314,8 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 200,
         .method = .post,
-        .allowed_statuses = statuses_routed,
+        .allowed_statuses = statuses_routed_body,
+        .carries_body = true,
         .routed_canonical = true,
     },
     .post_chunked = .{
@@ -311,7 +325,8 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 200,
         .method = .post,
-        .allowed_statuses = statuses_routed,
+        .allowed_statuses = statuses_routed_body,
+        .carries_body = true,
         .routed_canonical = true,
     },
     .post_chunked_malformed = .{
@@ -672,7 +687,20 @@ comptime {
         // one response per request. A script that drifts from any of
         // those stops being pairable and has to say so here first.
         if (entry.routed_canonical) {
-            assert(std.mem.eql(u16, entry.allowed_statuses, statuses_routed));
+            // The legal set is a plain GET's — or that set plus the #236
+            // cap's `413`, and only for a script that actually carries a
+            // body. The two differ by *leg*, which is the truth rather
+            // than a weakening: the harness draws a body cap on the
+            // plaintext listener only, so a terminated run of the same
+            // script cannot earn a `413`, and a terminated run is judged
+            // by `terminating_pair`'s spec rather than this one. The
+            // body test is what keeps a bodyless script from taking the
+            // exception and quietly widening its own oracle.
+            if (std.mem.eql(u16, entry.allowed_statuses, statuses_routed_body)) {
+                assert(entry.carries_body);
+            } else {
+                assert(std.mem.eql(u16, entry.allowed_statuses, statuses_routed));
+            }
             assert(entry.golden_status == 200);
             assert(entry.expected_responses == 1);
             assert(entry.transcript_cap == 1);

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -267,6 +267,20 @@ const uncovered = [_]Uncovered{
             "drain_deadline_ms directly, and asserts the loop reached idle",
     },
     .{
+        .name = "l7_body_cut_mid_stream",
+        .why = .unreached,
+        .reason = "the #236 cap's streaming half, and the sweep cannot reach it " ++
+            "for a reason that is a property of the draw rather than a gap in " ++
+            "ambition: the harness draws the cap in the single-byte range so " ++
+            "every body-carrying script trips it, which means the bytes " ++
+            "coalesced with the head are already over it and the *answered* " ++
+            "rung fires first. Reaching this one needs a cap above the first " ++
+            "delivery's excess and a body that outgrows it only later — a " ++
+            "combination the draw would have to be widened to produce, at the " ++
+            "cost of the answered rung's own coverage. src/http_proxy_test.zig " ++
+            "sends a 24 KiB chunked body under a 10 KiB cap directly",
+    },
+    .{
         .name = "l7_shed_upstream_head_buffers",
         .why = .unreached,
         .reason = "same shadow as l7_shed_upstream_slots: the relay rung " ++

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -264,6 +264,7 @@ pub fn Server(comptime IoType: type) type {
             /// reason as the tables above: an admitted connection asks its
             /// own socket what it may carry.
             upgrades: config_module.Config.Listener.Upgrades,
+            max_body_bytes: u64,
             /// The listener's §7 client-address forwarding mode (null = off),
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
@@ -696,6 +697,7 @@ pub fn Server(comptime IoType: type) type {
                     .cluster_index = listener_config.routes[0].cluster_index,
                     .routes = listener_config.routes,
                     .upgrades = listener_config.upgrades,
+                    .max_body_bytes = listener_config.max_body_bytes,
                     .request_filters = listener_config.request_filters,
                     .response_filters = listener_config.response_filters,
                     .forwarded = listener_config.forwarded,
@@ -1482,6 +1484,7 @@ pub fn Server(comptime IoType: type) type {
             conn.request_filters = listener.request_filters;
             conn.response_filters = listener.response_filters;
             conn.upgrades = listener.upgrades;
+            conn.max_body_bytes = listener.max_body_bytes;
             conn.forwarded = listener.forwarded;
             // The #140 captures live in a side table addressed by pool
             // slot, so a slot's bytes outlive the connection that wrote

--- a/src/config.zig
+++ b/src/config.zig
@@ -279,6 +279,15 @@ pub const Config = struct {
         /// listener applies to another byte of it, so which sockets may
         /// hand out that exemption is a property of the socket.
         upgrades: Upgrades = .{},
+        /// Cap on one request's body (#236), or `0` to accept any size.
+        ///
+        /// Per listener rather than in `limits`, and the distinction is
+        /// §5's own: `limits` sizes what this process *reserves*, and a
+        /// body cap reserves nothing — it states policy, which is the
+        /// footing `forwarded` and `upgrades` already stand on. One
+        /// listener fronting an upload endpoint and another fronting an
+        /// API want different numbers, and neither is a pool.
+        max_body_bytes: u64 = constants.request_body_bytes_default,
 
         /// The upgrade tokens a listener may allow, as a set rather than
         /// a list: the vocabulary is closed, so membership is a field
@@ -569,6 +578,8 @@ pub const ValidationError = error{
     ListenerL4ResponseFilters,
     ListenerL4Forwarded,
     ListenerL4Upgrades,
+    ListenerL4MaxBodyBytes,
+    ListenerMaxBodyBytesOutOfRange,
     ListenerUpgradesEmpty,
     ListenerUpgradeTokenUnknown,
     ListenerForwardedModeUnknown,
@@ -1709,6 +1720,9 @@ pub const ListenerJson = struct {
     /// `Upgrade` stays the 501 it has always been. HTTP-only — an l4
     /// relay parses no handshake to recognise.
     upgrades: ?[]const []const u8 = null,
+    /// Optional #236 request-body cap; absent means one MiB, `0` means
+    /// no cap. HTTP-only — an l4 relay has no request to measure.
+    max_body_bytes: ?u64 = null,
 
     pub const schema_doc =
         "One accepting socket. Exactly one of `cluster` or `routes` selects " ++
@@ -1744,6 +1758,14 @@ pub const ListenerJson = struct {
             .desc = "Terminate TLS on this listener with the given certificate " ++
                 "and key; absent is a plaintext socket. Inbound only — the " ++
                 "upstream leg stays plaintext.",
+        },
+        .max_body_bytes = .{
+            .desc = "Cap on one request body in bytes (http listeners only); " ++
+                "absent means 1 MiB, 0 accepts any size. A body over the cap is " ++
+                "refused 413 before the origin is dialed where its length was " ++
+                "declared, and the connection closes.",
+            .minimum = 0,
+            .maximum = constants.request_body_bytes_max,
         },
         .upgrades = .{
             .desc = "Protocol upgrades this listener will carry as tunnels (http " ++
@@ -2935,6 +2957,7 @@ fn resolveListener(
         .proxy_protocol = try resolveProxyProtocol(listener_json.proxy_protocol, protocol),
         .tls = try resolveTls(listener_json.tls, protocol),
         .upgrades = try resolveUpgrades(listener_json.upgrades, protocol),
+        .max_body_bytes = try resolveMaxBodyBytes(listener_json.max_body_bytes, protocol),
     };
     if (protocol == .http) {
         try rejectHttpClusterSend(listener.routes, clusters);
@@ -3770,6 +3793,29 @@ fn resolveRetries(retries: u16) ParseError!u16 {
         return error.ClusterRetriesOutOfRange;
     }
     return retries;
+}
+
+/// Resolve a listener's #236 body cap. Absent takes the default, `0`
+/// opts out, and either on an `l4` listener is refused rather than
+/// ignored: a byte relay parses no request to measure, so a cap there
+/// describes a proxy that is not running — the same refusal `forwarded`
+/// and `upgrades` get, for the same reason.
+fn resolveMaxBodyBytes(
+    max_body_bytes: ?u64,
+    protocol: Config.Listener.Protocol,
+) ValidationError!u64 {
+    const cap = max_body_bytes orelse {
+        // An l4 listener never reads the field, so absence is not a
+        // statement about it — only an explicit one is.
+        return if (protocol == .l4) 0 else constants.request_body_bytes_default;
+    };
+    if (protocol == .l4) {
+        return error.ListenerL4MaxBodyBytes;
+    }
+    if (cap > constants.request_body_bytes_max) {
+        return error.ListenerMaxBodyBytesOutOfRange;
+    }
+    return cap;
 }
 
 /// Resolve a listener's #180 upgrade allowlist. Absent allows none, so

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -504,6 +504,29 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// not a share.
 pub const endpoint_weight_max: u16 = 256;
 
+/// Default cap on one request's body (#236), per listener. One MiB —
+/// nginx's `client_max_body_size`, which ships on by default and is the
+/// figure most application stacks are deployed assuming something in
+/// front enforces.
+///
+/// zoxy itself is unharmed by a large body: the strict recv → send → recv
+/// relay (§6) means per-connection memory is constant whatever the stream
+/// size, so an unbounded upload costs one relay buffer and no more. The
+/// exposure this bounds is entirely the *origin's*, which is why the
+/// figure is borrowed from the reference whose default protects the same
+/// thing rather than derived from anything here. `0` opts out, for a
+/// listener fronting an upload endpoint that wants its origin's own limit
+/// to be the only one.
+pub const request_body_bytes_default: u64 = 1 << 20;
+
+/// Ceiling on a configured request-body cap (#236) — one TiB. Not a
+/// resource bound: nothing here reserves per body, and the relay carries
+/// any size in constant memory (§6). It is the units-mistake bound, the
+/// same job `timeout_ms_max` does for a duration — a cap above this is a
+/// operator meaning MiB and writing bytes, and `0` already spells "no
+/// cap" for anyone who genuinely wants none.
+pub const request_body_bytes_max: u64 = 1 << 40;
+
 /// Default budget for reading one request head (#235) — from the
 /// client's first byte to a complete head, which is exactly a slowloris's
 /// window (§7: "a slowloris meets the clock or `head_buffer_bytes`,
@@ -1265,6 +1288,8 @@ comptime {
     // and the first byte re-bases the idle deadline *down* to this — a
     // timer never moves later once armed, so an inversion either way
     // would silently leave the wider value in force.
+    assert(request_body_bytes_default >= 1);
+    assert(request_body_bytes_default <= request_body_bytes_max);
     assert(connect_ms_default < head_ms_default);
     assert(head_ms_default <= idle_ms_default);
     assert(cluster_retries_max >= 1);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -214,6 +214,23 @@ pub const Counters = struct {
     /// says an operator's deadline expired, this one says a deadline
     /// they never named was supplied for them (§8).
     tunnels_drained: Value = Value.init(0),
+    /// Requests refused for a body over the listener's cap (#236).
+    /// Distinct from `l7_body_too_large` beside it, which answers the
+    /// same `413` for a different question — that one is a *buffer*
+    /// verdict, a head that fit whose payload overran the head buffer in
+    /// the same delivery. This one is policy: a body the operator said
+    /// their origin should not be asked to carry.
+    l7_body_over_limit: Value = Value.init(0),
+    /// Chunked requests cut mid-body for outgrowing the listener's cap
+    /// (#236). Its own counter beside `l7_body_over_limit`, because the
+    /// two answer differently and an operator reading either wants to
+    /// know which: a declared length is refused `413` before the origin
+    /// is dialed, while a chunked body announces no size and can only be
+    /// caught as it streams — by which point the response leg is armed
+    /// and no status can be sent, so it is a teardown. A cap that caught
+    /// only the declared case would be bypassed by an encoding any client
+    /// can choose, which is worse than none for reading as protection.
+    l7_body_cut_mid_stream: Value = Value.init(0),
     /// Interim `1xx` responses relayed to the client (#232). Forwarded
     /// rather than absorbed, which is what both references do: a `103` is
     /// worthless to a client that never sees it, and a `100` the client is

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -428,6 +428,14 @@ pub const ChunkedScanner = struct {
     state: State = .size,
     /// Chunk-data bytes still to pass through in the current chunk.
     data_remaining: u64 = 0,
+    /// Payload bytes this message has carried so far, across every chunk
+    /// (#236). Distinct from the wire bytes the caller feeds: sizes,
+    /// extensions, terminators and trailers are framing, not body, and a
+    /// documented byte limit that counted them would refuse a body under
+    /// its own cap. The only running total either framing keeps — a
+    /// `Content-Length` body is bounded by a number the head already
+    /// declared, and needs none.
+    body_bytes: u64 = 0,
     /// Chunk-size value accumulating while in `.size`.
     size: u64 = 0,
     /// True once the current size line has at least one hex digit.
@@ -564,6 +572,7 @@ pub const ChunkedScanner = struct {
         const consumed: u32 = @intCast(wanted);
         assert(consumed >= 1);
         scanner.data_remaining -= wanted;
+        scanner.body_bytes += wanted;
         if (scanner.data_remaining == 0) {
             scanner.state = .data_cr;
         }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -776,6 +776,16 @@ pub fn Proxy(comptime IoType: type) type {
             if (parser.headerValue(request.headers, "upgrade")) |token| {
                 if (!admitUpgrade(server, conn, token)) return;
             }
+            // A declared body over the listener's cap is knowable now, so
+            // it is refused now (#236) — the §8 tunnel rung's own
+            // reasoning: admitting first and shedding after would spend an
+            // origin connection to produce a worse answer. The connection
+            // closes rather than keeps, because the body it declared is
+            // still unread in the socket and draining it only to reject it
+            // is the wrong trade at the size this triggers on.
+            if (bodyOverLimit(conn, request)) {
+                return respond(server, conn, 413, "l7_body_over_limit");
+            }
 
             // §7: canonicalize the host and path once, then apply filters
             // and routing to that one view before acquiring any resource,
@@ -856,6 +866,31 @@ pub fn Proxy(comptime IoType: type) type {
                     return .{ .endpoint = identity };
                 },
             }
+        }
+
+        /// Whether a chunked request body has outgrown the listener's cap
+        /// (#236). Only `chunked` can reach here: a length-delimited body
+        /// was refused before the dial on the number its own head
+        /// declared, and the other framings carry no body to measure.
+        fn streamOverLimit(conn: *const ConnType) bool {
+            assert(conn.state == .l7_exchanging);
+            if (conn.max_body_bytes == 0) return false; // Opted out.
+            return switch (conn.l7.request_framing) {
+                .chunked => |scanner| scanner.body_bytes > conn.max_body_bytes,
+                .none, .content_length, .until_close => false,
+            };
+        }
+
+        /// Whether this request's *declared* body exceeds the listener's
+        /// cap (#236). Only the length-delimited case is knowable here; a
+        /// chunked body announces no size and is caught as it streams.
+        fn bodyOverLimit(conn: *const ConnType, request: *const parser.RequestHead) bool {
+            assert(conn.state == .l7_reading_head);
+            if (conn.max_body_bytes == 0) return false; // Opted out.
+            return switch (request.framing) {
+                .content_length => |length| length > conn.max_body_bytes,
+                .none, .chunked, .until_close => false,
+            };
         }
 
         /// Decide an `Upgrade` request's fate before a byte of it is
@@ -1484,6 +1519,16 @@ pub fn Proxy(comptime IoType: type) type {
                 respond(server, conn, 400, "l7_bad_request");
                 return;
             }
+            // A chunked body that arrived coalesced with its head is over
+            // the cap *here*, before the response leg is armed — so it
+            // still earns a status rather than the teardown the streaming
+            // case can only take (#236). Same rung, better answer, and the
+            // reason the check lives at both sites rather than only in the
+            // pump: a small over-cap body never reaches the pump at all.
+            if (streamOverLimit(conn)) {
+                respond(server, conn, 413, "l7_body_over_limit");
+                return;
+            }
             // The response leg starts recving now — before the request body
             // finishes — so an early response cannot wedge both TCP windows
             // (§7). Its render into conn.head waits until the request head
@@ -1667,7 +1712,22 @@ pub fn Proxy(comptime IoType: type) type {
             }
 
             pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
-                return feedFraming(&conn.l7.request_framing, chunk);
+                const fr = feedFraming(&conn.l7.request_framing, chunk);
+                if (fr.malformed) return fr;
+                // A chunked body announces no size, so the cap can only be
+                // read off what has actually arrived (#236). Checked after
+                // the feed, on the scanner's own payload total rather than
+                // the wire bytes — sizes, terminators and trailers are
+                // framing, and a documented byte limit that counted them
+                // would refuse a body under its own cap.
+                if (!streamOverLimit(conn)) return fr;
+                conn.server.counters.increment("l7_body_cut_mid_stream");
+                return .{
+                    .consumed = fr.consumed,
+                    .done = false,
+                    .malformed = false,
+                    .over_limit = true,
+                };
             }
 
             pub fn afterFeed(conn: *ConnType, received: u32, fr: pump.FeedResult) void {
@@ -3628,6 +3688,10 @@ pub fn Proxy(comptime IoType: type) type {
             for (rejects) |name| {
                 if (std.mem.eql(u8, counter, name)) return .rejected;
             }
+            // A body over the listener's cap is a policy reject like a
+            // filter's (#236), not a shed: nothing of this proxy's ran
+            // out, and the operator wrote the rule that refused it.
+            if (std.mem.eql(u8, counter, "l7_body_over_limit")) return .rejected;
             if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_head_buffers")) return .shed;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -291,6 +291,9 @@ const HttpOrigin = struct {
         /// Total bytes expected for the current request (head + framed
         /// body), known once its head parses. 0 means not parsed yet.
         request_expected: u32 = 0,
+        /// The request in flight is chunked, so its total is unknown and
+        /// this connection only drains (#236).
+        chunked_request: bool = false,
         response_sent: u32 = 0,
 
         fn armRecv(oconn: *OConn) void {
@@ -335,9 +338,25 @@ const HttpOrigin = struct {
                 };
                 const body_length: u32 = switch (request.framing) {
                     .content_length => |length| @intCast(length),
+                    // A chunked body has no length to expect (#236's
+                    // streaming half is the only thing that sends one
+                    // here). Read whatever arrives and let the proxy's own
+                    // verdict — a teardown at the cap — end the exchange;
+                    // the assert below would otherwise fire on the first
+                    // body byte, since nothing was expected past the head.
+                    .chunked => {
+                        oconn.chunked_request = true;
+                        oconn.request_expected = request.head_len;
+                        oconn.armRecv();
+                        return;
+                    },
                     else => 0,
                 };
                 oconn.request_expected = request.head_len + body_length;
+            }
+            if (oconn.chunked_request) {
+                oconn.armRecv();
+                return;
             }
             const current_len = oconn.request_len - oconn.request_offset;
             assert(current_len <= oconn.request_expected);
@@ -532,6 +551,8 @@ const Http1Bed = struct {
         drain_deadline_ms: u32 = 1000,
         /// The #235 head-read budget; absent mirrors the bed's idle window.
         head_timeout_ms: ?u32 = null,
+        /// The #236 request-body cap; 0 accepts any size.
+        max_body_bytes: u64 = constants.request_body_bytes_default,
         /// Put an endpoint nothing listens on *ahead* of the origin, so
         /// the first pick of an `rr` cluster is always the one that
         /// refuses and the retry is the only way to reach the origin.
@@ -653,6 +674,7 @@ const Http1Bed = struct {
             .response_filters = options.response_filters,
             .protocol = .http,
             .upgrades = options.upgrades,
+            .max_body_bytes = options.max_body_bytes,
             .forwarded = options.forwarded,
             // Paths nothing reads: the bed embeds the PEMs, so what this
             // states is only that the listener terminates.
@@ -5131,5 +5153,122 @@ test "l7: an idle kept connection still gets the whole idle window" {
     // slowloris, and treating it as one is the churn the split avoids.
     try std.testing.expect(elapsed_ms > 500);
     try std.testing.expect(elapsed_ms < 2000);
+    try bed.expectDrained();
+}
+
+test "l7: a declared body over the cap is refused before the origin is dialed" {
+    // #236. The length is in the head, so the verdict is knowable before
+    // anything is spent on it — the §8 tunnel rung's own reasoning, that
+    // admitting first and shedding after would spend an origin connection
+    // to produce a worse answer.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 320,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .max_body_bytes = 8,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("POST /upload HTTP/1.1\r\nHost: o\r\n" ++
+        "Content-Length: 64\r\n\r\n" ++ ("x" ** 64));
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 413 Content Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    // No origin was contacted: the refusal is this proxy's own, decided
+    // from the head alone.
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_body_over_limit"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_body_cut_mid_stream"));
+    try bed.expectDrained();
+}
+
+test "l7: a chunked body cannot slip past the cap by announcing no size" {
+    // The half that decides whether the cap is protection or theatre: a
+    // client that does not want to declare its length simply does not,
+    // and any HTTP client can choose chunked. Caught on the scanner's own
+    // payload total as it streams — by which point the response leg is
+    // armed, so it is a teardown rather than a status (#236).
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 321,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .max_body_bytes = 8,
+    });
+    defer bed.tearDown();
+
+    // Two 16-byte chunks: the first already passes the 8-byte cap.
+    try bed.exchange("POST /upload HTTP/1.1\r\nHost: o\r\n" ++
+        "Transfer-Encoding: chunked\r\n\r\n" ++
+        "10\r\n" ++ ("x" ** 16) ++ "\r\n" ++
+        "10\r\n" ++ ("y" ** 16) ++ "\r\n0\r\n\r\n");
+
+    // Coalesced with its head, so the cap is met before the response leg
+    // is armed and the client still earns a status. A body large enough
+    // to stream takes the teardown instead — same rung, later verdict.
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 413 Content Too Large\r\n",
+    ));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_body_over_limit"));
+    // Counted apart from a framing violation: the body was well-formed,
+    // it was simply larger than this listener carries.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
+    try bed.expectDrained();
+}
+
+test "l7: a body under the cap, and an opted-out listener, are untouched" {
+    // The cap must not reach an ordinary request, and `0` must genuinely
+    // opt out — a listener fronting an upload endpoint wants its origin's
+    // own limit to be the only one.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 322,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .max_body_bytes = 0,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("POST /upload HTTP/1.1\r\nHost: o\r\n" ++
+        "Content-Length: 64\r\nConnection: close\r\n\r\n" ++ ("x" ** 64));
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_body_over_limit"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_body_cut_mid_stream"));
+    try bed.expectDrained();
+}
+
+test "l7: a chunked body that outgrows the cap while streaming is cut" {
+    // The streaming half of #236, and the one the coalesced test above
+    // does *not* reach: a body small enough to arrive with its head is
+    // measured before the response leg is armed, so it earns a status. A
+    // body larger than the head buffer cannot be — by the time the
+    // overrun is visible the response recv is armed, no status can be
+    // sent (§7), and the only honest end is a teardown.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 323,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        // Above what arrives coalesced with the head, below the body.
+        .max_body_bytes = 10_000,
+    });
+    defer bed.tearDown();
+
+    // One 24 KiB chunk: far past the 8 KiB head buffer, so most of it
+    // reaches the body pump rather than riding in with the head.
+    try bed.exchange("POST /upload HTTP/1.1\r\nHost: o\r\n" ++
+        "Transfer-Encoding: chunked\r\n\r\n" ++
+        "6000\r\n" ++ ("z" ** 24576) ++ "\r\n0\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_body_cut_mid_stream"));
+    // Not the answered rung, and not a framing verdict: the body was
+    // well-formed and simply outgrew what this listener carries.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_body_over_limit"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
     try bed.expectDrained();
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -380,6 +380,9 @@ pub fn Conn(comptime IoType: type) type {
         /// admission like the filter tables beside it, so the gate asks
         /// what *this* socket allows rather than consulting the config.
         upgrades: config_module.Config.Listener.Upgrades,
+        /// The listener's #236 request-body cap, handed over at admission
+        /// like the tables beside it; `0` accepts any size.
+        max_body_bytes: u64,
         request_filters: []const filter.Rule,
         /// The listener's #175 response filter rules, same lifetime:
         /// matched against the origin's parsed response head at the
@@ -736,6 +739,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.request_filters = &.{};
             conn.response_filters = &.{};
             conn.upgrades = .{};
+            conn.max_body_bytes = 0;
             conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -98,10 +98,19 @@ const assert = std.debug.assert;
 /// How many of a received chunk belong to the current message. `consumed`
 /// < chunk.len means the message ended mid-buffer (the rest is a pipelined
 /// tail); `done` means no more body follows; `malformed` fails the framing.
+///
+/// `over_limit` is a *policy* stop rather than a framing one (#236): the
+/// bytes were well-formed and the message simply outgrew what this
+/// listener said it would carry. Named apart from `malformed` because the
+/// two end the exchange the same way and mean opposite things — one is
+/// the client speaking badly, the other is the client speaking too much —
+/// and a counter that could not tell them apart would send an operator
+/// looking for a broken client that does not exist.
 pub const FeedResult = struct {
     consumed: u32,
     done: bool,
     malformed: bool,
+    over_limit: bool = false,
 };
 
 pub fn Pump(
@@ -258,7 +267,11 @@ pub fn Pump(
                 return;
             }
             const fr = Policy.feed(conn, chunk);
-            if (fr.malformed) {
+            if (fr.malformed or fr.over_limit) {
+                // Both end the exchange here and for the same reason: the
+                // response leg is already armed by now, so no status can
+                // be sent (§7) — the policy has already counted which of
+                // the two it was.
                 server.beginTeardown(conn);
                 return;
             }


### PR DESCRIPTION
Refs #236. **Second of a three-PR stack** — targets `head-read-budget` (#242), not `main`.

1. #242 — `timeouts.head_ms` (#235)
2. **this** — a request body cap (#236)
3. next — a keep-alive request cap (#237)

## The gap

Nothing bounded how many body bytes a request could carry. zoxy itself was unharmed, and that is why this is a *policy* gap rather than a §5 hole: §6's strict recv → send → recv relay keeps per-connection memory constant whatever the stream size, so an unbounded upload costs one relay buffer and no more.

The exposure was entirely the **origin's** — and "the proxy in front bounds it" is the assumption most application stacks are deployed under. The only `413` in the tree answered a different question (a head that fit whose payload overran the head buffer in the same delivery), which is a buffer verdict, not a size policy.

## ⚠️ This changes behaviour on upgrade

**A deployment proxying uploads larger than 1 MiB needs `max_body_bytes` raised, or set to `0`, before taking this.** The default is on, copying nginx's `client_max_body_size`. The README carries the warning where an operator will meet it.

## Shape

`max_body_bytes` is a **listener** field, not a `limits` one. §5's line is that `limits` sizes what the process *reserves*, and a body cap reserves nothing — it states policy, the same footing `forwarded` and `upgrades` stand on. One listener fronting an upload endpoint and another fronting an API want different numbers.

**Two paths, one cap**, separated by what the head declared:

- A `Content-Length` over the cap is knowable *before the dial* and refused there — the §8 tunnel rung's own reasoning, that admitting first and shedding after spends an origin connection to produce a worse answer. The connection closes: the declared body is still unread in the socket, and draining it only to reject it is the wrong trade at this size.
- A chunked body declares nothing and is measured as it arrives. Over the cap before the response leg is armed it still earns the `413`; over it later it can only be a teardown, because §7 has no status left to send by then.

**The chunked half is what decides whether this is protection or theatre.** Catching only the declared case leaves a limit any client bypasses by choosing an encoding. `ChunkedScanner` gained a payload total — body bytes, not wire bytes, since sizes, terminators and trailers are framing and a documented byte limit that counted them would refuse a body under its own cap. `FeedResult.over_limit` gives the pump a *named* abort rather than borrowing `malformed`: the two end an exchange the same way and mean opposite things — one is a client speaking badly, the other a client speaking too much.

Two counters, and the split matters when reading them: `l7_body_over_limit` is a client told why, `l7_body_cut_mid_stream` is a client that just lost its connection. Only the first is in the sim's `l7OutcomeTotal` — the second tears down without a status, so counting it there would explain the same log line twice.

## What the tests found

My first chunked test **passed for the wrong reason**: its body arrived coalesced with the head, so it took the pre-response path and earned a status rather than the teardown it asserted. That turned out to be the better behaviour and is kept — but it meant the streaming path had *no coverage at all*, which a 24 KiB body under a 10 KiB cap now supplies.

## What review found

The per-leg argument behind a relaxed comptime invariant in `sim/l7/scripts.zig` was **imprecise rather than false**. I widened `routed_canonical`'s legal status set for body-carrying scripts, arguing the sets differ by leg because the harness draws a cap on the plaintext listener only. But the terminating listener was *inheriting the 1 MiB default* rather than carrying no cap — never firing today, and turning the first script whose body outgrew it into an oracle failure that looked unrelated to its cause. It states `0` now, and the argument is exact.

Also taken: a comment claiming the sim's draw trips *every* body script (`post_chunked`'s 8-byte payload is under it about half the range — legal, and the claim is that the cap bites, not that it bites everything), and a missing state assert on the thinnest new function.

## Verification

- Four proxy tests: declared-over-cap refused before the dial, chunked caught coalesced, chunked caught streaming, and a body under the cap plus an opted-out listener untouched.
- Sim draws the cap on adversarial seeds only — a `413` is a status a clean seed's script did not ask for, the `deriveMaxInflight` precedent.
- `zig build ci` green — 4096 seeds, census ok (66 counters fired), smoke clean. `zig fmt --check` clean.
- One census exemption, with the reason stated precisely: the sweep's cap is drawn small so every body script trips it, which means the coalesced bytes are already over and the *answered* rung fires first. Reaching the streaming rung needs a cap above the first delivery's excess, which would cost the answered rung's own coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)