### PR TITLE
limits: bound how many requests one client connection may serve (#237)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1004,6 +1004,27 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   this proxy asked for it (#180) and a failed exchange when it did not,
   because relaying it as interim would carry on reading bytes that are no
   longer HTTP.
+- **One client connection serves a bounded number of requests** (#237).
+  `limits.keepalive_requests`, 1000 by default — nginx's figure, and one
+  zoxy can honestly borrow because unlike a body cap it bounds *this
+  proxy's* slot occupancy rather than stating anything about an origin.
+  It is the only bound that reaches a **busy** connection: `idle_ms`
+  reaps one that stopped speaking, `max_lifetime_ms` one open too long,
+  and neither touches one that keeps asking — which is exactly the
+  connection holding a conn slot and, per request, a head buffer and an
+  upstream lease. That matters more here than it would elsewhere,
+  because §5's pools are sized for concurrent *activity* and §8's
+  watermark biases all shed **idle** capacity, so a population that is
+  never idle is the shape none of those levers reach. A count rather
+  than more time, because it is the bound that is fair under an
+  adversarial client: the same reconnect whether it is fast or slow,
+  where a time cap punishes the slow-but-honest one and lets a fast
+  abusive one hold its slot indefinitely. Enforced where the response's
+  persistence is decided, so the last request a connection serves is the
+  one whose header announces the close — never a silent reset. A parked
+  *upstream* connection is deliberately uncapped: it is shared across
+  clients and carries the reuse win §3 cites, so churning it has a cost
+  churning a client's does not.
 - **A request body is bounded, and the bound is the origin's** (#236).
   Nothing here needs it: §6's strict recv → send → recv relay keeps
   per-connection memory constant whatever the stream size, so an

--- a/docs/README.md
+++ b/docs/README.md
@@ -913,7 +913,8 @@ reserves nor demands the ceiling's resources.
     "head_buffers": 1024,
     "upstream_head_buffers": 512,
     "head_buffer_bytes": 16384,
-    "tunnels": 512
+    "tunnels": 512,
+    "keepalive_requests": 1000
 }
 ```
 
@@ -946,6 +947,25 @@ it is **required**, since no default can be derived for it. Each costs one
 relay-buffer pair (8200 bytes), held for the tunnel's whole life rather than
 for the duration of a request, which is why they are reserved apart from
 `relay_buffers` instead of drawn from it.
+
+`keepalive_requests` bounds how many requests one client connection may
+serve — **1000 by default**, nginx's figure, and `0` is unlimited. It is
+the one bound that reaches a *busy* connection: `idle_ms` reaps one that
+stops speaking and `max_lifetime_ms` one that has been open too long, but
+neither touches a connection that keeps asking, which is exactly the one
+holding a conn slot and, on every request, a head buffer and an upstream
+lease. Past the cap the next response announces `Connection: close` — the
+same announced close every other rung uses, never a silent reset — and
+the client reconnects, which every HTTP client treats as routine.
+`zoxy_l7_keepalive_requests_capped` counts it, and only where the cap is
+the *binding* reason, so a rising count is the cap working rather than
+churn it merely coincided with.
+
+A parked *upstream* connection is deliberately not capped, where nginx
+caps both. One is shared across clients and carries the reuse win the
+design rests on, so churning it has a directly visible cost — and the occupancy this
+bounds is a client's, not an origin's. An origin that wants its own bound
+can announce it, and zoxy honours what an origin says about persistence.
 
 `cq_fill_eighths` trades connection ceiling for `io_uring` completion-queue
 burst headroom; `access_log_buffer_bytes` sizes the access log's staging

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -843,6 +843,13 @@ fn deriveServerConfig(
         // for coverage that does not exist. The draw arrives with the
         // tunnels themselves (#180).
         .tunnel_timeout_ms = zoxy.constants.tunnel_ms_default,
+        // The #237 cap is read off the config, where the loader puts it;
+        // `deriveInitOptions` sizes the pools separately. Drawn only under
+        // the adversary, for the reason `deriveMaxInflight` gives: a
+        // capped connection announces a close its script did not ask for,
+        // and a clean seed's golden transcript forbids that. `0` leaves it
+        // unlimited, which is every clean seed and most others.
+        .limits = .{ .keepalive_requests = deriveKeepaliveRequests(harness.clean, random) },
         // Three seeds in four run with the access log on, so the sink,
         // its staging swap, and the per-request captures all take the
         // schedule fuzz; the fourth leaves it off, which is the shape
@@ -920,6 +927,19 @@ fn deriveMaxBodyBytes(clean: bool, random: std.Random) u64 {
     if (clean) return 0;
     if (random.uintLessThan(u8, 3) != 0) return 0;
     return 1 + random.uintLessThan(u64, 16);
+}
+
+/// The #237 keep-alive request cap. One or two, so `keepalive_pair` —
+/// the script that sends a second request once the first settles
+/// reusable — actually meets it: at one the first response announces the
+/// close and the pair degrades to a single exchange, which its own spec
+/// already allows for ("degrades to a single-exchange transcript when its
+/// first response refuses reuse"), and at two it serves both and the
+/// second is the one capped.
+fn deriveKeepaliveRequests(clean: bool, random: std.Random) u32 {
+    if (clean) return 0;
+    if (random.uintLessThan(u8, 3) != 0) return 0;
+    return 1 + random.uintLessThan(u32, 2);
 }
 
 fn deriveMaxInflight(clean: bool, random: std.Random) ?u32 {

--- a/src/config.zig
+++ b/src/config.zig
@@ -191,6 +191,17 @@ pub const Config = struct {
         /// terminates TLS, and the struct default is the off state on the
         /// same terms as `head_buffers`.
         tls_engines: u32 = 0,
+        /// Requests one client connection may serve before the next
+        /// response announces `Connection: close` (#237); `0` is
+        /// unlimited.
+        ///
+        /// In `limits` rather than beside a listener's policy, and the
+        /// distinction is the one `max_body_bytes` draws from the other
+        /// side: a body cap states what an *origin* should be asked to
+        /// carry, while this bounds what one client may occupy *here*.
+        /// `cq_fill_eighths` sits in this block on the same terms — not a
+        /// pool size, but a knob about this process's own resources.
+        keepalive_requests: u32 = constants.keepalive_requests_default,
         /// The §5 tunnel pool (#180): how many upgraded connections may be
         /// carried at once, each holding its own relay buffer and upstream
         /// socket for its whole life rather than drawing from the shared
@@ -1235,6 +1246,8 @@ fn resolveLimits(
         .head_buffer_bytes = head_buffer_bytes,
         .tls_engines = tls_engines,
         .tunnels = tunnels,
+        .keepalive_requests = limits_json.keepalive_requests orelse
+            constants.keepalive_requests_default,
         .cq_fill_eighths = cq_fill_eighths,
         .access_log_buffer_bytes = access_log_buffer_bytes,
     };
@@ -1614,6 +1627,9 @@ pub const LimitsJson = struct {
     head_buffer_bytes: ?u32 = null,
     tls_engines: ?u32 = null,
     tunnels: ?u32 = null,
+    /// Optional #237 keep-alive request cap; absent means nginx's 1000,
+    /// `0` is unlimited.
+    keepalive_requests: ?u32 = null,
     cq_fill_eighths: ?u32 = null,
     access_log_buffer_bytes: ?u32 = null,
 
@@ -1667,6 +1683,13 @@ pub const LimitsJson = struct {
                 "follows. Zero exactly when no listener terminates TLS.",
             .minimum = 1,
             .maximum = constants.tls_engines_max,
+        },
+        .keepalive_requests = .{
+            .desc = "Requests one client connection may serve before the next " ++
+                "response announces Connection: close; absent means 1000, " ++
+                "0 is unlimited.",
+            .minimum = 0,
+            .maximum = std.math.maxInt(u32),
         },
         .tunnels = .{
             .desc = "Concurrent tunnelled upgrades (#180). Each holds its own relay " ++

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -504,6 +504,25 @@ pub const cluster_name_bytes_max: u16 = 64;
 /// not a share.
 pub const endpoint_weight_max: u16 = 256;
 
+/// Default cap on requests one client connection may serve (#237) —
+/// nginx's `keepalive_requests`, which also ships on. `0` is unlimited.
+///
+/// Unlike a body cap this one zoxy *can* honestly answer, and that is
+/// what earns it a default: it bounds this proxy's own slot occupancy
+/// rather than stating anything about an origin. `idle_ms` reaps a
+/// connection that stops speaking and `max_lifetime_ms` one that has been
+/// open too long; neither bounds a connection that is *busy* — and a busy
+/// connection is exactly the one holding a conn slot and, on every
+/// request, a head-ring buffer and an upstream lease. §8's watermark
+/// biases all aim at shedding *idle* capacity, so a population that is
+/// never idle is the shape none of them reach.
+///
+/// A count rather than more time, because it is the bound that is fair
+/// under an adversarial client: it costs the same reconnect whether a
+/// client is fast or slow, where a time cap punishes the slow-but-honest
+/// one and lets a fast abusive one hold its slot indefinitely.
+pub const keepalive_requests_default: u32 = 1000;
+
 /// Default cap on one request's body (#236), per listener. One MiB —
 /// nginx's `client_max_body_size`, which ships on by default and is the
 /// figure most application stacks are deployed assuming something in
@@ -1288,6 +1307,9 @@ comptime {
     // and the first byte re-bases the idle deadline *down* to this — a
     // timer never moves later once armed, so an inversion either way
     // would silently leave the wider value in force.
+    // The two #236/#237 client-side caps: each must be a real bound, or
+    // the default would spell the "unlimited" its own zero already does.
+    assert(keepalive_requests_default >= 1);
     assert(request_body_bytes_default >= 1);
     assert(request_body_bytes_default <= request_body_bytes_max);
     assert(connect_ms_default < head_ms_default);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -231,6 +231,13 @@ pub const Counters = struct {
     /// only the declared case would be bypassed by an encoding any client
     /// can choose, which is worse than none for reading as protection.
     l7_body_cut_mid_stream: Value = Value.init(0),
+    /// Connections whose response announced `Connection: close` because
+    /// they had served the §5 request cap (#237). Counted only where the
+    /// cap is the *binding* reason — a connection already closing for
+    /// pressure, a drain or the client's own ask did not need this rung —
+    /// so a rising count is the cap doing its job rather than churn it
+    /// merely coincided with.
+    l7_keepalive_requests_capped: Value = Value.init(0),
     /// Interim `1xx` responses relayed to the client (#232). Forwarded
     /// rather than absorbed, which is what both references do: a `103` is
     /// worthless to a client that never sees it, and a `100` the client is

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -769,6 +769,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             assert(request.head_len <= conn.head_len);
             recordRequestFacts(server, conn, request);
+            // Counted where a request becomes real (#237): a head that
+            // parsed and will be answered. A malformed one never reaches
+            // here, which is right — the cap bounds work this connection
+            // asked for, not bytes it fumbled.
+            conn.requests_served +|= 1;
             armRequestDeadline(server, conn);
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");
@@ -1925,6 +1930,49 @@ pub fn Proxy(comptime IoType: type) type {
             renderResponse(server, conn, &response);
         }
 
+        /// Whether this connection has served all the requests the §5 cap
+        /// allows (#237).
+        ///
+        /// Deliberately not applied to a *parked upstream* connection,
+        /// which nginx does cap. A parked upstream is shared across
+        /// clients (§3) and carries the reuse win §3 cites — measured by
+        /// the previous iteration at ~3x req/s, not by this one — so
+        /// churning it has a directly visible cost where churning a client
+        /// connection has none — and the occupancy this bounds is a client's, not an
+        /// origin's. If an origin wants its own bound it can announce it,
+        /// and §7 already honors what an origin says about persistence.
+        fn requestsCapReached(server: *const ServerType, conn: *const ConnType) bool {
+            // Every caller answers a request that `routeRequest` already
+            // counted, so a zero here would mean the cap was consulted for
+            // a request nobody served.
+            assert(conn.requests_served >= 1);
+            const cap = server.config.limits.keepalive_requests;
+            if (cap == 0) return false; // Unlimited.
+            return conn.requests_served >= cap;
+        }
+
+        /// The #237 cap as the last brake on any persistence decision that
+        /// would otherwise keep.
+        ///
+        /// One helper rather than a predicate each site remembers to
+        /// consult, because there are four such decisions — the proxied
+        /// response, a static answer, a #159 page and a #176 redirect —
+        /// and the cap is meaningless if it binds only the first. A client
+        /// whose every request lands on a filter reject or a 404 holds its
+        /// slot exactly as firmly as one being proxied, which is the
+        /// occupancy this bounds.
+        ///
+        /// It also owns the counter, so "the cap is why this closed" is
+        /// recorded once and only where it is the *binding* reason: a
+        /// connection already closing for pressure, a drain or the
+        /// client's own ask never reaches the check.
+        fn applyRequestCap(server: *ServerType, conn: *const ConnType, would_keep: bool) bool {
+            if (!would_keep) return false;
+            if (!requestsCapReached(server, conn)) return true;
+            server.counters.increment("l7_keepalive_requests_capped");
+            return false;
+        }
+
         /// The §8 persistence decision, made once and honored: keep the
         /// client's connection unless pipelining, pressure, or drain says
         /// otherwise — then announce whatever was decided (§7).
@@ -2426,7 +2474,16 @@ pub fn Proxy(comptime IoType: type) type {
             // an interim and an uninvited switch all divert first.
             if (!dispatchByStatus(server, conn, response)) return;
 
-            const keep_downstream = downstreamKeepAlive(server, conn, response);
+            // The #237 cap applies where the response's persistence is
+            // decided, not at the turnaround: §8's rule is that a close is
+            // announced rather than silent, so the last request a
+            // connection serves has to be the one carrying the header that
+            // says so.
+            const keep_downstream = applyRequestCap(
+                server,
+                conn,
+                downstreamKeepAlive(server, conn, response),
+            );
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const verdict = stickyVerdict(server, conn);
@@ -2464,22 +2521,38 @@ pub fn Proxy(comptime IoType: type) type {
                 excess[0..feed.consumed],
             );
 
+            commitResponse(server, conn, response, verdict, head_write_len);
+        }
+
+        /// The point of no return: from here the origin's answer is *this
+        /// exchange's* answer and no verdict may intervene (§7).
+        ///
+        /// Split from the render because everything here is a commitment
+        /// rather than a decision, and because each line is credited
+        /// deliberately *late*. The sticky stamp is counted only now —
+        /// the malformed-excess bail above can still discard a rendered
+        /// head, and a discarded try must not count (`l7_redirected`'s
+        /// placement rule). The status is recorded so a line can report
+        /// what the origin said even if the exchange never finishes,
+        /// while whether the client *got* it stays a separate fact:
+        /// `outcome` remains `aborted` until `finishExchange` earns `ok`
+        /// (§8). And the #140 response headers are captured at this same
+        /// moment because the origin's head is live now and this render is
+        /// what writes over it.
+        fn commitResponse(
+            server: *ServerType,
+            conn: *ConnType,
+            response: *const parser.ResponseHead,
+            verdict: StickyVerdict,
+            head_write_len: u32,
+        ) void {
+            assert(conn.state == .l7_exchanging);
+            assert(!conn.l7.response_started);
+            assert(head_write_len >= 1);
             conn.l7.response_leg = .sending_head;
-            // Committed to answering: no verdict may intervene from here (§7).
             conn.l7.response_started = true;
-            // Credited only here, at the point of no return — the
-            // malformed-excess bail above can still discard a rendered
-            // head, and a discarded try must not count (`l7_redirected`'s
-            // placement rule).
             creditSticky(server, verdict);
-            // What the origin said, so a line can report it even if the
-            // exchange never finishes. Whether the client *got* it is a
-            // separate fact, and `outcome` stays `aborted` until
-            // `finishExchange` earns `ok` (§8).
             conn.log.status = response.status;
-            // The #140 response headers, captured here for the same
-            // reason and at the same moment: the origin's head is live
-            // now, and this render is what writes over it.
             server.captureResponseLogHeaders(conn, response.headers);
             armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .response_excess);
         }
@@ -3398,10 +3471,12 @@ pub fn Proxy(comptime IoType: type) type {
             // shedding, and how a transient overshoot locks itself in as a
             // reconnect loop. Keeping is one send.
             //
-            // The same three brakes the render-time persistence decision
+            // The same four brakes the render-time persistence decision
             // honors apply here (§7, §8): the client's own ask, the drain,
-            // and relay pressure — a proxy shedding buffers should not also
-            // be holding connections open for their next request.
+            // relay pressure — a proxy shedding buffers should not also be
+            // holding connections open for their next request — and the
+            // #237 request cap, which binds a connection answered
+            // statically exactly as firmly as one being proxied.
             // The head-shed rung can never keep, structurally: nothing was
             // read (the ring was empty, so no buffer was ever bound), the
             // request's bytes wait unread in the socket, and a kept
@@ -3409,7 +3484,7 @@ pub fn Proxy(comptime IoType: type) type {
             // forever. Comptime, so the resync rule — whose asserts require
             // at least one byte read — is never consulted on that rung.
             const may_keep = comptime !std.mem.eql(u8, counter, "l7_shed_head_buffers");
-            const keep = may_keep and staticResponseResyncable(conn) and
+            const keep = applyRequestCap(server, conn, may_keep and staticResponseResyncable(conn)) and
                 conn.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();
@@ -3521,9 +3596,9 @@ pub fn Proxy(comptime IoType: type) type {
             server.counters.increment("l7_responded");
             conn.log.status = page.status;
             conn.log.outcome = .responded;
-            // The same three brakes every static answer honors (§7, §8):
+            // The same four brakes every static answer honors (§7, §8):
             // the client's own ask, the drain, and relay pressure.
-            const keep = staticResponseResyncable(conn) and
+            const keep = applyRequestCap(server, conn, staticResponseResyncable(conn)) and
                 conn.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();
@@ -3631,9 +3706,9 @@ pub fn Proxy(comptime IoType: type) type {
                     // answer requires.
                     error.NoHost => return respond(server, conn, 400, "l7_bad_request"),
                 };
-            // The same three brakes `respond` honors, decided before the
+            // The same four brakes `respond` honors, decided before the
             // render because the close is announced inside it (§7).
-            const keep = staticResponseResyncable(conn) and
+            const keep = applyRequestCap(server, conn, staticResponseResyncable(conn)) and
                 conn.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -553,6 +553,8 @@ const Http1Bed = struct {
         head_timeout_ms: ?u32 = null,
         /// The #236 request-body cap; 0 accepts any size.
         max_body_bytes: u64 = constants.request_body_bytes_default,
+        /// The #237 keep-alive request cap; 0 is unlimited.
+        keepalive_requests: u32 = constants.keepalive_requests_default,
         /// Put an endpoint nothing listens on *ahead* of the origin, so
         /// the first pick of an `rr` cluster is always the one that
         /// refuses and the retry is the only way to reach the origin.
@@ -686,6 +688,11 @@ const Http1Bed = struct {
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
+            // The #237 cap is read off the *config*, which is where the
+            // loader puts it; `InitOptions` sizes the pools. The bed keeps
+            // the rest of `limits` at its struct defaults, which is what
+            // every test before this one was measuring against.
+            .limits = .{ .keepalive_requests = options.keepalive_requests },
             .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
             // Mirrors the idle window unless a test is about the split
@@ -5270,5 +5277,130 @@ test "l7: a chunked body that outgrows the cap while streaming is cut" {
     // well-formed and simply outgrew what this listener carries.
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_body_over_limit"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
+    try bed.expectDrained();
+}
+
+test "l7: the request cap announces its close on the last response it serves" {
+    // #237. The cap has to bite where the response's persistence is
+    // decided, not at the turnaround: §8's rule is that a close is
+    // announced rather than silent, so the last request a connection
+    // serves must be the one carrying the header that says so. A client
+    // that read a reset where a status was due reports an error it cannot
+    // attribute.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 330,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .keepalive_requests = 1,
+    });
+    defer bed.tearDown();
+
+    // The client asks to keep the connection; the cap says this is the
+    // one and only request it gets.
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: a connection under the cap keeps serving, and 0 is unlimited" {
+    // Two requests over one connection with the cap at 2: the first must
+    // keep, and the counter must stay still — a cap that fired early
+    // would churn the population it exists to bound.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 331,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .keepalive_requests = 2,
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /b HTTP/1.1\r\nHost: o\r\n\r\n";
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    // First keeps, second is capped and says so.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" ++
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try std.testing.expectEqual(@as(u32, 2), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: a client that asked to close is not counted against the cap" {
+    // The counter must name the cap's own effect. A connection already
+    // closing — because the client asked, or pressure or a drain decided
+    // — did not need this rung, and counting it would read as churn the
+    // cap caused.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 332,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .keepalive_requests = 1,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try bed.expectDrained();
+}
+
+test "l7: the request cap binds a statically-answered connection too" {
+    // The hole review found: the cap first landed only on the proxied
+    // response path, so a client whose every request met a filter reject,
+    // a 404 or a redirect kept its conn slot indefinitely — the exact
+    // population the cap exists to bound, relocated rather than fixed.
+    // A static answer holds a slot exactly as firmly as a proxied one.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &[_]filter.Action{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 333,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .request_filters = &rules,
+        .keepalive_requests = 1,
+    });
+    defer bed.tearDown();
+
+    // A rejected request never reaches an origin, so nothing on the
+    // proxied path could have applied the cap to it.
+    try bed.exchange("GET /admin HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 403 Forbidden\r\n",
+    ));
+    // Announced, not silent: the client is told this connection is done.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        bed.client.response(),
+        "Connection: close",
+    ) != null);
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
     try bed.expectDrained();
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -383,6 +383,10 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's #236 request-body cap, handed over at admission
         /// like the tables beside it; `0` accepts any size.
         max_body_bytes: u64,
+        /// Requests this connection has served, for the #237 cap. On the
+        /// connection rather than in `l7`, which resets at every
+        /// turnaround — the whole point is a total that survives them.
+        requests_served: u32,
         request_filters: []const filter.Rule,
         /// The listener's #175 response filter rules, same lifetime:
         /// matched against the origin's parsed response head at the
@@ -740,6 +744,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.response_filters = &.{};
             conn.upgrades = .{};
             conn.max_body_bytes = 0;
+            conn.requests_served = 0;
             conn.forwarded = null;
             conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;


### PR DESCRIPTION
Refs #237. **Third and last of the stack** — targets `request-body-cap` (#243), not `main`.

1. #242 — `timeouts.head_ms` (#235)
2. #243 — a request body cap (#236)
3. **this** — a keep-alive request cap (#237)

## The gap

One client connection could serve unlimited requests. `idle_ms` reaps a connection that stops speaking; `max_lifetime_ms` one that has been open too long. Neither bounds a connection that is **busy** — and a busy connection is exactly the one holding a conn slot and, on every request, a head buffer and an upstream lease.

That matters more here than it would in nginx: §5's pools are sized for concurrent *activity*, and §8's watermark biases all shed **idle** capacity, so a population that is never idle is the shape none of those levers reach. Conn-slot pressure deliberately does not suppress keep-alive (#57, and rightly), so under slot scarcity nothing rotated a long-lived busy connection out.

## Shape

`limits.keepalive_requests`, **1000 by default** (nginx's figure), `0` unlimited.

It sits in `limits` rather than beside a listener's policy, and that argument is the **mirror** of the one that put #236's body cap on the listener: a body cap states what an *origin* should be asked to carry, while this bounds what one client may occupy *here*. `cq_fill_eighths` shares the block on the same terms, not being a pool size either.

A count rather than more time, because it is the bound that is fair under an adversarial client: the same reconnect whether it is fast or slow, where a time cap punishes the slow-but-honest one and lets a fast abusive one hold its slot indefinitely.

**Enforced where a response's persistence is decided, never at the turnaround.** §8's rule is that a close is announced rather than silent, so the last request a connection serves has to be the one carrying the header that says so. Checking at the turnaround would announce keep-alive and then close anyway — the failure the announcement exists to prevent.

The counter fires only where the cap is the **binding** reason. A connection already closing for pressure, a drain, or because the client asked did not need this rung, and counting those would make the metric read as churn the cap caused.

## What review caught

It bound only the **proxied** path. A static answer — a filter reject, a 404, a #159 page, a #176 redirect — makes its own keep-or-close decision, and none of them consulted the cap. A client whose every request met one held its conn slot indefinitely: the population the cap exists to bound, relocated rather than fixed.

Worse, the three static sites' own comments claimed they honoured *"the same three brakes the render-time persistence decision honors"* — so the code asserted a parity it had just lost. One `applyRequestCap` now owns the brake and its counter for all four sites, the comments say four, and a test pins the static path by rejecting every request before it can reach an origin at all. Mutation-verified: unbinding the static path alone fails that test.

Also taken: an attribution I had carried on trust. I wrote that a parked upstream is "the measured ~3× reuse win" — §3 attributes that figure to *the previous iteration's* benchmarking, not to this design. The prose now says so.

## Deliberately not capped: parked upstream connections

nginx caps both. A parked upstream is shared across clients (§3) and carries the reuse win §3 cites, so churning it has a directly visible cost where churning a client's connection has none — and the occupancy this bounds is a client's, not an origin's. An origin that wants its own bound can announce it, and §7 already honours what an origin says about persistence.

## Verification

- Four proxy tests: the cap announcing its close on the last response, a connection under the cap still serving, a client that asked to close *not* counted against it, and the static-answer path.
- Mutation-verified twice: neutering the cap fails two tests; unbinding the static path alone fails the fourth.
- Sim draws the cap on adversarial seeds at 1–2 so `keepalive_pair` meets it — that script's spec already anticipated this shape ("degrades to a single-exchange transcript when its first response refuses reuse"). No census exemption needed.
- `zig build ci` green — 4096 seeds, census ok (**67 counters fired**), smoke clean. `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)