### PR TITLE
http: accept absolute-form request-targets, and let their authority win

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -905,13 +905,37 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   9110 §4.2.3 makes `Host` case-insensitive, and the authority's port is
   not part of the routing name) — computed once in the trust boundary
   like the path. Unlike the path, the `Host` header is **forwarded
-  verbatim**: an origin virtual-host may legitimately be case- or
+  verbatim** (with the one absolute-form exception below): an origin
+  virtual-host may legitimately be case- or
   port-sensitive, and the proxy has no per-origin knowledge to justify
   rewriting it — the canonical form is a routing *key*, not a
   replacement. A request with no `Host` (legal in HTTP/1.0) or an empty
   one matches only the any-host routes; config hosts must themselves be
   canonical (rejected at load otherwise), so a request host compares
   byte-for-byte against them.
+- **An absolute-form target names its own authority, and that authority
+  wins** (#233). RFC 9112 §3.2.2 makes accepting `GET
+  http://api.example/v2/x HTTP/1.1` a MUST for a server, and it arrives
+  from clients that believe they are talking to a forward proxy — a JVM
+  with `http.proxyHost` set, a synthetic-check agent, an old cache. The
+  target is split at the same trust boundary that validates every other
+  form: the authority comes off, and the origin-form remainder goes
+  through the same canonicalization as any other path (an absent path is
+  the root). Only `http` and `https` are admitted — §7 speaks those two,
+  and a target naming another scheme is refused 400 rather than routed
+  by its path alone — and the authority must be a bare host, so a
+  userinfo prefix or a fragment is a 400 too.
+  The authority then **replaces the `Host`**: it is what routes, what
+  filters match, what the access log records, and what the forwarded
+  request carries as its one `Host` line. That is the RFC's own
+  prescription (a recipient ignores the received Host in favour of the
+  target's authority) and it is the only reading that keeps this
+  section's promise — the router and the origin cannot disagree about
+  which resource a request names — when a request names one twice. It is
+  also the single place the proxy rewrites a `Host`, which is why the
+  verbatim-forwarding rule above names it as its exception. An HTTP/1.1
+  request must still carry a `Host` at all (RFC 9112 §3.2, a separate
+  rule); the authority overrides its *value*, not the requirement.
 - **An allowed upgrade becomes a tunnel** (#180). The proxy does not
   speak WebSocket and will not: it forwards the handshake, recognises
   `101 Switching Protocols`, and relays bytes both ways for the rest of
@@ -2209,9 +2233,11 @@ header because that is what origins read. And the **PROXY protocol**
 pins its two writers to its parser by round-trip test: there is no
 independent text to be conformant *to*.
 
-**The deviations.** Four requirements this proxy does not meet today.
+**The deviations.** Three requirements this proxy does not meet today.
 The first is settled; the rest are open, and the issue is where each
-decision is being taken rather than here.
+decision is being taken rather than here. Absolute-form request-targets
+(9112 §3.2.2) left this list with #233: they are accepted, and §7 states
+what their authority does to the `Host` beside them.
 
 - **`Via` is not sent** (9110 §7.6.3, a MUST for intermediaries). The
   cost is real and worth naming: a request that loops through this proxy
@@ -2230,9 +2256,6 @@ decision is being taken rather than here.
   server with a clock, which this one has) — #234. §8's static
   responses are comptime bytes; a `Date` makes them a written region,
   which is a change to what that section claims.
-- **Absolute-form request-targets are rejected** (9112 §3.2.2, a MUST
-  for servers) — #233. `validateTarget` accepts origin-form and
-  `OPTIONS *` only.
 
 **There is no conformance suite**, official or otherwise, and §9's gates
 are internal by construction — the fuzzer asserts *this* parser never

--- a/docs/README.md
+++ b/docs/README.md
@@ -374,6 +374,14 @@ origin receives, so the router and the backend cannot disagree about which
 resource was named. Structure-changing escapes (`%2F`, `%00`, truncated
 escapes) are rejected with `400`; no matching route is a `404`.
 
+A request may also name its authority in the request line itself —
+`GET http://api.example.com/v2/x HTTP/1.1` — which is what a client sends
+when it thinks it is talking to a forward proxy. That form is accepted
+(RFC 9112 requires it), and the authority in the target **wins over the
+`Host` header**: it is what routes, what filters match, what the access
+log records, and what the origin receives as the request's `Host`. Only
+`http` and `https` targets are accepted; any other scheme is a `400`.
+
 ### Clusters and load balancing
 
 A cluster is a named set of endpoints — static `IP:port` literals, resolved

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -2501,6 +2501,16 @@ fn verifyAccessLog(harness: *Harness) !void {
     // range finishes, which is too late to explain a single seed.
     if (counters.get("access_log_dropped") != 0) return error.AccessLogDroppedInSweep;
 
+    // #233: an absolute-form request line's authority overrides the Host
+    // beside it, and what the log records is the name the request
+    // *routed* on. So the overridden spelling must never reach a line —
+    // the same check the origin makes on what it was forwarded, made
+    // here on what the operator is told. Only one script can produce
+    // these bytes, which is what makes a scan of the whole sink exact.
+    if (std.mem.indexOf(u8, sink, l7.canon.overridden_host) != null) {
+        return error.AccessLogHostNotOverridden;
+    }
+
     // Every HTTP line is either an outcome the data path counted or an
     // abort — an equality, and the reason this file no longer asks
     // whether the log wrote *enough* lines. The `>=` it replaces was

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -39,6 +39,13 @@ pub const response_edit_name = "X-Sim-Response";
 pub const response_edit_value = "on";
 pub const response_never_name = "X-Sim-Never";
 
+/// The Host header the `absolute_form` script sends beside a request
+/// line that names a different authority (#233). RFC 9112 §3.2.2 has the
+/// authority win, so these bytes must never reach an origin — the origin
+/// checks every forwarded head for them, and only that one script can
+/// produce them, which makes a global check a precise one.
+pub const overridden_host = "overridden.example";
+
 /// The one Location a sim 301 may carry (#176): the harness's redirect
 /// rule composes scheme + the request's own host and canonical path,
 /// and `filter_redirect` is the only script that earns a 301 — so the

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -244,6 +244,22 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 return std.mem.eql(u8, target[canonical.path.len..], canonical.query);
             }
 
+            /// The §7 promise an absolute-form request must not weaken
+            /// (#233): the forwarded request line is origin-form, and the
+            /// single `Host` it carries is the name that routed. A proxy
+            /// that forwarded the client's target verbatim would fail the
+            /// first test; one that routed on the authority but forwarded
+            /// the Host beside it would fail the second, which is the
+            /// disagreement RFC 9112 §3.2.2 exists to settle.
+            fn forwardedNamesOneAuthority(conn: *Conn, request: *const parser.RequestHead) bool {
+                _ = conn;
+                if (request.authority != null) {
+                    return false;
+                }
+                const host = request.host orelse return true;
+                return !std.mem.eql(u8, host, canon.overridden_host);
+            }
+
             /// Returns true when the head is parsed and the phase moved
             /// on; false when it armed a recv or closed on a violation.
             fn parseHead(conn: *Conn) bool {
@@ -286,6 +302,17 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 // A raw dot-segment or decodable escape here would mean the
                 // router and the origin could disagree about the resource.
                 if (!conn.targetIsCanonical(request.target)) {
+                    conn.origin.violations += 1;
+                    conn.close();
+                    return false;
+                }
+                // #233: whatever form a client used to name the resource,
+                // the origin is spoken to in origin-form, and the Host it
+                // reads is the authority that routed — never the one an
+                // absolute-form request line overruled. Checked for every
+                // script because only one can produce either shape, which
+                // makes a blanket check an exact one.
+                if (!conn.forwardedNamesOneAuthority(&request)) {
                     conn.origin.violations += 1;
                     conn.close();
                     return false;

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -66,6 +66,13 @@ pub const Script = enum(u8) {
     /// `/sim` would; the origin's canonical oracle catches a raw-path
     /// forward, and a router matching raw bytes would route it elsewhere.
     confusion,
+    /// A GET whose request line is absolute-form (#233), beside a `Host`
+    /// naming somewhere else. RFC 9112 §3.2.2 has the authority win, so
+    /// this must route, forward and log exactly as `get` does — the
+    /// request the origin sees is `get`'s, byte for byte. What proves it
+    /// is the origin's own oracle: it refuses any forwarded head still
+    /// in absolute-form, and any carrying the overridden Host.
+    absolute_form,
     /// A GET under `/reject`: a §7 filter rejects it with 403 before any
     /// resource is acquired or origin dialed. The golden outcome is exactly
     /// that 403, and the origin must never see the request.
@@ -198,6 +205,24 @@ pub const get_request = "GET /sim HTTP/1.1\r\nHost: sim\r\n" ++ trace_line ++ "\
 /// left to say.
 pub const get_request_close = "GET /sim HTTP/1.1\r\nHost: sim\r\nConnection: close\r\n" ++
     trace_line ++ "\r\n";
+/// The #233 absolute-form spelling of `get_request`: the same resource,
+/// named the way a client with `http.proxyHost` set names it, with a
+/// `Host` that disagrees. Once the split and the override are right,
+/// what the proxy forwards is `get_request` — the comptime block below
+/// pins the two halves the render assembles it from, so an edit to
+/// either spelling has to keep them in step.
+pub const absolute_form_request = "GET http://sim/sim HTTP/1.1\r\n" ++
+    "Host: " ++ canon.overridden_host ++ "\r\n" ++ trace_line ++ "\r\n";
+comptime {
+    // The authority names the same host the origin-form script sends, so
+    // the two route identically and any difference the sweep sees comes
+    // from the form alone.
+    assert(std.mem.indexOf(u8, absolute_form_request, "http://sim/sim") != null);
+    assert(std.mem.indexOf(u8, get_request, "Host: sim\r\n") != null);
+    // And the Host it carries is the one no origin may ever see.
+    assert(std.mem.indexOf(u8, absolute_form_request, canon.overridden_host) != null);
+}
+
 /// A keep-alive POST for the same caller (#204): the request-body leg,
 /// which a GET cannot reach, on a connection the exchange leaves open so
 /// a second request can follow it. Byte-identical to `post_sized`'s
@@ -448,6 +473,18 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .allowed_statuses = statuses_routed,
         .routed_canonical = true,
     },
+    .absolute_form = .{
+        // Absolute-form, so what routes is the request line's authority
+        // rather than the Host beside it (#233). Indistinguishable from
+        // `get` from here on: same route, same forwarded head, same 200.
+        .request = absolute_form_request,
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
+    },
     // §7 filter scripts: a distinct path per action so the listener's
     // rules fire only for these, never the others.
     .filter_reject = .{
@@ -623,6 +660,7 @@ pub const terminating_scripts = [_]Script{
     .connect_method,
     .pipelined,
     .confusion,
+    .absolute_form,
     .filter_reject,
     .filter_redirect,
     .filter_respond,

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -88,6 +88,19 @@ pub const Counters = struct {
     /// path, where a read cannot deliver more than the buffer holds.
     l7_body_too_large: Value = Value.init(0),
     l7_not_implemented: Value = Value.init(0),
+    /// A request whose target arrived in absolute-form (RFC 9112 §3.2.2,
+    /// #233), counted where the parser's split is read. Neither a reject
+    /// nor an outcome: the request goes on to be routed, filtered or
+    /// refused exactly like an origin-form one, and this records only
+    /// that the client named its own authority in the request line.
+    ///
+    /// It earns a counter because it is the single signal that something
+    /// is addressing this listener as though it were a forward proxy —
+    /// a JVM client with `http.proxyHost` set, a synthetic-check agent,
+    /// an old cache. The form is one a server MUST accept, so this is
+    /// not an error; a *rate* of it is still nearly always a client
+    /// misconfiguration worth finding.
+    l7_absolute_form: Value = Value.init(0),
     /// No route matched the request's canonical path (§7), answered 404.
     /// A valid head, so the connection keeps serving when its stream is
     /// still on a message boundary — see `l7_shed_*` below.

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -215,12 +215,24 @@ pub const RequestHead = struct {
     /// The method's raw token bytes ("GET", "PROPFIND", ...) — what the
     /// renderer writes into the upstream request line, whatever the tag.
     method_token: []const u8,
+    /// The request-target in the form §7 routes and forwards. Absolute-form
+    /// is split at the trust boundary (RFC 9112 §3.2.2), so this is its
+    /// origin-form remainder — "/" when the target named no path, and a
+    /// bare "?query" when it named only a query. Asterisk-form and
+    /// CONNECT's authority-form keep their own spelling; every other
+    /// admitted target begins with '/'.
     target: []const u8,
     version: Version,
     headers: []const Header,
     /// Non-null whenever `version == .http_1_1` (exactly-one-Host is
     /// enforced); HTTP/1.0 may omit it.
     host: ?[]const u8,
+    /// The authority an absolute-form request line carried, verbatim and
+    /// including any port — null for every other form. It *overrides*
+    /// `host`: RFC 9112 §3.2.2 has the recipient ignore the Host header
+    /// field and use this instead, which `routingAuthority` states once
+    /// for every consumer.
+    authority: ?[]const u8,
     framing: BodyFraming,
     /// Whether the downstream connection may serve another request after
     /// this exchange, per version defaults and Connection tokens.
@@ -229,6 +241,22 @@ pub const RequestHead = struct {
     /// from the analysis pass so rendering need not re-split the value.
     connection_nominates_header: bool,
     head_len: u32,
+
+    /// The authority this request names, which is what §7 routes on and
+    /// what the forwarded request must carry as its `Host` — the
+    /// absolute-form's when the request line carried one, the Host
+    /// header's otherwise (RFC 9112 §3.2.2: a recipient MUST ignore the
+    /// received Host when the target is absolute-form). Null only when
+    /// an HTTP/1.0 request named neither, which routes to any-host
+    /// routes alone.
+    ///
+    /// One function rather than an `orelse` at each of the three call
+    /// sites: the router, the filter view and the renderer must agree
+    /// about which name this request gave, or the origin can be sent to
+    /// a vhost the policy never saw.
+    pub fn routingAuthority(request: *const RequestHead) ?[]const u8 {
+        return request.authority orelse request.host;
+    }
 };
 
 /// A fully parsed and validated response head. Same slice lifetime rules
@@ -324,7 +352,7 @@ pub fn parseRequestHead(
     const method_token = raw.method_token.?; // Same contract as the target.
     assert(method_token.len >= 1);
     const method = methodFromRaw(raw.method);
-    try validateTarget(target, method);
+    const split = try validateTarget(target, method);
     const version = versionFromRaw(raw.version);
 
     const analysis = try analyzeHeaders(raw_headers[0..raw.header_count], headers_storage);
@@ -341,10 +369,11 @@ pub fn parseRequestHead(
     return .{
         .method = method,
         .method_token = method_token,
-        .target = target,
+        .target = split.target,
         .version = version,
         .headers = headers_storage[0..raw.header_count],
         .host = analysis.host,
+        .authority = split.authority,
         .framing = framing,
         .keep_alive = keepAliveDefault(version, &analysis),
         .connection_nominates_header = analysis.connection_nominates_header,
@@ -944,6 +973,10 @@ pub const CanonicalTarget = struct {
 /// and so is a path that climbs above the root. Routing matches this
 /// form and the renderer forwards it, so the router and the origin can
 /// never disagree about which resource a request names.
+///
+/// The input is origin-form, or the query-only remainder an
+/// absolute-form target leaves when it names no path (#233) — whose
+/// empty path is the root, so the canonical form still begins with '/'.
 pub fn canonicalTarget(
     target: []const u8,
     /// Caller-owned decode target, at least `target.len` wide — a slice
@@ -955,11 +988,19 @@ pub fn canonicalTarget(
     // validateTarget admitted only origin-form here; asterisk-form and
     // CONNECT never route by path and stay with the caller.
     assert(target.len >= 1);
-    assert(target[0] == '/');
+    assert(target[0] == '/' or target[0] == '?');
     assert(target.len <= out.len);
     const question = std.mem.indexOfScalar(u8, target, '?');
     const raw_path = target[0 .. question orelse target.len];
     const query = target[question orelse target.len ..];
+    if (raw_path.len == 0) {
+        // The one target that reaches here without a path: an
+        // absolute-form "http://host?q", whose empty path-abempty names
+        // the root (RFC 3986 §3.3). Nothing to decode or collapse.
+        assert(target[0] == '?');
+        out[0] = '/';
+        return .{ .path = out[0..1], .query = query };
+    }
     const decoded_len = try decodeTargetPath(raw_path, out);
     const path_len = try collapseDotSegments(out[0..decoded_len]);
     // Canonicalization only ever shrinks; both stages keep the leading
@@ -1134,26 +1175,110 @@ pub fn canonicalHost(host: []const u8, out: *[constants.host_bytes_max]u8) ?[]co
     return out[0..authority_end];
 }
 
+/// What one request-target resolved to: the form §7 routes, plus the
+/// authority an absolute-form one carried.
+const TargetSplit = struct {
+    target: []const u8,
+    authority: ?[]const u8 = null,
+};
+
 /// A reverse proxy routes origin-form targets (§7 routes host/path);
 /// asterisk-form is legal for OPTIONS. CONNECT's authority-form passes
 /// through so the proxy can answer it with 501 rather than 400.
-fn validateTarget(target: []const u8, method: Method) error{Malformed}!void {
+/// Absolute-form is split into authority and origin-form remainder here,
+/// at the one boundary that sees the raw target, so nothing downstream
+/// has to know the request line had two spellings (#233).
+fn validateTarget(target: []const u8, method: Method) error{Malformed}!TargetSplit {
     if (target.len == 0) {
         return error.Malformed;
     }
     assert(target.len >= 1);
     if (method == .connect) {
-        return;
+        return .{ .target = target };
     }
     if (target[0] == '/') {
-        return;
+        return .{ .target = target };
     }
     if (method == .options) {
         if (std.mem.eql(u8, target, "*")) {
-            return;
+            return .{ .target = target };
         }
     }
-    return error.Malformed;
+    return splitAbsoluteForm(target);
+}
+
+/// The absolute-form split (RFC 9112 §3.2.2, which makes accepting the
+/// form a MUST for servers): `scheme "://" authority path-abempty
+/// [ "?" query ]`. Only http and https are admitted — §7 speaks those
+/// two and a target naming any other scheme is a request this proxy
+/// cannot honor, so it is refused at the boundary rather than routed by
+/// its path alone.
+///
+/// The authority is returned verbatim, port included, because it becomes
+/// the forwarded `Host` value; the routing key is folded from it later
+/// by `canonicalHost`, exactly as a Host header's would be.
+fn splitAbsoluteForm(target: []const u8) error{Malformed}!TargetSplit {
+    assert(target.len >= 1);
+    assert(target[0] != '/');
+    const mark = std.mem.indexOf(u8, target, "://") orelse return error.Malformed;
+    const scheme = target[0..mark];
+    // RFC 3986 §3.1: scheme comparison is case-insensitive.
+    const known = std.ascii.eqlIgnoreCase(scheme, "http") or
+        std.ascii.eqlIgnoreCase(scheme, "https");
+    if (!known) {
+        return error.Malformed;
+    }
+    const rest = target[mark + 3 ..];
+    const authority_end = std.mem.indexOfAny(u8, rest, "/?") orelse rest.len;
+    const authority = rest[0..authority_end];
+    if (authority.len == 0) {
+        return error.Malformed; // A scheme naming no host routes nowhere.
+    }
+    if (!authorityIsWellFormed(authority)) {
+        return error.Malformed;
+    }
+    const remainder = rest[authority_end..];
+    return .{
+        // "http://host" names the root, and the origin-form request line
+        // this proxy forwards must say so (RFC 9112 §3.2.1). A remainder
+        // that is only a query keeps its leading '?' — it cannot be given
+        // a '/' without a buffer to build one in, so `canonicalTarget`
+        // reads the empty path as the root instead.
+        .target = if (remainder.len == 0) "/" else remainder,
+        .authority = authority,
+    };
+}
+
+/// Whether an absolute-form authority is one this proxy will both route
+/// on and write back out as a `Host` line: a positive charset — RFC 3986
+/// reg-name, IP-literal brackets, percent-escapes and the port colon.
+///
+/// Positive rather than a list of rejects because these bytes are
+/// *emitted*, not just matched: hparse's target charset already excludes
+/// CR, LF and controls, and this closes the rest of the gap. It also
+/// settles two cases by construction — a userinfo prefix ("user@host",
+/// which RFC 9110 §4.2.1 forbids a sender from generating) and a
+/// fragment, neither of which belongs in a request-target.
+///
+/// A charset, deliberately, and not the RFC 3986 host grammar: `a:b:c%zz`
+/// passes here despite being no host at all. That is the same latitude
+/// `canonicalHost` already takes with a `Host` header — an authority is a
+/// routing *key*, and a key that spells nothing matches no configured
+/// host, so it reaches the any-host routes and no further. What the
+/// charset is for is the byte-level guarantee the grammar would not add:
+/// these bytes are written into a header line.
+fn authorityIsWellFormed(authority: []const u8) bool {
+    assert(authority.len >= 1);
+    for (authority) |byte| {
+        if (std.ascii.isAlphanumeric(byte)) {
+            continue;
+        }
+        switch (byte) {
+            '-', '.', '_', '~', '%', ':', '[', ']' => {},
+            else => return false,
+        }
+    }
+    return true;
 }
 
 /// 1*DIGIT (RFC 9112 §6.2): digits only — no sign, no whitespace, no
@@ -1434,24 +1559,101 @@ test "http parser: extension methods parse with their raw token" {
     );
 }
 
-test "http parser: request targets must be origin-form (or OPTIONS *)" {
-    // Absolute-form belongs to forward proxies.
-    try expectRequestError(
-        error.Malformed,
-        "GET http://other/ HTTP/1.1\r\nHost: a\r\n\r\n",
-        false,
-    );
+test "http parser: request targets are origin-form, OPTIONS *, or absolute-form" {
     try expectRequestError(error.Malformed, "GET * HTTP/1.1\r\nHost: a\r\n\r\n", false);
     var storage: HeaderStorage = undefined;
     const options = try parseRequestHead("OPTIONS * HTTP/1.1\r\nHost: a\r\n\r\n", false, &storage);
     try testing.expectEqualStrings("*", options.target);
-    // CONNECT's authority-form parses so the proxy can answer 501 itself.
+    try testing.expectEqual(@as(?[]const u8, null), options.authority);
+    // CONNECT's authority-form parses so the proxy can answer 501 itself,
+    // and is not an absolute-form authority: it names a tunnel endpoint,
+    // not the resource's origin.
     const connect = try parseRequestHead(
         "CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n",
         false,
         &storage,
     );
     try testing.expectEqual(Method.connect, connect.method);
+    try testing.expectEqual(@as(?[]const u8, null), connect.authority);
+}
+
+test "http parser: absolute-form splits into authority and origin-form" {
+    const Case = struct {
+        line: []const u8,
+        /// null means Malformed — the whole head is rejected.
+        authority: ?[]const u8,
+        target: []const u8 = "",
+    };
+    const cases = [_]Case{
+        // The form RFC 9112 §3.2.2 makes a MUST, with and without a path.
+        .{ .line = "GET http://api.example/v2/x", .authority = "api.example", .target = "/v2/x" },
+        .{ .line = "GET https://api.example/v2/x", .authority = "api.example", .target = "/v2/x" },
+        .{ .line = "GET http://api.example/", .authority = "api.example", .target = "/" },
+        // An empty path names the root; the forwarded request line must
+        // say "/" rather than nothing at all.
+        .{ .line = "GET http://api.example", .authority = "api.example", .target = "/" },
+        // A query with no path keeps its '?' — canonicalTarget reads the
+        // empty path as the root, which is where the '/' appears.
+        .{ .line = "GET http://api.example?q=1", .authority = "api.example", .target = "?q=1" },
+        .{ .line = "GET http://api.example/a?q=1", .authority = "api.example", .target = "/a?q=1" },
+        // A port travels with the authority: it is the Host value to be.
+        .{ .line = "GET http://api.example:8080/x", .authority = "api.example:8080", .target = "/x" },
+        // Case is the scheme's own business (RFC 3986 §3.1); the
+        // authority's case is folded later, by the same `canonicalHost`
+        // a Host header goes through.
+        .{ .line = "GET HTTP://API.Example/x", .authority = "API.Example", .target = "/x" },
+        // An IPv6 literal wears brackets and colons.
+        .{ .line = "GET http://[2001:db8::1]:80/x", .authority = "[2001:db8::1]:80", .target = "/x" },
+        // Rejects. A scheme §7 does not speak, whatever its path says.
+        .{ .line = "GET ftp://files.example/x", .authority = null },
+        .{ .line = "GET gopher://files.example/x", .authority = null },
+        // A scheme with no authority routes nowhere.
+        .{ .line = "GET http:///x", .authority = null },
+        .{ .line = "GET http://", .authority = null },
+        // Userinfo (RFC 9110 §4.2.1 forbids generating it) and a fragment
+        // (no request-target carries one) both fall out of the charset.
+        .{ .line = "GET http://user@api.example/x", .authority = null },
+        .{ .line = "GET http://api.example#frag", .authority = null },
+        // Not absolute-form at all, and not any other admitted form.
+        .{ .line = "GET api.example/x", .authority = null },
+        .{ .line = "GET //api.example/x", .authority = null, .target = "//api.example/x" },
+    };
+    for (cases) |case| {
+        var storage: HeaderStorage = undefined;
+        var buffer: [256]u8 = undefined;
+        const head = try std.fmt.bufPrint(
+            &buffer,
+            "{s} HTTP/1.1\r\nHost: sent-by-the-client\r\n\r\n",
+            .{case.line},
+        );
+        const parsed = parseRequestHead(head, false, &storage) catch |err| {
+            try testing.expectEqual(@as(?[]const u8, null), case.authority);
+            try testing.expectEqual(HeadError.Malformed, err);
+            continue;
+        };
+        // "//api.example/x" is origin-form with an empty first segment:
+        // admitted, no authority, and it routes by path like any other.
+        if (case.authority) |authority| {
+            try testing.expectEqualStrings(authority, parsed.authority.?);
+            try testing.expectEqualStrings(authority, parsed.routingAuthority().?);
+        } else {
+            try testing.expectEqual(@as(?[]const u8, null), parsed.authority);
+            try testing.expectEqualStrings("sent-by-the-client", parsed.routingAuthority().?);
+        }
+        try testing.expectEqualStrings(case.target, parsed.target);
+    }
+}
+
+test "http parser: an absolute-form request still needs its Host on HTTP/1.1" {
+    // The authority overrides the Host for routing, but RFC 9112 §3.2's
+    // "a client MUST send a Host in every HTTP/1.1 request" is a separate
+    // rule and this proxy still holds the client to it.
+    try expectRequestError(error.Malformed, "GET http://api.example/x HTTP/1.1\r\n\r\n", false);
+    var storage: HeaderStorage = undefined;
+    // HTTP/1.0 may omit it, and then the authority is the only name given.
+    const parsed = try parseRequestHead("GET http://api.example/x HTTP/1.0\r\n\r\n", false, &storage);
+    try testing.expectEqual(@as(?[]const u8, null), parsed.host);
+    try testing.expectEqualStrings("api.example", parsed.routingAuthority().?);
 }
 
 test "http parser: partial heads are Incomplete until the buffer fills" {
@@ -1804,6 +2006,10 @@ test "canonicalTarget: table of canonical forms and rejects" {
         .{ .target = "/a?", .path = "/a", .query = "?" },
         .{ .target = "/?a", .path = "/", .query = "?a" },
         .{ .target = "/a?%2F%zz/../", .path = "/a", .query = "?%2F%zz/../" },
+        // The query-only remainder an absolute-form target leaves behind
+        // (#233): an empty path names the root.
+        .{ .target = "?q=1", .path = "/", .query = "?q=1" },
+        .{ .target = "?", .path = "/", .query = "?" },
         // Unreserved escapes decode; others keep uppercased hex.
         .{ .target = "/%61%2D%5F%7E", .path = "/a-_~" },
         .{ .target = "/caf%c3%a9", .path = "/caf%C3%A9" },

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -558,7 +558,7 @@ pub fn Proxy(comptime IoType: type) type {
             host_scratch: *[constants.host_bytes_max]u8,
         ) error{BadPath}!RequestKeys {
             assert(request.target.len >= 1);
-            const host: ?[]const u8 = if (request.host) |raw|
+            const host: ?[]const u8 = if (request.routingAuthority()) |raw|
                 parser.canonicalHost(raw, host_scratch)
             else
                 null;
@@ -573,7 +573,10 @@ pub fn Proxy(comptime IoType: type) type {
         /// They differ in exactly one case, and this is the only place that
         /// case is written: OPTIONS asterisk-form matches and routes as the
         /// origin root but is forwarded as `*`. Origin-form canonicalizes,
-        /// and both views are then the same bytes.
+        /// and both views are then the same bytes. Absolute-form was split
+        /// back to origin-form by the parser (#233), so it takes that same
+        /// path — the authority it also carried is a routing key, not a
+        /// target view, and never reaches here.
         ///
         /// Canonicalizing decodes percent-escapes and collapses dot
         /// segments over the whole path, so it is done once and both
@@ -592,7 +595,7 @@ pub fn Proxy(comptime IoType: type) type {
             scratch: []u8,
         ) error{BadPath}!TargetViews {
             assert(request.target.len >= 1);
-            if (request.target[0] != '/') {
+            if (request.authority == null and request.target[0] != '/') {
                 // validateTarget admitted only asterisk-form here.
                 assert(request.method == .options);
                 return .{
@@ -656,7 +659,7 @@ pub fn Proxy(comptime IoType: type) type {
             // with its frame at the connect await, so this path would need
             // to rebuild it regardless — and unlike the target, nothing
             // else is asking for one canonical spelling of it.
-            const host: ?[]const u8 = if (request.host) |raw|
+            const host: ?[]const u8 = if (request.routingAuthority()) |raw|
                 parser.canonicalHost(raw, host_scratch)
             else
                 null;
@@ -774,6 +777,15 @@ pub fn Proxy(comptime IoType: type) type {
             // here, which is right — the cap bounds work this connection
             // asked for, not bytes it fumbled.
             conn.requests_served +|= 1;
+            // Counted here, beside the request tally and ahead of every
+            // verdict, because it records what the *client sent* rather
+            // than what this proxy decided (#233): an absolute-form
+            // request refused for its method, its body size or its path
+            // is still one more client naming its own authority, which
+            // is the whole question this counter answers.
+            if (request.authority != null) {
+                server.counters.increment("l7_absolute_form");
+            }
             armRequestDeadline(server, conn);
             if (request.method == .connect) {
                 return respond(server, conn, 501, "l7_not_implemented");

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -128,12 +128,24 @@ pub fn renderRequestHead(
         .http_1_0 => " HTTP/1.0\r\n",
         .http_1_1 => " HTTP/1.1\r\n",
     });
+    // An absolute-form request line named its own authority, and that
+    // authority is what routed (#233). RFC 9112 §3.2.2 has a recipient
+    // ignore the Host header field and use it instead — so this proxy
+    // writes the Host the origin will see, rather than forwarding a
+    // header the router already overruled. Written here, ahead of the
+    // source headers, because that is where a client would have put it;
+    // the inbound copies are suppressed as the headers are walked.
+    if (request.authority) |authority| {
+        assert(authority.len >= 1);
+        try staging.appendHeaderLine("Host", authority);
+    }
     try appendEndToEndHeaders(
         &staging,
         request.headers,
         request.connection_nominates_header,
         edits,
         forwarded_for != null,
+        request.authority != null,
         keep_upgrade,
     );
     if (forwarded_for) |value| {
@@ -199,6 +211,9 @@ pub fn renderResponseHead(
         response.headers,
         response.connection_nominates_header,
         edits,
+        false,
+        // Both suppressions are request-side: a response carries neither
+        // an X-Forwarded-For this proxy wrote nor a Host at all.
         false,
         keep_upgrade,
     );
@@ -334,6 +349,13 @@ fn appendEndToEndHeaders(
     /// because the caller already folded it into the line it will write.
     /// Either way the header must appear exactly once downstream.
     suppress_forwarded_for: bool,
+    /// True when the request render has already written its own `Host`
+    /// line from an absolute-form authority (#233), so the client's
+    /// inbound copy must not be forwarded beside it. RFC 9112 §3.2.2 has
+    /// the received Host ignored in favour of the target's authority, and
+    /// a forwarded request carrying both would hand the origin the very
+    /// disagreement that rule exists to settle.
+    suppress_host: bool,
     /// True when this hop is *participating* in a protocol upgrade
     /// (#180), which is the one case where `Upgrade` must travel.
     ///
@@ -385,6 +407,9 @@ fn appendEndToEndHeaders(
             if (!participating) continue;
         }
         if (suppress_forwarded_for and header.tag == .x_forwarded_for) {
+            continue;
+        }
+        if (suppress_host and header.tag == .host) {
             continue;
         }
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
@@ -521,6 +546,35 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
     );
+}
+
+test "render: an absolute-form authority replaces the client's Host" {
+    // RFC 9112 §3.2.2: the received Host is ignored and the target's
+    // authority used instead — so exactly one Host reaches the origin,
+    // and it is the one that routed (#233).
+    const head = "GET http://api.example:8080/v2/x HTTP/1.1\r\n" ++
+        "Host: stale.example\r\nX-Keep: yes\r\n\r\n";
+    var storage: parser.HeaderStorage = undefined;
+    const request = try parser.parseRequestHead(head, false, &storage);
+    var buffer: [oracle_buffer_bytes]u8 = undefined;
+    const rendered = try renderRequestHead(
+        &request,
+        .{ .path = "/v2/x", .query = "" },
+        &.{},
+        false,
+        null,
+        false,
+        &buffer,
+    );
+    try testing.expectEqualStrings(
+        "GET /v2/x HTTP/1.1\r\nHost: api.example:8080\r\nX-Keep: yes\r\n\r\n",
+        rendered,
+    );
+    // The request line is origin-form downstream, whatever form arrived.
+    var reparse_storage: parser.HeaderStorage = undefined;
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    try testing.expectEqual(@as(?[]const u8, null), reparsed.authority);
+    try testing.expectEqualStrings("api.example:8080", reparsed.host.?);
 }
 
 test "render: filter edits set, add, and remove headers" {
@@ -762,20 +816,37 @@ test "render: a head that no longer fits is Oversize" {
 // turn into a head the parser accepts again, with routing and framing
 // intact and hop-by-hop headers gone.
 
+/// The `targetViews` gate (§7), mirrored once for all three oracles
+/// below: an origin-form target that will not canonicalize is a 400 and
+/// never reaches the renderer (null here), while OPTIONS asterisk-form
+/// has no path and forwards verbatim.
+///
+/// The discriminator is the *authority*, not the target's first byte,
+/// for the same reason `targetViews` uses it (#233): an absolute-form
+/// target that named only a query leaves a remainder beginning with '?',
+/// which is origin-form's business to canonicalize and asterisk-form's
+/// to be mistaken for. Kept in one function because three copies of this
+/// gate is how the oracles came to mirror a rule production no longer
+/// had — and an oracle that diverges panics on input the proxy accepts.
+fn oracleTarget(
+    request: *const parser.RequestHead,
+    scratch: []u8,
+) ?parser.CanonicalTarget {
+    assert(request.target.len >= 1);
+    if (request.authority == null and request.target[0] != '/') {
+        return .{ .path = request.target, .query = "" };
+    }
+    return parser.canonicalTarget(request.target, scratch) catch null;
+}
+
 fn checkRequestRender(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
     const request = parser.parseRequestHead(input, false, &storage) catch return;
     if (request.method == .connect) {
         return; // Never rendered: the proxy answers CONNECT itself.
     }
-    // Mirror the routeRequest gate (§7): an origin-form target that will
-    // not canonicalize is a 400 and never reaches the renderer; OPTIONS
-    // asterisk-form has no path and forwards verbatim.
     var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
-    const target: parser.CanonicalTarget = if (request.target[0] == '/')
-        (parser.canonicalTarget(request.target, &scratch) catch return)
-    else
-        .{ .path = request.target, .query = "" };
+    const target = oracleTarget(&request, &scratch) orelse return;
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = renderRequestHead(&request, target, &.{}, false, null, false, &buffer) catch unreachable;
@@ -801,8 +872,14 @@ fn checkRequestRender(input: []const u8) void {
     assert(std.mem.eql(u8, reparsed.target[target.path.len..], target.query));
     assert(reparsed.version == request.version);
     assert(std.meta.eql(reparsed.framing, request.framing));
-    if (request.host) |host| {
-        assert(std.mem.eql(u8, reparsed.host.?, host));
+    // The Host the origin reads is the name the request *routed* on, and
+    // exactly one of them reaches it: the absolute-form authority where
+    // the request line carried one, the client's own header otherwise
+    // (#233). Stated as `routingAuthority` rather than as `request.host`,
+    // which is what this asserted before absolute-form existed — an
+    // oracle demanding the overruled name would forbid the override.
+    if (request.routingAuthority()) |expected| {
+        assert(std.mem.eql(u8, reparsed.host.?, expected));
     }
     for (reparsed.headers) |header| {
         for (hop_by_hop_names) |hop_name| {
@@ -822,10 +899,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         return;
     }
     var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
-    const target: parser.CanonicalTarget = if (request.target[0] == '/')
-        (parser.canonicalTarget(request.target, &scratch) catch return)
-    else
-        .{ .path = request.target, .query = "" };
+    const target = oracleTarget(&request, &scratch) orelse return;
 
     // Names the fuzzed input cannot collide with a proxy-managed header on;
     // config forbids editing those, so the renderer never sees them.
@@ -881,8 +955,36 @@ test "fuzz: parse-render-reparse keeps routing and framing intact" {
             "POST /submit HTTP/1.1\r\nHost: origin\r\nContent-Length: 5\r\n\r\nhello",
             "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-N\r\nX-N: v\r\nTE: t\r\n\r\n",
             "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+            // Absolute-form, and the one shape of it whose remainder is
+            // not origin-form (#233): the oracles' gate must read the
+            // authority rather than the first byte, or this renders a
+            // request line the reparse cannot accept.
+            "GET http://a?q HTTP/1.1\r\nHost: a\r\n\r\n",
+            "GET http://a HTTP/1.1\r\nHost: elsewhere\r\nX-Forwarded-For: 1.1.1.1\r\n\r\n",
         },
     });
+}
+
+test "render: the fuzz oracles hold for every target form the parser admits" {
+    // The oracles mirror `targetViews`, and a mirror is only worth
+    // something while it still matches. When these three drifted from it
+    // (#233), an absolute-form target whose remainder is query-only took
+    // the asterisk-form branch, rendered `GET ?q HTTP/1.1`, and panicked
+    // the oracle's own reparse — on input the proxy itself handles fine.
+    // Reached from here rather than from the corpus, because the corpus
+    // feeds the Smith's entropy rather than arriving as an input verbatim.
+    const inputs = [_][]const u8{
+        "GET http://a?q HTTP/1.1\r\nHost: a\r\n\r\n",
+        "GET http://a HTTP/1.1\r\nHost: elsewhere\r\n\r\n",
+        "GET http://a/p?q HTTP/1.1\r\nHost: a\r\n\r\n",
+        "OPTIONS * HTTP/1.1\r\nHost: a\r\n\r\n",
+        "GET /p?q HTTP/1.1\r\nHost: a\r\n\r\n",
+    };
+    for (inputs) |input| {
+        checkRequestRender(input);
+        checkRequestRenderEdited(input);
+        checkRequestRenderForwarded(input);
+    }
 }
 
 fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
@@ -914,10 +1016,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
         return;
     }
     var scratch: [constants.head_buffer_bytes_default]u8 = undefined;
-    const target: parser.CanonicalTarget = if (request.target[0] == '/')
-        (parser.canonicalTarget(request.target, &scratch) catch return)
-    else
-        .{ .path = request.target, .query = "" };
+    const target = oracleTarget(&request, &scratch) orelse return;
 
     // A fixed value stands in for the caller's assembled one: what varies
     // here is the *input head*, and the value's own assembly is bounded

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -988,6 +988,79 @@ test "l7: a head that fits on arrival but not after forwarding is 431" {
     }
 }
 
+test "l7: an absolute-form target routes on its authority, not on Host" {
+    // RFC 9112 §3.2.2 makes accepting absolute-form a MUST and has the
+    // received Host ignored in favour of the target's authority (#233).
+    // Both halves are asserted: what the policy saw, and what the origin
+    // saw — they must be the same name, or the router and the origin
+    // disagree about which resource was named (§7).
+    {
+        // The rule matches the *authority*, and the disagreeing Host is
+        // the name it would have matched had the override not happened.
+        const rules = [_]filter.Rule{.{
+            .match = .{ .host = "api.example" },
+            .actions = &.{.{ .reject = 403 }},
+        }};
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{ .seed = 41, .request_filters = &rules });
+        defer bed.tearDown();
+
+        try bed.exchange("GET http://API.Example/v2/x HTTP/1.1\r\nHost: stale.example\r\n\r\n");
+
+        // Case is folded on the way to the routing key, exactly as a Host
+        // header's would be, so the mixed-case authority still matches.
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_absolute_form"));
+        try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+        try bed.expectDrained();
+    }
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 42,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange(
+            "GET http://api.example:8080/v2/../x?q=1 HTTP/1.1\r\nHost: stale.example\r\n\r\n",
+        );
+
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try forwardedRequest(&bed, &storage);
+        // Origin-form upstream, canonicalized like any other target, and
+        // carrying exactly one Host — the authority, port and all.
+        try std.testing.expectEqualStrings("/x?q=1", forwarded.target);
+        try std.testing.expectEqualStrings("api.example:8080", forwarded.host.?);
+        try std.testing.expectEqual(@as(?[]const u8, null), forwarded.authority);
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_absolute_form"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: an unsupported absolute-form scheme is 400" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{ .seed = 43 });
+    defer bed.tearDown();
+
+    // §7 speaks http and https; a target naming anything else is refused
+    // at the boundary rather than routed by its path alone (#233).
+    try bed.exchange("GET ftp://files.example/x HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+    // The head never parsed, so nothing counted the form it was in.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_absolute_form"));
+    try bed.expectDrained();
+}
+
 // Both heads parse cleanly and carry no body, so the 501 keeps the
 // connection (§8) — the method is refused, not the framing.
 test "l7: CONNECT and Upgrade are answered 501" {


### PR DESCRIPTION
Closes #233.

RFC 9112 §3.2.2 makes accepting `GET http://api.example/v2/x HTTP/1.1` a MUST for a server, and zoxy answered it `400`. Nothing that matters sends it — until something does: a JVM client with `http.proxyHost` set, a synthetic-check agent, an old cache, or anything pointed at this proxy as a forward proxy that reached a reverse-proxy listener instead. Each got a `400` with nothing in the log to explain it, because the head never parsed far enough to capture a method or a path.

## The split

The target is decomposed where every other form is validated, so nothing downstream learns the request line had two spellings. The authority comes off and the origin-form remainder goes through the same canonicalization as any other path.

Two edges the issue asked to settle:

- **Only `http` and `https` are admitted.** §7 speaks those two; a target naming another scheme is refused at the boundary rather than routed by its path alone.
- **The authority is held to a positive charset**, not RFC 3986's host grammar. These bytes are *written* into a `Host:` line, and a charset is what makes that safe — it also settles userinfo (which RFC 9110 §4.2.1 forbids a sender from generating) and fragments by construction. An authority that is charset-legal but spells no real host is a routing *key* that matches nothing, which is the same latitude `canonicalHost` already takes with a `Host` header.

The one shape that is not origin-form is `http://host?q`, whose empty `path-abempty` names the root; `canonicalTarget` reads it as such, since it cannot be given a `/` without a buffer to build one in.

## The authority wins

It routes, it is what filters match, it is what the access log records, and it is the one `Host` line the origin receives. That is the RFC's own prescription — a recipient ignores the received Host in favour of the target's authority — and it is the only reading that keeps §7's promise that *the router and the origin cannot disagree about which resource a request names* when a request names one twice. `routingAuthority` states the rule once, so the router, the filter view and the renderer cannot answer it differently.

An HTTP/1.1 request must still carry a `Host` at all (RFC 9112 §3.2, a separate rule); the authority overrides its *value*, not the requirement.

## What holds it, from outside

Two oracles, each verified by mutation:

- The sim's origin refuses any forwarded head still in absolute-form, or carrying the overruled name. **Dropping the Host override fails the sweep within 64 seeds.**
- The access-log verifier refuses a line recording the overruled name. **Routing on the `Host` instead of the authority fails there** — a gap the directed tests alone had been carrying, since the sim's routes are any-host.

Only one script can produce those bytes, which is what makes a blanket scan an exact check.

## Also fixed here

The render's three fuzz oracles mirrored `routeRequest`'s target gate and were left behind by it: they discriminated on the target's first byte, so a query-only remainder took the asterisk-form branch and rendered a request line their own reparse then panicked on — on input the proxy handles fine. The gate is now one function all three share, reached by a directed test, because the fuzz corpus feeds the Smith's entropy rather than arriving as an input. That test then caught a second stale oracle: it demanded the `Host` travel verbatim, which this change makes conditional.

## Gates

`zig build ci` green: 4096 seeds, census ok (68 counters fired at the time of this commit), smoke clean, `zig fmt` clean.

§12's deviation register drops from four entries to three.