### PR TITLE
http: a Date and a Server on every response this proxy originates

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1545,8 +1545,8 @@ disables it: what counts as too slow is a property of the operator's
 origin, not one this proxy can pick for them.
 
 - **Static error responses.** `400`/`404`/`414`/`431`/`501`/`503`/`504`
-  are comptime byte arrays sent directly from static memory — never
-  staged through
+  are comptime-rendered byte arrays sent directly from server memory —
+  never staged through
   the connection's head buffer, whose bytes the parsed head's zero-copy
   slices may still reference (§7). Shedding costs one send, no
   allocation, no copy. The #176 redirect is the one proxy-originated
@@ -1554,6 +1554,34 @@ origin, not one this proxy can pick for them.
   per-request — and it may do so only because its render runs after
   every read of those bytes: the Location is composed first, into the
   rewrite scratch, so nothing aliases what the render overwrites (§7).
+- **Every proxy-generated response carries a `Date` and a `Server`**
+  (#234, RFC 9110 §6.6.1 makes the first a MUST for a server with a
+  clock, and §4 gives this one). The responses that most want a
+  timestamp are exactly the ones this section originates: an operator
+  placing a shed `503` against an incident timeline is reading the one
+  response that had no time on it, and `Server` is the cheapest tell
+  that a `503` is the ladder's rather than the origin's — the two are
+  the same three digits and opposite events. A forwarded response is
+  untouched: the origin's own `Date` travels through the §7 re-render.
+  This **changes what the point above claims**, and the change is worth
+  stating rather than burying. A `Date` is per-second, so a static
+  response stops being `const` and gains a written region: the value is
+  fixed-width (IMF-fixdate always is), so each response carries a slot
+  at a comptime-known offset that the serving path patches in place —
+  29 bytes, at most once per response. Nothing is acquired, assembled or
+  copied per response, so the cost that mattered is unchanged; what the
+  section can no longer say is that the bytes never change.
+  The patch is **safe rather than merely conventional**, and that is the
+  whole of the design. A submitted send holds a pointer the kernel may
+  read at any moment before its completion, so a patch landing under one
+  could put a *torn* date on the wire — nginx keeps one cached date
+  string and lives with exactly that race. Here a slot is stamped only
+  while no static send is in flight, which the server tracks as a
+  per-connection claim, so the bytes a send was handed can never change
+  under it. The cost lands the right way round: under a sustained shed
+  storm the date goes stale, never malformed. Every slot is stamped once
+  at startup, where nothing is in flight by construction, so no response
+  is ever the first user of an un-stamped one.
 - **Those responses can carry a body, and bodies are a named table**
   (#159, settled 2026-08-03). `bodies` maps a name to bytes — a `file`
   read once at startup or an `inline` string, exactly one, plus the
@@ -2199,7 +2227,7 @@ is a trap rather than a synonym.
 
 | spec | what binds a gateway | here |
 |---|---|---|
-| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §15.2.1 `100 Continue` | §7, with three deviations below |
+| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §5.6.7 date format; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §15.2.1 `100 Continue` | §7, §8's `Date`, with two deviations below |
 | **9112** HTTP/1.1 | §3.2 target forms; §6.3 body length; §7 transfer codings; §9 connection management | §7 framing, §8 close announcement |
 | **6585** additional statuses | defines `429` and `431` — **9110 did not absorb these**, the registry still points here | §8's static set |
 | **8297** early hints | defines `103` | §7's interim relay (#232) |
@@ -2233,11 +2261,13 @@ header because that is what origins read. And the **PROXY protocol**
 pins its two writers to its parser by round-trip test: there is no
 independent text to be conformant *to*.
 
-**The deviations.** Three requirements this proxy does not meet today.
-The first is settled; the rest are open, and the issue is where each
-decision is being taken rather than here. Absolute-form request-targets
-(9112 §3.2.2) left this list with #233: they are accepted, and §7 states
-what their authority does to the `Host` beside them.
+**The deviations.** Two requirements this proxy does not meet today.
+The first is settled; the second is open, and the issue is where that
+decision is being taken rather than here. Two left this list together:
+absolute-form request-targets (9112 §3.2.2) with #233 — §7 states what
+their authority does to the `Host` beside them — and the missing `Date`
+(9110 §6.6.1) with #234, which §8 states, along with what carrying one
+costs a response that used to be immutable.
 
 - **`Via` is not sent** (9110 §7.6.3, a MUST for intermediaries). The
   cost is real and worth naming: a request that loops through this proxy
@@ -2252,10 +2282,6 @@ what their authority does to the `Host` beside them.
   the remaining `OPTIONS` half needs a header whose value this proxy
   *computes*, which the render machinery has exactly one instance of
   (`X-Forwarded-For`) and no general mechanism for.
-- **Proxy-generated responses carry no `Date`** (§6.6.1, a MUST for a
-  server with a clock, which this one has) — #234. §8's static
-  responses are comptime bytes; a `Date` makes them a written region,
-  which is a change to what that section claims.
 
 **There is no conformance suite**, official or otherwise, and §9's gates
 are internal by construction — the fuzzer asserts *this* parser never

--- a/docs/README.md
+++ b/docs/README.md
@@ -827,6 +827,12 @@ config, so **changing one needs a restart**.
 `403`, `404`, `414`, `429`, `431`, `501`, `502`, `503`, `504` — and a
 page for anything else is refused at load.
 
+Every response zoxy answers *itself* — those pages, the empty defaults,
+the redirects — carries a `Date` and `Server: zoxy`. Responses that come
+from an origin are forwarded with the origin's own headers and gain
+neither, so `Server: zoxy` on a `503` tells you the proxy raised it and
+the backend was never asked.
+
 Bodies live in memory, and that is the point rather than a shortcut: a
 `503` is raised *because* something ran out, so an error page whose
 delivery needed a resource would fail exactly when it is needed. The

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -916,16 +916,48 @@ fn deriveSticky(harness: *Harness, random: std.Random) zoxy.config.Config.Cluste
 /// The #236 body cap, drawn only under the adversary and for the same
 /// reason `deriveMaxInflight` caps only there: a `413` is a status an L7
 /// script did not ask for, and a clean seed's golden outcomes forbid it.
-/// Drawn in the single-byte range so the rung is reached by ordinary
-/// scheduling rather than a coincidence of sizes: `post_big`'s few
+/// Drawn in two ranges, because the cap has two rungs and a single range
+/// only ever reaches one of them.
+///
+/// The **single-byte** range reaches the *answered* rung: `post_big`'s few
 /// thousand bytes and `post_sized`'s twenty-four are over it on every
-/// draw. `post_chunked`'s eight-byte payload is the one that is not —
-/// roughly half the range leaves it under the cap — which is legal and
-/// which the directed tests cover regardless; the claim here is that the
-/// cap *bites*, not that it bites everything.
+/// draw, and they are over it in the bytes coalesced with the head — so
+/// the request is refused `413` before a byte is pumped.
+/// `post_chunked`'s eight-byte payload is the one that is not — roughly
+/// half the range leaves it under the cap — which is legal and which the
+/// directed tests cover regardless.
+///
+/// The **kilobyte** range reaches the *streaming* rung, which the first
+/// cannot. Cutting a body mid-stream needs three things at once: a body
+/// whose head declares no length (a declared one is refused before a
+/// byte is pumped), a cap the first delivery does not already exceed,
+/// and a total that outgrows it later. `post_chunked_big` is the body,
+/// and this range is the cap — starting just above the widest a single
+/// delivery can be, so the first always passes under it, and staying a
+/// kilobyte wide so it stays far below that script's six thousand.
+/// The widest a single delivery can be: the simulator's default socket
+/// ring, which this harness never widens. A cap at or above it cannot be
+/// exceeded by the bytes that arrive alongside the head, whatever the
+/// schedule chops them into.
+const first_delivery_bytes_max: u64 = 4096;
+
+/// How wide the streaming range is. Named because the two bounds below
+/// are one claim, not two: the cap must land above every byte a first
+/// delivery can carry and below what `post_chunked_big` sends, and a
+/// script whose body stopped clearing that gap would make the streaming
+/// rung silently unreachable rather than fail here.
+const body_cap_stream_span: u64 = 1024;
+comptime {
+    assert(l7.scripts.chunked_big_body_bytes >
+        first_delivery_bytes_max + body_cap_stream_span);
+}
+
 fn deriveMaxBodyBytes(clean: bool, random: std.Random) u64 {
     if (clean) return 0;
     if (random.uintLessThan(u8, 3) != 0) return 0;
+    if (random.boolean()) {
+        return first_delivery_bytes_max + random.uintLessThan(u64, body_cap_stream_span);
+    }
     return 1 + random.uintLessThan(u64, 16);
 }
 
@@ -1161,9 +1193,11 @@ fn deriveClockJump(tls_clients: u8, random: std.Random) bool {
 /// loader's exact byte layout, which `config.zig`'s own tests pin
 /// instead (`bodies render into complete pages`). Same trade, same
 /// reason, as `src/http_proxy_test.zig`'s hand-spelled page.
-const error_page: zoxy.config.Config.StaticPage = renderSimPage(403, l7.canon.error_page_body);
-const respond_page: zoxy.config.Config.StaticPage = renderSimPage(200, l7.canon.respond_body);
-const error_pages = [_]*const zoxy.config.Config.StaticPage{&error_page};
+const ErrorPage = SimPage(403, l7.canon.error_page_body);
+const RespondPage = SimPage(200, l7.canon.respond_body);
+const error_page = &ErrorPage.page;
+const respond_page = &RespondPage.page;
+const error_pages = [_]*const zoxy.config.Config.StaticPage{error_page};
 
 /// The #140 names every seed's config logs, already lowercased the way
 /// the loader would leave them (the simulator builds its `Config` by
@@ -1171,28 +1205,45 @@ const error_pages = [_]*const zoxy.config.Config.StaticPage{&error_page};
 const log_request_headers = [_][]const u8{l7.canon.log_request_header};
 const log_response_headers = [_][]const u8{l7.canon.log_response_header};
 
-fn renderSimPage(comptime status: u16, comptime body: []const u8) zoxy.config.Config.StaticPage {
-    // The loader's own preconditions, restated where the loader is
-    // being stood in for: a status a page may carry, and a body the
-    // client oracle can demand.
-    comptime assert(zoxy.shed.isPageStatus(status));
-    comptime assert(body.len >= 1);
-    const head = std.fmt.comptimePrint(
-        "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\n",
-        .{ status, zoxy.shed.reasonPhrase(status), body.len, l7.canon.page_content_type },
-    );
-    const keep = head ++ "\r\n" ++ body;
-    const close = head ++ "Connection: close\r\n\r\n" ++ body;
-    // `renderStaticPage`'s postcondition: the head is a real prefix, so
-    // the HEAD slice the serve path takes is never the whole response.
-    comptime assert(keep.len > body.len);
-    comptime assert(close.len > keep.len);
-    return .{
-        .status = status,
-        .keep = keep,
-        .close = close,
-        .keep_head_len = keep.len - body.len,
-        .close_head_len = close.len - body.len,
+/// One #159 page as the loader would have rendered it — storage rather
+/// than a constant, because a page now carries a `Date` slot the serving
+/// path stamps in place (#234). A type per page, so each owns its bytes
+/// the way two arena allocations would.
+fn SimPage(comptime status: u16, comptime body: []const u8) type {
+    return struct {
+        // The loader's own preconditions, restated where the loader is
+        // being stood in for: a status a page may carry, and a body the
+        // client oracle can demand.
+        comptime {
+            assert(zoxy.shed.isPageStatus(status));
+            assert(body.len >= 1);
+        }
+        const head = std.fmt.comptimePrint(
+            "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\nDate: ",
+            .{ status, zoxy.shed.reasonPhrase(status), body.len, l7.canon.page_content_type },
+        );
+        const keep_template = head ++ zoxy.shed.date_placeholder ++ "\r\n" ++
+            zoxy.shed.server_line ++ "\r\n" ++ body;
+        const close_template = head ++ zoxy.shed.date_placeholder ++ "\r\n" ++
+            zoxy.shed.server_line ++ "Connection: close\r\n\r\n" ++ body;
+        // `renderStaticPage`'s postcondition: the head is a real prefix, so
+        // the HEAD slice the serve path takes is never the whole response.
+        comptime {
+            assert(keep_template.len > body.len);
+            assert(close_template.len > keep_template.len);
+        }
+
+        var keep: [keep_template.len]u8 = keep_template.*;
+        var close: [close_template.len]u8 = close_template.*;
+        var page: zoxy.config.Config.StaticPage = .{
+            .status = status,
+            .keep = &keep,
+            .close = &close,
+            .keep_head_len = keep_template.len - body.len,
+            .close_head_len = close_template.len - body.len,
+            .keep_date = keep[head.len..][0..zoxy.shed.date_bytes],
+            .close_date = close[head.len..][0..zoxy.shed.date_bytes],
+        };
     };
 }
 
@@ -1222,7 +1273,7 @@ fn wireFilters(harness: *Harness) void {
             // origin. The page is pre-rendered like the loader's, so
             // the sweep exercises the static path's body-carrying arm.
             .match = .{ .path_prefix = "/respond" },
-            .actions = &.{.{ .respond = &respond_page }},
+            .actions = &.{.{ .respond = respond_page }},
         },
         .{
             .match = .{ .path_prefix = "/edit" },

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -55,6 +55,19 @@ pub const ClientError = error{
     /// anywhere (the scripted origin answers no 5xx) — either way a
     /// predicate fired where it could not have.
     ResponseEditForged,
+    /// A response this proxy originated arrived without the `Date` and
+    /// `Server` lines RFC 9110 §6.6.1 requires of it (#234) — or with a
+    /// `Date` still holding the un-stamped placeholder, which is the
+    /// shape a slot never patched would take.
+    ProxyDateMissing,
+    /// A `Date` that is not an IMF-fixdate: the value is fixed-width by
+    /// construction, so any other width is a slot patched wrongly rather
+    /// than a formatting preference.
+    ProxyDateMalformed,
+    /// A *forwarded* response carried a `Date` or `Server` the sim origin
+    /// never sent, which would mean the proxy is stamping responses that
+    /// are not its own to stamp.
+    ProxyDateForged,
     /// A sticky seed's proxied 200 arrived without the exact #178
     /// Set-Cookie stamp the drawn cookie cluster owes it — every routed
     /// request but `sticky_follow`'s is assigned or repicked, and the
@@ -466,6 +479,10 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = violation;
                     return walk;
                 }
+                if (dateViolation(entry, &response)) |violation| {
+                    walk.violation = violation;
+                    return walk;
+                }
                 if (stickyViolation(connection, entry, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
@@ -550,6 +567,56 @@ pub fn Client(comptime IoType: type) type {
             }
             if (headerPresent(response.headers, canon.response_never_name)) {
                 return ClientError.ResponseEditForged;
+            }
+            return null;
+        }
+
+        /// The #234 oracle over one parsed response head: whatever this
+        /// proxy *originates* carries a `Date` and a `Server`, and
+        /// whatever it merely *forwards* carries neither.
+        ///
+        /// Both halves have teeth. The sim origin sends no `Date` and no
+        /// `Server` on any of its canonical responses, so the forwarded
+        /// half proves the proxy is not stamping answers that are not its
+        /// own — the shape a `Date` written on the response render rather
+        /// than on the static path would take. The originated half proves
+        /// the slot was actually patched: an un-stamped one still has the
+        /// right width and the right shape, and would pass every check
+        /// but the placeholder comparison.
+        ///
+        /// Which is which comes from the same predicate `#175`'s oracle
+        /// uses, because it is the same distinction: a `200` that is not
+        /// a #159 page came from an origin, a `101` is the origin's
+        /// switch (#180), and every other status here is one this proxy
+        /// raised — the §8 ladder's, a filter's reject, a redirect.
+        fn dateViolation(entry: Spec, response: *const parser.ResponseHead) ?ClientError {
+            assert(response.status >= 100);
+            const from_memory = pageBodyFor(entry, response.status) != null;
+            const forwarded = !from_memory and
+                (response.status == 200 or response.status == 101);
+            const stamped_server = headerEquals(response.headers, "Server", "zoxy");
+            const date = parser.headerValue(response.headers, "Date");
+            if (forwarded) {
+                if (stamped_server or date != null) {
+                    return ClientError.ProxyDateForged;
+                }
+                return null;
+            }
+            if (!stamped_server) {
+                return ClientError.ProxyDateMissing;
+            }
+            const value = date orelse return ClientError.ProxyDateMissing;
+            if (std.mem.eql(u8, value, zoxy.shed.date_placeholder)) {
+                return ClientError.ProxyDateMissing; // The slot was never patched.
+            }
+            if (value.len != zoxy.shed.date_bytes) {
+                return ClientError.ProxyDateMalformed;
+            }
+            if (!std.mem.endsWith(u8, value, " GMT")) {
+                return ClientError.ProxyDateMalformed;
+            }
+            if (value[3] != ',') {
+                return ClientError.ProxyDateMalformed;
             }
             return null;
         }

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -33,6 +33,13 @@ pub const Script = enum(u8) {
     post_big,
     /// A POST with a valid chunked body; expects one canonical 200.
     post_chunked,
+    /// A POST with a chunked body too big for one delivery. `post_big`'s
+    /// shape without a declared length, and the only script that can
+    /// reach the #236 cap's *streaming* half: a declared body is refused
+    /// before a byte is pumped, so cutting one mid-stream needs a body
+    /// whose size the head never states and a cap it outgrows only after
+    /// the first delivery has already passed under it.
+    post_chunked_big,
     /// A chunked POST whose first body byte violates chunk framing —
     /// the silent-teardown-instead-of-400 shape (§7): clean seeds
     /// demand the 400.
@@ -241,6 +248,18 @@ const big_body = blk: {
     const frozen = bytes;
     break :blk frozen;
 };
+/// `post_chunked_big`'s payload — `big_body`'s bytes, so the two scripts
+/// differ in their *framing* alone and any difference the sweep sees
+/// comes from the declared length rather than the size. Public because
+/// the harness sizes the #236 cap against it, and that relation is
+/// asserted where both halves are visible rather than guessed at from
+/// either side.
+pub const chunked_big_body_bytes: u32 = big_body.len;
+
+/// That payload in one chunk, framed so the head states no length at all.
+const big_chunked_wire = std.fmt.comptimePrint("{x}\r\n", .{big_body.len}) ++
+    big_body ++ "\r\n0\r\n\r\n";
+
 comptime {
     assert(post_body.len == 24);
     assert(big_body.len == 6000);
@@ -346,6 +365,20 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
     .post_chunked = .{
         .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
             "Transfer-Encoding: chunked\r\n\r\n" ++ "8\r\nabcdefgh\r\n0\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .post,
+        .allowed_statuses = statuses_routed_body,
+        .carries_body = true,
+        .routed_canonical = true,
+    },
+    .post_chunked_big = .{
+        // No declared length, so nothing about this request is refusable
+        // before the body is pumped — which is what makes it the one
+        // script that can reach the #236 cap's streaming half.
+        .request = "POST /sim HTTP/1.1\r\nHost: sim\r\n" ++
+            "Transfer-Encoding: chunked\r\n\r\n" ++ big_chunked_wire,
         .expected_responses = 1,
         .transcript_cap = 1,
         .golden_status = 200,
@@ -654,6 +687,7 @@ pub const terminating_scripts = [_]Script{
     .post_sized,
     .post_big,
     .post_chunked,
+    .post_chunked_big,
     .post_chunked_malformed,
     .malformed_head,
     .oversize_uri,

--- a/sim/main.zig
+++ b/sim/main.zig
@@ -267,20 +267,6 @@ const uncovered = [_]Uncovered{
             "drain_deadline_ms directly, and asserts the loop reached idle",
     },
     .{
-        .name = "l7_body_cut_mid_stream",
-        .why = .unreached,
-        .reason = "the #236 cap's streaming half, and the sweep cannot reach it " ++
-            "for a reason that is a property of the draw rather than a gap in " ++
-            "ambition: the harness draws the cap in the single-byte range so " ++
-            "every body-carrying script trips it, which means the bytes " ++
-            "coalesced with the head are already over it and the *answered* " ++
-            "rung fires first. Reaching this one needs a cap above the first " ++
-            "delivery's excess and a body that outgrows it only later — a " ++
-            "combination the draw would have to be widened to produce, at the " ++
-            "cost of the answered rung's own coverage. src/http_proxy_test.zig " ++
-            "sends a 24 KiB chunked body under a 10 KiB cap directly",
-    },
-    .{
         .name = "l7_shed_upstream_head_buffers",
         .why = .unreached,
         .reason = "same shadow as l7_shed_upstream_slots: the relay rung " ++

--- a/smoke/client.zig
+++ b/smoke/client.zig
@@ -55,6 +55,15 @@ pub const Response = struct {
     /// attributes — so a present-but-mangled stamp fails the read
     /// instead of passing as either presence or absence.
     sticky_tag: ?[16]u8,
+    /// The `Date` value this response carried, or null when it carried
+    /// none (#234). Kept verbatim so the caller can hold it against its
+    /// own clock: the simulator's oracle can only prove the stamp is
+    /// well-formed, because its clock is the one the proxy reads — this
+    /// tier is where the real `nowWallNs` is on the other side of a
+    /// socket and a wrong one is visible.
+    date: ?[29]u8,
+    /// Whether the head named this proxy as the responder (#234).
+    from_proxy: bool,
 };
 
 /// How much entropy `std.crypto.tls` wants to seed one handshake — the
@@ -277,6 +286,8 @@ fn readResponse(reader: *Io.Reader) !Response {
         .body_bytes = head.body_bytes,
         .edited = head.edited,
         .sticky_tag = head.sticky_tag,
+        .date = head.date,
+        .from_proxy = head.from_proxy,
     };
 }
 
@@ -302,6 +313,8 @@ const Head = struct {
     body_bytes: u32,
     edited: bool,
     sticky_tag: ?[16]u8,
+    date: ?[29]u8,
+    from_proxy: bool,
 };
 
 /// Header lines up to the blank one, returning the body length they
@@ -314,9 +327,16 @@ const Head = struct {
 fn readHeaders(reader: *Io.Reader) !Head {
     const length_name = "content-length:";
     const stamp = "x-zoxy-smoke: 1";
+    // #234, spelled here for the same reason the stamp is: what this
+    // gate reads is what the binary wrote, so a drift must fail rather
+    // than agree with itself.
+    const date_name = "date:";
+    const server_line = "server: zoxy";
     var body_bytes: ?u32 = null;
     var edited = false;
     var sticky_tag: ?[16]u8 = null;
+    var date: ?[29]u8 = null;
+    var from_proxy = false;
     var lines: u32 = 0;
     while (lines < response_headers_max) : (lines += 1) {
         const taken = try reader.takeDelimiter('\n');
@@ -324,7 +344,27 @@ fn readHeaders(reader: *Io.Reader) !Head {
         const trimmed = std.mem.trimEnd(u8, line, "\r");
         if (trimmed.len == 0) {
             const framed = body_bytes orelse return error.ResponseUnframed;
-            return .{ .body_bytes = framed, .edited = edited, .sticky_tag = sticky_tag };
+            return .{
+                .body_bytes = framed,
+                .edited = edited,
+                .sticky_tag = sticky_tag,
+                .date = date,
+                .from_proxy = from_proxy,
+            };
+        }
+        if (std.ascii.eqlIgnoreCase(trimmed, server_line)) {
+            from_proxy = true;
+            continue;
+        }
+        if (std.ascii.startsWithIgnoreCase(trimmed, date_name)) {
+            const value = std.mem.trim(u8, trimmed[date_name.len..], " \t");
+            // Fixed-width by construction (RFC 9110 §5.6.7), so any other
+            // width is a slot patched wrongly rather than a spelling
+            // choice — and a second `Date` would mean two writers.
+            if (value.len != 29) return error.ResponseMalformed;
+            if (date != null) return error.ResponseMalformed;
+            date = value[0..29].*;
+            continue;
         }
         if (std.ascii.eqlIgnoreCase(trimmed, stamp)) {
             edited = true;

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -1180,12 +1180,14 @@ fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
     // page rather than the empty static it would have been.
     const not_found = try single_client.get(unrouted_host, "/", .keep_alive, null);
     var passed = expectBodyResponse(not_found, 404, not_found_body.len, "error page");
+    if (!expectProxyDate(not_found, "error page")) passed = false;
 
     // The respond action, off the file arm: the body zoxy read at
     // startup, byte count and all, on a request that never reached an
     // origin.
     const robots = try single_client.get(host, "/robots.txt", .close, null);
     if (!expectBodyResponse(robots, 200, robots_body.len, "respond")) passed = false;
+    if (!expectProxyDate(robots, "respond")) passed = false;
 
     const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
     const responded = counterOf(&scrape, "l7_responded") orelse return false;
@@ -1210,6 +1212,88 @@ fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         passed = false;
     }
     return passed;
+}
+
+/// The #234 stamp on a response zoxy answered itself, against this
+/// gate's own clock.
+///
+/// The simulator proves the slot is patched and well-formed, but its
+/// clock is the same one the proxy reads, so it cannot prove the value
+/// *means* anything. Here the two are genuinely separate — a real
+/// `nowWallNs` on the far side of a socket — so agreement to the minute
+/// is a real check: it catches a date stamped from the wrong clock, a
+/// slot left at a stale second, and the epoch a never-stamped one would
+/// carry.
+fn expectProxyDate(response: client_module.Response, role: []const u8) bool {
+    assert(role.len >= 1);
+    if (!response.from_proxy) {
+        std.debug.print("FAIL: the {s} response named no Server\n", .{role});
+        return false;
+    }
+    const date = response.date orelse {
+        std.debug.print("FAIL: the {s} response carried no Date\n", .{role});
+        return false;
+    };
+    var wall: std.posix.timespec = undefined;
+    // Through `posix.system` so the return convention matches the
+    // `posix.errno` that reads it — the #184 lesson, which cost a macOS
+    // live-gate panic the one time the two were mixed.
+    const rc = std.posix.system.clock_gettime(std.posix.CLOCK.REALTIME, &wall);
+    if (std.posix.errno(rc) != .SUCCESS) {
+        std.debug.print("FAIL: this gate could not read its own clock\n", .{});
+        return false;
+    }
+    assert(wall.sec >= 0);
+    const now: u64 = @intCast(wall.sec);
+    // A minute either side. The two clocks are the same system clock, so
+    // this bounds the seconds between the stamp and this comparison, not
+    // any drift — and the loop is bounded by that window, not by a match.
+    var offset: u64 = 0;
+    while (offset <= 120) : (offset += 1) {
+        var buffer: [64]u8 = undefined;
+        const rendered = imfFixdate((now -| 60) + offset, &buffer) orelse {
+            std.debug.print("FAIL: this gate could not render a date to compare\n", .{});
+            return false;
+        };
+        if (std.mem.eql(u8, rendered, &date)) return true;
+    }
+    std.debug.print(
+        "FAIL: the {s} response is dated {s}, which is not within a minute of now\n",
+        .{ role, date },
+    );
+    return false;
+}
+
+/// This gate's own IMF-fixdate (RFC 9110 §5.6.7), assembled here rather
+/// than imported for the reason every other spelling in this file is:
+/// the gate must read what the binary wrote, and a formatter shared with
+/// it would agree with a wrong weekday, an off-by-one month or a missing
+/// zero-pad as readily as with a right one. Null only if the format
+/// outgrew the buffer, which four-digit years cannot.
+fn imfFixdate(second: u64, buffer: []u8) ?[]const u8 {
+    const weekdays = [_][]const u8{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+    const months = [_][]const u8{
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    };
+    const epoch: std.time.epoch.EpochSeconds = .{ .secs = second };
+    const epoch_day = epoch.getEpochDay();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_seconds = epoch.getDaySeconds();
+    return std.fmt.bufPrint(
+        buffer,
+        "{s}, {d:0>2} {s} {d:0>4} {d:0>2}:{d:0>2}:{d:0>2} GMT",
+        .{
+            weekdays[(epoch_day.day + 4) % 7],
+            @as(u32, month_day.day_index) + 1,
+            months[month_day.month.numeric() - 1],
+            year_day.year,
+            day_seconds.getHoursIntoDay(),
+            day_seconds.getMinutesIntoHour(),
+            day_seconds.getSecondsIntoMinute(),
+        },
+    ) catch null;
 }
 
 /// One #159 response: the status the config asked for, and a body of

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -170,6 +170,43 @@ pub fn Server(comptime IoType: type) type {
         /// Empty on an L4-only config, which never canonicalizes.
         target_scratch: []u8,
         rewrite_scratch: []u8,
+        /// The §8 static responses in writable memory, because each now
+        /// carries a `Date` slot (#234). Comptime-sized and held inline:
+        /// a closed status set times two persistence variants, so this is
+        /// a fixed field like `drain_sink`, not a budget the config can
+        /// move.
+        static_responses: shed.StaticTable,
+        /// The one rendering of the current second every proxy-generated
+        /// response is stamped from, and the second it renders. Cached
+        /// because the calendar arithmetic is per-second work and the
+        /// responses that need it arrive per-request; re-rendered lazily,
+        /// on the first stamp of a new second.
+        ///
+        /// Never read by a send — only ever copied *out of*, into a
+        /// response's own slot — so unlike those slots this one is safe
+        /// to rewrite at any moment.
+        date_line: [shed.date_bytes]u8,
+        date_second: u64,
+        /// How many static responses are on the wire right now (#234):
+        /// armed and not yet fully written, counting the whole span
+        /// because a partial write re-arms on the same shared bytes.
+        ///
+        /// This is what makes patching a `Date` in place safe rather than
+        /// merely conventional. A submitted send holds a pointer the
+        /// kernel may read at any point before its completion, so a patch
+        /// landing underneath one could put a torn date on the wire —
+        /// nginx lives with exactly that race; this does not. A stamp
+        /// happens only while this reads zero, so the bytes a send was
+        /// handed can never change under it. The cost is the right way
+        /// round: under a sustained shed storm the date goes *stale*,
+        /// never malformed.
+        ///
+        /// A claim, not a tally: `Conn.static_send` records who holds one,
+        /// so the release is a no-op wherever nothing was taken and the
+        /// conn's own release path is the backstop. A leak would freeze
+        /// the date silently, which is why `isIdle` asserts a drained
+        /// server holds none.
+        static_sends_inflight: u32,
         /// The #140 capture table: one value slot per connection slot per
         /// named header, and the length of each. A logged value is copied
         /// out of the head buffer while it is still live (the response
@@ -399,6 +436,16 @@ pub fn Server(comptime IoType: type) type {
             assert(io.bufferGroupBytes() == options.head_buffer_bytes);
             server.io = io;
             server.config = config;
+            // The static answers, and the clock they will be stamped from
+            // (#234). Both start at the epoch rather than at `nowWallNs`:
+            // the second and the line then agree by construction, so the
+            // first stamp of any real second re-renders instead of
+            // trusting whatever the field happened to hold.
+            server.static_responses.init();
+            server.date_second = 0;
+            shed.formatHttpDate(0, &server.date_line);
+            server.static_sends_inflight = 0;
+            server.initDateSlots();
             try server.conns.init(arena, options.conn_slots);
             try server.relay_buffers.init(arena, options.relay_buffers);
             try server.initTunnelBuffers(arena, &options);
@@ -678,6 +725,115 @@ pub fn Server(comptime IoType: type) type {
         /// time and its key's sealing clock are both measured on.
         fn nowUnix(server: *const Self) u64 {
             return @divFloor(server.io.nowWallNs(), std.time.ns_per_s);
+        }
+
+        /// The current second as a `Date` value, re-rendered only when
+        /// the second has turned over (#234). Safe to call at any moment:
+        /// nothing sends these bytes, they are only ever copied into a
+        /// response's own slot.
+        pub fn currentDate(server: *Self) *const [shed.date_bytes]u8 {
+            const second = server.nowUnix();
+            if (second != server.date_second) {
+                shed.formatHttpDate(second, &server.date_line);
+                server.date_second = second;
+            }
+            // The pair is the whole cache: a line rendered from one second
+            // and a field claiming another would hand every later response
+            // a date nothing ever measured.
+            assert(server.date_second == second);
+            return &server.date_line;
+        }
+
+        /// Stamp a *shared* static response's `Date` slot — the one thing
+        /// `currentDate` is not enough for, because those bytes may be
+        /// under a submitted send (#234).
+        ///
+        /// The whole rule is the early return: with a send outstanding,
+        /// the kernel may read this slot at any moment before its
+        /// completion, so the response goes out carrying whatever second
+        /// it was last stamped with. That is a stale `Date`, which is
+        /// legal and honest; patching anyway would risk a torn one, which
+        /// is neither.
+        pub fn stampStaticDate(server: *Self, slot: *[shed.date_bytes]u8) void {
+            if (server.static_sends_inflight != 0) {
+                server.counters.increment("l7_static_date_stale");
+                return;
+            }
+            @memcpy(slot, server.currentDate());
+            // Startup stamped every slot, and nothing writes one but this,
+            // so a placeholder surviving a stamp is impossible — said here
+            // because it is the property the wire depends on, and the one a
+            // future slot that escaped `initDateSlots` would break.
+            assert(!std.mem.eql(u8, slot, shed.date_placeholder));
+        }
+
+        /// Stamp every shared `Date` slot with the second the server
+        /// started (#234) — the static table's, and every #159 page the
+        /// config rendered.
+        ///
+        /// Without this, a slot's *first* use could fall while some other
+        /// static send was in flight, and `stampStaticDate` would rightly
+        /// decline to patch it — putting the un-stamped placeholder on the
+        /// wire, which is not a date at all. Here nothing is in flight by
+        /// construction, so every slot holds a real one from the first
+        /// response onward and the in-flight rule can only ever cost
+        /// freshness, which is what it was chosen to cost.
+        ///
+        /// The pages are reached through the config rather than through a
+        /// list the loader hands over, because the simulator and the
+        /// directed tests build their `Config` by hand: a list would be a
+        /// field they could each forget, and the walk cannot be.
+        fn initDateSlots(server: *Self) void {
+            // Nothing has been served yet, which is exactly what makes this
+            // the one moment a slot can be written unconditionally.
+            assert(server.static_sends_inflight == 0);
+            const now = server.currentDate();
+            server.static_responses.stampAll(now);
+            for (server.config.error_pages) |page| {
+                @memcpy(page.keep_date, now);
+                @memcpy(page.close_date, now);
+            }
+            // A `respond` action's page is shared with every other
+            // reference to the same body and status (#159), so a page
+            // reached twice is stamped twice with the same bytes.
+            for (server.config.listeners) |listener| {
+                for (listener.request_filters) |rule| {
+                    for (rule.actions) |action| {
+                        switch (action) {
+                            .respond => |page| {
+                                @memcpy(page.keep_date, now);
+                                @memcpy(page.close_date, now);
+                            },
+                            else => {},
+                        }
+                    }
+                }
+            }
+        }
+
+        /// Take the claim that says this connection's pending write is
+        /// reading shared static bytes (#234). Paired with
+        /// `releaseStaticSend`, which every path out of that write runs.
+        pub fn claimStaticSend(server: *Self, conn: *ConnType) void {
+            // One write at a time per connection (`armClientWrite`), so a
+            // conn already holding one would mean two are in flight.
+            assert(!conn.static_send);
+            conn.static_send = true;
+            server.static_sends_inflight += 1;
+            assert(server.static_sends_inflight <= server.conns.capacity());
+        }
+
+        /// Hand back the claim, if this connection holds one. A no-op
+        /// otherwise, so the paths that end a write do not each re-test
+        /// what they were writing — and so the connection's own release
+        /// can be the backstop for the ones that end it abruptly.
+        pub fn releaseStaticSend(server: *Self, conn: *ConnType) void {
+            if (!conn.static_send) {
+                return;
+            }
+            conn.static_send = false;
+            assert(server.static_sends_inflight >= 1);
+            server.static_sends_inflight -= 1;
         }
 
         pub fn start(server: *Self) Io.ListenError!void {
@@ -1138,6 +1294,15 @@ pub fn Server(comptime IoType: type) type {
         /// all the same, so its quiescence is part of "idle" — and so is
         /// an endpoint left carrying a charge for a connection that ended.
         pub fn isIdle(server: *const Self) bool {
+            // Every #234 claim is a connection's, so a released conn pool
+            // and an outstanding claim contradict each other — and a
+            // leaked one would silently freeze the `Date`. Asserted here
+            // rather than merely reported, because an idle server with a
+            // claim standing is a bug in the release path, not a state a
+            // caller should be asked to handle.
+            if (server.conns.isFullyReleased()) {
+                assert(server.static_sends_inflight == 0);
+            }
             return server.l4Released() and
                 server.conns.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
@@ -1842,6 +2007,11 @@ pub fn Server(comptime IoType: type) type {
         /// every slot return goes through here and the flag can never
         /// outlive the occupancy that raised it.
         fn releaseConn(server: *Self, conn: *ConnType) void {
+            // The backstop for the #234 claim: a static answer torn down
+            // mid-write ends here like every other, and a claim that
+            // outlived its connection would freeze the `Date` for the
+            // life of the process.
+            server.releaseStaticSend(conn);
             server.conns.release(conn);
             server.updateConnPressure();
         }

--- a/src/config.zig
+++ b/src/config.zig
@@ -1062,6 +1062,8 @@ fn pageFor(
         .close = close.bytes,
         .keep_head_len = keep.head_len,
         .close_head_len = close.head_len,
+        .keep_date = keep.date,
+        .close_date = close.date,
     };
     // What every consumer of a page relies on, stated where every page
     // is made rather than at one call site: the head is a prefix of its
@@ -1093,17 +1095,26 @@ fn renderStaticPage(
     status: u16,
     body: *const ResolvedBody,
     persistence: shed.Persistence,
-) ParseError!struct { bytes: []const u8, head_len: u32 } {
+) ParseError!struct { bytes: []const u8, head_len: u32, date: *[shed.date_bytes]u8 } {
     assert(shed.isPageStatus(status));
     assert(body.content_type.len >= 1);
+    // The `Date` value is a placeholder here and a slot from here on
+    // (#234): fixed-width, so the serving path patches it in place and a
+    // page stays one contiguous send. Its offset is recorded rather than
+    // re-derived, because the only thing that knows it is this format
+    // string.
+    const prefix = try std.fmt.allocPrint(
+        arena,
+        "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\nDate: ",
+        .{ status, shed.reasonPhrase(status), body.bytes.len, body.content_type },
+    );
     const rendered = try std.fmt.allocPrint(
         arena,
-        "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: {s}\r\n{s}\r\n{s}",
+        "{s}{s}\r\n{s}{s}\r\n{s}",
         .{
-            status,
-            shed.reasonPhrase(status),
-            body.bytes.len,
-            body.content_type,
+            prefix,
+            shed.date_placeholder,
+            shed.server_line,
             switch (persistence) {
                 .keep => "",
                 .close => "Connection: close\r\n",
@@ -1112,9 +1123,14 @@ fn renderStaticPage(
         },
     );
     assert(rendered.len > body.bytes.len);
+    const head_len: u32 = @intCast(rendered.len - body.bytes.len);
+    // The slot must sit inside the *head*, or a HEAD request would be
+    // sent the prefix without it.
+    assert(prefix.len + shed.date_bytes <= head_len);
     return .{
         .bytes = rendered,
-        .head_len = @intCast(rendered.len - body.bytes.len),
+        .head_len = head_len,
+        .date = rendered[prefix.len..][0..shed.date_bytes],
     };
 }
 
@@ -6124,12 +6140,12 @@ test "config: bodies render into complete pages, both variants, HEAD as prefix" 
     try std.testing.expectEqual(@as(u16, 404), not_found.status);
     try std.testing.expectEqualStrings(
         "HTTP/1.1 404 Not Found\r\nContent-Length: 4\r\n" ++
-            "Content-Type: text/plain\r\n\r\ngone",
+            "Content-Type: text/plain\r\n" ++ page_date ++ "\r\ngone",
         not_found.keep,
     );
     try std.testing.expectEqualStrings(
         "HTTP/1.1 404 Not Found\r\nContent-Length: 4\r\n" ++
-            "Content-Type: text/plain\r\nConnection: close\r\n\r\ngone",
+            "Content-Type: text/plain\r\n" ++ page_date ++ "Connection: close\r\n\r\ngone",
         not_found.close,
     );
     // The head lengths are the HEAD contract: the prefix ends exactly at
@@ -6371,6 +6387,12 @@ test "config: the two header lists share one cap, and widen the line (#140)" {
     try expectParseError(error.LimitAccessLogBufferUnderLine, with_narrow_buffer);
 }
 
+/// The two lines every rendered #159 page now carries (#234). The date
+/// is still the placeholder here because a page is rendered at *load*,
+/// before any response is served — the serving path stamps the slot, and
+/// what the loader owes is a slot of exactly the right shape.
+const page_date = "Date: " ++ shed.date_placeholder ++ "\r\n" ++ shed.server_line;
+
 test "config: a respond action compiles to a page, sharing one buffer (#159)" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -6398,7 +6420,7 @@ test "config: a respond action compiles to a page, sharing one buffer (#159)" {
     try std.testing.expectEqual(@as(u16, 200), robots.status);
     try std.testing.expectEqualStrings(
         "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
-            "Content-Type: text/plain\r\n\r\nUser-agent: *\n",
+            "Content-Type: text/plain\r\n" ++ page_date ++ "\r\nUser-agent: *\n",
         robots.keep,
     );
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -88,6 +88,18 @@ pub const Counters = struct {
     /// path, where a read cannot deliver more than the buffer holds.
     l7_body_too_large: Value = Value.init(0),
     l7_not_implemented: Value = Value.init(0),
+    /// A proxy-generated response that went out carrying a `Date` older
+    /// than the current second (#234), because another static answer was
+    /// already on the wire when this one was armed.
+    ///
+    /// That is the deliberate cost of stamping a shared slot only while
+    /// nothing is reading it: a submitted send holds a pointer the kernel
+    /// may read at any moment, so patching under one could put a *torn*
+    /// date on the wire. Stale is the trade, and this is what makes the
+    /// trade visible rather than merely argued — a rate of these says how
+    /// concurrent this proxy's own answers are, and the §9 census is what
+    /// keeps the branch reachable rather than dead.
+    l7_static_date_stale: Value = Value.init(0),
     /// A request whose target arrived in absolute-form (RFC 9112 §3.2.2,
     /// #233), counted where the parser's split is read. Neither a reject
     /// nor an outcome: the request goes on to be routed, filtered or

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -2751,6 +2751,12 @@ pub fn Proxy(comptime IoType: type) type {
                 resumeClientWrite(server, conn); // More to write (§6).
                 return;
             }
+            // The shared static bytes are off the wire (#234). Released
+            // here rather than left to the connection's own teardown,
+            // because a kept connection holds its slot for as long as the
+            // client stays — and a claim standing that long would freeze
+            // the `Date` every later response is stamped from.
+            server.releaseStaticSend(conn);
             assertWriteContinuation(conn, write.then);
             switch (write.then) {
                 // The origin's `101` has reached the client, so the HTTP
@@ -3542,11 +3548,17 @@ pub fn Proxy(comptime IoType: type) type {
             if (configuredPage(server, status)) |page| {
                 return armPageWrite(server, conn, page, keep);
             }
-            if (keep) {
-                armClientWrite(server, conn, shed.staticResponse(status, .keep), .next_request);
-            } else {
-                armClientWrite(server, conn, shed.staticResponse(status, .close), .lingering_close);
-            }
+            const persistence: shed.Persistence = if (keep) .keep else .close;
+            const answer = server.static_responses.get(status, persistence);
+            // The `Date` this answer will carry (#234), written now
+            // because now is when the server can still prove nothing is
+            // reading these bytes — the claim taken below is what makes
+            // that true for the next one to ask.
+            server.stampStaticDate(answer.date);
+            server.claimStaticSend(conn);
+            const then: conn_module.ClientWrite.Then =
+                if (keep) .next_request else .lingering_close;
+            armClientWrite(server, conn, answer.bytes, then);
         }
 
         /// Send one pre-rendered #159 page: the persistence variant the
@@ -3571,6 +3583,12 @@ pub fn Proxy(comptime IoType: type) type {
             else
                 (if (head_only) page.close[0..page.close_head_len] else page.close);
             assert(bytes.len >= 1);
+            // A configured page is shared arena memory exactly as the
+            // comptime statics are shared server memory, so its `Date`
+            // slot is stamped under the same claim (#234). The slot sits
+            // in the head, so the HEAD prefix carries it too.
+            server.stampStaticDate(if (keep) page.keep_date else page.close_date);
+            server.claimStaticSend(conn);
             const then: conn_module.ClientWrite.Then =
                 if (keep) .next_request else .lingering_close;
             armClientWrite(server, conn, bytes, then);
@@ -3728,6 +3746,7 @@ pub fn Proxy(comptime IoType: type) type {
                 redirect.status,
                 location,
                 !keep,
+                server.currentDate(),
                 headBytes(server, conn),
             ) catch {
                 // The Location fit the scratch but head + Location does

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -14,6 +14,7 @@ const std = @import("std");
 const constants = @import("../constants.zig");
 const parser = @import("parser.zig");
 const filter = @import("filter.zig");
+const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
 
@@ -245,6 +246,14 @@ pub fn renderRedirectHead(
     status: u16,
     location: []const u8,
     inject_close: bool,
+    /// The current second as an IMF-fixdate (#234). Passed in rather than
+    /// read here: this file assembles bytes and owns no clock, which is
+    /// the same split `X-Forwarded-For` is written on.
+    ///
+    /// Unlike the static answers, a redirect is rendered per response
+    /// into the connection's own head buffer, so it shares nothing and
+    /// its date is always the current one — no slot, no claim.
+    date: *const [shed.date_bytes]u8,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     assert(filter.isRedirectStatus(status));
@@ -257,7 +266,10 @@ pub fn renderRedirectHead(
     try staging.append(redirectReason(status));
     try staging.append("\r\nLocation: ");
     try staging.append(location);
-    try staging.append("\r\nContent-Length: 0\r\n");
+    try staging.append("\r\nContent-Length: 0\r\nDate: ");
+    try staging.append(date);
+    try staging.append("\r\n");
+    try staging.append(shed.server_line);
     if (inject_close) {
         try staging.append("Connection: close\r\n");
     }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -10,6 +10,23 @@ const std = @import("std");
 
 const Balancer = @import("balancer.zig").Balancer;
 const config_module = @import("config.zig");
+const shed = @import("shed.zig");
+
+/// The `Date` and `Server` every proxy-generated response carries
+/// (#234), as this bed's clock renders them. `SimIo`'s wall clock starts
+/// at a fixed epoch and a directed scenario rarely spans a second, so
+/// this is the value nearly every expectation below wants — the few
+/// scenarios that *do* cross a second spell their own, which is the
+/// clock proving it is live rather than pinned.
+const expected_date = "Date: Wed, 01 Jan 2020 00:00:00 GMT\r\nServer: zoxy\r\n";
+
+/// The `Date` and `Server` the bed's *origin* sends on the fixtures that
+/// carry them — deliberately unlike anything this proxy would write
+/// (#234). A forwarded response keeps the origin's own headers, and an
+/// origin spelling them the way the proxy does would make that property
+/// invisible: the bytes would match whether they were passed through or
+/// silently replaced.
+const origin_date = "Date: Tue, 31 Dec 2019 23:59:59 GMT\r\nServer: origin/1.0\r\n";
 const constants = @import("constants.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
@@ -831,7 +848,7 @@ test "l7: a malformed request head is answered 400 and closed with FIN" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -856,7 +873,7 @@ test "l7: a malformed chunked body coalesced with the head is answered 400" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -874,7 +891,7 @@ test "l7: oversize request line is 414, oversize header section is 431" {
         try bed.exchange("GET " ++ long_target ++ " HTTP/1.1\r\n");
 
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
@@ -898,7 +915,7 @@ test "l7: oversize request line is 414, oversize header section is 431" {
         try bed.exchange(request[0..len]);
 
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_headers_too_large"));
@@ -911,7 +928,7 @@ test "l7: oversize request line is 414, oversize header section is 431" {
 /// is the origin: it accepted a connection and never saw a request on it.
 fn expectRejectedAfterDial(bed: *const Http1Bed) !void {
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_headers_too_large"));
@@ -1010,7 +1027,7 @@ test "l7: an absolute-form target routes on its authority, not on Host" {
         // Case is folded on the way to the routing key, exactly as a Host
         // header's would be, so the mixed-case authority still matches.
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
@@ -1052,7 +1069,7 @@ test "l7: an unsupported absolute-form scheme is 400" {
     try bed.exchange("GET ftp://files.example/x HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -1070,7 +1087,7 @@ test "l7: CONNECT and Upgrade are answered 501" {
         defer bed.tearDown();
         try bed.exchange("CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n");
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
@@ -1082,7 +1099,7 @@ test "l7: CONNECT and Upgrade are answered 501" {
         defer bed.tearDown();
         try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\nUpgrade: websocket\r\nConnection: upgrade\r\n\r\n");
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
@@ -1180,7 +1197,7 @@ test "l7: an unroutable path is answered 404" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n",
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
@@ -1202,7 +1219,7 @@ test "l7: a structure-changing escape in the path is answered 400" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -1253,7 +1270,7 @@ test "l7: a request to a host with no route is answered 404" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n",
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
@@ -1288,7 +1305,7 @@ test "l7: a filter reject answers its policy status before the origin is dialed"
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
@@ -1346,7 +1363,7 @@ test "l7: a filter reject survives 1-byte adversarial delivery across seeds" {
         try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nX-Env: prod\r\n\r\n");
 
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
@@ -1388,8 +1405,8 @@ test "l7: an upstream-slot shed keeps the connection, and the client's ask decid
     try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n" ++
-            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n" ++
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_shed_upstream_slots"));
@@ -1427,7 +1444,7 @@ test "l7: a head-ring shed answers 503 and always closes" {
     try bed.exchange("GET /held HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_shed_head_buffers"));
@@ -1490,8 +1507,8 @@ test "l7: an upstream head-pool shed keeps the connection like any post-parse ru
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_shed_upstream_slots"));
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_shed_upstream_head_buffers"));
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n" ++
-            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n" ++
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try bed.expectDrained();
@@ -1522,7 +1539,7 @@ test "l7: the configured head size is the accepted head size" {
 
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try std.testing.expect(std.mem.startsWith(u8, bed.client.response(), "HTTP/1.1 200 OK"));
@@ -1581,7 +1598,7 @@ test "l7: a 501 keeps the connection, and the next request is served" {
     // The 501 keeps, and the request after it is proxied normally — the
     // connection was never lost to a method it happened not to support.
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n\r\n" ++
+        "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n" ++
             "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
         bed.client.response(),
     );
@@ -1619,7 +1636,7 @@ test "l7: a reject closes when the client pipelined the next request" {
     // One response, and it announces the close: the second head is never
     // answered on this connection.
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
@@ -1649,7 +1666,7 @@ test "l7: a reject closes when the body has not arrived with the head" {
         try bed.exchange("POST /admin HTTP/1.1\r\nHost: o\r\nContent-Length: 4\r\n\r\nbody");
 
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try bed.expectDrained();
@@ -1682,7 +1699,7 @@ test "l7: a drain closes a reject that would otherwise be kept" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     // The drain finished because the connection left, not because the
@@ -1722,7 +1739,7 @@ test "l7: relay pressure closes a reject that would otherwise be kept" {
 
     try std.testing.expect(bed.server.counters.get("relay_pressure_engaged") >= 1);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try bed.expectDrained();
@@ -1751,7 +1768,7 @@ test "l7: a reject closes when the request carries a body" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
@@ -1912,7 +1929,7 @@ test "l7: an HTTP/1.0 request with no Host matches only any-host routes" {
         defer bed.tearDown();
         try bed.exchange("GET /x HTTP/1.0\r\n\r\n");
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
@@ -2119,7 +2136,7 @@ test "l7: an unreachable origin is answered 502" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2145,7 +2162,7 @@ test "l7: kernel pressure on the upstream dial is witnessed and answered 502" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2178,7 +2195,7 @@ test "l7: an origin response head the proxy cannot parse is 502" {
 
         try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2202,7 +2219,7 @@ test "l7: an origin response head the proxy cannot parse is 502" {
 
         try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2236,7 +2253,7 @@ test "l7: an origin head that no longer fits once the close is injected is 502" 
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2269,7 +2286,7 @@ test "l7: a redirect composes Location from the request and keeps serving (#176)
     try std.testing.expectEqualStrings(
         "HTTP/1.1 301 Moved Permanently\r\n" ++
             "Location: https://o/old/path?q=1\r\n" ++
-            "Content-Length: 0\r\n\r\n" ++
+            "Content-Length: 0\r\n" ++ expected_date ++ "\r\n" ++
             "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
         bed.client.response(),
     );
@@ -2307,10 +2324,10 @@ test "l7: a redirect can replace the host, or name a fixed target (#176)" {
     try std.testing.expectEqualStrings(
         "HTTP/1.1 308 Permanent Redirect\r\n" ++
             "Location: https://example.com/www?keep=1\r\n" ++
-            "Content-Length: 0\r\n\r\n" ++
+            "Content-Length: 0\r\n" ++ expected_date ++ "\r\n" ++
             "HTTP/1.1 302 Found\r\n" ++
             "Location: https://status.example.com/\r\n" ++
-            "Content-Length: 0\r\nConnection: close\r\n\r\n",
+            "Content-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 2), bed.server.counters.get("l7_redirected"));
@@ -2335,7 +2352,7 @@ test "l7: a composed redirect with no authority to compose from is 400 (#176)" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -2377,7 +2394,7 @@ test "l7: a redirect whose Location cannot be carried is 414 (#176)" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 414 URI Too Long\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
@@ -2432,7 +2449,8 @@ test "l7: a 5xx-scoped response filter fires on the status that names it (#175)"
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
         .seed = 22,
-        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            origin_date ++ "\r\n",
         .response_filters = &rules,
     });
     defer bed.tearDown();
@@ -2443,7 +2461,7 @@ test "l7: a 5xx-scoped response filter fires on the status that names it (#175)"
     // The origin's 503 forwards — a response filter edits, never
     // rewrites the verdict — and the edit rides along.
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++ origin_date ++
             "Retry-After: 1\r\nConnection: close\r\n\r\n",
         bed.client.response(),
     );
@@ -2486,7 +2504,7 @@ test "l7: an origin head that no longer fits after response edits is 502 (#175)"
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
@@ -2695,21 +2713,41 @@ test "l7: a header-keyed cluster stamps nothing (#178)" {
 }
 
 /// A hand-rendered #159 page for the directed tests: exactly what the
-/// loader's `renderStaticPage` produces for a 5-byte text body, so the
-/// serve path's output can be pinned byte-for-byte here without a
-/// loader round trip.
+/// loader's `renderStaticPage` produces for a text body, so the serve
+/// path's output can be pinned byte-for-byte here without a loader round
+/// trip.
+///
+/// Storage, not a constant, because a rendered page now carries a `Date`
+/// slot the serve path stamps in place (#234) — this is the loader's
+/// arena in miniature, and a distinct type per page so each owns its own
+/// bytes the way two arena allocations would.
+fn TestPage(comptime status: u16, comptime reason: []const u8, comptime body: []const u8) type {
+    return struct {
+        const head_prefix = std.fmt.comptimePrint(
+            "HTTP/1.1 {d} {s}\r\nContent-Length: {d}\r\nContent-Type: text/plain\r\nDate: ",
+            .{ status, reason, body.len },
+        );
+        const keep_template = head_prefix ++ shed.date_placeholder ++ "\r\n" ++
+            shed.server_line ++ "\r\n" ++ body;
+        const close_template = head_prefix ++ shed.date_placeholder ++ "\r\n" ++
+            shed.server_line ++ "Connection: close\r\n\r\n" ++ body;
+
+        var keep: [keep_template.len]u8 = keep_template.*;
+        var close: [close_template.len]u8 = close_template.*;
+        var page: config_module.Config.StaticPage = .{
+            .status = status,
+            .keep = &keep,
+            .close = &close,
+            .keep_head_len = keep_template.len - body.len,
+            .close_head_len = close_template.len - body.len,
+            .keep_date = keep[head_prefix.len..][0..shed.date_bytes],
+            .close_date = close[head_prefix.len..][0..shed.date_bytes],
+        };
+    };
+}
+
 const test_page_body = "gone\n";
-const test_not_found_keep = "HTTP/1.1 404 Not Found\r\nContent-Length: 5\r\n" ++
-    "Content-Type: text/plain\r\n\r\n" ++ test_page_body;
-const test_not_found_close = "HTTP/1.1 404 Not Found\r\nContent-Length: 5\r\n" ++
-    "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ test_page_body;
-const test_not_found_page = config_module.Config.StaticPage{
-    .status = 404,
-    .keep = test_not_found_keep,
-    .close = test_not_found_close,
-    .keep_head_len = test_not_found_keep.len - test_page_body.len,
-    .close_head_len = test_not_found_close.len - test_page_body.len,
-};
+const TestNotFound = TestPage(404, "Not Found", test_page_body);
 
 test "l7: a configured 404 page serves where the empty static did (#159)" {
     var bed: Http1Bed = undefined;
@@ -2717,7 +2755,7 @@ test "l7: a configured 404 page serves where the empty static did (#159)" {
         .seed = 41,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{&test_not_found_page},
+        .error_pages = &.{&TestNotFound.page},
     });
     defer bed.tearDown();
 
@@ -2727,7 +2765,7 @@ test "l7: a configured 404 page serves where the empty static did (#159)" {
     try bed.exchange("GET /nope HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
-    try std.testing.expectEqualStrings(test_not_found_page.close, bed.client.response());
+    try std.testing.expectEqualStrings(TestNotFound.page.close, bed.client.response());
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_no_route"));
     try bed.expectDrained();
 }
@@ -2738,7 +2776,7 @@ test "l7: a keep-alive reject serves the page and keeps serving (#159)" {
         .seed = 42,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{&test_not_found_page},
+        .error_pages = &.{&TestNotFound.page},
     });
     defer bed.tearDown();
 
@@ -2755,7 +2793,7 @@ test "l7: a keep-alive reject serves the page and keeps serving (#159)" {
     const expected = std.fmt.bufPrint(
         &expected_buffer,
         "{s}HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
-        .{test_not_found_page.keep},
+        .{TestNotFound.page.keep},
     ) catch unreachable;
     try std.testing.expectEqualStrings(expected, bed.client.response());
     try bed.expectDrained();
@@ -2767,7 +2805,7 @@ test "l7: a HEAD request gets a page's head and none of its body (#159)" {
         .seed = 43,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .route_prefix = "/api",
-        .error_pages = &.{&test_not_found_page},
+        .error_pages = &.{&TestNotFound.page},
     });
     defer bed.tearDown();
 
@@ -2778,7 +2816,7 @@ test "l7: a HEAD request gets a page's head and none of its body (#159)" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        test_not_found_page.close[0..test_not_found_page.close_head_len],
+        TestNotFound.page.close[0..TestNotFound.page.close_head_len],
         bed.client.response(),
     );
     try bed.expectDrained();
@@ -2788,18 +2826,8 @@ test "l7: a filter reject wears its configured page too (#159)" {
     // `respondFilter` routes through the same `respond`, so a 403 page
     // fires for policy rejects without any per-feature wiring — the
     // point of pages living behind the one static path.
-    const forbidden_body = "no\n";
-    const forbidden_keep = "HTTP/1.1 403 Forbidden\r\nContent-Length: 3\r\n" ++
-        "Content-Type: text/plain\r\n\r\n" ++ forbidden_body;
-    const forbidden_close = "HTTP/1.1 403 Forbidden\r\nContent-Length: 3\r\n" ++
-        "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ forbidden_body;
-    const page = config_module.Config.StaticPage{
-        .status = 403,
-        .keep = forbidden_keep,
-        .close = forbidden_close,
-        .keep_head_len = forbidden_keep.len - forbidden_body.len,
-        .close_head_len = forbidden_close.len - forbidden_body.len,
-    };
+    const Forbidden = TestPage(403, "Forbidden", "no\n");
+    const page = &Forbidden.page;
     const rules = [_]filter.Rule{.{
         .match = .{ .path_prefix = "/private" },
         .actions = &.{.{ .reject = 403 }},
@@ -2809,7 +2837,7 @@ test "l7: a filter reject wears its configured page too (#159)" {
         .seed = 44,
         .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi",
         .request_filters = &rules,
-        .error_pages = &.{&page},
+        .error_pages = &.{page},
     });
     defer bed.tearDown();
 
@@ -2822,21 +2850,11 @@ test "l7: a filter reject wears its configured page too (#159)" {
 }
 
 test "l7: a respond action answers from memory and never dials (#159)" {
-    const robots_body = "User-agent: *\n";
-    const robots_keep = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
-        "Content-Type: text/plain\r\n\r\n" ++ robots_body;
-    const robots_close = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n" ++
-        "Content-Type: text/plain\r\nConnection: close\r\n\r\n" ++ robots_body;
-    const robots_page = config_module.Config.StaticPage{
-        .status = 200,
-        .keep = robots_keep,
-        .close = robots_close,
-        .keep_head_len = robots_keep.len - robots_body.len,
-        .close_head_len = robots_close.len - robots_body.len,
-    };
+    const Robots = TestPage(200, "OK", "User-agent: *\n");
+    const robots_page = &Robots.page;
     const rules = [_]filter.Rule{.{
         .match = .{ .path_prefix = "/robots.txt" },
-        .actions = &.{.{ .respond = &robots_page }},
+        .actions = &.{.{ .respond = robots_page }},
     }};
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{
@@ -2860,7 +2878,7 @@ test "l7: a respond action answers from memory and never dials (#159)" {
     const expected = std.fmt.bufPrint(
         &expected_buffer,
         "{s}HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi",
-        .{robots_keep},
+        .{Robots.page.keep},
     ) catch unreachable;
     try std.testing.expectEqualStrings(expected, bed.client.response());
     // Answered as the origin, counted apart from refusals — and only
@@ -2887,7 +2905,8 @@ test "l7: a hung dial fires 504 at the connect budget, not the idle timeout" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++
+            expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
@@ -2915,7 +2934,7 @@ test "l7: rejects survive 1-byte adversarial delivery across seeds" {
 
         try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
         try std.testing.expectEqualStrings(
-            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
@@ -2950,8 +2969,13 @@ test "l7: a mute origin earns the §8 request-deadline 504 verdict" {
     try bed.exchange("GET /stalled HTTP/1.1\r\nHost: o\r\n\r\n");
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // A second later than every other scenario's, and spelled out rather
+    // than shared: the request deadline this test waits out is measured in
+    // virtual seconds, so the `Date` moving with it is the cheapest proof
+    // that the stamp reads a live clock rather than a pinned one (#234).
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++
+            "Date: Wed, 01 Jan 2020 00:00:01 GMT\r\nServer: zoxy\r\nConnection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
@@ -3074,7 +3098,7 @@ test "l7: the request deadline fires 504 ahead of the connect and idle budgets" 
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
@@ -3628,7 +3652,7 @@ test "l7: the replay budget is one — a second early failure answers 502" {
     try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client2.response(),
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_replayed"));
@@ -3954,7 +3978,8 @@ test "l7: a shed and an origin 503 are the same status and different outcomes" {
     var origin_bed: Http1Bed = undefined;
     try origin_bed.setUp(std.testing.allocator, .{
         .seed = 11,
-        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            origin_date ++ "\r\n",
         .access_log = true,
     });
     defer origin_bed.tearDown();
@@ -4133,7 +4158,8 @@ test "health: an http probe fails on a status it was not promised" {
         .seed = 62,
         // The origin is listening and answering — a TCP check would call
         // this endpoint healthy. Only reading the status can tell.
-        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        .origin_response = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            origin_date ++ "\r\n",
         .check = .{
             .kind = .http,
             .timeout_ms = Http1Bed.connect_timeout_ms,
@@ -4760,7 +4786,7 @@ test "l7: a retry runs out of endpoints before its budget and answers 502" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     // Two dials, one retry between them, and no third: the exclusion
@@ -4795,7 +4821,7 @@ test "l7: our own dial exhaustion is not retried onto another endpoint" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     // The healthy origin sat there untried, and that is correct: the
@@ -4832,7 +4858,7 @@ test "l7: a dial that times out does not retry, because it spent the budget" {
 
     try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     // One budget, not one per endpoint: three tries at a fresh deadline
@@ -5136,7 +5162,7 @@ test "l7: a 101 nobody asked for fails the exchange" {
     try bed.exchange("GET / HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_interim_forwarded"));
@@ -5253,7 +5279,7 @@ test "l7: a declared body over the cap is refused before the origin is dialed" {
         "Content-Length: 64\r\n\r\n" ++ ("x" ** 64));
 
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 413 Content Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 413 Content Too Large\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
         bed.client.response(),
     );
     // No origin was contacted: the refusal is this proxy's own, decided

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -298,6 +298,13 @@ pub fn Conn(comptime IoType: type) type {
         /// upgrade being admitted and the origin answering; at `101` the
         /// shared one goes back and this one takes its place.
         tunnel_buffer: ?*relay.RelayBuffer,
+        /// Whether this connection's pending client write is reading the
+        /// server's shared static response memory (#234) — the claim that
+        /// holds the `Date` stamp off those bytes while a send may be
+        /// reading them. False for every other write, including the #176
+        /// redirect, which renders into this connection's own head buffer
+        /// and so shares nothing.
+        static_send: bool,
         /// Absolute deadline; state transitions only store a new value —
         /// the armed timer op is never touched (§4).
         deadline_ns: u64,
@@ -722,6 +729,11 @@ pub fn Conn(comptime IoType: type) type {
             conn.upstream_socket = null;
             conn.relay_buffer = buffer;
             conn.tunnel_buffer = null;
+            // The claim is the server's counter to release, and
+            // `releaseConn` has already done so by the time a slot is
+            // handed out again — this only states the invariant the reset
+            // inherits.
+            conn.static_send = false;
             conn.deadline_ns = 0;
             conn.birth_ns = server.io.nowNs();
             conn.armed = .{};

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -16,26 +16,238 @@ pub const Persistence = enum {
     close,
 };
 
-/// A comptime-rendered static error response (§8): sent directly from
-/// static memory, never staged through the connection's head buffer —
-/// whose bytes the parsed head's zero-copy slices may still reference.
-/// Shedding costs one send, no allocation, no copy. The status set is
-/// closed in `reasonPhrase`: an unlisted status is a compile error.
-pub fn staticResponse(comptime status: u16, comptime persistence: Persistence) []const u8 {
+/// The `Date` every proxy-generated response carries (#234). RFC 9110
+/// §6.6.1 makes it a MUST for a server with a clock, and §4 gives this
+/// one a wall clock; the responses that most want a timestamp are
+/// exactly the ones §8 originates, since a shed `503` under load is what
+/// an operator places against an incident timeline.
+///
+/// IMF-fixdate is fixed-width — always these 29 bytes, whatever the
+/// date. That is the whole reason a static response can carry one: the
+/// value occupies a *slot* at a comptime-known offset, patched in place,
+/// so serving stays one send from memory that is neither assembled nor
+/// copied per response (§8).
+pub const date_bytes: u32 = 29;
+
+/// What a rendered response holds before its first patch, and the shape
+/// every patch writes back. Only ever sent if a response goes out before
+/// the clock is ever read, which cannot happen: the arming path stamps
+/// the slot it is about to hand to a send. Public because the #159 pages
+/// are rendered by the config loader rather than here, and both
+/// renderers must leave a slot of exactly one shape.
+pub const date_placeholder = "Xxx, 00 Xxx 0000 00:00:00 GMT";
+
+/// The identity this proxy puts on the responses it originates (#234).
+/// Forwarded responses carry the origin's own — this names the hop that
+/// answered, which is the cheapest tell that a `503` is the ladder's and
+/// not the origin's (§8: they are the same three digits and opposite
+/// events).
+pub const server_line = "Server: zoxy\r\n";
+
+comptime {
+    assert(date_placeholder.len == date_bytes);
+}
+
+/// One static response's template: the comptime bytes, and where in them
+/// the `Date` value sits. Both are properties of the status and the
+/// persistence alone, so they are computed once at comptime and the
+/// runtime table below only ever holds the mutable copy.
+const Template = struct {
+    bytes: []const u8,
+    date_offset: u32,
+};
+
+/// The comptime-rendered static error response (§8), with its `Date`
+/// slot still holding the placeholder. Never sent as-is — `StaticTable`
+/// copies it into writable memory at startup, and the arming path stamps
+/// the slot. The status set is closed in `reasonPhrase`: an unlisted
+/// status is a compile error.
+fn staticTemplate(comptime status: u16, comptime persistence: Persistence) Template {
     comptime assert(status >= 400);
     comptime assert(status <= 599);
-    const bytes = comptime std.fmt.comptimePrint(
-        "HTTP/1.1 {d} {s}\r\nContent-Length: 0\r\n{s}\r\n",
-        .{
-            status,
-            reasonPhrase(status),
-            switch (persistence) {
-                .keep => "",
-                .close => "Connection: close\r\n",
-            },
-        },
+    const prefix = comptime std.fmt.comptimePrint(
+        "HTTP/1.1 {d} {s}\r\nContent-Length: 0\r\nDate: ",
+        .{ status, reasonPhrase(status) },
     );
-    return bytes;
+    const suffix = "\r\n" ++ server_line ++ switch (persistence) {
+        .keep => "",
+        .close => "Connection: close\r\n",
+    } ++ "\r\n";
+    return .{
+        .bytes = prefix ++ date_placeholder ++ suffix,
+        .date_offset = prefix.len,
+    };
+}
+
+/// The widest static response any status and persistence can render to,
+/// which is what one table slot must hold. Comptime, so the table is
+/// sized by the responses themselves rather than by a guess that a new
+/// status could outgrow (§5).
+pub const static_response_bytes_max: u32 = blk: {
+    var widest: u32 = 0;
+    for (static_statuses) |status| {
+        for ([_]Persistence{ .keep, .close }) |persistence| {
+            const template = staticTemplate(status, persistence);
+            if (template.bytes.len > widest) {
+                widest = @intCast(template.bytes.len);
+            }
+        }
+    }
+    break :blk widest;
+};
+
+comptime {
+    // The three numbers the table's memory rests on, related here rather
+    // than trusted apart. It lives in this file and not `constants.zig`
+    // because nothing may set it: it is *derived* from the responses
+    // themselves, so a new status or a longer reason phrase moves it, and
+    // a copy in `constants.zig` would be the thing that went stale.
+    //
+    // Every response must hold its own date slot, and the whole table
+    // must stay small enough to be an unremarkable server field — 8 KiB
+    // is a head buffer, and this is a closed set of empty responses, so
+    // anything near it means a status grew a body it should not have.
+    for (static_statuses) |status| {
+        for ([_]Persistence{ .keep, .close }) |persistence| {
+            const template = staticTemplate(status, persistence);
+            assert(template.date_offset + date_bytes <= template.bytes.len);
+            assert(template.bytes.len <= static_response_bytes_max);
+        }
+    }
+    assert(static_response_bytes_max > date_bytes);
+    assert(static_statuses.len * 2 * static_response_bytes_max <= 8 * 1024);
+}
+
+const templates: [static_statuses.len][2]Template = blk: {
+    var table: [static_statuses.len][2]Template = undefined;
+    for (static_statuses, 0..) |status, index| {
+        table[index] = .{
+            staticTemplate(status, .keep),
+            staticTemplate(status, .close),
+        };
+    }
+    const frozen = table;
+    break :blk frozen;
+};
+
+/// One static response as the serving path takes it: the bytes to send,
+/// and the slot inside them the caller stamps first.
+pub const StaticResponse = struct {
+    bytes: []const u8,
+    date: *[date_bytes]u8,
+};
+
+/// The §8 static responses in writable memory — one copy per status and
+/// persistence, held by the server rather than as a module global so two
+/// servers in one process (every directed test runs two clocks) cannot
+/// patch each other's dates.
+///
+/// This is the change #234 makes to what §8 claims: these responses stop
+/// being `const` and gain a written region. What survives is the part
+/// that mattered — a shed is still one send, from memory that is neither
+/// acquired nor assembled nor copied per response. What is written is 29
+/// bytes, at most once per response, and only when the server can prove
+/// no submitted send is reading them.
+pub const StaticTable = struct {
+    storage: [static_statuses.len][2][static_response_bytes_max]u8,
+
+    pub fn init(table: *StaticTable) void {
+        for (&table.storage, 0..) |*variants, index| {
+            for (variants, 0..) |*slot, persistence| {
+                const template = templates[index][persistence];
+                assert(template.bytes.len <= slot.len);
+                @memcpy(slot[0..template.bytes.len], template.bytes);
+            }
+        }
+    }
+
+    /// Write `date` into every slot at once — what startup does, so no
+    /// response can be the first user of an un-stamped one (#234).
+    pub fn stampAll(table: *StaticTable, date: *const [date_bytes]u8) void {
+        for (static_statuses) |status| {
+            for ([_]Persistence{ .keep, .close }) |persistence| {
+                @memcpy(table.get(status, persistence).date, date);
+            }
+        }
+    }
+
+    /// The response for one verdict. `status` is a runtime value on the
+    /// filter-reject path, so membership is a lookup rather than a
+    /// comptime switch — but it is still the closed set, and a status
+    /// outside it is a caller that never consulted `isStaticStatus`.
+    pub fn get(
+        table: *StaticTable,
+        status: u16,
+        persistence: Persistence,
+    ) StaticResponse {
+        const index = staticStatusIndex(status).?;
+        const template = templates[index][@intFromEnum(persistence)];
+        const slot = &table.storage[index][@intFromEnum(persistence)];
+        assert(template.date_offset + date_bytes <= template.bytes.len);
+        return .{
+            .bytes = slot[0..template.bytes.len],
+            .date = slot[template.date_offset..][0..date_bytes],
+        };
+    }
+};
+
+/// Where `status` sits in `static_statuses`, or null when it is not one
+/// — `pageStatusIndex`'s sibling, for the table above.
+pub fn staticStatusIndex(status: u16) ?u8 {
+    assert(static_statuses.len <= std.math.maxInt(u8));
+    for (static_statuses, 0..) |candidate, index| {
+        assert(candidate >= 400);
+        if (status == candidate) return @intCast(index);
+    }
+    return null;
+}
+
+/// Render `unix_seconds` as the IMF-fixdate a `Date` header carries (RFC
+/// 9110 §5.6.7): `Sun, 06 Nov 1994 08:49:37 GMT`, always exactly
+/// `date_bytes` wide. Written field by field rather than through a
+/// formatter, because a formatter returns an error this cannot handle —
+/// the slot is the exact width, so there is nothing to fall back to, and
+/// `catch unreachable` on a reachable error is what Tiger Style forbids.
+pub fn formatHttpDate(unix_seconds: u64, out: *[date_bytes]u8) void {
+    const weekday_names = [7][3]u8{
+        "Sun".*, "Mon".*, "Tue".*, "Wed".*, "Thu".*, "Fri".*, "Sat".*,
+    };
+    const month_names = [12][3]u8{
+        "Jan".*, "Feb".*, "Mar".*, "Apr".*, "May".*, "Jun".*,
+        "Jul".*, "Aug".*, "Sep".*, "Oct".*, "Nov".*, "Dec".*,
+    };
+    const epoch: std.time.epoch.EpochSeconds = .{ .secs = unix_seconds };
+    const epoch_day = epoch.getEpochDay();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_seconds = epoch.getDaySeconds();
+    // Four digits is what the slot holds, and the fixed width is the
+    // whole premise of patching in place.
+    assert(year_day.year <= 9999);
+    // 1970-01-01 was a Thursday, and an IMF-fixdate week starts on Sunday.
+    const weekday: usize = @intCast((epoch_day.day + 4) % 7);
+    @memcpy(out[0..3], &weekday_names[weekday]);
+    out[3] = ',';
+    out[4] = ' ';
+    writeTwoDigits(out[5..7], @as(u32, month_day.day_index) + 1);
+    out[7] = ' ';
+    @memcpy(out[8..11], &month_names[month_day.month.numeric() - 1]);
+    out[11] = ' ';
+    writeTwoDigits(out[12..14], year_day.year / 100);
+    writeTwoDigits(out[14..16], year_day.year % 100);
+    out[16] = ' ';
+    writeTwoDigits(out[17..19], day_seconds.getHoursIntoDay());
+    out[19] = ':';
+    writeTwoDigits(out[20..22], day_seconds.getMinutesIntoHour());
+    out[22] = ':';
+    writeTwoDigits(out[23..25], day_seconds.getSecondsIntoMinute());
+    @memcpy(out[25..29], " GMT");
+}
+
+fn writeTwoDigits(out: *[2]u8, value: u32) void {
+    assert(value <= 99);
+    out[0] = '0' + @as(u8, @intCast(value / 10));
+    out[1] = '0' + @as(u8, @intCast(value % 10));
 }
 
 /// The closed set of statuses the ladder (§8) and the L7 state machine
@@ -68,6 +280,13 @@ pub const StaticPage = struct {
     close: []const u8,
     keep_head_len: u32,
     close_head_len: u32,
+    /// Each variant's `Date` slot (#234), inside its own head so the
+    /// HEAD prefix carries it too. A mutable view of arena bytes the
+    /// page otherwise holds as `const`: the page is immutable in every
+    /// respect a reader cares about, and these 29 bytes are the one
+    /// region the serving path writes.
+    keep_date: *[date_bytes]u8,
+    close_date: *[date_bytes]u8,
 };
 
 /// Whether `error_pages` may carry this status (#159) — membership in
@@ -142,14 +361,81 @@ pub fn closeQuietly(comptime IoType: type, io: *IoType, socket: IoType.Socket) v
 }
 
 test "shed: static responses are exact bytes with close announced" {
+    var table: StaticTable = undefined;
+    table.init();
+    // Before any stamp the slot holds the placeholder, which is what
+    // makes the offset checkable without a clock.
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-        staticResponse(503, .close),
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\nConnection: close\r\n\r\n",
+        table.get(503, .close).bytes,
     );
     try std.testing.expectEqualStrings(
-        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
-        staticResponse(503, .keep),
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n\r\n",
+        table.get(503, .keep).bytes,
     );
+    // And a stamp lands in the response, not beside it: the slice the
+    // send is handed changes under exactly those 29 bytes.
+    formatHttpDate(784_111_777, table.get(503, .keep).date);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            "Date: Sun, 06 Nov 1994 08:49:37 GMT\r\nServer: zoxy\r\n\r\n",
+        table.get(503, .keep).bytes,
+    );
+    // Each entry owns its own slot: stamping one leaves the rest alone.
+    try std.testing.expectEqualStrings(
+        date_placeholder,
+        table.get(503, .close).date,
+    );
+}
+
+test "shed: IMF-fixdate is fixed-width and matches the RFC's own example" {
+    const Case = struct { seconds: u64, want: []const u8 };
+    for ([_]Case{
+        // RFC 9110 §5.6.7's example, and the two epochs the tests use.
+        .{ .seconds = 784_111_777, .want = "Sun, 06 Nov 1994 08:49:37 GMT" },
+        .{ .seconds = 0, .want = "Thu, 01 Jan 1970 00:00:00 GMT" },
+        .{ .seconds = 1_577_836_800, .want = "Wed, 01 Jan 2020 00:00:00 GMT" },
+        // A leap day, and the last second before one.
+        .{ .seconds = 1_582_934_400, .want = "Sat, 29 Feb 2020 00:00:00 GMT" },
+        .{ .seconds = 1_582_934_399, .want = "Fri, 28 Feb 2020 23:59:59 GMT" },
+        // Every field at its widest.
+        .{ .seconds = 4_102_444_799, .want = "Thu, 31 Dec 2099 23:59:59 GMT" },
+    }) |case| {
+        var out: [date_bytes]u8 = undefined;
+        formatHttpDate(case.seconds, &out);
+        try std.testing.expectEqualStrings(case.want, &out);
+    }
+}
+
+test "fuzz: every renderable second formats to a well-formed fixdate" {
+    try std.testing.fuzz({}, fuzzHttpDate, .{ .corpus = &.{ "\x00", "\xff\xff\xff\xff" } });
+}
+
+fn fuzzHttpDate(context: void, smith: *std.testing.Smith) !void {
+    _ = context;
+    // Bounded to the four-digit years the slot can hold: 253402300800 is
+    // 10000-01-01, the first second `formatHttpDate` refuses.
+    const seconds = smith.valueRangeLessThan(u64, 0, 253_402_300_800);
+    var out: [date_bytes]u8 = undefined;
+    formatHttpDate(seconds, &out);
+    // Shape alone, checked against the fixed grammar: every separator in
+    // its place, every digit a digit. The values are the table above's.
+    assert(out[3] == ',');
+    assert(out[4] == ' ');
+    assert(out[7] == ' ');
+    assert(out[11] == ' ');
+    assert(out[16] == ' ');
+    assert(out[19] == ':');
+    assert(out[22] == ':');
+    assert(std.mem.eql(u8, out[25..29], " GMT"));
+    for ([_]usize{ 5, 6, 12, 13, 14, 15, 17, 18, 20, 21, 23, 24 }) |index| {
+        assert(std.ascii.isDigit(out[index]));
+    }
+    for ([_]usize{ 0, 1, 2, 8, 9, 10 }) |index| {
+        assert(std.ascii.isAlphabetic(out[index]));
+    }
 }
 
 test "shed: the status set is one set, comptime and runtime" {
@@ -185,9 +471,14 @@ test "shed: every static response parses as a valid bodiless head" {
     // complete, correctly framed head whose persistence matches the
     // requested one — the same verdict a strict client would reach.
     const parser = @import("http/parser.zig");
+    var table: StaticTable = undefined;
+    table.init();
+    // A real date, so the head under test is the one that ships rather
+    // than the placeholder's shape.
     inline for (static_statuses) |status| {
         inline for ([_]Persistence{ .keep, .close }) |persistence| {
-            const bytes = staticResponse(status, persistence);
+            formatHttpDate(1_577_836_800, table.get(status, persistence).date);
+            const bytes = table.get(status, persistence).bytes;
             var storage: parser.HeaderStorage = undefined;
             const head = try parser.parseResponseHead(bytes, false, &storage, .get);
             try std.testing.expectEqual(status, head.status);


### PR DESCRIPTION
Closes #234. Replaces #249, which GitHub closed when its base branch (#248) was deleted on merge — same commit, rebased onto `main`, and its CI was green before the close.

RFC 9110 §6.6.1 makes `Date` a MUST for a server with a clock, and §4 gives this one. Every response §8 raises went out without one — and those are precisely the responses that most want a timestamp: a shed `503` under load is the one an operator needs to place against an incident timeline, and it was the one carrying no time. `Server: zoxy` rides the same change, because an origin's own `503` and this proxy's shed `503` are the same three digits and opposite events, and until now nothing on the wire told them apart.

Forwarded responses are untouched: the origin's own `Date` travels through the §7 re-render.

## What this costs §8

A `Date` is per-second, so the static responses stop being `const` and gain a written region. The value is fixed-width (IMF-fixdate always is), so each response carries a slot at a comptime-known offset that the serving path patches in place — 29 bytes, at most once per response. Nothing is acquired, assembled or copied per response, so the cost that mattered is unchanged; what §8 can no longer say is that the bytes never change. That is stated in the section rather than left as an implementation detail.

## Why the patch is safe, and not just conventional

A submitted send holds a pointer the kernel may read at any moment before its completion, so a patch landing under one could put a **torn** date on the wire. nginx keeps one cached date string and lives with exactly that race; this does not.

A slot is stamped only while no static send is in flight, tracked as a per-connection claim (`Conn.static_send`) released both at write completion and by the connection's own teardown — the `releaseTunnelClaim` pattern. The cost lands the right way round: under a sustained shed storm the date goes **stale, never malformed**, and `l7_static_date_stale` makes that visible rather than merely argued.

**The sweep found the hole in that rule, at seed 110.** Declining to stamp is right for a stale slot and wrong for a never-stamped one: a slot's first use could fall while another send was in flight, and the response shipped the placeholder — not a date at all. Every slot is now stamped at startup, where nothing is in flight by construction. The placeholder deliberately stays un-date-like, so a slot that ever escapes that pass fails loudly instead of quietly shipping 1970.

## Three oracles, each verified by mutation

- **The sim client** demands that what this proxy originates carries both lines and what it forwards carries neither. The sim origin sends no `Date`, so the forwarded half proves the response render is not stamping answers that are not its own. Never stamping fails at seed 2; leaking the claim fails at seed 10 (completion) and 110 (teardown).
- **The census** proves the in-flight guard is a live branch, not dead code: removing the guard fails the sweep for want of `l7_static_date_stale`.
- **The smoke gate** holds the stamp against its *own* clock, with its own fixdate renderer rather than zoxy's — the simulator's clock is the one the proxy reads, so it can prove the value is well-formed but never that it means anything. Stamping from a frozen clock passes every sim seed and fails here.

## Fallout, both real rather than cosmetic

- The longer responses shift the adversary's delivery splits, and a seed began reaching `l7_body_cut_mid_stream` — whose census exemption said the draw could not produce it. It was right about the draw and wrong about the schedule. Rather than restore an exemption that now depends on luck, the #236 cap gains a second draw range and the scripts gain the body that range needs: cutting a body mid-stream wants a head that declares no length, a cap above what one delivery can carry, and a total above the cap. The relation between the three is asserted where all of them are visible.
- Three `origin_response` fixtures were spelling their headers the way the proxy does, which would have made the pass-through property invisible — the bytes matched whether they were forwarded or silently replaced. The origin now sends `Server: origin/1.0` and a 2019 date.

## Gates

`zig build ci` green after the rebase: 4096 seeds, census ok (70 counters fired, 17 exempt — one exemption deleted), smoke clean, `zig fmt` clean.

§12's deviation register drops to two.