### PR TITLE
http: refuse TRACE, and spend the Max-Forwards budget on OPTIONS

### DIFF
--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -52,11 +52,21 @@ pub fn main() void {
     while (index < iterations) : (index += 1) {
         const request = parser.parseRequestHead(request_head, false, &request_storage) catch unreachable;
         const target = parser.canonicalTarget(request.target, &path_scratch) catch unreachable;
-        // `null` forwarding is the shape to hold steady here: §7 client
-        // address forwarding is opt-in per listener, so the case that must
-        // not regress is the one where it is off and the render's
-        // suppression test is pure overhead.
-        const upstream = render.renderRequestHead(&request, target, no_edits, false, null, false, &upstream_head) catch unreachable;
+        // Both `null`s are the shape to hold steady here: §7 client
+        // address forwarding is opt-in per listener and a hop budget is
+        // rarer still, so the case that must not regress is the one where
+        // both are off and the render's suppression tests are pure
+        // overhead.
+        const upstream = render.renderRequestHead(
+            &request,
+            target,
+            no_edits,
+            false,
+            null,
+            null,
+            false,
+            &upstream_head,
+        ) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
         const downstream = render.renderResponseHead(&response, true, no_edits, false, &downstream_head) catch unreachable;
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -913,6 +913,41 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   one matches only the any-host routes; config hosts must themselves be
   canonical (rejected at load otherwise), so a request host compares
   byte-for-byte against them.
+- **`TRACE` is refused, and `Max-Forwards` is spent** (#240). RFC 9110
+  §7.6.2 is one of the few places the spec names intermediaries
+  directly: a hop in an `OPTIONS` or `TRACE` chain MUST check the
+  budget, MUST answer as the final recipient at zero, and MUST forward
+  its own decrement otherwise.
+  `TRACE` closes half of it by being refused outright — `501`, the
+  answer `CONNECT` already earns and for a related reason. Reflecting a
+  request back is the Cross-Site Tracing vector, and a gateway has
+  nothing truthful to reflect anyway: by the time the echo returned, the
+  request line would have been rewritten, the hop-by-hop headers
+  stripped and an `X-Forwarded-For` added, so what came back would not
+  be the message the client sent. Refusing it makes this proxy the final
+  recipient of every `TRACE` chain unconditionally.
+  That leaves `OPTIONS`, where the budget is read and spent. Zero is
+  answered here — `200` with an `Allow` naming *this hop*, since "stop
+  here and describe yourself" is what a zero budget means and the origin
+  is deliberately never dialled — and anything higher travels
+  decremented. The value is checked before any resource is acquired, so
+  a budget that ran out costs no origin connection.
+  The field is read for `OPTIONS` alone. RFC 9110 lets a recipient
+  ignore it elsewhere, and reading it everywhere would let a garbage
+  value on a `POST` reject a request the spec never asked this proxy to
+  look at. Where it *is* read, an unparseable or duplicated budget is a
+  `400`: two readings of one number is not something to guess between.
+  Decrementing means **rewriting a header's value**, which the §7 render
+  could not do — filter edits write constants by design. `Max-Forwards`
+  therefore becomes the second header this proxy writes on the client's
+  behalf, on `X-Forwarded-For`'s pattern: a parser tag, suppression of
+  the inbound copy by tag during the render, one computed value
+  appended, and the name barred from filter edits so a rule cannot
+  restate a number that must count down.
+  Both references ignore this requirement entirely. That is a reason to
+  weigh it, not to skip it: §12 exists so a MUST is a decision written
+  down, and this one was cheap enough that recording a deviation would
+  have cost more argument than the code.
 - **An absolute-form target names its own authority, and that authority
   wins** (#233). RFC 9112 §3.2.2 makes accepting `GET
   http://api.example/v2/x HTTP/1.1` a MUST for a server, and it arrives
@@ -2227,7 +2262,7 @@ is a trap rather than a synonym.
 
 | spec | what binds a gateway | here |
 |---|---|---|
-| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §5.6.7 date format; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §15.2.1 `100 Continue` | §7, §8's `Date`, with two deviations below |
+| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §5.6.7 date format; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §10.2.1 `Allow`; §15.2.1 `100 Continue` | §7, §8's `Date`, with one deviation below |
 | **9112** HTTP/1.1 | §3.2 target forms; §6.3 body length; §7 transfer codings; §9 connection management | §7 framing, §8 close announcement |
 | **6585** additional statuses | defines `429` and `431` — **9110 did not absorb these**, the registry still points here | §8's static set |
 | **8297** early hints | defines `103` | §7's interim relay (#232) |
@@ -2261,13 +2296,14 @@ header because that is what origins read. And the **PROXY protocol**
 pins its two writers to its parser by round-trip test: there is no
 independent text to be conformant *to*.
 
-**The deviations.** Two requirements this proxy does not meet today.
-The first is settled; the second is open, and the issue is where that
-decision is being taken rather than here. Two left this list together:
-absolute-form request-targets (9112 §3.2.2) with #233 — §7 states what
-their authority does to the `Host` beside them — and the missing `Date`
-(9110 §6.6.1) with #234, which §8 states, along with what carrying one
-costs a response that used to be immutable.
+**The deviation.** One requirement this proxy does not meet today, and
+it is settled rather than open. Three left this list in quick
+succession: absolute-form request-targets (9112 §3.2.2) with #233 — §7
+states what their authority does to the `Host` beside them — the missing
+`Date` (9110 §6.6.1) with #234, which §8 states along with what carrying
+one costs a response that used to be immutable, and `Max-Forwards`
+(§7.6.2) with #240, which §7 states beside the `TRACE` refusal that
+closed the other half of it.
 
 - **`Via` is not sent** (9110 §7.6.3, a MUST for intermediaries). The
   cost is real and worth naming: a request that loops through this proxy
@@ -2277,11 +2313,6 @@ costs a response that used to be immutable.
   is absent from the chains this proxy actually sits in, and emitting it
   alone would add a field no downstream reads. It returns as a decision
   if a deployment ever needs loop detection this proxy can see.
-- **`Max-Forwards` is ignored and `TRACE` is forwarded** (§7.6.2, two
-  MUSTs) — #240. Refusing `TRACE` closes half of it for one predicate;
-  the remaining `OPTIONS` half needs a header whose value this proxy
-  *computes*, which the render machinery has exactly one instance of
-  (`X-Forwarded-For`) and no general mechanism for.
 
 **There is no conformance suite**, official or otherwise, and §9's gates
 are internal by construction — the fuzzer asserts *this* parser never

--- a/docs/README.md
+++ b/docs/README.md
@@ -374,6 +374,19 @@ origin receives, so the router and the backend cannot disagree about which
 resource was named. Structure-changing escapes (`%2F`, `%00`, truncated
 escapes) are rejected with `400`; no matching route is a `404`.
 
+`CONNECT` and `TRACE` are answered `501` and never reach a backend.
+`CONNECT` asks the proxy to open an arbitrary destination, which is
+forward-proxy behaviour; `TRACE` echoes a request back, which is the
+Cross-Site Tracing vector and, through a proxy that has already rewritten
+the request, an echo of a message nobody sent.
+
+`OPTIONS` honours `Max-Forwards`. At `0` zoxy answers it — `200` with an
+`Allow` describing zoxy itself, since that is what the client asked for —
+and never dials a backend; above `0` the request is forwarded with the
+value decremented, as an intermediary is required to. The field is read
+only for `OPTIONS`, so it changes nothing about ordinary traffic, and
+CORS preflights are unaffected: those carry no `Max-Forwards` at all.
+
 A request may also name its authority in the request line itself —
 `GET http://api.example.com/v2/x HTTP/1.1` — which is what a client sends
 when it thinks it is talking to a forward proxy. That form is accepted

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -2705,6 +2705,9 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_filtered",
         "l7_redirected",
         "l7_responded",
+        // The #240 final-recipient answer: served, so it owes a line like
+        // every other answered exchange.
+        "l7_max_forwards_exhausted",
         "l7_shed_relay_buffers",
         "l7_shed_tunnels",
         // A tunnel is an *answered* exchange like any other here (#180):

--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -39,6 +39,14 @@ pub const response_edit_name = "X-Sim-Response";
 pub const response_edit_value = "on";
 pub const response_never_name = "X-Sim-Never";
 
+/// The #240 hop budget `options_hop` sends, and the one the origin must
+/// read. RFC 9110 §7.6.2 has each intermediary forward the received value
+/// decremented by one, so these two numbers are the whole property: a
+/// proxy that forwarded the header verbatim would show the first, and one
+/// that dropped it would show neither.
+pub const max_forwards_sent = "3";
+pub const max_forwards_forwarded = "2";
+
 /// The Host header the `absolute_form` script sends beside a request
 /// line that names a different authority (#233). RFC 9112 §3.2.2 has the
 /// authority win, so these bytes must never reach an origin — the origin

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -55,6 +55,11 @@ pub const ClientError = error{
     /// anywhere (the scripted origin answers no 5xx) — either way a
     /// predicate fired where it could not have.
     ResponseEditForged,
+    /// A `200` this proxy answered as the final recipient of an
+    /// `OPTIONS` (#240) carried no `Allow`, or one naming methods this
+    /// hop does not offer — which is the whole of what the answer was
+    /// asked for.
+    AllowMissing,
     /// A response this proxy originated arrived without the `Date` and
     /// `Server` lines RFC 9110 §6.6.1 requires of it (#234) — or with a
     /// `Date` still holding the un-stamped placeholder, which is the
@@ -497,6 +502,16 @@ pub fn Client(comptime IoType: type) type {
                         return walk;
                     }
                 }
+                // The #240 oracle: a final-recipient answer's whole
+                // content is what it says about this hop, so a `200` that
+                // reached the client without an exact `Allow` answered
+                // the question with nothing.
+                if (response.status == 200 and entry.answered_here) {
+                    if (!headerEquals(response.headers, "Allow", parser.allow_value)) {
+                        walk.violation = ClientError.AllowMissing;
+                        return walk;
+                    }
+                }
                 // The #180 oracle, and the mirror of the redirect check
                 // above: §7 lets the participating `Upgrade` survive
                 // hop-by-hop stripping precisely so the client is told
@@ -555,7 +570,8 @@ pub fn Client(comptime IoType: type) type {
             // is sent from immutable memory and never crosses the
             // response render, so the stamp on one would mean a
             // configured body had grown filter edits.
-            const from_memory = pageBodyFor(entry, response.status) != null;
+            const from_memory = pageBodyFor(entry, response.status) != null or
+                (response.status == 200 and entry.answered_here);
             if (response.status == 200 and !from_memory) {
                 if (!stamped) {
                     return ClientError.ResponseEditMissing;
@@ -591,7 +607,8 @@ pub fn Client(comptime IoType: type) type {
         /// raised — the §8 ladder's, a filter's reject, a redirect.
         fn dateViolation(entry: Spec, response: *const parser.ResponseHead) ?ClientError {
             assert(response.status >= 100);
-            const from_memory = pageBodyFor(entry, response.status) != null;
+            const from_memory = pageBodyFor(entry, response.status) != null or
+                (response.status == 200 and entry.answered_here);
             const forwarded = !from_memory and
                 (response.status == 200 or response.status == 101);
             const stamped_server = headerEquals(response.headers, "Server", "zoxy");
@@ -644,11 +661,13 @@ pub fn Client(comptime IoType: type) type {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
-            // Same rule as the #175 stamp, one mechanism over: a page
-            // reaches no origin and runs no response render, so a
-            // cookie on one would be the stamp path firing for an
-            // exchange that never happened.
-            if (response.status != 200 or pageBodyFor(entry, response.status) != null) {
+            // Same rule as the #175 stamp, one mechanism over: an answer
+            // this proxy raised itself — a configured page (#159) or the
+            // final-recipient `OPTIONS` (#240) — reaches no origin and
+            // runs no response render, so a cookie on one would be the
+            // stamp path firing for an exchange that never happened.
+            const raised_here = pageBodyFor(entry, response.status) != null or entry.answered_here;
+            if (response.status != 200 or raised_here) {
                 if (named) return ClientError.StickyStampForged;
                 return null;
             }
@@ -776,6 +795,16 @@ pub fn Client(comptime IoType: type) type {
                         }
                         return prefixVerdict(body, expected, @intCast(length));
                     }
+                    // The #240 final-recipient answer: the one 200 in the
+                    // sweep that is neither an origin's canonical body nor
+                    // a configured page's, because "stop here and describe
+                    // yourself" is answered in headers alone.
+                    if (response.status == 200 and entry.answered_here) {
+                        if (length != 0) {
+                            return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
+                        }
+                        return .{ .body_len = 0, .violation = null };
+                    }
                     if (response.status == 200) {
                         if (length != canon.sized_body.len) {
                             return .{ .body_len = 0, .violation = ClientError.ResponseBodyCorrupted };
@@ -791,13 +820,13 @@ pub fn Client(comptime IoType: type) type {
                 // renders it that way — so either streaming framing on
                 // one is the render inventing a shape.
                 .chunked => {
-                    if (response.status != 200 or page_body != null) {
+                    if (response.status != 200 or page_body != null or entry.answered_here) {
                         return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
                     }
                     return prefixVerdict(body, canon.chunked_wire, canon.chunked_wire.len);
                 },
                 .until_close => {
-                    if (response.status != 200 or page_body != null) {
+                    if (response.status != 200 or page_body != null or entry.answered_here) {
                         return .{ .body_len = 0, .violation = ClientError.ResponseCorrupted };
                     }
                     // The FIN delimits this body, so it is transcript-

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -260,6 +260,25 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 return !std.mem.eql(u8, host, canon.overridden_host);
             }
 
+            /// RFC 9110 §7.6.2 seen from the far end (#240): whatever
+            /// budget a request arrived with, the one this origin reads
+            /// is a hop shorter — and a `TRACE` never arrives at all,
+            /// because §7 answers it rather than forwarding it.
+            ///
+            /// The exact value is checkable because one script sends the
+            /// header and the numbers are canon's: a proxy forwarding it
+            /// verbatim shows the sent value, one dropping it shows none,
+            /// and either is a rule this hop did not apply.
+            fn forwardedSpentAHop(conn: *Conn, request: *const parser.RequestHead) bool {
+                _ = conn;
+                if (request.method == .trace) {
+                    return false;
+                }
+                const budget = parser.headerValue(request.headers, "max-forwards") orelse
+                    return true;
+                return std.mem.eql(u8, budget, canon.max_forwards_forwarded);
+            }
+
             /// Returns true when the head is parsed and the phase moved
             /// on; false when it armed a recv or closed on a violation.
             fn parseHead(conn: *Conn) bool {
@@ -313,6 +332,11 @@ pub fn HttpOrigin(comptime IoType: type) type {
                 // script because only one can produce either shape, which
                 // makes a blanket check an exact one.
                 if (!conn.forwardedNamesOneAuthority(&request)) {
+                    conn.origin.violations += 1;
+                    conn.close();
+                    return false;
+                }
+                if (!conn.forwardedSpentAHop(&request)) {
                     conn.origin.violations += 1;
                     conn.close();
                     return false;

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -73,6 +73,19 @@ pub const Script = enum(u8) {
     /// `/sim` would; the origin's canonical oracle catches a raw-path
     /// forward, and a router matching raw bytes would route it elsewhere.
     confusion,
+    /// A `TRACE` with a hop budget (#240). §7 answers it `501` and never
+    /// forwards it, whatever the budget says — the refusal precedes
+    /// routing, so the origin must never see one.
+    trace_method,
+    /// An `OPTIONS` whose `Max-Forwards` is already zero (#240). RFC 9110
+    /// §7.6.2 makes this proxy the final recipient: it answers `200` with
+    /// an `Allow` describing itself, and no origin is dialed.
+    options_final,
+    /// An `OPTIONS` with a budget left to spend (#240). It routes and
+    /// forwards like any other request, except that the header the origin
+    /// reads is this hop's decrement rather than the client's value — the
+    /// origin's own oracle is what checks that.
+    options_hop,
     /// A GET whose request line is absolute-form (#233), beside a `Host`
     /// naming somewhere else. RFC 9112 §3.2.2 has the authority win, so
     /// this must route, forward and log exactly as `get` does — the
@@ -164,6 +177,13 @@ pub const Spec = struct {
     /// the pipelined shape: the proxy serves the first request and
     /// refuses to look at the second.
     golden_first_announces_close: bool = false,
+    /// This script's 200 is this proxy's own answer rather than an
+    /// origin's, and carries no body at all (#240): the final-recipient
+    /// `OPTIONS`. Like a #159 page it crosses neither response-side
+    /// render, but unlike one it has no configured body to demand — so
+    /// the two flags are separate, and a script claiming both would be
+    /// claiming a bodiless response with a body.
+    answered_here: bool = false,
     /// This script's 200 is answered from a configured page (#159) rather
     /// than proxied, so it crosses neither response-side render — no #175
     /// stamp, no #178 cookie — and its body is the page's, byte for byte.
@@ -506,6 +526,42 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .allowed_statuses = statuses_routed,
         .routed_canonical = true,
     },
+    .trace_method = .{
+        // The 501 verdict precedes routing, like CONNECT's. The method
+        // context maps to GET: the refusal carries no body either way.
+        .request = "TRACE /sim HTTP/1.1\r\nHost: sim\r\nMax-Forwards: " ++
+            canon.max_forwards_sent ++ "\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 501,
+        .method = .get,
+        // Only the §5 head ring's 503 precedes the parse the 501 rides on.
+        .allowed_statuses = &.{ 501, 503 },
+    },
+    .options_final = .{
+        // Answered here, so the only rung that can precede it is the head
+        // ring's — nothing past the parse is ever acquired.
+        .request = "OPTIONS * HTTP/1.1\r\nHost: sim\r\nMax-Forwards: 0\r\n" ++
+            trace_line ++ "\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .options,
+        .allowed_statuses = &.{ 200, 503 },
+        // A `200` from this proxy's own memory, not from an origin: it
+        // crosses neither response-side render, and carries no body.
+        .answered_here = true,
+    },
+    .options_hop = .{
+        .request = "OPTIONS /sim HTTP/1.1\r\nHost: sim\r\nMax-Forwards: " ++
+            canon.max_forwards_sent ++ "\r\n" ++ trace_line ++ "\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .options,
+        .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
+    },
     .absolute_form = .{
         // Absolute-form, so what routes is the request line's authority
         // rather than the Host beside it (#233). Indistinguishable from
@@ -694,6 +750,9 @@ pub const terminating_scripts = [_]Script{
     .connect_method,
     .pipelined,
     .confusion,
+    .trace_method,
+    .options_final,
+    .options_hop,
     .absolute_form,
     .filter_reject,
     .filter_redirect,

--- a/src/config.zig
+++ b/src/config.zig
@@ -3561,6 +3561,14 @@ fn validateEditableHeaderName(name: []const u8) ParseError!void {
     if (std.ascii.eqlIgnoreCase(name, render.forwarded_for_name)) {
         return error.FilterHeaderNameReserved;
     }
+    // Reserved for the same reason and a stricter one (#240): the value
+    // is not merely computed but *required* to be — RFC 9110 §7.6.2 has
+    // each hop forward its own decrement, so a rule writing a constant
+    // here would restate a number this proxy recomputes per request and
+    // hand the next hop a budget that never counts down.
+    if (std.ascii.eqlIgnoreCase(name, render.max_forwards_name)) {
+        return error.FilterHeaderNameReserved;
+    }
 }
 
 /// A header value must be an RFC 9110 field-value: VCHAR / SP / HTAB /
@@ -4712,6 +4720,11 @@ test "config: filter schema rejects malformed rules" {
     try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"Host\",\"value\":\"evil\"}}]}]}]," ++ tail);
     try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_remove\":\"content-length\"}]}]}]," ++ tail);
     try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_add\":{\"name\":\"Connection\",\"value\":\"close\"}}]}]}]," ++ tail);
+    // The two headers this proxy writes on the client's behalf: a
+    // constant here would restate a value it computes per request (§7,
+    // #240).
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"X-Forwarded-For\",\"value\":\"1.2.3.4\"}}]}]}]," ++ tail);
+    try expectParseError(error.FilterHeaderNameReserved, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"max-forwards\",\"value\":\"9\"}}]}]}]," ++ tail);
     // A matched header predicate may still name a managed header (read-only).
     try expectParseError(error.FilterHeaderMatchKind, head ++ "{\"match\":{\"headers\":[{\"name\":\"Host\"}]},\"actions\":[{\"reject\":403}]}]}]," ++ tail);
 }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -100,6 +100,16 @@ pub const Counters = struct {
     /// concurrent this proxy's own answers are, and the §9 census is what
     /// keeps the branch reachable rather than dead.
     l7_static_date_stale: Value = Value.init(0),
+    /// An `OPTIONS` this proxy answered as the final recipient, because
+    /// its `Max-Forwards` had reached zero (RFC 9110 §7.6.2, #240).
+    ///
+    /// An answer, not a refusal: the client asked to be told about this
+    /// hop rather than the origin, and was. It is counted apart from
+    /// `l7_responded` — which is a configured body, the operator's
+    /// content — because this one is the proxy describing *itself*, and
+    /// the two say different things about a deployment. A rate of these
+    /// at all is worth noticing: almost nothing sends the field.
+    l7_max_forwards_exhausted: Value = Value.init(0),
     /// A request whose target arrived in absolute-form (RFC 9112 §3.2.2,
     /// #233), counted where the parser's split is read. Neither a reject
     /// nor an outcome: the request goes on to be routed, filtered or

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -78,12 +78,22 @@ pub const HeaderName = enum(u8) {
     /// copies in O(1) like every other managed header, rather than
     /// comparing this spelling against every header of every request.
     x_forwarded_for,
+    /// RFC 9110 §7.6.2's hop budget, which an intermediary must check
+    /// and *rewrite* rather than forward (#240). Tagged for the same
+    /// reason `x_forwarded_for` is: the render suppresses the inbound
+    /// copy and writes the decremented one itself, so the two spellings
+    /// can never both reach the origin.
+    max_forwards,
 
     /// Connection-specific headers (RFC 9110 §7.6.1): never forwarded.
     pub fn hopByHop(tag: HeaderName) bool {
         return switch (tag) {
             .connection, .keep_alive, .proxy_connection, .te, .upgrade => true,
-            .other, .host, .content_length, .transfer_encoding, .x_forwarded_for => false,
+            // `max_forwards` is deliberately not here. It is end-to-end —
+            // it travels the whole chain — and what each hop owes it is a
+            // *decrement*, not removal (#240); stripping it would tell the
+            // next hop the budget was never set.
+            .other, .host, .content_length, .transfer_encoding, .x_forwarded_for, .max_forwards => false,
         };
     }
 
@@ -93,7 +103,14 @@ pub const HeaderName = enum(u8) {
     pub fn protected(tag: HeaderName) bool {
         return switch (tag) {
             .host, .content_length, .transfer_encoding => true,
-            .other, .connection, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for => false,
+            // Not protected: a client nominating its own `Max-Forwards`
+            // away through `Connection` is asking for the budget to be
+            // dropped, which loses it nothing this proxy owes it — an
+            // absent budget is one no hop has to check. It desynchronizes
+            // no framing and unroutes nothing, which is what this list is
+            // for. What a filter must not do to it is a different rule,
+            // enforced where filters are compiled.
+            .other, .connection, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for, .max_forwards => false,
         };
     }
 
@@ -111,6 +128,7 @@ pub const HeaderName = enum(u8) {
             .te => "te",
             .upgrade => "upgrade",
             .x_forwarded_for => "x-forwarded-for",
+            .max_forwards => "max-forwards",
         };
     }
 };
@@ -126,6 +144,7 @@ pub fn classifyHeaderName(name: []const u8) HeaderName {
         2 => if (eql(name, "te")) .te else .other,
         4 => if (eql(name, "host")) .host else .other,
         7 => if (eql(name, "upgrade")) .upgrade else .other,
+        12 => if (eql(name, "max-forwards")) .max_forwards else .other,
         10 => length_10: {
             if (eql(name, "connection")) break :length_10 .connection;
             if (eql(name, "keep-alive")) break :length_10 .keep_alive;
@@ -806,7 +825,7 @@ fn analyzeHeaders(
                 if (analysis.content_length != null) {
                     return error.Malformed;
                 }
-                analysis.content_length = try parseContentLength(raw_header.value);
+                analysis.content_length = try parseDecimal(raw_header.value);
             },
             .transfer_encoding => {
                 // A second Transfer-Encoding header is the list form in
@@ -825,10 +844,15 @@ fn analyzeHeaders(
                 // Multiple Connection headers combine as one list (RFC 9110).
                 scanConnectionTokens(raw_header.value, &analysis);
             },
-            // `x_forwarded_for` joins the no-analysis set: the tag exists
-            // so the *render* can find it cheaply (§7), and nothing about
-            // framing, routing or persistence reads it here.
-            .other, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for => {},
+            // `x_forwarded_for` and `max_forwards` join the no-analysis
+            // set: their tags exist so the *render* can find them cheaply
+            // (§7), and nothing about framing, routing or persistence
+            // reads either here. `Max-Forwards` in particular is read
+            // only for the two methods RFC 9110 §7.6.2 names, by
+            // `maxForwards` below — parsing it for every request would
+            // let a garbage value on a POST reject a request the spec
+            // says may ignore the field entirely (#240).
+            .other, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for, .max_forwards => {},
         }
     }
     assert(!(analysis.te_chunked and analysis.te_other));
@@ -1281,10 +1305,55 @@ fn authorityIsWellFormed(authority: []const u8) bool {
     return true;
 }
 
-/// 1*DIGIT (RFC 9112 §6.2): digits only — no sign, no whitespace, no
-/// comma list. 19 digits bound the value below 10^19 < 2^64, so the
-/// accumulation cannot overflow.
-fn parseContentLength(value: []const u8) error{Malformed}!u64 {
+/// What a request's `Max-Forwards` says, for the two methods RFC 9110
+/// §7.6.2 binds an intermediary on (#240).
+///
+/// `absent` is the common case and the one every other method takes: the
+/// field MAY be ignored elsewhere, so it is read here rather than during
+/// header analysis — a garbage value on a POST must not reject a request
+/// the spec never asked this proxy to look at.
+///
+/// `malformed` is a value that is not 1*DIGIT, or a second header of the
+/// same name. The RFC does not say what to do with either, and this
+/// proxy answers the way it answers every other unparseable field it
+/// *does* read: a `400`, rather than a guess about which of two budgets
+/// the client meant.
+pub const MaxForwards = union(enum) {
+    absent,
+    malformed,
+    hops: u64,
+};
+
+pub fn maxForwards(headers: []const Header) MaxForwards {
+    assert(headers.len <= constants.headers_max);
+    var found: ?u64 = null;
+    for (headers) |header| {
+        if (header.tag != .max_forwards) {
+            continue;
+        }
+        if (found != null) {
+            return .malformed; // Two budgets are no budget.
+        }
+        found = parseDecimal(header.value) catch return .malformed;
+    }
+    const hops = found orelse return .absent;
+    // The grammar's whole range, restated where the value leaves the
+    // parser: `parseDecimal` admits at most nineteen digits, and the
+    // decrement downstream renders back into a slot sized for exactly
+    // that. A budget wider than the grammar would overrun it.
+    assert(hops < 10_000_000_000_000_000_000);
+    return .{ .hops = hops };
+}
+
+/// 1*DIGIT: digits only — no sign, no whitespace, no comma list. 19
+/// digits bound the value below 10^19 < 2^64, so the accumulation cannot
+/// overflow.
+///
+/// One parser for the two fields that share the grammar: `Content-Length`
+/// (RFC 9112 §6.2) and `Max-Forwards` (RFC 9110 §7.6.2). They are read at
+/// different times and mean different things, but a second copy of this
+/// would be a second chance to disagree about what a digit is.
+fn parseDecimal(value: []const u8) error{Malformed}!u64 {
     if (value.len == 0) {
         return error.Malformed;
     }
@@ -1321,15 +1390,52 @@ fn oversizeRequestError(head: []const u8) HeadError {
 /// the canonical uppercase spelling matches — filters name registered
 /// methods this way; an extension method (`.extension`) is not selectable
 /// by token here (§7).
+const method_table = .{
+    .{ "GET", Method.get },         .{ "POST", Method.post },
+    .{ "HEAD", Method.head },       .{ "PUT", Method.put },
+    .{ "DELETE", Method.delete },   .{ "CONNECT", Method.connect },
+    .{ "OPTIONS", Method.options }, .{ "TRACE", Method.trace },
+    .{ "PATCH", Method.patch },
+};
+
+/// The methods this proxy will carry, as an `Allow` field value (RFC 9110
+/// §10.2.1) — every registered method except the two §7 answers itself:
+/// CONNECT, a §1 non-goal, and TRACE, refused as the Cross-Site Tracing
+/// vector (#240). Built from the same table `methodFromToken` reads, so a
+/// method added there is advertised here without a second list to keep in
+/// step.
+///
+/// It describes *this hop*, which is the only thing a final-recipient
+/// answer is entitled to describe. An extension method still forwards —
+/// §7 carries whatever token it was given — so this is what the proxy
+/// supports by name, not the whole of what it will pass along.
+pub const allow_value = blk: {
+    var value: []const u8 = "";
+    for (method_table) |entry| {
+        if (entry[1] == .connect or entry[1] == .trace) {
+            continue;
+        }
+        value = if (value.len == 0) entry[0] else value ++ ", " ++ entry[0];
+    }
+    const frozen = value;
+    break :blk frozen;
+};
+
+comptime {
+    // The advertised set is the registered set minus the two refusals —
+    // said as a count, so a method added to the table without a decision
+    // about whether this hop offers it fails here rather than silently
+    // appearing in, or vanishing from, what clients are told.
+    var offered: u32 = 0;
+    for (method_table) |entry| {
+        if (entry[1] != .connect and entry[1] != .trace) offered += 1;
+    }
+    assert(offered == method_table.len - 2);
+    assert(allow_value.len >= 1);
+}
+
 pub fn methodFromToken(token: []const u8) ?Method {
-    const table = .{
-        .{ "GET", Method.get },         .{ "POST", Method.post },
-        .{ "HEAD", Method.head },       .{ "PUT", Method.put },
-        .{ "DELETE", Method.delete },   .{ "CONNECT", Method.connect },
-        .{ "OPTIONS", Method.options }, .{ "TRACE", Method.trace },
-        .{ "PATCH", Method.patch },
-    };
-    inline for (table) |entry| {
+    inline for (method_table) |entry| {
         if (std.mem.eql(u8, token, entry[0])) {
             return entry[1];
         }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -626,6 +626,53 @@ pub fn Proxy(comptime IoType: type) type {
             unreachable;
         }
 
+        /// The widest a decremented `Max-Forwards` can render to: the
+        /// field is 1*DIGIT and `parseDecimal` refuses past nineteen, so
+        /// nineteen digits is the whole range a decrement can land in.
+        const max_forwards_digits_max: u32 = 19;
+
+        /// The `Max-Forwards` this hop forwards, or null to leave the
+        /// header exactly as it arrived (#240) — which is every request
+        /// but an `OPTIONS` that carried a budget.
+        ///
+        /// RFC 9110 §7.6.2 has each intermediary in an OPTIONS or TRACE
+        /// chain send the received value decremented by one. TRACE never
+        /// reaches here (§7 answers it 501), and a zero budget never
+        /// reaches here either — `routeRequest` answered it as the final
+        /// recipient before anything was acquired — so what is left is
+        /// arithmetic on a value already checked.
+        ///
+        /// Re-read from the head rather than carried on the connection,
+        /// deliberately: a replayed try (§7) rebuilds its render from the
+        /// same head, and per-exchange state that has to survive that
+        /// rebuild is exactly what #232 got wrong. The head is identical,
+        /// so the two reads cannot disagree.
+        fn planMaxForwards(request: *const parser.RequestHead, scratch: []u8) ?[]const u8 {
+            assert(scratch.len >= max_forwards_digits_max);
+            if (request.method != .options) {
+                return null;
+            }
+            switch (parser.maxForwards(request.headers)) {
+                .absent => return null,
+                // Both were settled before the dial: a malformed budget is
+                // a 400 and a zero one is answered here, so neither can
+                // reach a render.
+                .malformed => unreachable,
+                .hops => |hops| {
+                    assert(hops >= 1);
+                    // Nineteen digits is the whole range `parseDecimal`
+                    // admits, and the scratch is that wide: the format
+                    // cannot overrun it, which is why the error is
+                    // unreachable rather than absorbed into a null that
+                    // would silently forward the budget unchanged.
+                    const text = std.fmt.bufPrint(scratch, "{d}", .{hops - 1}) catch unreachable;
+                    assert(text.len >= 1);
+                    assert(text.len <= max_forwards_digits_max);
+                    return text;
+                },
+            }
+        }
+
         /// The forwarded target and header edits after applying the
         /// listener's §7 filters to `request` — `base` unchanged and no
         /// edits when the listener has no filters (the common path pays
@@ -787,8 +834,40 @@ pub fn Proxy(comptime IoType: type) type {
                 server.counters.increment("l7_absolute_form");
             }
             armRequestDeadline(server, conn);
-            if (request.method == .connect) {
+            // The two methods this proxy answers rather than forwards
+            // (§7). CONNECT is a §1 non-goal; TRACE is refused because
+            // reflecting a request back is the Cross-Site Tracing vector
+            // and because a gateway has nothing truthful to reflect —
+            // by the time the message would come back it has had its
+            // request line rewritten, its hop-by-hop headers stripped
+            // and an `X-Forwarded-For` added, so the echo is not the
+            // request the client sent (#240). Refusing it also makes
+            // this proxy the final recipient of every TRACE chain
+            // unconditionally, which is half of RFC 9110 §7.6.2.
+            if (request.method == .connect or request.method == .trace) {
                 return respond(server, conn, 501, "l7_not_implemented");
+            }
+            // RFC 9110 §7.6.2's hop budget, checked before anything is
+            // acquired because a budget that ran out means no origin is
+            // involved at all (#240). Only OPTIONS reaches this: TRACE is
+            // refused above, and for every other method the field MAY be
+            // ignored — so it is not even parsed, and a garbage value on
+            // a POST cannot reject a request the spec never asked this
+            // proxy to look at.
+            if (request.method == .options) {
+                switch (parser.maxForwards(request.headers)) {
+                    .absent => {},
+                    // Unparseable, or two of them. The RFC says nothing
+                    // about either; this proxy answers the way it answers
+                    // every other field it reads and cannot parse, rather
+                    // than guessing which budget was meant.
+                    .malformed => return respond(server, conn, 400, "l7_bad_request"),
+                    .hops => |hops| {
+                        if (hops == 0) {
+                            return respondMaxForwardsExhausted(server, conn);
+                        }
+                    },
+                }
             }
             if (parser.headerValue(request.headers, "upgrade")) |token| {
                 if (!admitUpgrade(server, conn, token)) return;
@@ -1371,6 +1450,8 @@ pub fn Proxy(comptime IoType: type) type {
             };
             var forwarded_scratch: [constants.forwarded_value_bytes_max]u8 = undefined;
             const forwarded = planForwarded(server, conn, request, &forwarded_scratch);
+            var hops_scratch: [max_forwards_digits_max]u8 = undefined;
+            const hops = planMaxForwards(request, &hops_scratch);
             // No close announcement upstream (the `false` below): the
             // connection is a parking candidate (§5), and stripping the
             // client's Connection header already made persistence the wire
@@ -1381,6 +1462,7 @@ pub fn Proxy(comptime IoType: type) type {
                 plan.edits,
                 false,
                 forwarded,
+                hops,
                 // The participating `Upgrade` travels only when this
                 // listener agreed to carry it (#180); the gate already
                 // refused every other spelling.
@@ -3464,22 +3546,53 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.armed.data_client_to_upstream);
             assert(!conn.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
+            // The head-shed rung can never keep, structurally: nothing was
+            // read (the ring was empty, so no buffer was ever bound), the
+            // request's bytes wait unread in the socket, and a kept
+            // connection would re-arm onto those same bytes and shed them
+            // forever. Comptime, so the resync rule — whose asserts require
+            // at least one byte read — is never consulted on that rung.
+            const may_keep = comptime !std.mem.eql(u8, counter, "l7_shed_head_buffers");
+            const keep = commitStaticVerdict(server, conn, status, counter, may_keep);
+            conn.state = .l7_responding;
+            armStaticAnswer(server, conn, status, keep);
+        }
+
+        /// Everything a static verdict does before its bytes are chosen:
+        /// release what the request held, retire the §8 request deadline
+        /// so it cannot expire the connection out from under the write
+        /// that delivers the answer, count it, record what the access log
+        /// will say, and decide persistence. Returns whether the
+        /// connection survives the answer.
+        ///
+        /// Shared by `respond` and the #240 `OPTIONS` answer, which are
+        /// opposite verdicts — a refusal and a request served on its own
+        /// terms — reached through the same machinery. The alternative
+        /// was a second copy of the deadline handling and the four
+        /// brakes, which is precisely the parity #237's review found had
+        /// already been lost once.
+        fn commitStaticVerdict(
+            server: *ServerType,
+            conn: *ConnType,
+            status: u16,
+            comptime counter: []const u8,
+            may_keep: bool,
+        ) bool {
+            assert(!conn.l7.response_started);
             releaseForStaticResponse(server, conn);
-            // A rung committed to an answer: retire the §8 request deadline
-            // so it cannot expire the connection out from under the write
-            // that delivers it (`clearRequestDeadline` owns the rule).
-            // Retiring the *cap* is only half of it — `conn.deadline_ns` is
-            // still standing wherever the cap clamped it, and the armed
-            // timer is still aimed there, so widen it back to the idle
-            // budget that owns a slow-reading client. No arm: whatever
-            // timer is already out re-arms itself for the remainder once it
-            // sees the later target (§4's lazy tick-and-compare).
+            // Retiring the *cap* is only half of it — `conn.deadline_ns`
+            // is still standing wherever the cap clamped it, and the
+            // armed timer is still aimed there, so widen it back to the
+            // idle budget that owns a slow-reading client. No arm:
+            // whatever timer is already out re-arms itself for the
+            // remainder once it sees the later target (§4's lazy
+            // tick-and-compare).
             ServerType.clearRequestDeadline(conn);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment(counter);
             // What the line will say, recorded here where the verdict is
-            // made; it is written once the response is on the wire, so the
-            // byte count includes the answer itself (§8).
+            // made; it is written once the response is on the wire, so
+            // the byte count includes the answer itself (§8).
             conn.log.status = status;
             conn.log.outcome = comptime outcomeOfCounter(counter);
             // §8's "then keep or close per pressure". Closing is not free:
@@ -3490,24 +3603,42 @@ pub fn Proxy(comptime IoType: type) type {
             // reconnect loop. Keeping is one send.
             //
             // The same four brakes the render-time persistence decision
-            // honors apply here (§7, §8): the client's own ask, the drain,
-            // relay pressure — a proxy shedding buffers should not also be
+            // honors (§7, §8): the client's own ask, the drain, relay
+            // pressure — a proxy shedding buffers should not also be
             // holding connections open for their next request — and the
             // #237 request cap, which binds a connection answered
             // statically exactly as firmly as one being proxied.
-            // The head-shed rung can never keep, structurally: nothing was
-            // read (the ring was empty, so no buffer was ever bound), the
-            // request's bytes wait unread in the socket, and a kept
-            // connection would re-arm onto those same bytes and shed them
-            // forever. Comptime, so the resync rule — whose asserts require
-            // at least one byte read — is never consulted on that rung.
-            const may_keep = comptime !std.mem.eql(u8, counter, "l7_shed_head_buffers");
-            const keep = applyRequestCap(server, conn, may_keep and staticResponseResyncable(conn)) and
+            return applyRequestCap(server, conn, may_keep and staticResponseResyncable(conn)) and
                 conn.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();
+        }
+
+        /// Answer an `OPTIONS` whose `Max-Forwards` reached zero: this
+        /// proxy is the final recipient, and says so about itself (RFC
+        /// 9110 §7.6.2, #240). Reached before anything is acquired, so
+        /// like the #176 redirect it sits clear of every rung past the
+        /// head ring — the origin is deliberately never dialed, which is
+        /// the whole meaning of a budget that ran out here.
+        fn respondMaxForwardsExhausted(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            assert(!conn.armed.data_client_to_upstream);
+            assert(!conn.armed.data_upstream_to_client);
+            assert(conn.relay_buffer == null);
+            assert(conn.upstream == null);
+            const keep = commitStaticVerdict(server, conn, 200, "l7_max_forwards_exhausted", true);
+            const persistence: shed.Persistence = if (keep) .keep else .close;
+            const answer = server.static_responses.getOptions(persistence);
+            server.stampStaticDate(answer.date);
+            server.claimStaticSend(conn);
             conn.state = .l7_responding;
-            armStaticAnswer(server, conn, status, keep);
+            // The answer is bodiless, so a HEAD would take the same bytes
+            // — and a HEAD never reaches here anyway: this is the OPTIONS
+            // path alone.
+            assert(conn.l7.request_method == .options);
+            const then: conn_module.ClientWrite.Then =
+                if (keep) .next_request else .lingering_close;
+            armClientWrite(server, conn, answer.bytes, then);
         }
 
         /// Send one static answer: the #159 configured page for this
@@ -3798,6 +3929,11 @@ pub fn Proxy(comptime IoType: type) type {
             // filter's (#236), not a shed: nothing of this proxy's ran
             // out, and the operator wrote the rule that refused it.
             if (std.mem.eql(u8, counter, "l7_body_over_limit")) return .rejected;
+            // The #240 final-recipient answer is this proxy responding as
+            // the origin, which is exactly what `.responded` means — the
+            // counter keeps it apart from a configured body, the log does
+            // not need to.
+            if (std.mem.eql(u8, counter, "l7_max_forwards_exhausted")) return .responded;
             if (std.mem.eql(u8, counter, "l7_shed_relay_buffers")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_upstream_slots")) return .shed;
             if (std.mem.eql(u8, counter, "l7_shed_head_buffers")) return .shed;

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -48,6 +48,13 @@ pub const protected_names = [_][]const u8{
 /// opposite of forwarding one.
 pub const forwarded_for_name = "X-Forwarded-For";
 
+/// The second header this proxy writes on the client's behalf, and for a
+/// stricter reason (#240): RFC 9110 §7.6.2 requires each intermediary to
+/// replace the received value with its own decrement. Public for the same
+/// filter-edit guard — a rule writing a constant here would restate a
+/// number this proxy computes per hop.
+pub const max_forwards_name = "Max-Forwards";
+
 /// True when `list` names `name` exactly. Comptime-only, for the check
 /// below; the runtime path compares tags, not strings.
 fn nameListHas(list: []const []const u8, name: []const u8) bool {
@@ -105,6 +112,15 @@ pub fn renderRequestHead(
     /// deliberate: the trust rule is a security decision with a counter
     /// attached, and a byte-assembler should have access to neither.
     forwarded_for: ?[]const u8,
+    /// The decremented `Max-Forwards` to emit, or null to leave whatever
+    /// arrived exactly as it arrived (#240) — which is every request but
+    /// an `OPTIONS` that carried a budget.
+    ///
+    /// Assembled by the caller, like `forwarded_for` and for the same
+    /// reason: the check that a zero budget stops here is a §7 decision
+    /// with a verdict attached, and by the time it reaches this file the
+    /// only question left is where the bytes go.
+    max_forwards: ?[]const u8,
     /// True when this request is a protocol upgrade this listener has
     /// agreed to carry (#180): the participating `Upgrade` travels and
     /// the proxy writes its own `Connection: upgrade`.
@@ -145,13 +161,24 @@ pub fn renderRequestHead(
         request.headers,
         request.connection_nominates_header,
         edits,
-        forwarded_for != null,
-        request.authority != null,
+        .{
+            .forwarded_for = forwarded_for != null,
+            .host = request.authority != null,
+            .max_forwards = max_forwards != null,
+        },
         keep_upgrade,
     );
     if (forwarded_for) |value| {
         assert(value.len >= 1);
         try staging.appendHeaderLine(forwarded_for_name, value);
+    }
+    // The hop budget RFC 9110 §7.6.2 has each intermediary decrement
+    // (#240). Written here for the same reason the forwarded line is:
+    // the caller did the arithmetic and the check that goes with it, and
+    // this file is a byte-assembler with no business deciding either.
+    if (max_forwards) |value| {
+        assert(value.len >= 1);
+        try staging.appendHeaderLine(max_forwards_name, value);
     }
     // A carried upgrade announces the opposite of a close: this hop is
     // continuing, in a different protocol. The two are mutually exclusive
@@ -212,10 +239,9 @@ pub fn renderResponseHead(
         response.headers,
         response.connection_nominates_header,
         edits,
-        false,
-        // Both suppressions are request-side: a response carries neither
-        // an X-Forwarded-For this proxy wrote nor a Host at all.
-        false,
+        // Every suppression is request-side: a response carries no
+        // header this proxy writes on the client's behalf.
+        .{},
         keep_upgrade,
     );
     // A carried upgrade announces the opposite of a close: this hop is
@@ -350,24 +376,46 @@ const Staging = struct {
 /// suppresses the source copies of its name; each `set`/`add` edit then
 /// appends its own line after the surviving source headers. Bounded by
 /// `headers_max` and `header_edits_max`.
+/// Which proxy-written headers are replacing their inbound copies on
+/// this hop (§7). Each is `true` only where the caller has already
+/// written, or is about to write, its own line — so the header reaches
+/// the next hop exactly once and says what *this* hop decided.
+const Suppress = struct {
+    /// The §7 forwarded-address line: under `replace` because the inbound
+    /// chain is untrusted, under `append` because the caller already
+    /// folded it into the line it will write.
+    forwarded_for: bool = false,
+    /// The `Host` an absolute-form authority overruled (#233). RFC 9112
+    /// §3.2.2 has the received Host ignored in favour of the target's
+    /// authority, and a request carrying both would hand the origin the
+    /// very disagreement that rule exists to settle.
+    host: bool = false,
+    /// The `Max-Forwards` budget this hop decrements (#240). RFC 9110
+    /// §7.6.2 requires the *updated* value travel, so the received one
+    /// must not travel beside it.
+    max_forwards: bool = false,
+
+    fn claims(suppress: Suppress, tag: parser.HeaderName) bool {
+        return switch (tag) {
+            .x_forwarded_for => suppress.forwarded_for,
+            .host => suppress.host,
+            .max_forwards => suppress.max_forwards,
+            else => false,
+        };
+    }
+};
+
 fn appendEndToEndHeaders(
     staging: *Staging,
     headers: []const parser.Header,
     connection_nominates_header: bool,
     edits: []const filter.AppliedHeaderEdit,
-    /// True when the caller writes its own `X-Forwarded-For` line, so
-    /// inbound copies must not be forwarded beside it — under `replace`
-    /// because the inbound chain is untrusted, and under `append`
-    /// because the caller already folded it into the line it will write.
-    /// Either way the header must appear exactly once downstream.
-    suppress_forwarded_for: bool,
-    /// True when the request render has already written its own `Host`
-    /// line from an absolute-form authority (#233), so the client's
-    /// inbound copy must not be forwarded beside it. RFC 9112 §3.2.2 has
-    /// the received Host ignored in favour of the target's authority, and
-    /// a forwarded request carrying both would hand the origin the very
-    /// disagreement that rule exists to settle.
-    suppress_host: bool,
+    /// The headers this proxy writes itself on this hop, whose inbound
+    /// copies must therefore not travel beside them (§7). One struct
+    /// rather than a row of bools: they are the same rule three times,
+    /// and three adjacent booleans at a call site is an argument swap
+    /// waiting to happen.
+    suppress: Suppress,
     /// True when this hop is *participating* in a protocol upgrade
     /// (#180), which is the one case where `Upgrade` must travel.
     ///
@@ -418,10 +466,7 @@ fn appendEndToEndHeaders(
             const participating = keep_upgrade and header.tag == .upgrade;
             if (!participating) continue;
         }
-        if (suppress_forwarded_for and header.tag == .x_forwarded_for) {
-            continue;
-        }
-        if (suppress_host and header.tag == .host) {
+        if (suppress.claims(header.tag)) {
             continue;
         }
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {
@@ -547,13 +592,13 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, null, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, false, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, null, false, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
@@ -574,6 +619,7 @@ test "render: an absolute-form authority replaces the client's Host" {
         .{ .path = "/v2/x", .query = "" },
         &.{},
         false,
+        null,
         null,
         false,
         &buffer,
@@ -603,7 +649,7 @@ test "render: filter edits set, add, and remove headers" {
         .{ .kind = .remove, .name = "cookie", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &buffer);
     // Surviving source headers first (Host, kept X-Trace, X-Keep), then the
     // injected set/add lines; the source X-Env and Cookie are gone.
     try testing.expectEqualStrings(
@@ -633,7 +679,7 @@ test "render: an edit that overflows the buffer is Oversize" {
     var tight: [34]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, false, &tight),
+        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &tight),
     );
 }
 
@@ -666,7 +712,7 @@ test "render: the edited oracle skips a head that grows past head_buffer_bytes_d
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var render_buf: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, false, &render_buf);
+    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, null, false, &render_buf);
     try testing.expect(rendered.len > constants.head_buffer_bytes_default);
     // Must return cleanly instead of panicking in the reparse precondition.
     checkRequestRenderEdited(&source);
@@ -680,7 +726,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -698,7 +744,7 @@ test "render: a nomination on a second Connection line still strips" {
     const request = try parser.parseRequestHead(head, false, &storage);
     try testing.expect(request.connection_nominates_header);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
     // Both Connection lines are hop-by-hop; X-Nominated goes because the
     // second line named it; X-Keep is untouched.
     try testing.expectEqualStrings(
@@ -718,7 +764,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -733,7 +779,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -744,7 +790,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -821,7 +867,7 @@ test "render: a head that no longer fits is Oversize" {
     const request = try parser.parseRequestHead(head, false, &storage);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, false, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, null, false, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -861,7 +907,7 @@ fn checkRequestRender(input: []const u8) void {
     const target = oracleTarget(&request, &scratch) orelse return;
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &.{}, false, null, false, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, &.{}, false, null, null, false, &buffer) catch unreachable;
 
     // The oracle buffer carries slack past `head_buffer_bytes_default` so normalization
     // growth never truncates the comparison; production renders into an
@@ -921,7 +967,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &edits, false, null, false, &buffer) catch return;
+    const rendered = renderRequestHead(&request, target, &edits, false, null, null, false, &buffer) catch return;
 
     // The appended edits can push an already-large head past `head_buffer_bytes_default`
     // — the oversize-after-edits verdict (431 in production, which renders
@@ -1041,6 +1087,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
         &.{},
         false,
         forwarded_for,
+        null,
         false,
         &buffer,
     ) catch return;

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -1080,7 +1080,7 @@ test "l7: an unsupported absolute-form scheme is 400" {
 
 // Both heads parse cleanly and carry no body, so the 501 keeps the
 // connection (§8) — the method is refused, not the framing.
-test "l7: CONNECT and Upgrade are answered 501" {
+test "l7: CONNECT, TRACE and Upgrade are answered 501" {
     {
         var bed: Http1Bed = undefined;
         try bed.setUp(std.testing.allocator, .{ .seed = 4 });
@@ -1094,6 +1094,28 @@ test "l7: CONNECT and Upgrade are answered 501" {
         try bed.expectDrained();
     }
     {
+        // TRACE reflects the request back, which is the Cross-Site
+        // Tracing vector and, through a gateway, an echo of a message
+        // the client never sent (#240). Refused here rather than
+        // forwarded, whatever `Max-Forwards` says — the header is read
+        // only where the request would otherwise travel.
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 45,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+        try bed.exchange("TRACE /echo HTTP/1.1\r\nHost: o\r\nMax-Forwards: 5\r\n\r\n");
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+        // The refusal precedes routing, so no origin was ever dialed.
+        try std.testing.expectEqual(@as(u32, 0), bed.origin.accepted_count);
+        try bed.expectDrained();
+    }
+    {
         var bed: Http1Bed = undefined;
         try bed.setUp(std.testing.allocator, .{ .seed = 5 });
         defer bed.tearDown();
@@ -1103,6 +1125,123 @@ test "l7: CONNECT and Upgrade are answered 501" {
             bed.client.response(),
         );
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_not_implemented"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: a zero Max-Forwards stops at this proxy and describes it (#240)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 46,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // RFC 9110 §7.6.2: at zero the intermediary MUST NOT forward, and
+    // MUST respond as the final recipient. What it has to say about
+    // itself is `Allow`, which names this hop rather than the origin's
+    // resource — the origin was deliberately never asked.
+    try bed.exchange("OPTIONS * HTTP/1.1\r\nHost: o\r\nMax-Forwards: 0\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
+            "Allow: " ++ parser.allow_value ++ "\r\n" ++ expected_date ++
+            "Connection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_max_forwards_exhausted"),
+    );
+    try std.testing.expectEqual(@as(u32, 0), bed.origin.accepted_count);
+    // Neither refused nor forwarded: CONNECT and TRACE are the 501s, and
+    // this is the opposite verdict reached through the same machinery.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_not_implemented"));
+    try bed.expectDrained();
+}
+
+test "l7: a non-zero Max-Forwards travels decremented (#240)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 47,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("OPTIONS /x HTTP/1.1\r\nHost: o\r\nMax-Forwards: 5\r\n\r\n");
+
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try forwardedRequest(&bed, &storage);
+    // Exactly one budget reaches the origin, and it counts down: the
+    // inbound copy is suppressed by tag and this hop writes its own.
+    var seen: u32 = 0;
+    for (forwarded.headers) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "max-forwards")) {
+            seen += 1;
+            try std.testing.expectEqualStrings("4", header.value);
+        }
+    }
+    try std.testing.expectEqual(@as(u32, 1), seen);
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("l7_max_forwards_exhausted"),
+    );
+    try bed.expectDrained();
+}
+
+test "l7: Max-Forwards is read for OPTIONS alone, and must parse there (#240)" {
+    {
+        // Garbage on a method the field MAY be ignored for is ignored —
+        // and travels untouched, because this hop is not in its chain.
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 48,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /x HTTP/1.1\r\nHost: o\r\nMax-Forwards: not-a-number\r\n\r\n");
+
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try forwardedRequest(&bed, &storage);
+        try std.testing.expectEqualStrings(
+            "not-a-number",
+            parser.headerValue(forwarded.headers, "max-forwards").?,
+        );
+        try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_request"));
+        try bed.expectDrained();
+    }
+    {
+        // The same value on the method that binds this hop is a 400: two
+        // readings of one budget is not something to guess between.
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{ .seed = 49 });
+        defer bed.tearDown();
+
+        try bed.exchange("OPTIONS /x HTTP/1.1\r\nHost: o\r\nMax-Forwards: not-a-number\r\n\r\n");
+
+        // Kept, not closed — the distinction `l7_bad_request` documents:
+        // the head *parsed*, so the message boundary is known and the
+        // connection can serve the next request. Only a head the parser
+        // could not frame closes.
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+        try bed.expectDrained();
+    }
+    {
+        // Two of them, on OPTIONS: same verdict, same reason.
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{ .seed = 50 });
+        defer bed.tearDown();
+
+        try bed.exchange(
+            "OPTIONS /x HTTP/1.1\r\nHost: o\r\nMax-Forwards: 1\r\nMax-Forwards: 9\r\n\r\n",
+        );
+
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
         try bed.expectDrained();
     }
 }

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -6,6 +6,8 @@
 
 const std = @import("std");
 
+const parser = @import("http/parser.zig");
+
 const assert = std.debug.assert;
 
 /// Whether the downstream connection survives a static response. `close`
@@ -79,6 +81,34 @@ fn staticTemplate(comptime status: u16, comptime persistence: Persistence) Templ
     };
 }
 
+/// The `200` this proxy answers an `OPTIONS` with when it becomes the
+/// final recipient — a `Max-Forwards: 0` that stops here (RFC 9110
+/// §7.6.2, #240).
+///
+/// It sits beside the error statuses rather than among them: the closed
+/// set above is refusals, and this is the opposite — a request answered
+/// on its own terms, by the hop the client asked about. `Allow` is the
+/// answer's whole content, since "stop here and describe yourself" is
+/// what a zero budget means, and it names this proxy rather than the
+/// origin's resource because the origin was deliberately never asked.
+fn optionsTemplate(comptime persistence: Persistence) Template {
+    const prefix = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
+        "Allow: " ++ parser.allow_value ++ "\r\nDate: ";
+    const suffix = "\r\n" ++ server_line ++ switch (persistence) {
+        .keep => "",
+        .close => "Connection: close\r\n",
+    } ++ "\r\n";
+    return .{
+        .bytes = prefix ++ date_placeholder ++ suffix,
+        .date_offset = prefix.len,
+    };
+}
+
+const options_templates: [2]Template = .{
+    optionsTemplate(.keep),
+    optionsTemplate(.close),
+};
+
 /// The widest static response any status and persistence can render to,
 /// which is what one table slot must hold. Comptime, so the table is
 /// sized by the responses themselves rather than by a guess that a new
@@ -91,6 +121,13 @@ pub const static_response_bytes_max: u32 = blk: {
             if (template.bytes.len > widest) {
                 widest = @intCast(template.bytes.len);
             }
+        }
+    }
+    // The OPTIONS answer shares the table's slot width, and being the one
+    // response carrying an `Allow` it is the one that sets it.
+    for (options_templates) |template| {
+        if (template.bytes.len > widest) {
+            widest = @intCast(template.bytes.len);
         }
     }
     break :blk widest;
@@ -150,6 +187,11 @@ pub const StaticResponse = struct {
 /// no submitted send is reading them.
 pub const StaticTable = struct {
     storage: [static_statuses.len][2][static_response_bytes_max]u8,
+    /// The #240 `OPTIONS` final-recipient answer, in the same writable
+    /// memory and under the same `Date` rule. A field of its own because
+    /// it is the one static this proxy sends that is not a refusal, so it
+    /// has no place in a table keyed by `static_statuses`.
+    options: [2][static_response_bytes_max]u8,
 
     pub fn init(table: *StaticTable) void {
         for (&table.storage, 0..) |*variants, index| {
@@ -159,6 +201,22 @@ pub const StaticTable = struct {
                 @memcpy(slot[0..template.bytes.len], template.bytes);
             }
         }
+        for (&table.options, 0..) |*slot, persistence| {
+            const template = options_templates[persistence];
+            assert(template.bytes.len <= slot.len);
+            @memcpy(slot[0..template.bytes.len], template.bytes);
+        }
+    }
+
+    /// The #240 answer for one persistence choice.
+    pub fn getOptions(table: *StaticTable, persistence: Persistence) StaticResponse {
+        const template = options_templates[@intFromEnum(persistence)];
+        const slot = &table.options[@intFromEnum(persistence)];
+        assert(template.date_offset + date_bytes <= template.bytes.len);
+        return .{
+            .bytes = slot[0..template.bytes.len],
+            .date = slot[template.date_offset..][0..date_bytes],
+        };
     }
 
     /// Write `date` into every slot at once — what startup does, so no
@@ -168,6 +226,9 @@ pub const StaticTable = struct {
             for ([_]Persistence{ .keep, .close }) |persistence| {
                 @memcpy(table.get(status, persistence).date, date);
             }
+        }
+        for ([_]Persistence{ .keep, .close }) |persistence| {
+            @memcpy(table.getOptions(persistence).date, date);
         }
     }
 
@@ -470,7 +531,6 @@ test "shed: every static response parses as a valid bodiless head" {
     // Round-trip through zoxy's own parser: each response must be a
     // complete, correctly framed head whose persistence matches the
     // requested one — the same verdict a strict client would reach.
-    const parser = @import("http/parser.zig");
     var table: StaticTable = undefined;
     table.init();
     // A real date, so the head under test is the one that ships rather
@@ -489,5 +549,25 @@ test "shed: every static response parses as a valid bodiless head" {
             try std.testing.expectEqual(persistence == .keep, head.keep_alive);
             try std.testing.expectEqual(@as(u32, @intCast(bytes.len)), head.head_len);
         }
+    }
+    // The #240 answer shares the table's memory and the same contract,
+    // so it is held to the same round trip — including the `keep`
+    // variant, which no directed test spells out byte for byte. It
+    // differs in exactly two ways, and both are checked: a `200` rather
+    // than a refusal, and an `Allow` that is the whole of what a
+    // final-recipient answer has to say.
+    inline for ([_]Persistence{ .keep, .close }) |persistence| {
+        formatHttpDate(1_577_836_800, table.getOptions(persistence).date);
+        const bytes = table.getOptions(persistence).bytes;
+        var storage: parser.HeaderStorage = undefined;
+        const head = try parser.parseResponseHead(bytes, false, &storage, .options);
+        try std.testing.expectEqual(@as(u16, 200), head.status);
+        try std.testing.expectEqual(parser.BodyFraming{ .content_length = 0 }, head.framing);
+        try std.testing.expectEqual(persistence == .keep, head.keep_alive);
+        try std.testing.expectEqual(@as(u32, @intCast(bytes.len)), head.head_len);
+        try std.testing.expectEqualStrings(
+            parser.allow_value,
+            parser.headerValue(head.headers, "allow").?,
+        );
     }
 }


### PR DESCRIPTION
Closes #240.

RFC 9110 §7.6.2 is one of the few places the spec names intermediaries directly: a hop in an `OPTIONS` or `TRACE` chain MUST check the budget, MUST answer as the final recipient at zero, and MUST forward its own decrement otherwise. `max-forwards` appeared nowhere in the tree, so a `TRACE` with `Max-Forwards: 0` reached the origin instead of being answered here, and one with `5` reached it still saying 5.

Both references ignore this requirement entirely — nginx and HAProxy alike. That is a reason to weigh it, not to skip it: §12 exists so a MUST is a decision written down, and this one turned out cheap enough that recording a deviation would have cost more argument than the code.

## TRACE is refused

`501`, the answer `CONNECT` already earns and for a related reason. Reflecting a request back is the Cross-Site Tracing vector, and a gateway has nothing truthful to reflect anyway: by the time the echo returned, the request line would have been rewritten, the hop-by-hop headers stripped and an `X-Forwarded-For` added, so what came back would not be the message the client sent. Refusing it makes this proxy the final recipient of every `TRACE` chain unconditionally, which is half the requirement for one predicate.

## OPTIONS spends the budget

| request | result |
|---|---|
| `TRACE /x` + `Max-Forwards: 5` | `501`, never forwarded |
| `OPTIONS *` + `Max-Forwards: 0` | answered here — `200` + `Allow`, no origin dialled |
| `OPTIONS *` + `Max-Forwards: 5` | forwarded as `4` |
| `OPTIONS *`, no header | forwarded untouched |

Zero means "stop here and describe yourself", so the answer describes *this hop* — `Allow` derived at comptime from the same table `methodFromToken` reads, minus the two methods §7 answers itself, so a method added there cannot drift out of what clients are told. The check runs before any resource is acquired, so a budget that ran out costs no origin connection.

The field is read for `OPTIONS` alone. The RFC lets a recipient ignore it elsewhere, and reading it everywhere would let a garbage value on a `POST` reject a request nothing asked this proxy to look at. Where it *is* read, an unparseable or duplicated budget is a `400` — two readings of one number is not something to guess between. CORS preflights are unaffected: they carry no `Max-Forwards` at all.

## The structural wrinkle

Decrementing means rewriting a header's value, which the §7 render could not do — filter edits write constants by design. `Max-Forwards` becomes the **second header this proxy writes on the client's behalf**, on `X-Forwarded-For`'s pattern: a parser tag, suppression of the inbound copy by tag, one computed value appended, and the name barred from filter edits so a rule cannot restate a number that must count down.

That left three suppression booleans adjacent at one call site, which is an argument swap waiting to happen, so they became a named `Suppress` struct.

`respond`'s preamble — the deadline handling, the counter, the log verdict and the four persistence brakes — moves into `commitStaticVerdict`, shared with the new answer. The two are opposite verdicts reached through one mechanism, which is exactly the parity #237's review found had already been lost once by writing the second copy.

## Three rules, three mutations

- Forwarding `TRACE` again → fails at seed 11: the sim origin refuses any forwarded `TRACE`.
- Forwarding an **undecremented** budget → fails at seed 38: the origin refuses any budget that is not exactly one hop shorter than what was sent.
- Forwarding a **zero** budget → fails on `planMaxForwards`'s own assert on the first seed that reaches it, rather than sending a budget that underflowed to `2^64-1`.

## Gates

`zig build ci` green: 4096 seeds, census ok (71 counters fired, 17 exempt), smoke clean, `zig fmt` clean. Review found no Tiger Style violations; its four judgement calls are all addressed — including a `.keep` variant of the new answer that had no strict parser round-trip, now covered beside its siblings.

§12's deviation register is down to one entry, and that one is settled.