### PR TITLE
proxy: a retry may find its deadline mid-rebase, not missing

### DIFF
--- a/sim/main.zig
+++ b/sim/main.zig
@@ -16,6 +16,35 @@ const assert = std.debug.assert;
 const Counters = zoxy.counters.Counters;
 const SimIo = zoxy.Io.SimIo;
 
+/// The seed `checkSeed` is currently running, for the panic handler
+/// below. A plain global because that is what a panic handler can read:
+/// by the time one runs, every frame that knew the seed is gone.
+var running_seed: u64 = 0;
+
+/// Name the seed on the way down (#253).
+///
+/// An oracle failure returns an error and `checkSeed` prints the seed it
+/// belongs to. An *assert* does neither: the process aborts inside
+/// `io.run()`, and what reaches the operator is a stack trace with no
+/// seed in it — which is how a nightly soak came to report a panic it
+/// could not reproduce, and why finding the schedule that caused one
+/// meant bisecting a million-seed shard by hand. §9's whole claim is
+/// that a failure replays from its seed; a failure that cannot name one
+/// is outside it.
+pub const panic = std.debug.FullPanic(panicWithSeed);
+
+fn panicWithSeed(message: []const u8, first_trace_address: ?usize) noreturn {
+    // Printed before the default handler runs, so it survives however the
+    // trace itself is truncated. A zero here is not a seed but an answer:
+    // the panic happened outside any run — during setup, the census, or
+    // the failure report — and no schedule replays it.
+    std.debug.print("sim: PANIC seed={d} — replay with: zig build sim -- {d} 1\n", .{
+        running_seed,
+        running_seed,
+    });
+    std.debug.defaultPanic(message, first_trace_address);
+}
+
 const default_seed: u64 = 1;
 /// What `zig build sim` (and so `ci`) sweeps. Sized by census, not by
 /// feel: at 64 the gate left three scripts — `post_chunked_malformed`,
@@ -715,6 +744,13 @@ fn reportFailures(options: *const Sweep, failed: []const u64, swept_last: u64) v
 /// feeds the census — the replay would double every total, and a census
 /// is a claim about what one pass over the range reached.
 fn checkSeed(arena_state: *std.heap.ArenaAllocator, seed: u64, census: ?*Census) !void {
+    running_seed = seed;
+    // Cleared on the way out, so the seed the handler prints is only ever
+    // one a run was *inside*. A panic does not run this — which is the
+    // point — but the census and the failure report that follow the sweep
+    // do, and a panic in either would otherwise name the last seed swept
+    // as though its schedule were the cause.
+    defer running_seed = 0;
     const first = runSeed(arena_state, seed, census) catch |err| {
         std.debug.print("sim: FAILURE seed={d} error={t}\n", .{ seed, err });
         return err;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1218,12 +1218,36 @@ pub fn Proxy(comptime IoType: type) type {
                 server.rebaseDeadline(conn);
             } else {
                 // Stated rather than assumed: the budget being carried is
-                // only a budget if it is still running. It must be, since
-                // a fired deadline reaches `onUpstreamConnect` as a
-                // pending verdict and answers 504 before any failure could
-                // ask to retry — but a future path that disarmed it would
-                // otherwise leave this dial with no clock at all.
-                assert(conn.armed.deadline);
+                // only a budget if it is still running, and what makes it
+                // running is that *something* will fire on it. Two states
+                // qualify, and both have to be named or a legal one reads
+                // as a bug.
+                //
+                // The timer is armed — the ordinary case. Or it is down
+                // with the first dial's rebase cancel still draining: that
+                // dial tightened the head-read timer to the connect budget
+                // by cancelling it (§4's lazy timer never moves earlier on
+                // its own), and the cancel and the timer's own `Canceled`
+                // both land, whichever is second re-arming at the stored
+                // target. In between, the timer is legitimately down with a
+                // re-arm already on its way — at exactly the target this
+                // carried budget is counting on, because `deadline_ns` is
+                // shared. A `Refused` delivered inside that window is what
+                // brings a retry here, and it is rare enough that a
+                // 4096-seed sweep never produced one; a million-seed soak
+                // did (#253).
+                //
+                // This is not a new relaxation but the spelling the rest
+                // of the file already uses: `resetForNextRequest` and the
+                // keep-alive turnaround both assert this same disjunction,
+                // for this same straggler, and `rebaseDeadline` opens by
+                // deferring to a draining cancel. The retry path was the
+                // one place that asked for the stricter half alone. What
+                // it still refuses is the state that would be a bug:
+                // neither armed nor about to be, which is a dial with no
+                // clock at all, where a hung origin would never reach its
+                // §8 504.
+                assert(conn.armed.deadline or conn.armed.deadline_cancel);
             }
             conn.arm(&conn.op_connect, "connect");
             server.io.connect(

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -3028,6 +3028,74 @@ test "l7: a respond action answers from memory and never dials (#159)" {
     try bed.expectDrained();
 }
 
+test "l7: a retry whose deadline rebase is still draining still has a clock (#253)" {
+    // The window a million-seed soak found and a 4096-seed sweep never
+    // did. A dial re-bases the head-read timer to the tighter connect
+    // budget by *cancelling* it (§4's lazy timer never moves earlier on
+    // its own), and two completions then race: the timer's own
+    // `Canceled`, and the cancel op's. Whichever lands second re-arms at
+    // the stored target. Between them the timer is legitimately down —
+    // and a `Refused` delivered in that gap brings a retry to a
+    // connection whose clock is microseconds from being re-armed.
+    //
+    // `dialUpstream` used to assert the timer was armed outright, which
+    // read that legal state as a bug and aborted the process. Seed 16
+    // under partial delivery lands the three completions in exactly that
+    // order; before the fix this test panics rather than fails.
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 16,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+            .refusing_endpoint_first = true,
+            .retries = 1,
+            .pick = .rr,
+            .partial_io = true,
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+        // The retry ran and reached the origin: the window is survivable,
+        // not merely un-asserted.
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_retried"));
+        try bed.expectDrained();
+    }
+    {
+        // And the clock the retry carried is a *real* one, which is the
+        // half an assert-only fix would leave unproven: relaxing the
+        // assert would look identical here if the timer were simply gone.
+        // The retried dial goes to a blackholed address, so nothing but
+        // the carried budget can end it — the §8 504 arriving is the
+        // re-arm, observed from outside.
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 16,
+            .refusing_endpoint_first = true,
+            .retries = 1,
+            .pick = .rr,
+            .partial_io = true,
+        });
+        defer bed.tearDown();
+        bed.sim_io.blackholeAddress(Http1Bed.originAddress());
+
+        try bed.exchange("GET /r HTTP/1.1\r\nHost: o\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++
+                expected_date ++ "Connection: close\r\n\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+        try bed.expectDrained();
+    }
+}
+
 test "l7: a hung dial fires 504 at the connect budget, not the idle timeout" {
     var bed: Http1Bed = undefined;
     try bed.setUp(std.testing.allocator, .{ .seed = 74, .origin_listens = false });


### PR DESCRIPTION
Closes #253. Found by the nightly soak ([run 31924956084](https://github.com/zoxy-io/zoxy/actions/runs/31924956084)); **0.4.0 is held behind this** — #252 sits on the commit with the reachable assert.

## The window

`dialUpstream`'s carried-budget branch asserted the connection's deadline timer was armed. Its comment named the premise: a fired deadline reaches `onUpstreamConnect` as a pending verdict and answers `504` before any failure could ask to retry. That premise is true. It is not the only way the timer can be down.

A dial tightens the head-read timer to the connect budget by **cancelling** it — §4's lazy timer never moves earlier on its own — and two completions then race: the timer's own `Canceled`, and the cancel op's. Each defers to the other, so whichever lands second re-arms at the stored target. In between, the timer is legitimately down with a re-arm already on its way, aimed at exactly the target a carried budget wants, because `deadline_ns` is shared.

A `Refused` delivered in that gap reaches a retry with no pending verdict, and the assert reads a legal state as a bug — aborting the process.

## The fix is the spelling the file already uses

```zig
assert(conn.armed.deadline or conn.armed.deadline_cancel);
```

`resetForNextRequest` and the keep-alive turnaround both assert this same disjunction, for this same straggler, and `rebaseDeadline` opens by deferring to a draining cancel. The retry path was the one place that asked for the stricter half alone.

What the assert still refuses is the state that would be a bug: neither armed nor about to be — a dial with no clock, where a hung origin would never reach its §8 `504`.

## Not a regression, and not resting on a soak seed

The assert has been there since #181. Reaching it needs three completions to interleave one specific way, which is why 4096 seeds never produced one and a million-seed shard did.

The regression test does not depend on that: **bed seed 16 under partial delivery lands the three in exactly that order**, and the test *panics* without the fix rather than failing.

Its second arm is the half that matters. Relaxing an assert can hide the thing it guarded, so the retried dial is sent at a blackholed address where nothing but the carried budget can end it — the §8 `504` arriving is the re-arm, observed from outside. A fix that left the connection with no clock at all would pass the first arm and fail this one.

I also ruled out the explanation I would have bet on: the simulator can *strand* an op, and a stranded `timer_cancel` looked like the obvious culprit — but `armDropNext` drops the cancel at submit time, so the timer is never cancelled and stays armed. That state cannot produce the window at all.

## The gate's own defect

**The soak could not name the seed it died on.** An oracle failure returns an error and `checkSeed` prints `seed=`; an assert aborts inside `io.run()` and leaves a stack trace with no seed in it. The shard reported `"kind": "invariant", "extent": "unknown", "failed": []`, so finding the schedule meant bisecting a million seeds by hand.

The simulator now installs a panic handler that prints the seed and the command that replays it:

```
sim: PANIC seed=41 — replay with: zig build sim -- 41 1
```

Cleared on the way out of each run, so the number is only ever one a run was *inside* — a panic in the census or the failure report prints `0` rather than naming the last seed swept as though its schedule were the cause. §9's claim is that a failure replays from its seed; one that could not name its own was outside it.

## Gates

`zig build ci` green: 4096 seeds, census ok (71 counters fired, 17 exempt), smoke clean, `zig fmt` clean. I also re-ran 40,000 seeds from the failing shard (`68000001..68040000`) clean.