### PR TITLE
perf: a performance review of 0.4.0, and the head budget's two gaps

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -187,6 +187,20 @@ pub fn Server(comptime IoType: type) type {
         /// to rewrite at any moment.
         date_line: [shed.date_bytes]u8,
         date_second: u64,
+        /// The `nowNs` tick this pair was last refreshed on, which is what
+        /// keeps the wall clock *off* the per-response path (§9).
+        ///
+        /// `nowWallNs` is deliberately precise and deliberately uncached —
+        /// it exists for access-log durations, where a coarse granule
+        /// would report 0 µs and a per-tick cache would give every request
+        /// in one batch the same start. Neither property is worth paying
+        /// for here: a `Date` is a *second*, and a shed storm answers a
+        /// whole completion batch from this one line. So the wall clock is
+        /// read at most once per tick — §4 guarantees `nowNs` returns one
+        /// value for the whole of a tick — rather than once per response,
+        /// and what a batch of responses shares is a date that is at worst
+        /// one tick old.
+        date_tick_ns: u64,
         /// How many static responses are on the wire right now (#234):
         /// armed and not yet fully written, counting the whole span
         /// because a partial write re-arms on the same shared bytes.
@@ -437,13 +451,17 @@ pub fn Server(comptime IoType: type) type {
             server.io = io;
             server.config = config;
             // The static answers, and the clock they will be stamped from
-            // (#234). Both start at the epoch rather than at `nowWallNs`:
-            // the second and the line then agree by construction, so the
-            // first stamp of any real second re-renders instead of
-            // trusting whatever the field happened to hold.
+            // (#234). Seeded from the real clock here rather than left at
+            // the epoch, because `currentDate` now re-reads the wall clock
+            // only when the `nowNs` tick advances: a table stamped by
+            // `initDateSlots` before the first advance must already hold a
+            // real date, not 1970. The three fields are written together
+            // so the line, the second it renders and the tick it was taken
+            // on cannot disagree.
             server.static_responses.init();
-            server.date_second = 0;
-            shed.formatHttpDate(0, &server.date_line);
+            server.date_tick_ns = server.io.nowNs();
+            server.date_second = server.nowUnix();
+            shed.formatHttpDate(server.date_second, &server.date_line);
             server.static_sends_inflight = 0;
             server.initDateSlots();
             try server.conns.init(arena, options.conn_slots);
@@ -727,20 +745,39 @@ pub fn Server(comptime IoType: type) type {
             return @divFloor(server.io.nowWallNs(), std.time.ns_per_s);
         }
 
-        /// The current second as a `Date` value, re-rendered only when
-        /// the second has turned over (#234). Safe to call at any moment:
-        /// nothing sends these bytes, they are only ever copied into a
-        /// response's own slot.
+        /// The current second as a `Date` value (#234). Safe to call at
+        /// any moment: nothing sends these bytes, they are only ever
+        /// copied into a response's own slot.
+        ///
+        /// Two nested caches, and the outer one is the point. The inner
+        /// skips the calendar arithmetic while the second has not turned
+        /// over; the outer skips the *clock read itself* while the tick
+        /// has not. Without it a shed storm — the load this path exists
+        /// for (§8) — would pay one precise `CLOCK_REALTIME` read per
+        /// response, on the path that is otherwise one send from memory
+        /// that is neither assembled nor copied. `nowNs` is the coarse,
+        /// tick-cached clock §4 already refreshes once per tick, so the
+        /// gate costs a load and a compare and a whole completion batch
+        /// reads the wall clock once between them.
         pub fn currentDate(server: *Self) *const [shed.date_bytes]u8 {
-            const second = server.nowUnix();
-            if (second != server.date_second) {
-                shed.formatHttpDate(second, &server.date_line);
-                server.date_second = second;
+            const tick_ns = server.io.nowNs();
+            if (tick_ns != server.date_tick_ns) {
+                server.date_tick_ns = tick_ns;
+                const second = server.nowUnix();
+                if (second != server.date_second) {
+                    shed.formatHttpDate(second, &server.date_line);
+                    server.date_second = second;
+                }
             }
-            // The pair is the whole cache: a line rendered from one second
-            // and a field claiming another would hand every later response
-            // a date nothing ever measured.
-            assert(server.date_second == second);
+            // Both caches, stated as the cheap invariants they are — this
+            // runs per response in a ReleaseSafe binary, so an assertion
+            // that re-rendered the line to compare it would cost more than
+            // the clock read this function exists to avoid.
+            assert(server.date_tick_ns == tick_ns);
+            // Seeded from a real clock at `init` and only ever moved
+            // forward by one, so a zero here means a slot is about to be
+            // stamped from a second nothing measured.
+            assert(server.date_second >= 1);
             return &server.date_line;
         }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -180,7 +180,7 @@ pub fn Server(comptime IoType: type) type {
         /// response is stamped from, and the second it renders. Cached
         /// because the calendar arithmetic is per-second work and the
         /// responses that need it arrive per-request; re-rendered lazily,
-        /// on the first stamp of a new second.
+        /// on the first tick of a new second.
         ///
         /// Never read by a send — only ever copied *out of*, into a
         /// response's own slot — so unlike those slots this one is safe
@@ -1522,10 +1522,12 @@ pub fn Server(comptime IoType: type) type {
         /// Not the head budget, and the distinction is #235's: a connection
         /// that has connected and not spoken is quiet, not slow, and
         /// bounding it as a slowloris would reap the honest client that
-        /// opened early. The slowloris clock starts at its first byte,
-        /// where `onHeadGroupRecv` re-bases this down to
-        /// `head_timeout_ms` — a client mid-sentence meets that or
-        /// `limits.head_buffer_bytes`, whichever comes first (§7).
+        /// opened early. The slowloris clock starts where the head proves
+        /// to be *fragmented* — `installHeadBudget`, on the first parse
+        /// that returns Incomplete — and narrows this to the head budget
+        /// or this same window, whichever is tighter. A client mid-sentence
+        /// meets that or `limits.head_buffer_bytes`, whichever comes first
+        /// (§7); a head that arrived whole never needed either.
         fn entryTimeoutMs(
             server: *const Self,
             protocol: config_module.Config.Listener.Protocol,
@@ -3234,6 +3236,42 @@ pub fn Server(comptime IoType: type) type {
             );
         }
 
+        /// Store a target and re-base only if it actually moved *earlier*
+        /// — `storeDeadline` and `rebaseDeadline` as one step, for the
+        /// caller that cannot prove the narrowing statically.
+        ///
+        /// The two callers that can prove it — the dial's per-try connect
+        /// budget and the routing cap — say so by calling the pair
+        /// directly. #235's head budget cannot: it is a config value
+        /// compared against a window that shrinks under pressure, so
+        /// whether it narrows anything is a runtime fact. Asking here
+        /// keeps the cancel off the keep-alive hot path in the common
+        /// case, where the head budget is already the wider of the two and
+        /// §4's lazy tick-and-compare re-arms for a later target for free.
+        pub fn narrowDeadline(server: *Self, conn: *ConnType, timeout_ms: u32) void {
+            assert(timeout_ms >= 1);
+            // A connection with no deadline stored has none to narrow:
+            // every state that reaches here was given one on entry.
+            assert(conn.deadline_ns != 0);
+            const previous_ns = conn.deadline_ns;
+            server.storeDeadline(conn, timeout_ms);
+            assert(conn.deadline_ns != 0);
+            // Compared against the previously *stored* target, not the
+            // armed timer's — which is never recorded. That is sound for
+            // this caller because nothing stores a deadline between the
+            // entry window and the head budget: in `.l7_reading_head` the
+            // only prior store is the idle window, and the armed timer is
+            // aimed at it. Said that narrowly on purpose — "the armed
+            // target is always at or before the stored one" is *not* a
+            // general §4 fact, since `storeDeadline`'s max-lifetime clamp
+            // can move the stored target earlier with no rebase and leave
+            // `onDeadline` to self-heal a tick late. Where the two can
+            // diverge, this comparison would only ever decline a cancel
+            // that was unnecessary, never skip one that was needed.
+            if (conn.deadline_ns >= previous_ns) return;
+            server.rebaseDeadline(conn);
+        }
+
         /// Re-base the armed deadline to the freshly stored (earlier) target
         /// (§8): the single lazy timer never moves *earlier* once armed (§4),
         /// so an L7 dial needing a tighter per-try connect budget than the
@@ -3247,10 +3285,13 @@ pub fn Server(comptime IoType: type) type {
             // timer. The dial's per-try connect budget (`.l7_dialing`); the
             // request deadline installed at routing (`.l7_reading_head`,
             // §8), which must re-base here because the reuse path never
-            // reaches the dial; and the #235 head budget, installed at the
-            // client's first byte — also from `.l7_reading_head`, but a
-            // different narrowing: routing tightens to the *exchange* cap,
-            // this one tightens the idle window to the head read.
+            // reaches the dial; and the #235 head budget, installed on the
+            // first parse that comes back Incomplete — also from
+            // `.l7_reading_head`, but a different narrowing: routing
+            // tightens to the *exchange* cap, this one tightens the idle
+            // window to the head read. That third one reaches here through
+            // `narrowDeadline`, which is what establishes "earlier" for it
+            // rather than assuming it.
             assert(conn.state == .l7_dialing or conn.state == .l7_reading_head);
             // A prior dial's rebase cancel can still be draining if the
             // exchange outran it across a keep-alive turnaround. It re-arms

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -459,13 +459,6 @@ pub fn Proxy(comptime IoType: type) type {
             // the parse: a slowloris that dribbles for the whole head-read
             // deadline must report the time it spent doing it (§8).
             server.beginLogRequest(conn);
-            // The idle window ends where the head read begins (#235). Until
-            // this byte the connection was quiet and bounded by `idle_ms`;
-            // from here it is a client mid-sentence, bounded by the much
-            // tighter head budget — which is the slowloris's whole window,
-            // and the reason the two stopped being one number.
-            server.storeDeadline(conn, server.config.head_timeout_ms);
-            server.rebaseDeadline(conn);
             conn.log.bytes_in += bound.len;
             fillHead(conn, bound.len, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
@@ -516,6 +509,7 @@ pub fn Proxy(comptime IoType: type) type {
                     // converts it to the oversize verdicts below — so here
                     // there is room to read more.
                     assert(!head_is_full);
+                    installHeadBudget(server, conn);
                     if (conn.tls != null) {
                         armTlsHeadRecv(server, conn);
                     } else {
@@ -528,6 +522,40 @@ pub fn Proxy(comptime IoType: type) type {
                 error.HeadTooLarge => return respond(server, conn, 431, "l7_headers_too_large"),
             };
             routeRequest(server, conn, &request);
+        }
+
+        /// Start this head's #235 slowloris clock: the idle window ends
+        /// where the head read stops being instantaneous, and from here
+        /// the client is bounded by the much tighter head budget.
+        ///
+        /// Installed on the first `Incomplete`, not on the first byte.
+        /// Reaching that branch is what makes a client *mid-sentence* —
+        /// a head that arrives whole in one recv was never slow, and
+        /// bounding it bought nothing while costing a timer cancel and a
+        /// re-arm (§4's lazy timer cannot move earlier on its own) on
+        /// every request of every keep-alive connection. The budget the
+        /// cancel installed then lived for the microseconds until routing
+        /// and the render stored the idle window over it again.
+        ///
+        /// Once per head, never once per fragment: a budget a dribbling
+        /// client could push out by dribbling would bound nothing, which
+        /// is the whole failure #235 exists to answer.
+        ///
+        /// Narrowed against the *effective* idle window rather than the
+        /// configured one. `idleTimeoutMs` divides by
+        /// `pressure_idle_divisor` under downstream pressure (§8) while
+        /// the budget is a flat config value the loader only ever related
+        /// to `idle_ms` as written — so under pressure the budget can be
+        /// the wider of the two, and taking it unclamped would hand a
+        /// slowloris a longer window in exactly the load condition the
+        /// bias exists for.
+        fn installHeadBudget(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            if (conn.l7.head_budget_installed) return;
+            conn.l7.head_budget_installed = true;
+            const budget_ms = @min(server.config.head_timeout_ms, server.idleTimeoutMs());
+            assert(budget_ms >= 1);
+            server.narrowDeadline(conn, budget_ms);
         }
 
         /// The §7 canonical routing keys for `request`: the canonical host

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -395,7 +395,22 @@ const Suppress = struct {
     /// must not travel beside it.
     max_forwards: bool = false,
 
+    /// Whether this hop writes any of the three. Hoisted out of the
+    /// header walk for the same reason `has_suppressing_edit` is: all
+    /// three are off for an ordinary forwarded request — forwarding is
+    /// opt-in per listener, absolute-form is rare and a hop budget rarer
+    /// — and that case should cost one predictable branch for the whole
+    /// walk rather than a tag dispatch on every header (§9: the render is
+    /// the top user-CPU cost under load).
+    fn any(suppress: Suppress) bool {
+        return suppress.forwarded_for or suppress.host or suppress.max_forwards;
+    }
+
     fn claims(suppress: Suppress, tag: parser.HeaderName) bool {
+        // Only reached when `any` already said one of the three is on, so
+        // the common answer here is "some *other* header" rather than
+        // "nothing is suppressed at all".
+        assert(suppress.any());
         return switch (tag) {
             .x_forwarded_for => suppress.forwarded_for,
             .host => suppress.host,
@@ -455,6 +470,10 @@ fn appendEndToEndHeaders(
             break;
         }
     }
+    // The same decision for the proxy's own three, and made here for the
+    // same reason: a request this hop writes none of them for skips the
+    // per-header tag dispatch entirely.
+    const has_suppression = suppress.any();
 
     for (headers) |*header| {
         assert(header.name.len >= 1);
@@ -466,7 +485,7 @@ fn appendEndToEndHeaders(
             const participating = keep_upgrade and header.tag == .upgrade;
             if (!participating) continue;
         }
-        if (suppress.claims(header.tag)) {
+        if (has_suppression and suppress.claims(header.tag)) {
             continue;
         }
         if (has_suppressing_edit and suppressedByEdit(header.name, edits)) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -5440,6 +5440,78 @@ test "l7: a partial head is reaped at the head budget, not the idle window" {
     try bed.expectDrained();
 }
 
+test "l7: under pressure the head budget cannot outlive the shrunk idle window" {
+    // The head budget is a flat config value; the idle window divides by
+    // `pressure_idle_divisor` under downstream pressure (§8). The loader
+    // only ever relates the two as *written*, so a budget legal at rest
+    // can be the wider of the pair once pressure engages — and narrowing
+    // to it would then hand a slowloris a longer window in exactly the
+    // load condition the bias exists for. It is a min, not an assignment.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 312,
+        // Legal at rest: 400 <= the bed's 1000 ms idle window. Under
+        // pressure that window becomes 250 ms, and 400 would widen it.
+        .head_timeout_ms = 400,
+    });
+    defer bed.tearDown();
+
+    bed.server.relay_pressure = true;
+    try std.testing.expectEqual(@as(u32, 1000 / 4), bed.server.idleTimeoutMs());
+
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("GET /slow HTTP/1.1\r\nHost: o\r\n");
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    // The pressured window, not the budget. Anything at or past 400 means
+    // the first byte widened a deadline it was installed to tighten.
+    try std.testing.expect(elapsed_ms >= 250);
+    try std.testing.expect(elapsed_ms < 400);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try bed.expectDrained();
+}
+
+test "l7: a terminated listener's partial head meets the head budget too" {
+    // The budget used to be installed in `onHeadGroupRecv`, which is the
+    // plaintext arm alone — a terminated connection reads ciphertext
+    // through `armTlsHeadRecv` and reached the parse by another road. So
+    // #235 protected exactly the listeners least likely to be facing the
+    // internet, and an HTTPS slowloris kept the whole idle window.
+    // Installing at the parse rather than at the read covers both arms
+    // because both arrive there.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 313,
+        .tls = true,
+        .head_timeout_ms = 100,
+    });
+    defer bed.tearDown();
+
+    // A head that never finishes, inside a real TLS session.
+    var client: TlsClient = undefined;
+    try client.start(&bed.sim_io, Http1Bed.bindAddress(), .{
+        .host_name = fixture_host_name,
+        .app_data = "GET /slow HTTP/1.1\r\nHost: o\r\n",
+    });
+    var wind_down: TlsWindDown = .{ .bed = &bed };
+    wind_down.attach(&client);
+    const start_ns = bed.sim_io.nowNs();
+    try bed.sim_io.run();
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("tls_handshakes_completed"),
+    );
+    // The head budget, not the 1000 ms idle window. The handshake spends
+    // sim time before the first head byte, so the floor is the budget and
+    // the ceiling is well short of the window it must not have inherited.
+    try std.testing.expect(elapsed_ms >= 100);
+    try std.testing.expect(elapsed_ms < 500);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try bed.expectDrained();
+}
+
 test "l7: an idle kept connection still gets the whole idle window" {
     // The other half of the split, and the reason it is a split rather
     // than a tightening: between requests a connection is quiet and

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -574,6 +574,25 @@ pub fn Conn(comptime IoType: type) type {
             /// across by hand — a replay is the same request retrying, not
             /// a new one earning a fresh budget.
             request_deadline_ns: u64 = 0,
+            /// Whether this request's #235 head budget is already
+            /// installed. Set on the first parse that comes back
+            /// `Incomplete` — the moment a client is provably mid-sentence
+            /// — and read so the *next* fragment does not install it
+            /// again: a budget a dribbling client could push out by
+            /// dribbling would bound nothing at all.
+            ///
+            /// In `l7` rather than on the connection because the budget is
+            /// one head's, and the wholesale clear at every keep-alive
+            /// turnaround is what makes the next request earn its own.
+            ///
+            /// Unlike `request_deadline_ns` above, the §7 replay does *not*
+            /// carry this across its rebuild, and does not need to: a
+            /// replay runs from `.l7_exchanging` and moves to
+            /// `.l7_dialing`, so it never re-enters the `.l7_reading_head`
+            /// state `installHeadBudget` asserts on. There is no second
+            /// head to budget, so a flag reset to false is inert rather
+            /// than a budget silently reissued.
+            head_budget_installed: bool = false,
             /// The endpoint identity this request's stickiness cookie
             /// named (#178), or null when the cluster is not
             /// cookie-keyed or the request carried nothing usable.


### PR DESCRIPTION
A performance-focused review of `v0.3.0..v0.4.0` turned up three things
worth fixing. One of them turned out to be hiding two correctness gaps
rather than the single overhead I went looking for.

Three commits, one per finding, smallest first.

## `render`: decide suppression once, not once per header (§9)

#240 turned the render's single suppression test into three. The old
shape short-circuited on a bool that is false for an ordinary forwarded
request; the struct that replaced it loads the tag and dispatches on it
for every header, whatever the flags say — and all three are off for an
ordinary request, since forwarding is opt-in per listener, absolute-form
is rare and a hop budget rarer still.

That is the case `bench/micro/l7_head_pipeline.zig` says it exists to
protect. The bench was updated for the new *argument* rather than the new
*shape*, so nothing noticed. Fixed the way the same function already
handles edits two lines above: decide once, before the walk.

## `server`: read the wall clock once a tick, not once a response (#234)

`nowWallNs` is deliberately precise and deliberately uncached, and its
own comment says why that is affordable — "two vDSO reads per logged
request … paid only when an operator turned the log on." `currentDate`
calls it per static answer, per #159 page and per redirect, log or no
log. The `date_second` cache skipped the calendar arithmetic but not the
read that discovers whether it was needed.

It lands on the wrong path: §8 describes a shed as one send from memory
that is neither acquired nor assembled nor copied, and a storm of them is
when the read repeats hardest. It also walks back a measurement already
taken — `nowNs` moved to `CLOCK_MONOTONIC_COARSE` with a per-tick cache
because §9's flamegraph put the monotonic read at ~7% of on-CPU.

The gate is now the tick, which §4 already guarantees is stable, so a
completion batch reads the wall clock once between its responses. `init`
seeds line, second and tick together from the real clock, because the old
"start at the epoch and let the first stamp re-render" no longer holds
once the read is gated.

## `proxy`: the head budget starts where the head fragments (#235)

This is the one that grew. I went in to remove a timer cancel and found
two gaps underneath it.

**It never reached a terminated listener.** The install sat in
`onHeadGroupRecv` — the plaintext arm alone, since `armHeadGroupRecv` is
chosen only when `conn.tls == null`. A terminated connection reads
ciphertext through `armTlsHeadRecv` and reaches the parse by another
road, so #235 protected exactly the listeners least likely to be facing
the internet. An HTTPS slowloris kept the whole idle window. The directed
tests are plaintext and the sweep's adversary does not dribble a TLS
head, so nothing said so.

**Under pressure it widened the window it was meant to narrow.** The
budget was a flat `head_timeout_ms`; the window it tightens is
`idleTimeoutMs()`, which divides by `pressure_idle_divisor` under
downstream pressure. The loader relates the two only as *written*, so a
pair legal at rest inverts under load — with `idle_ms: 30000` the window
becomes 7500 ms and the default 10000 ms budget is the wider of the two.
The first byte then stored a target *later* than the armed timer and
`rebaseDeadline` re-armed out to it, which is both the §8 bias defeated
in the condition it exists for and a breach of that function's own
stated contract.

Both fall out of moving the install from the read to the parse. Every arm
reaches `parseAndDispatch`, and `error.Incomplete` is the branch that
means what #235 said it was bounding: a client mid-sentence. A head that
arrives whole in one recv was never slow — routing and the render stored
the idle window back over its budget microseconds later — while costing a
cancel and a re-arm per request, two submissions and two completions that
a keep-alive connection did not previously pay with `request_ms` off,
which is the default.

`narrowDeadline` makes "earlier" a fact rather than a convention: the two
callers that can prove their narrowing statically still call the pair
directly, and the head budget, which cannot, asks.

## Verification

`zig build ci` (4096 seeds, live gate) and `zig fmt --check` pass on each
commit. Both new tests were verified by mutation — reverted to the
shipped placement, the pressure case and the TLS case each pass at the
1000 ms window they must not have inherited:

```
error: 'l7: under pressure the head budget cannot outlive the shrunk idle window' failed
error: 'l7: a terminated listener's partial head meets the head budget too' failed
```

That also closes part of a coverage gap the review flagged separately:
both harnesses set `head_timeout_ms = idle_timeout_ms`, so nothing
exercised the two being distinct, let alone distinct under pressure.

## Not addressed here

From the same review, left for their own slices:

- `l7_keepalive_requests_capped` over-counts on the three static paths —
  the cap is evaluated on `staticResponseResyncable` alone and the other
  three brakes are `and`-ed after, so it fires where it was not the
  binding reason.
- `respondRedirect` double-counts that same counter when
  `renderRedirectHead` returns `Oversize` and the 414 fallback re-enters
  `commitStaticVerdict`.
- The `Date` in-flight guard means staleness is unbounded under a
  sustained shed storm — legal and counted, but the freshness argument
  is weakest exactly when the timestamp is most wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)