### PR TITLE
perf: lend the scratches ReleaseSafe was filling per call

### DIFF
--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -43,6 +43,7 @@ const no_edits: []const zoxy.http.filter.AppliedHeaderEdit = &.{};
 pub fn main() void {
     var request_storage: parser.HeaderStorage = undefined;
     var response_storage: parser.HeaderStorage = undefined;
+    var head_scratch: render.HeadScratch = undefined;
     var path_scratch: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
     var upstream_head: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
     var downstream_head: [zoxy.constants.head_buffer_bytes_default]u8 = undefined;
@@ -65,10 +66,18 @@ pub fn main() void {
             null,
             null,
             false,
+            &head_scratch,
             &upstream_head,
         ) catch unreachable;
         const response = parser.parseResponseHead(response_head, false, &response_storage, request.method) catch unreachable;
-        const downstream = render.renderResponseHead(&response, true, no_edits, false, &downstream_head) catch unreachable;
+        const downstream = render.renderResponseHead(
+            &response,
+            true,
+            no_edits,
+            false,
+            &head_scratch,
+            &downstream_head,
+        ) catch unreachable;
 
         // Consume the outputs so nothing is dead-code-eliminated.
         checksum +%= upstream[upstream.len - 1];

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -195,6 +195,15 @@ pub fn Server(comptime IoType: type) type {
         /// Whether `header_scratch` is out on loan (see the field). Only
         /// ever true inside one parse-and-consume window.
         header_scratch_lent: bool,
+        /// The serving path's render scratches, on exactly the terms
+        /// `header_scratch` sets out and for the same measured reason:
+        /// these are the locals the render path was still filling once the
+        /// parse path stopped. See `proxy.RenderScratch` for what a render
+        /// borrows and why one aggregate covers both hops.
+        render_scratch: proxy.RenderScratch,
+        /// Whether `render_scratch` is out on loan (see the field). Only
+        /// ever true inside one render-and-send window.
+        render_scratch_lent: bool,
         /// The §8 static responses in writable memory, because each now
         /// carries a `Date` slot (#234). Comptime-sized and held inline:
         /// a closed status set times two persistence variants, so this is
@@ -584,6 +593,29 @@ pub fn Server(comptime IoType: type) type {
             server.header_scratch_lent = false;
         }
 
+        /// Lend the serving path's render scratches for one head render
+        /// and the send it feeds. The window ends where the callback does,
+        /// same as the header scratch, and for the same §7 reason: the
+        /// rendered bytes are copied into the upstream head buffer (or the
+        /// client's) before this returns, so nothing here outlives it.
+        ///
+        /// A request render and a response render are each reached from
+        /// their own completion callback and neither suspends, so the two
+        /// are never live together — which is what lets one aggregate
+        /// serve both hops. The assert is what says so if that changes.
+        pub fn borrowRenderScratch(server: *Self) *proxy.RenderScratch {
+            assert(!server.render_scratch_lent);
+            server.render_scratch_lent = true;
+            return &server.render_scratch;
+        }
+
+        /// Return what `borrowRenderScratch` lent (see `returnHeaderScratch`
+        /// for why the bytes are left as they are).
+        pub fn returnRenderScratch(server: *Self) void {
+            assert(server.render_scratch_lent);
+            server.render_scratch_lent = false;
+        }
+
         /// The §4 engine pool and the one slab its plaintext destinations
         /// carve out of. Both are empty on a deployment where no listener
         /// terminates TLS — the whole feature reserving nothing, which is
@@ -720,6 +752,8 @@ pub fn Server(comptime IoType: type) type {
             // this one, at startup, instead of one per parse.
             server.header_scratch = undefined;
             server.header_scratch_lent = false;
+            server.render_scratch = undefined;
+            server.render_scratch_lent = false;
             server.armed_ops_peak = 0;
             server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -170,6 +170,31 @@ pub fn Server(comptime IoType: type) type {
         /// Empty on an L4-only config, which never canonicalizes.
         target_scratch: []u8,
         rewrite_scratch: []u8,
+        /// The serving path's one header scratch, on the same terms as the
+        /// two above and for a sharper reason: a `parser.HeaderStorage`
+        /// local is 0xaa-filled on every call under ReleaseSafe, and §9's
+        /// flamegraph put that fill at 62% of user cycles under L7 load —
+        /// ~9.2 KiB per request across the four frames a keep-alive
+        /// exchange parses. Lent once per parse and filled once at init.
+        ///
+        /// One, not two, and the argument has two halves. Across callbacks:
+        /// §4 runs each to completion and never nests one inside another,
+        /// so two borrows cannot interleave that way. Within a callback: no
+        /// synchronous chain from a borrow site reaches a second one —
+        /// `parseAndDispatch`'s borrow stays live through `routeRequest`
+        /// into `beginUpstream`'s reuse path and on into
+        /// `renderRequestAndStartLegs`, none of which parse again, and the
+        /// paths that do parse again are the ones reached *after* an await,
+        /// where §7 re-parses from byte 0 precisely because nothing parsed
+        /// survives its callback. `header_scratch_lent` makes the whole of
+        /// that a checked fact rather than a reviewed one.
+        ///
+        /// Comptime-sized, so inline like `drain_sink`: part of no budget
+        /// term, and never under-counted.
+        header_scratch: parser.HeaderStorage,
+        /// Whether `header_scratch` is out on loan (see the field). Only
+        /// ever true inside one parse-and-consume window.
+        header_scratch_lent: bool,
         /// The §8 static responses in writable memory, because each now
         /// carries a `Date` slot (#234). Comptime-sized and held inline:
         /// a closed status set times two persistence variants, so this is
@@ -533,6 +558,32 @@ pub fn Server(comptime IoType: type) type {
             try server.initLogHeaders(arena, options);
         }
 
+        /// Lend the serving path's header scratch for one parse and the
+        /// window that reads it (§7: nothing parsed survives its callback,
+        /// so that window ends where the callback does — hence the `defer
+        /// returnHeaderScratch` at every call site).
+        ///
+        /// The assert is the whole safety argument. A borrow that outlives
+        /// its parse was always wrong; what is new is that a *second*
+        /// borrow taken while the first is live would hand two parses the
+        /// same array, and the first one's `headers` slice would change
+        /// under it. Nothing reaches that today, and this is what says so
+        /// if something ever does.
+        pub fn borrowHeaderScratch(server: *Self) *parser.HeaderStorage {
+            assert(!server.header_scratch_lent);
+            server.header_scratch_lent = true;
+            return &server.header_scratch;
+        }
+
+        /// Return what `borrowHeaderScratch` lent. The bytes stay as the
+        /// parse left them: the next borrow overwrites the prefix it fills
+        /// and reads no further, which is what makes one buffer reusable
+        /// without a clear between loans.
+        pub fn returnHeaderScratch(server: *Self) void {
+            assert(server.header_scratch_lent);
+            server.header_scratch_lent = false;
+        }
+
         /// The §4 engine pool and the one slab its plaintext destinations
         /// carve out of. Both are empty on a deployment where no listener
         /// terminates TLS — the whole feature reserving nothing, which is
@@ -664,6 +715,11 @@ pub fn Server(comptime IoType: type) type {
             // Deliberately not zeroed: a discard sink's contents are never
             // read, the same argument the head buffers make (§5).
             server.drain_sink = undefined;
+            // Same argument, and the reason the scratch exists: every parse
+            // writes the prefix it then reads. The one fill this costs is
+            // this one, at startup, instead of one per parse.
+            server.header_scratch = undefined;
+            server.header_scratch_lent = false;
             server.armed_ops_peak = 0;
             server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -194,10 +194,24 @@ pub const Header = struct {
     }
 };
 
-/// Header storage for one parsed head. A stack local at every call site —
-/// nothing parsed survives the callback that parsed it (§7 detect-and-retry
-/// re-parses from byte 0), so this costs frame, not a connection slot.
-pub const HeaderStorage = [constants.headers_max]Header;
+/// Header storage for one parsed head: the mapped headers a caller reads,
+/// and the raw span hparse fills on the way to them. Nothing parsed
+/// survives the callback that parsed it (§7 detect-and-retry re-parses
+/// from byte 0), so one of these serves a whole parse and no more.
+///
+/// Both arrays live in the one aggregate so that a caller lends a single
+/// buffer rather than two, and so the raw span stops being a local of
+/// `parseRequestHead`/`parseResponseHead` — which is what makes the
+/// serving path's long-lived scratch (`Server.header_scratch`) cover the
+/// whole cost. Under ReleaseSafe an `= undefined` local is 0xaa-filled on
+/// every call, and §9's flamegraph put that fill at 62% of zoxy's user
+/// cycles under L7 load: ~9.2 KiB per request across the four frames a
+/// keep-alive exchange parses. A cold call site may still declare one on
+/// the stack; the serving path may not.
+pub const HeaderStorage = struct {
+    headers: [constants.headers_max]Header,
+    raw: [constants.headers_max]hparse.Header,
+};
 
 /// How the message body is delimited (RFC 9112 §6.3). `until_close` is
 /// legal only on responses; requests are always length-delimited.
@@ -364,8 +378,7 @@ pub fn parseRequestHead(
     }
 
     var raw: RawRequest = .{};
-    var raw_headers: [constants.headers_max]hparse.Header = undefined;
-    const head_len = try parseRequestRaw(head, head_is_full, &raw, &raw_headers);
+    const head_len = try parseRequestRaw(head, head_is_full, &raw, &headers_storage.raw);
 
     const target = raw.target.?; // A successful parse always sets the target.
     const method_token = raw.method_token.?; // Same contract as the target.
@@ -374,7 +387,7 @@ pub fn parseRequestHead(
     const split = try validateTarget(target, method);
     const version = versionFromRaw(raw.version);
 
-    const analysis = try analyzeHeaders(raw_headers[0..raw.header_count], headers_storage);
+    const analysis = try analyzeHeaders(raw.header_count, headers_storage);
     // An HTTP/1.1 request must carry exactly one Host (RFC 9112 §3.2);
     // duplicates were already rejected during analysis.
     if (version == .http_1_1) {
@@ -390,7 +403,7 @@ pub fn parseRequestHead(
         .method_token = method_token,
         .target = split.target,
         .version = version,
-        .headers = headers_storage[0..raw.header_count],
+        .headers = headers_storage.headers[0..raw.header_count],
         .host = analysis.host,
         .authority = split.authority,
         .framing = framing,
@@ -416,14 +429,13 @@ pub fn parseResponseHead(
     var raw_version: hparse.Version = .@"1.0";
     var raw_status: u16 = 0;
     var raw_status_message: ?[]const u8 = null;
-    var raw_headers: [constants.headers_max]hparse.Header = undefined;
     var raw_header_count: usize = 0;
     const head_len = hparse.parseResponse(
         head,
         &raw_version,
         &raw_status,
         &raw_status_message,
-        &raw_headers,
+        &headers_storage.raw,
         &raw_header_count,
     ) catch |err| switch (err) {
         // No 414-class verdict on the origin side: an oversize response
@@ -450,14 +462,14 @@ pub fn parseResponseHead(
     }
     const version = versionFromRaw(raw_version);
 
-    const analysis = try analyzeHeaders(raw_headers[0..raw_header_count], headers_storage);
+    const analysis = try analyzeHeaders(raw_header_count, headers_storage);
     const framing = try responseFraming(request_method, raw_status, version, &analysis);
 
     return .{
         .status = raw_status,
         .status_message = raw_status_message,
         .version = version,
-        .headers = headers_storage[0..raw_header_count],
+        .headers = headers_storage.headers[0..raw_header_count],
         .framing = framing,
         .keep_alive = keepAliveDefault(version, &analysis) and framing != .until_close,
         .connection_nominates_header = analysis.connection_nominates_header,
@@ -787,11 +799,16 @@ const HeaderAnalysis = struct {
     connection_nominates_header: bool,
 };
 
+/// Maps the `header_count` raw headers hparse left in `headers_storage.raw`
+/// into the tagged `headers_storage.headers`, in place. The count rather
+/// than a slice: both spans are fields of the one aggregate now, and
+/// handing this a slice of `raw` while it writes `headers` would state an
+/// aliasing relation the caller cannot check.
 fn analyzeHeaders(
-    raw_headers: []const hparse.Header,
+    header_count: usize,
     headers_storage: *HeaderStorage,
 ) error{Malformed}!HeaderAnalysis {
-    assert(raw_headers.len <= headers_storage.len);
+    assert(header_count <= headers_storage.headers.len);
     var analysis = HeaderAnalysis{
         .host = null,
         .content_length = null,
@@ -801,12 +818,12 @@ fn analyzeHeaders(
         .connection_keep_alive = false,
         .connection_nominates_header = false,
     };
-    for (raw_headers, 0..) |raw_header, index| {
+    for (headers_storage.raw[0..header_count], 0..) |raw_header, index| {
         assert(raw_header.key.len >= 1);
         // The one name comparison this header will cost: every later §7
         // decision, here and in the render walk, tests the tag instead.
         const header: Header = .init(raw_header.key, raw_header.value);
-        headers_storage[index] = header;
+        headers_storage.headers[index] = header;
         switch (header.tag) {
             .host => {
                 // A second Host changes routing depending on who reads which —

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -81,6 +81,66 @@ fn bareAddress(
     return text[0..colon];
 }
 
+/// The widest a decremented `Max-Forwards` can render to: the field is
+/// 1*DIGIT and `parseDecimal` refuses past nineteen, so nineteen digits is
+/// the whole range a decrement can land in.
+///
+/// At file scope for the same reason as `RenderScratch` below, which sizes
+/// a field from it: it depends on no backend.
+const max_forwards_digits_max: u32 = 19;
+
+/// The #178 sticky cookie's attributes, and the widest value composed from
+/// them. `Secure` rides along only where zoxy terminates TLS and so knows
+/// the scheme is https; on a plaintext listener something in front may
+/// have terminated it, and a `Secure` cookie the client can only return
+/// over http is one it will never return at all.
+///
+/// At file scope beside the buffer they size (see `max_forwards_digits_max`).
+const sticky_attributes = "; Path=/; HttpOnly";
+const sticky_attributes_secure = sticky_attributes ++ "; Secure";
+const sticky_value_bytes_max = constants.pick_name_bytes_max + 1 +
+    Balancer.endpoint_tag_len + sticky_attributes_secure.len;
+
+/// The serving path's render scratches, held as one aggregate so the
+/// render borrows once rather than six times (`Server.render_scratch`).
+///
+/// Same reasoning as `parser.HeaderStorage`, and the same measurement:
+/// under ReleaseSafe an `= undefined` local is 0xaa-filled on every call,
+/// which §9's flamegraph found is what the render path costs once the
+/// parse path stopped paying it. Every field was a local of some function
+/// on that path, each running once per exchange: most of
+/// `renderRequestAndStartLegs` or `renderResponse`, `route_host` of
+/// `routeRequest`, and `head` of a function private to the render module.
+///
+/// One aggregate, not two, because no render of a request and a render of
+/// a response are ever live together: each is reached from its own
+/// completion callback, and neither suspends. `head` is the render
+/// module's own, threaded through `renderRequestHead`/`renderResponseHead`
+/// because the array it holds is a local of a function private to it.
+///
+/// At file scope: it names no backend, so `Server` can hold one without
+/// instantiating `Proxy`.
+pub const RenderScratch = struct {
+    /// `routeRequest`'s host scratch, kept distinct from `host` below on
+    /// the same grounds as `target_scratch` vs `rewrite_scratch`: the
+    /// routed keys alias this one across the call that writes the other.
+    ///
+    /// Conservative rather than forced. Every present reader of
+    /// `keys.host` — the log capture, which copies; the filter match; the
+    /// route lookup — has finished before `planForward` writes `host`, so
+    /// one field would work today. Two means a render write cannot
+    /// invalidate a routing view at all, which is a property worth holding
+    /// rather than a trace worth re-deriving whenever either side moves.
+    route_host: [constants.host_bytes_max]u8,
+    host: [constants.host_bytes_max]u8,
+    request_edits: [constants.header_edits_max]filter.AppliedHeaderEdit,
+    response_edits: [constants.response_edits_max]filter.AppliedHeaderEdit,
+    forwarded: [constants.forwarded_value_bytes_max]u8,
+    hops: [max_forwards_digits_max]u8,
+    sticky: [sticky_value_bytes_max]u8,
+    head: render.HeadScratch,
+};
+
 pub fn Proxy(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
@@ -656,11 +716,6 @@ pub fn Proxy(comptime IoType: type) type {
             unreachable;
         }
 
-        /// The widest a decremented `Max-Forwards` can render to: the
-        /// field is 1*DIGIT and `parseDecimal` refuses past nineteen, so
-        /// nineteen digits is the whole range a decrement can land in.
-        const max_forwards_digits_max: u32 = 19;
-
         /// The `Max-Forwards` this hop forwards, or null to leave the
         /// header exactly as it arrived (#240) — which is every request
         /// but an `OPTIONS` that carried a budget.
@@ -923,8 +978,11 @@ pub fn Proxy(comptime IoType: type) type {
             // single-threaded, and the window (through routing into the
             // checkout path's render) neither suspends nor re-enters.
             const scratch = server.target_scratch;
-            var host_scratch: [constants.host_bytes_max]u8 = undefined;
-            const keys = requestKeys(request, scratch, &host_scratch) catch {
+            // Borrowed here rather than in the render it feeds: this frame
+            // holds `keys`, which alias `route_host`, across the call.
+            const render_scratch = server.borrowRenderScratch();
+            defer server.returnRenderScratch();
+            const keys = requestKeys(request, scratch, &render_scratch.route_host) catch {
                 captureTarget(conn, null, request.target);
                 return respond(server, conn, 400, "l7_bad_request");
             };
@@ -954,7 +1012,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
             };
-            beginUpstream(server, conn, request, &keys.views);
+            beginUpstream(server, conn, request, &keys.views, render_scratch);
         }
 
         /// The request-derived half of this exchange's pick (#178): what
@@ -1124,6 +1182,10 @@ pub fn Proxy(comptime IoType: type) type {
             conn: *ConnType,
             request: *const parser.RequestHead,
             views: *const TargetViews,
+            /// The caller's render scratches, carried through to the reuse
+            /// path's render (see `RenderScratch`). The dial path re-parses
+            /// in its own callback and borrows there instead.
+            scratch: *RenderScratch,
         ) void {
             assert(conn.state == .l7_reading_head);
             assert(conn.relay_buffer != null);
@@ -1168,7 +1230,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // the hot one — skips the re-parse the dial path needs,
                 // and hands over the canonical target it already built
                 // rather than having it decoded and collapsed again.
-                renderRequestAndStartLegs(server, conn, request, views);
+                renderRequestAndStartLegs(server, conn, request, views, scratch);
                 return;
             }
             dialUpstream(server, conn, pick, .fresh);
@@ -1454,7 +1516,9 @@ pub fn Proxy(comptime IoType: type) type {
             // Same bytes routeRequest already canonicalized, so this cannot
             // fail — the §7 single-source-of-truth rule again.
             const views = targetViews(&request, server.target_scratch) catch unreachable;
-            renderRequestAndStartLegs(server, conn, &request, &views);
+            const render_scratch = server.borrowRenderScratch();
+            defer server.returnRenderScratch();
+            renderRequestAndStartLegs(server, conn, &request, &views, render_scratch);
         }
 
         /// Render the request head into the upstream slot's staging
@@ -1474,6 +1538,10 @@ pub fn Proxy(comptime IoType: type) type {
             /// (§9). Origin-form aliases the caller's stack scratch, so both
             /// are read out entirely before this returns.
             views: *const TargetViews,
+            /// The caller's render scratches. Borrowed by the caller rather
+            /// than here because `routeRequest` holds keys aliasing
+            /// `route_host` across this call (see `RenderScratch`).
+            scratch: *RenderScratch,
         ) void {
             assert(conn.state == .l7_dialing);
             assert(request.head_len == conn.l7.request_head_len);
@@ -1487,8 +1555,6 @@ pub fn Proxy(comptime IoType: type) type {
             // Apply the listener's filters (empty when none): a rewrite of
             // the forwarded path and any header edits, against the same
             // canonical view the reject/route phase used.
-            var host_scratch: [constants.host_bytes_max]u8 = undefined;
-            var edit_buffer: [constants.header_edits_max]filter.AppliedHeaderEdit = undefined;
             // The rewrite scratch is the server's, distinct from the
             // target scratch: on the checkout path the routed views still
             // alias that one while the rewrite runs.
@@ -1496,18 +1562,16 @@ pub fn Proxy(comptime IoType: type) type {
                 conn,
                 request,
                 views,
-                &host_scratch,
+                &scratch.host,
                 server.rewrite_scratch,
-                &edit_buffer,
+                &scratch.request_edits,
             ) catch {
                 // A rewritten path too long to forward: the §7 oversize
                 // verdict, answered like an oversize head.
                 return respond(server, conn, 431, "l7_headers_too_large");
             };
-            var forwarded_scratch: [constants.forwarded_value_bytes_max]u8 = undefined;
-            const forwarded = planForwarded(server, conn, request, &forwarded_scratch);
-            var hops_scratch: [max_forwards_digits_max]u8 = undefined;
-            const hops = planMaxForwards(request, &hops_scratch);
+            const forwarded = planForwarded(server, conn, request, &scratch.forwarded);
+            const hops = planMaxForwards(request, &scratch.hops);
             // No close announcement upstream (the `false` below): the
             // connection is a parking candidate (§5), and stripping the
             // client's Connection header already made persistence the wire
@@ -1523,6 +1587,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // listener agreed to carry it (#180); the gate already
                 // refused every other spelling.
                 conn.l7.upgrade_requested,
+                &scratch.head,
                 upstreamHeadBytes(upstream),
             ) catch {
                 // Valid on arrival but no longer fits after edits: the §7
@@ -2221,11 +2286,6 @@ pub fn Proxy(comptime IoType: type) type {
         /// something in front may have terminated TLS, and `Secure` on a
         /// cookie the client can only ever return over http is a cookie
         /// it will never return at all.
-        const sticky_attributes = "; Path=/; HttpOnly";
-        const sticky_attributes_secure = sticky_attributes ++ "; Secure";
-        const sticky_value_bytes_max = constants.pick_name_bytes_max + 1 +
-            Balancer.endpoint_tag_len + sticky_attributes_secure.len;
-
         /// This render's full edit set: the #175 filter edits, plus —
         /// when the verdict owes the client an announcement — the #178
         /// stamp in the one buffer slot reserved past the filter budget.
@@ -2334,11 +2394,14 @@ pub fn Proxy(comptime IoType: type) type {
             // that serving has stopped being HTTP. A `Set-Cookie` naming
             // the endpoint of a session about to become opaque would be a
             // statement about a request that no longer exists.
+            const scratch = server.borrowRenderScratch();
+            defer server.returnRenderScratch();
             const rendered = render.renderResponseHead(
                 response,
                 false,
                 &.{},
                 true,
+                &scratch.head,
                 headBytes(server, conn),
             ) catch {
                 upstreamFailed(server, conn);
@@ -2498,11 +2561,14 @@ pub fn Proxy(comptime IoType: type) type {
             }
             conn.l7.interims_seen += 1;
             const upstream = conn.upstream.?;
+            const scratch = server.borrowRenderScratch();
+            defer server.returnRenderScratch();
             const rendered = render.renderResponseHead(
                 response,
                 false,
                 &.{},
                 false,
+                &scratch.head,
                 headBytes(server, conn),
             ) catch {
                 upstreamFailed(server, conn);
@@ -2639,13 +2705,21 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.downstream_close_announced = !keep_downstream;
             conn.l7.upstream_reusable = response.keep_alive;
             const verdict = stickyVerdict(server, conn);
-            var edit_buffer: [constants.response_edits_max]filter.AppliedHeaderEdit = undefined;
-            var cookie_scratch: [sticky_value_bytes_max]u8 = undefined;
+            const scratch = server.borrowRenderScratch();
+            defer server.returnRenderScratch();
             const rendered = render.renderResponseHead(
                 response,
                 !keep_downstream,
-                responseEditsWithStamp(server, conn, response, verdict, &edit_buffer, &cookie_scratch),
+                responseEditsWithStamp(
+                    server,
+                    conn,
+                    response,
+                    verdict,
+                    &scratch.response_edits,
+                    &scratch.sticky,
+                ),
                 false,
+                &scratch.head,
                 headBytes(server, conn),
             ) catch {
                 // The head no longer fits — after the #175 edits or the

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -217,11 +217,12 @@ pub fn Proxy(comptime IoType: type) type {
         fn answerHeadOverflow(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
             assert(conn.tls != null);
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             if (parser.parseRequestHead(
                 headBytes(server, conn)[0..conn.head_len],
                 true,
-                &storage,
+                storage,
             )) |_| {
                 // The head completed inside the buffer, so what overran it
                 // was payload.
@@ -502,8 +503,9 @@ pub fn Proxy(comptime IoType: type) type {
             const head = bytes[0..conn.head_len];
             const head_is_full = conn.head_len == bytes.len;
 
-            var storage: parser.HeaderStorage = undefined;
-            const request = parser.parseRequestHead(head, head_is_full, &storage) catch |err| switch (err) {
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
+            const request = parser.parseRequestHead(head, head_is_full, storage) catch |err| switch (err) {
                 error.Incomplete => {
                     // A full buffer never yields Incomplete — the parser
                     // converts it to the oversize verdicts below — so here
@@ -1408,11 +1410,12 @@ pub fn Proxy(comptime IoType: type) type {
             // pool cannot have been emptied in between.
             server.releaseUpstream(failed);
             conn.upstream = null;
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             const request = parser.parseRequestHead(
                 headBytes(server, conn)[0..conn.head_len],
                 false,
-                &storage,
+                storage,
             ) catch unreachable;
             // Re-derived rather than remembered, like the replay's
             // framing: same bytes, same key. A cookie cluster's #178
@@ -1433,14 +1436,15 @@ pub fn Proxy(comptime IoType: type) type {
         /// calls `renderRequestAndStartLegs` directly instead.
         fn renderAndStartLegs(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_dialing);
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             // The same bytes parsed successfully in routeRequest (§7:
             // bytes are the single source of truth), so a failure here is
             // an invariant violation, not an input condition.
             const request = parser.parseRequestHead(
                 headBytes(server, conn)[0..conn.head_len],
                 false,
-                &storage,
+                storage,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
             // Only this path pays for canonicalization twice, and it has
@@ -2023,11 +2027,12 @@ pub fn Proxy(comptime IoType: type) type {
             const head = upstreamHeadBytes(upstream)[0..upstream.head_len];
             const head_is_full = upstream.head_len == upstreamHeadBytes(upstream).len;
 
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             const response = parser.parseResponseHead(
                 head,
                 head_is_full,
-                &storage,
+                storage,
                 conn.l7.request_method,
             ) catch |err| switch (err) {
                 error.Incomplete => {
@@ -2065,11 +2070,12 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_leg == .awaiting_head);
             assert(conn.l7.request_head_vacated);
             const upstream = conn.upstream.?;
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             const response = parser.parseResponseHead(
                 upstreamHeadBytes(upstream)[0..upstream.head_len],
                 false,
-                &storage,
+                storage,
                 conn.l7.request_method,
             ) catch unreachable;
             assert(response.head_len == conn.l7.response_head_len_marker);
@@ -3396,11 +3402,12 @@ pub fn Proxy(comptime IoType: type) type {
             // cannot fail; the framing tracker MUST re-derive from the
             // parse — the coalesced excess was already fed once and will
             // be fed again on the fresh try.
-            var storage: parser.HeaderStorage = undefined;
+            const storage = server.borrowHeaderScratch();
+            defer server.returnHeaderScratch();
             const request = parser.parseRequestHead(
                 headBytes(server, conn)[0..conn.head_len],
                 false,
-                &storage,
+                storage,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
             conn.l7 = .{

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -88,6 +88,23 @@ comptime {
     }
 }
 
+/// What one head render needs beyond its output buffer, lent by the
+/// caller rather than declared per call.
+///
+/// The array inside is a local of `appendEndToEndHeaders` by rights —
+/// nothing in it outlives the render. It is a parameter because under
+/// ReleaseSafe an `= undefined` local is 0xaa-filled on every call, and
+/// this one is 1 KiB filled twice per exchange (once per hop), which §9's
+/// flamegraph found is most of what the render path costs. The serving
+/// path lends `Server.render_scratch`; a test or a bench may still declare
+/// one on the stack.
+pub const HeadScratch = struct {
+    /// The `Connection` header's nominated values, collected once per
+    /// render. Re-finding them inside the per-header hop-by-hop test made
+    /// the walk O(headers²) — the render's top user-CPU cost under load.
+    connection_values: [constants.headers_max][]const u8,
+};
+
 /// Renders the upstream request line and end-to-end headers from a
 /// parsed head. The client's version is preserved — framing decisions on
 /// both hops key off the real versions — and `inject_close` announces
@@ -125,6 +142,8 @@ pub fn renderRequestHead(
     /// agreed to carry (#180): the participating `Upgrade` travels and
     /// the proxy writes its own `Connection: upgrade`.
     keep_upgrade: bool,
+    /// The caller's scratch for this render (see `HeadScratch`).
+    scratch: *HeadScratch,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     // The proxy answers CONNECT with 501 itself, never forwards it (§7).
@@ -167,6 +186,7 @@ pub fn renderRequestHead(
             .max_forwards = max_forwards != null,
         },
         keep_upgrade,
+        scratch,
     );
     if (forwarded_for) |value| {
         assert(value.len >= 1);
@@ -216,6 +236,8 @@ pub fn renderResponseHead(
     /// True when this response is the `101` completing an upgrade this
     /// proxy is carrying (#180), the mirror of the request-side flag.
     keep_upgrade: bool,
+    /// The caller's scratch for this render (see `HeadScratch`).
+    scratch: *HeadScratch,
     buffer: []u8,
 ) error{Oversize}![]const u8 {
     assert(response.status >= 100);
@@ -243,6 +265,7 @@ pub fn renderResponseHead(
         // header this proxy writes on the client's behalf.
         .{},
         keep_upgrade,
+        scratch,
     );
     // A carried upgrade announces the opposite of a close: this hop is
     // continuing, in a different protocol. The two are mutually exclusive
@@ -446,6 +469,8 @@ fn appendEndToEndHeaders(
     /// `Connection: upgrade` line rather than forwarding whatever
     /// spelling arrived.
     keep_upgrade: bool,
+    /// The caller's scratch for this render (see `HeadScratch`).
+    scratch: *HeadScratch,
 ) error{Oversize}!void {
     assert(headers.len <= constants.headers_max);
     // One slot past the filter budget: the #178 Set-Cookie stamp.
@@ -453,11 +478,10 @@ fn appendEndToEndHeaders(
     // Collect the Connection header value(s) once (usually zero or one).
     // Re-finding them inside the per-header hop-by-hop test made the walk
     // O(headers²) — the render's top user-CPU cost under load (§9).
-    var connection_values: [constants.headers_max][]const u8 = undefined;
     const active_nominations = collectNominations(
         headers,
         connection_nominates_header,
-        &connection_values,
+        &scratch.connection_values,
     );
 
     // Only `set`/`remove` edits suppress source copies; `add` never does.
@@ -604,6 +628,13 @@ const testing = std.testing;
 /// `head_buffer_bytes_default` and overflowing it is the 431/teardown verdict.
 const oracle_buffer_bytes = constants.head_buffer_bytes_default + @as(u32, constants.headers_max) + 64;
 
+/// The one `HeadScratch` the tests below lend, which is exactly the shape
+/// the serving path uses: a render at a time, so one buffer serves them
+/// all. File scope rather than a local per test only to keep the call
+/// sites reading as the assertions they are. Referenced from tests alone,
+/// so a non-test build never analyses it.
+var test_head_scratch: HeadScratch = undefined;
+
 test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const head = "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-Nominated\r\n" ++
         "Keep-Alive: timeout=5\r\nTE: trailers\r\nX-Nominated: v\r\nX-Keep: yes\r\n\r\n";
@@ -611,13 +642,13 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, null, false, &buffer);
+    const closed = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, true, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "GET /p HTTP/1.1\r\nHost: a\r\nX-Keep: yes\r\nConnection: close\r\n\r\n",
         closed,
@@ -641,6 +672,7 @@ test "render: an absolute-form authority replaces the client's Host" {
         null,
         null,
         false,
+        &test_head_scratch,
         &buffer,
     );
     try testing.expectEqualStrings(
@@ -668,7 +700,7 @@ test "render: filter edits set, add, and remove headers" {
         .{ .kind = .remove, .name = "cookie", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &test_head_scratch, &buffer);
     // Surviving source headers first (Host, kept X-Trace, X-Keep), then the
     // injected set/add lines; the source X-Env and Cookie are gone.
     try testing.expectEqualStrings(
@@ -698,7 +730,7 @@ test "render: an edit that overflows the buffer is Oversize" {
     var tight: [34]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &tight),
+        renderRequestHead(&request, .{ .path = "/p", .query = "" }, &edits, false, null, null, false, &test_head_scratch, &tight),
     );
 }
 
@@ -731,7 +763,7 @@ test "render: the edited oracle skips a head that grows past head_buffer_bytes_d
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var render_buf: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, null, false, &render_buf);
+    const rendered = try renderRequestHead(&parsed, .{ .path = "/", .query = "" }, &edits, false, null, null, false, &test_head_scratch, &render_buf);
     try testing.expect(rendered.len > constants.head_buffer_bytes_default);
     // Must return cleanly instead of panicking in the reparse precondition.
     checkRequestRenderEdited(&source);
@@ -745,7 +777,7 @@ test "render: nominating a protected header does not strip it" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "POST /u HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n",
         rendered,
@@ -763,7 +795,7 @@ test "render: a nomination on a second Connection line still strips" {
     const request = try parser.parseRequestHead(head, false, &storage);
     try testing.expect(request.connection_nominates_header);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     // Both Connection lines are hop-by-hop; X-Nominated goes because the
     // second line named it; X-Keep is untouched.
     try testing.expectEqualStrings(
@@ -783,7 +815,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
     // hop-by-hop name); the "Close" header survives — close nominates
     // nothing.
@@ -798,7 +830,7 @@ test "render: framing headers travel with the body" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead(head, false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
@@ -809,7 +841,7 @@ test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
     const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &buffer);
+    const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
 }
 
@@ -820,13 +852,13 @@ test "render: response preserves status line and strips hop-by-hop" {
     const response = try parser.parseResponseHead(head, false, &storage, .get);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
-    const rendered = try renderResponseHead(&response, false, &.{}, false, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n\r\n",
         rendered,
     );
 
-    const closed = try renderResponseHead(&response, true, &.{}, false, &buffer);
+    const closed = try renderResponseHead(&response, true, &.{}, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 418 I'm a teapot\r\nContent-Length: 0\r\nX-Origin: yes\r\n" ++
             "Connection: close\r\n\r\n",
@@ -849,7 +881,7 @@ test "render: response edits suppress, replace and append (#175)" {
         .{ .kind = .set, .name = "X-Keep", .value = "edited" },
         .{ .kind = .add, .name = "Strict-Transport-Security", .value = "max-age=63072000" },
     };
-    const rendered = try renderResponseHead(&response, false, &edits, false, &buffer);
+    const rendered = try renderResponseHead(&response, false, &edits, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
         "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n" ++
             "X-Keep: edited\r\n" ++
@@ -859,7 +891,7 @@ test "render: response edits suppress, replace and append (#175)" {
 
     // The close injection lands after the edits, exactly as it lands
     // after the origin's own headers.
-    const closed = try renderResponseHead(&response, true, &edits, false, &buffer);
+    const closed = try renderResponseHead(&response, true, &edits, false, &test_head_scratch, &buffer);
     try testing.expect(std.mem.endsWith(u8, closed, "Connection: close\r\n\r\n"));
 
     // Growth from edits is a real overflow: the same head with an added
@@ -867,7 +899,7 @@ test "render: response edits suppress, replace and append (#175)" {
     var tight: [head.len - 1]u8 = undefined;
     try testing.expectError(
         error.Oversize,
-        renderResponseHead(&response, false, &edits, false, &tight),
+        renderResponseHead(&response, false, &edits, false, &test_head_scratch, &tight),
     );
 }
 
@@ -876,7 +908,7 @@ test "render: bare status line without a reason phrase round-trips" {
     const response = try parser.parseResponseHead("HTTP/1.0 204\r\n\r\n", false, &storage, .get);
     try testing.expectEqual(@as(?[]const u8, null), response.status_message);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = try renderResponseHead(&response, false, &.{}, false, &buffer);
+    const rendered = try renderResponseHead(&response, false, &.{}, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings("HTTP/1.0 204\r\n\r\n", rendered);
 }
 
@@ -886,7 +918,7 @@ test "render: a head that no longer fits is Oversize" {
     const request = try parser.parseRequestHead(head, false, &storage);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
-    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, null, false, &small));
+    try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, null, false, &test_head_scratch, &small));
 }
 
 // Fuzzing (§9 gate 2): whatever the parser accepts, the renderer must
@@ -926,7 +958,7 @@ fn checkRequestRender(input: []const u8) void {
     const target = oracleTarget(&request, &scratch) orelse return;
 
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &.{}, false, null, null, false, &buffer) catch unreachable;
+    const rendered = renderRequestHead(&request, target, &.{}, false, null, null, false, &test_head_scratch, &buffer) catch unreachable;
 
     // The oracle buffer carries slack past `head_buffer_bytes_default` so normalization
     // growth never truncates the comparison; production renders into an
@@ -986,7 +1018,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         .{ .kind = .remove, .name = "X-Fuzz-Remove", .value = "" },
     };
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderRequestHead(&request, target, &edits, false, null, null, false, &buffer) catch return;
+    const rendered = renderRequestHead(&request, target, &edits, false, null, null, false, &test_head_scratch, &buffer) catch return;
 
     // The appended edits can push an already-large head past `head_buffer_bytes_default`
     // — the oversize-after-edits verdict (431 in production, which renders
@@ -1013,7 +1045,7 @@ fn checkResponseRender(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
     const response = parser.parseResponseHead(input, false, &storage, .get) catch return;
     var buffer: [oracle_buffer_bytes]u8 = undefined;
-    const rendered = renderResponseHead(&response, false, &.{}, false, &buffer) catch unreachable;
+    const rendered = renderResponseHead(&response, false, &.{}, false, &test_head_scratch, &buffer) catch unreachable;
 
     var reparse_storage: parser.HeaderStorage = undefined;
     const reparsed = parser.parseResponseHead(rendered, false, &reparse_storage, .get) catch unreachable;
@@ -1108,6 +1140,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
         forwarded_for,
         null,
         false,
+        &test_head_scratch,
         &buffer,
     ) catch return;
     if (rendered.len > constants.head_buffer_bytes_default) {


### PR DESCRIPTION
`ReleaseSafe` writes `0xaa` over every `= undefined` local on **every
call**. The serving path declared ten of them per exchange, so a
keep-alive request paid ~12.9 KiB of fill before either head was looked
at. `zig build profile` had been reporting it for weeks and nothing read
it that way: `compiler_rt.memset` was **62% of user cycles** under L7
load, the top symbol by eighteen times over the next one.

That is most of what the ReleaseFast → ReleaseSafe move actually cost.
The mode was priced as "the assertions", and the assertions are not the
bill.

Two slices, one per path, smallest first.

## `parser`: lend one header scratch (§5, §9)

`parser.HeaderStorage` was a local at seven sites — twice for the mapped
headers, twice more for the raw span hparse fills, per exchange. ~9.2 KiB
a request.

The premise it was written on is what expired. Its own comment says a
stack local "costs frame, not a connection slot", and that was true when
written: the earlier trap here was a struct-with-defaults zero-filling an
`undefined` array *field*, fixed by making the array a loose local, which
then "measured zero". Under ReleaseSafe a loose local is filled too, so
the fix quietly stopped holding.

`HeaderStorage` becomes an aggregate carrying the raw span as a second
field — which is what lets one loan cover a whole parse rather than the
caller's half of it, and keeps the type name so all sixty-odd
`*HeaderStorage` call sites are untouched.

## `render`: lend the render scratches too (§5, §9)

With the parse path lent a buffer, memset fell 62% → 37%, and every
remaining caller was a render frame. Six more locals, ~3.7 KiB a request.

The largest is not in `proxy.zig` at all: `connection_values` is 1 KiB,
belongs to `appendEndToEndHeaders`, and is filled once per hop. It
becomes `render.HeadScratch` and a parameter only so a caller can lend
one — a caller cannot lend what it cannot name.

## Why sharing one buffer is safe

Both `*_lent` flags assert the same two-part argument rather than leaving
it reviewed:

- **Across callbacks** — §4 runs each to completion and never nests one
  inside another.
- **Within a callback** — no synchronous chain from a borrow site reaches
  a second one. The paths that parse or render again are the ones reached
  *after* an await, where §7 re-parses from byte 0 precisely because
  nothing parsed survives its callback.

Each scratch also outlives every local it replaces, so nothing that was
sound becomes unsound; only a double borrow would be new, and that is
what the assert catches.

Both fields are comptime-sized and inline, so they join `drain_sink` and
`static_responses` outside every §5 budget term rather than adding one
the config can move.

## Measured

`zig build profile --protocol http`, one pinned core, 20k req/s, ~409k
requests:

| | memset, user cycles | user cycles |
|---|---|---|
| before | 62.6% | 4.744 B |
| after slice 1 | 36.6% | 2.525 B |
| after slice 2 | **absent from the report** | **1.582 B** |
| same tree, ReleaseFast | absent | 1.375 B |

ReleaseSafe went from **3.45x** the ReleaseFast user-cycle cost to
**1.15x**.

Throughput, L7, 200k offered, 64 connections, three interleaved rounds
per arm (interleaved because a blocked run on this box reads drift as
effect — an earlier blocked measurement did exactly that and had to be
thrown out):

| arm | achieved req/s |
|---|---|
| before | 150553 / 151446 / 149939 — a real ceiling, it saturates |
| after | 199810 / 199961 / 195942 — tracking the offer |
| ReleaseFast reference | 199973 / 199963 / 190678 |

**+33%**, and ReleaseSafe now costs what ReleaseFast does at this shape.
Every safety check is still on; what went away was the fill, not a check.

## Notes

- `@setRuntimeSafety(false)` also suppresses the fill (verified against
  the emitted object). It is deliberately **not** used here: it would
  disable bounds and overflow checks in the hottest parsing and rendering
  code, which is the opposite of why ReleaseSafe was chosen. Lending a
  buffer removes the work instead of eliding the initialisation.
- `bench/micro/l7_head_pipeline` hoists its storages out of the loop, so
  it never measured any of this — which is why the Tier-0 micros stayed
  quiet while the flamegraph had been saying 62%.
- The cold sites keep their stack locals: the health prober parses per
  interval, not per request, and the tests and config oracles are not a
  serving path.
- Two pre-existing over-length functions (`beginReplay` 80 lines,
  `analyzeHeaders` 74) are touched by these slices but not split — that
  overage predates this work and splitting it here would bury the change.

`zig build ci` (4096 seeds, census, live gate) and `zig fmt --check` pass
on each commit, with both borrow asserts never firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)