### PR TITLE
proxy: count the request cap where it is the reason (#237)

### DIFF
--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -2168,26 +2168,97 @@ pub fn Proxy(comptime IoType: type) type {
             return conn.requests_served >= cap;
         }
 
-        /// The #237 cap as the last brake on any persistence decision that
-        /// would otherwise keep.
+        /// The #237 cap as the last brake on the *proxied* response's
+        /// persistence decision, and the counter that goes with it.
         ///
-        /// One helper rather than a predicate each site remembers to
-        /// consult, because there are four such decisions — the proxied
-        /// response, a static answer, a #159 page and a #176 redirect —
-        /// and the cap is meaningless if it binds only the first. A client
+        /// One path, not four. The cap binds a connection answered
+        /// statically exactly as firmly as one being proxied — a client
         /// whose every request lands on a filter reject or a 404 holds its
-        /// slot exactly as firmly as one being proxied, which is the
-        /// occupancy this bounds.
+        /// slot the same way — but the other three reach it through
+        /// `staticPersistence` below, which separates the verdict from the
+        /// count for the reason its own doc gives. This one is safe to
+        /// keep coupled because nothing between the decision and the
+        /// answer can discard it: `renderResponse` can still fail after
+        /// counting, but its fallback runs from `.l7_exchanging`, and
+        /// `staticResponseResyncable` gates the static path on
+        /// `.l7_reading_head` — so the cap is never weighed twice for one
+        /// request. A future path that *could* be discarded after deciding
+        /// wants `staticPersistence`, not this.
         ///
-        /// It also owns the counter, so "the cap is why this closed" is
-        /// recorded once and only where it is the *binding* reason: a
-        /// connection already closing for pressure, a drain or the
-        /// client's own ask never reaches the check.
+        /// The counter records "the cap is why this closed" only where it
+        /// is the *binding* reason. `downstreamKeepAlive` is what earns
+        /// that here: it folds in the client's own ask, the drain and
+        /// relay pressure before this is consulted, so a connection
+        /// already closing for one of those never reaches the check.
         fn applyRequestCap(server: *ServerType, conn: *const ConnType, would_keep: bool) bool {
             if (!would_keep) return false;
             if (!requestsCapReached(server, conn)) return true;
             server.counters.increment("l7_keepalive_requests_capped");
             return false;
+        }
+
+        /// Whether a static answer keeps its connection, and whether the
+        /// #237 cap is *why* it does not.
+        ///
+        /// The four brakes in one place because the three static sites had
+        /// each spelled them out, and spelled them in an order that made
+        /// the counter say something untrue: the cap was consulted first
+        /// and the other three `and`-ed after it, so a client sending
+        /// `Connection: close` on its capped request — or any static
+        /// answer served while draining or relay-pressured — counted the
+        /// cap as the reason it closed when the reason was the client's,
+        /// the drain's or the pool's. `applyRequestCap` says it records
+        /// "only where it is the binding reason"; only the proxied path,
+        /// whose `downstreamKeepAlive` folds the others in itself, was
+        /// holding to that.
+        ///
+        /// The verdict and the counter are separated because one caller
+        /// can still fail between them: the #176 redirect needs `keep` to
+        /// render its head and may then find the head does not fit, and a
+        /// discarded answer must not leave a count behind
+        /// (`l7_redirected`'s placement rule, applied to the cap).
+        const StaticPersistence = struct {
+            keep: bool,
+            /// True only where `keep` is false *and* the cap is the reason
+            /// — which is exactly what the counter claims to measure.
+            capped: bool,
+        };
+
+        fn staticPersistence(
+            server: *const ServerType,
+            conn: *const ConnType,
+            may_keep: bool,
+        ) StaticPersistence {
+            const would_keep = may_keep and
+                staticResponseResyncable(conn) and
+                conn.l7.client_keep_alive and
+                !server.draining and
+                !server.keepAliveSuppressed();
+            if (!would_keep) return .{ .keep = false, .capped = false };
+            const persistence: StaticPersistence = blk: {
+                const capped = requestsCapReached(server, conn);
+                break :blk .{ .keep = !capped, .capped = capped };
+            };
+            // The negative space the struct's doc promises, checked on the
+            // value rather than argued from how it was built — `capped`
+            // names the cap as the reason a connection closed, so it can
+            // never ride alongside one that stayed open. True by
+            // construction today; the assert is what makes a future
+            // construction that breaks it fail here instead of quietly
+            // teaching the counter to lie again.
+            assert(!(persistence.keep and persistence.capped));
+            return persistence;
+        }
+
+        /// The verdict for a caller that commits to its answer straight
+        /// away, so the count can be taken with it.
+        fn staticKeepAlive(server: *ServerType, conn: *const ConnType, may_keep: bool) bool {
+            const persistence = staticPersistence(server, conn, may_keep);
+            if (persistence.capped) {
+                assert(!persistence.keep);
+                server.counters.increment("l7_keepalive_requests_capped");
+            }
+            return persistence.keep;
         }
 
         /// The §8 persistence decision, made once and honored: keep the
@@ -3741,10 +3812,7 @@ pub fn Proxy(comptime IoType: type) type {
             // holding connections open for their next request — and the
             // #237 request cap, which binds a connection answered
             // statically exactly as firmly as one being proxied.
-            return applyRequestCap(server, conn, may_keep and staticResponseResyncable(conn)) and
-                conn.l7.client_keep_alive and
-                !server.draining and
-                !server.keepAliveSuppressed();
+            return staticKeepAlive(server, conn, may_keep);
         }
 
         /// Answer an `OPTIONS` whose `Max-Forwards` reached zero: this
@@ -3891,11 +3959,9 @@ pub fn Proxy(comptime IoType: type) type {
             conn.log.status = page.status;
             conn.log.outcome = .responded;
             // The same four brakes every static answer honors (§7, §8):
-            // the client's own ask, the drain, and relay pressure.
-            const keep = applyRequestCap(server, conn, staticResponseResyncable(conn)) and
-                conn.l7.client_keep_alive and
-                !server.draining and
-                !server.keepAliveSuppressed();
+            // the client's own ask, the drain, relay pressure and the
+            // #237 cap.
+            const keep = staticKeepAlive(server, conn, true);
             conn.state = .l7_responding;
             armPageWrite(server, conn, page, keep);
         }
@@ -4001,22 +4067,35 @@ pub fn Proxy(comptime IoType: type) type {
                     error.NoHost => return respond(server, conn, 400, "l7_bad_request"),
                 };
             // The same four brakes `respond` honors, decided before the
-            // render because the close is announced inside it (§7).
-            const keep = applyRequestCap(server, conn, staticResponseResyncable(conn)) and
-                conn.l7.client_keep_alive and
-                !server.draining and
-                !server.keepAliveSuppressed();
+            // render because the close is announced inside it (§7) — but
+            // *counted* after it. This is the one static answer that can
+            // still be discarded once its persistence is known: an
+            // oversize head sends the request to `respond`, which reaches
+            // `commitStaticVerdict` and weighs the cap again for the same
+            // request. Counting here too would record one request twice,
+            // and #234's added `Date` and `Server` lines made that
+            // fallback measurably easier to reach — a `Location` that used
+            // to fit may not now.
+            const persistence = staticPersistence(server, conn, true);
             const rendered = render.renderRedirectHead(
                 redirect.status,
                 location,
-                !keep,
+                !persistence.keep,
                 server.currentDate(),
                 headBytes(server, conn),
             ) catch {
                 // The Location fit the scratch but head + Location does
-                // not fit the buffer: same fault, same status.
+                // not fit the buffer: same fault, same status. No count
+                // taken: the answer this decided for is not the one going
+                // out, and `respond` weighs the cap for the one that is.
                 return respond(server, conn, 414, "l7_uri_too_long");
             };
+            // Committed to the redirect, so the verdict earns its count.
+            const keep = persistence.keep;
+            if (persistence.capped) {
+                assert(!keep);
+                server.counters.increment("l7_keepalive_requests_capped");
+            }
             ServerType.clearRequestDeadline(conn);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment("l7_redirected");

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -5782,3 +5782,85 @@ test "l7: the request cap binds a statically-answered connection too" {
     try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
     try bed.expectDrained();
 }
+
+test "l7: a static answer to a client that asked to close is not counted either" {
+    // The proxied path already held to this — `downstreamKeepAlive` folds
+    // the client's ask in before the cap is consulted. The three static
+    // sites spelled the four brakes out themselves and put the cap
+    // *first*, `and`-ing the rest after, so the counter named the cap for
+    // a connection the client had already closed. Same rule, same
+    // scenario, the other path.
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/admin" },
+        .actions = &[_]filter.Action{.{ .reject = 403 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 334,
+        .request_filters = &rules,
+        .keepalive_requests = 1,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /admin HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        bed.client.response(),
+        "HTTP/1.1 403 Forbidden\r\n",
+    ));
+    // The connection still closes — it was always going to. What must not
+    // happen is the cap taking credit for it.
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try bed.expectDrained();
+}
+
+test "l7: a redirect discarded for an oversize head counts the cap once" {
+    // Two verdicts, one request. `respondRedirect` decides persistence
+    // before the render because the close is announced inside it, then the
+    // render finds the head does not fit and hands the request to
+    // `respond`, which weighs the cap again for the same request. Counted
+    // at both, one client's one request read as two capped connections.
+    //
+    // #234 made the fallback easier to reach, not the bug: a `Location`
+    // that fit before now shares the head with a `Date` and a `Server`.
+    const rules = [_]filter.Rule{
+        .{ .match = .{}, .actions = &.{
+            .{ .redirect = .{ .status = 301, .target = .{ .composed = .{ .scheme = .https } } } },
+        } },
+    };
+    const head_buffer_bytes: u32 = 1024;
+    const prefix = "GET /";
+    // Keep-alive, deliberately: the cap must be the binding reason, which
+    // it cannot be for a client that already asked to close.
+    const suffix = " HTTP/1.1\r\nHost: o\r\n\r\n";
+    var request: [prefix.len + 960 + suffix.len]u8 = undefined;
+    @memcpy(request[0..prefix.len], prefix);
+    @memset(request[prefix.len..][0..960], 'p');
+    @memcpy(request[prefix.len + 960 ..][0..suffix.len], suffix);
+    comptime assert(prefix.len + 960 + suffix.len <= head_buffer_bytes);
+
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 335,
+        .request_filters = &rules,
+        .head_buffer_bytes = head_buffer_bytes,
+        .keepalive_requests = 1,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange(&request);
+
+    // The 414 is the answer that went out, so the 414 is the answer that
+    // counts — exactly once.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_uri_too_long"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_redirected"));
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("l7_keepalive_requests_capped"),
+    );
+    try bed.expectDrained();
+}


### PR DESCRIPTION
Two accounting defects in `l7_keepalive_requests_capped`, both found in
the 0.4.0 review. Neither changes what the proxy *does* — connections
keep and close exactly as before — only what it reports about why.

## The cap was consulted before the other three brakes

`applyRequestCap`'s doc promises the counter records "only where it is
the **binding** reason: a connection already closing for pressure, a
drain or the client's own ask never reaches the check." The proxied path
earns that, because `downstreamKeepAlive` folds those three in first. The
three static paths — `commitStaticVerdict`, the #159 page, the #176
redirect — each spelled the brakes out by hand and put the cap first:

```zig
applyRequestCap(server, conn, staticResponseResyncable(conn)) and
    conn.l7.client_keep_alive and
    !server.draining and
    !server.keepAliveSuppressed()
```

So a client sending `Connection: close` on its capped request, or any
static answer served while draining or relay-pressured, counted the cap
as the reason it closed. An operator sizing `keepalive_requests` off that
number reads churn the cap did not cause.

Three copies of one rule is how the order drifted, so there is one now:
`staticPersistence` computes all four in the order that makes the counter
true. Same shape as the defect #237's own review found — the second copy
of `respond`'s preamble, which is why `commitStaticVerdict` exists.

## The redirect counted a verdict it then discarded

`respondRedirect` has to decide persistence before the render, because
the close is announced inside it. The render can then fail on an oversize
head and fall back to `respond(..., 414, ...)`, which re-enters
`commitStaticVerdict` and weighs the cap **again** for the same request —
one client's one request recorded as two capped connections.

So the verdict and the count are separated: `staticPersistence` returns
`{keep, capped}`, and the redirect takes the count only once its answer
is the one going out. `staticKeepAlive` wraps both for the callers that
commit straight away. This is `l7_redirected`'s placement rule — a
discarded try must not count — applied to the cap.

#234 did not cause this but made it reachable: a `Location` that fit the
head buffer before now shares it with a `Date` and a `Server` line.

## Verification

Two new tests, each mutation-verified against the bug it covers:

| restored bug | failure |
|---|---|
| brake order (cap first) | `expected 0, found 1` |
| redirect counts before the render | `expected 1, found 2` |

The existing `l7: a client that asked to close is not counted against the
cap` could not have caught either — it exercises the proxied path, which
was never wrong. That is why both survived #237's review and 0.4.0.

`zig build ci` (4096 seeds, live gate) and `zig fmt --check` pass.

## Note

`respondRedirect` is now at exactly 70 lines, the TIGER_STYLE hard limit,
with no slack left. Flagged rather than addressed — shrinking it is a
refactor that does not belong in an accounting fix, but the next change
to that function will have to do it first.

Sim coverage for the head-budget gap this review also turned up is filed
separately as #258, with the measurements showing why the obvious fix
does not work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)