### PR TITLE
sim: the origin sends hop-by-hop headers, so the strip is witnessed (§7, §9)

### DIFF
--- a/sim/l7/canon.zig
+++ b/sim/l7/canon.zig
@@ -19,9 +19,32 @@ pub const log_request_value = "sim-trace-1";
 pub const log_response_header = "x-sim-origin";
 pub const log_response_value = "sized";
 
+/// The hop-by-hop headers the sized origin answers with, and the one it
+/// nominates through `Connection` (RFC 9110 §7.6.1, §7). All three must
+/// die at this hop: two because they are hop-by-hop by name, the third
+/// because the connection option names it.
+///
+/// They ride the *canonical* response rather than a script of their own so
+/// that every seed, every schedule and both populations exercise the strip
+/// — and because a response whose headers are all removed leaves the
+/// client's bytes exactly as they were, so this costs no other oracle a
+/// change. The nominated name is lowercase on the wire and matched
+/// case-insensitively, so a proxy that only strips the spelling it was
+/// sent still fails.
+///
+/// The gap this closes was found by measurement, not review: a build that
+/// forwarded the origin's response head verbatim — hop-by-hop headers
+/// included — passed `zig build ci` in full, 4096 seeds and the live gate,
+/// because nothing here had ever sent one.
+pub const hop_nominated_header = "x-sim-nominated";
+pub const hop_by_hop_lines = "Connection: keep-alive, " ++ hop_nominated_header ++ "\r\n" ++
+    "Keep-Alive: timeout=5\r\n" ++
+    hop_nominated_header ++ ": dropme\r\n";
+
 pub const sized_body = "canonical-sized-response-body-00";
 pub const sized_head = "HTTP/1.1 200 OK\r\nContent-Length: 32\r\n" ++
-    log_response_header ++ ": " ++ log_response_value ++ "\r\n\r\n";
+    log_response_header ++ ": " ++ log_response_value ++ "\r\n" ++
+    hop_by_hop_lines ++ "\r\n";
 pub const sized_response = sized_head ++ sized_body;
 pub const chunked_wire = "10\r\nchunked-body-16b\r\n0\r\n\r\n";
 pub const chunked_head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
@@ -121,8 +144,20 @@ pub const interim_continue = "HTTP/1.1 100 Continue\r\n\r\n";
 pub const interim_hints = "HTTP/1.1 103 Early Hints\r\nLink: </s.css>; rel=preload\r\n\r\n";
 
 comptime {
+    // The scans below walk whole heads at comptime; the default quota is
+    // spent before the last of them finishes.
+    @setEvalBranchQuota(20_000);
     assert(sticky_tag.len == 16);
     assert(sized_body.len == 32);
+    // The strip oracle is only as good as what the origin actually sends:
+    // pin all three lines here so a tidy-up of `sized_head` that drops one
+    // fails the build rather than quietly retiring a check.
+    assert(std.mem.indexOf(u8, sized_head, "Connection: keep-alive") != null);
+    assert(std.mem.indexOf(u8, sized_head, "Keep-Alive: timeout=5") != null);
+    assert(std.mem.indexOf(u8, sized_head, hop_nominated_header ++ ": dropme") != null);
+    // The connection option must name the third header, or it is stripped
+    // for being unknown rather than for being nominated.
+    assert(std.mem.indexOf(u8, sized_head, "keep-alive, " ++ hop_nominated_header) != null);
     assert(chunked_wire[0] == '1' and chunked_wire[1] == '0');
     assert(chunked_wire.len == 4 + 16 + 2 + 5);
     assert(oversize_head.len == 8190);

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -60,6 +60,11 @@ pub const ClientError = error{
     /// hop does not offer — which is the whole of what the answer was
     /// asked for.
     AllowMissing,
+    /// A hop-by-hop header the origin sent survived the hop (RFC 9110
+    /// §7.6.1, §7): `Keep-Alive`, the header the origin's `Connection`
+    /// nominated, or a `Connection` carrying anything but this proxy's own
+    /// close announcement.
+    ResponseHopByHopLeaked,
     /// A response this proxy originated arrived without the `Date` and
     /// `Server` lines RFC 9110 §6.6.1 requires of it (#234) — or with a
     /// `Date` still holding the un-stamped placeholder, which is the
@@ -488,6 +493,10 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = violation;
                     return walk;
                 }
+                if (hopByHopViolation(&response)) |violation| {
+                    walk.violation = violation;
+                    return walk;
+                }
                 if (stickyViolation(connection, entry, &response)) |violation| {
                     walk.violation = violation;
                     return walk;
@@ -583,6 +592,44 @@ pub fn Client(comptime IoType: type) type {
             }
             if (headerPresent(response.headers, canon.response_never_name)) {
                 return ClientError.ResponseEditForged;
+            }
+            return null;
+        }
+
+        /// The §7 strip oracle over one parsed response head: nothing the
+        /// origin sent as hop-by-hop may reach the client.
+        ///
+        /// The sized origin answers with `Keep-Alive`, a `Connection` that
+        /// both is hop-by-hop itself and nominates a third header, and that
+        /// nominated header (`canon.hop_by_hop_lines`). Two of the three can
+        /// be demanded absent outright: this proxy writes no header called
+        /// either, so a sighting can only be a forward.
+        ///
+        /// `Connection` needs the narrower rule, because it is the one such
+        /// name this proxy writes itself — to announce a close (§7), which
+        /// several scripts earn. So any value but `close` is a leak: the
+        /// origin's `keep-alive` above all, which is what a verbatim
+        /// forward produces. A `101` is exempt and checked elsewhere
+        /// (`UpgradePairMissing`): there the participating pair travels on
+        /// purpose, which is §7's one hop-by-hop exemption (#180).
+        fn hopByHopViolation(response: *const parser.ResponseHead) ?ClientError {
+            assert(response.status >= 100);
+            assert(response.headers.len <= zoxy.constants.headers_max);
+            if (response.status == 101) return null;
+            if (headerPresent(response.headers, "Keep-Alive")) {
+                return ClientError.ResponseHopByHopLeaked;
+            }
+            if (headerPresent(response.headers, canon.hop_nominated_header)) {
+                return ClientError.ResponseHopByHopLeaked;
+            }
+            // Every `Connection` line, not the first: a leaked one and this
+            // proxy's own announcement can both be present, and which lands
+            // first is the renderer's business rather than this oracle's.
+            for (response.headers) |header| {
+                if (!std.ascii.eqlIgnoreCase(header.name, "connection")) continue;
+                if (!std.ascii.eqlIgnoreCase(header.value, "close")) {
+                    return ClientError.ResponseHopByHopLeaked;
+                }
             }
             return null;
         }


### PR DESCRIPTION
§7 requires this hop to strip what the origin marked hop-by-hop, and
nothing proved it did. The sim origin's canonical responses carried no
`Connection`, no `Keep-Alive` and nominated nothing, so the response-side
strip had no adversary — only the *request* side was witnessed
(`get_request_close`).

## How it was found

Not by review. While measuring whether forwarding a response head verbatim
would be faster than re-rendering it, I built exactly that — a byte-for-byte
copy of the origin's head, hop-by-hop headers included, which is the §7
violation this gate exists to prevent.

**`zig build ci` passed it.** 4096 seeds, the census, and the live gate, all
green on code that leaks `Connection: keep-alive` to the client. The gates
were only ever asking whether the proxy strips headers the origin never sent.

## What changed

The canonical sized response now sends three headers that must all die at
this hop:

```
Connection: keep-alive, x-sim-nominated
Keep-Alive: timeout=5
x-sim-nominated: dropme
```

The nomination is the part that earns its place: `x-sim-nominated` is on no
static list, so its removal can only be the connection option being honoured
— the half a strip-list check would miss. It is lowercase on the wire and
matched case-insensitively, so a proxy that strips only the spelling it was
sent still fails.

They ride the **canonical** response rather than a script of their own, which
is the point: every seed, every schedule the adversary produces, and both the
plaintext and terminating populations exercise the strip, instead of one
scripted path. It costs no other oracle a change, because a stripped header
leaves the client's bytes exactly as they were — the whole diff is the new
demand, not a re-baselining of the old ones.

`hopByHopViolation` is that demand:

- `Keep-Alive` and the nominated name may never appear **at all** — this proxy
  writes no header called either, so a sighting can only be a forward.
- `Connection` gets the narrower rule, being the one such name this proxy
  writes itself, to announce a close (§7). Any other value is a leak — the
  origin's `keep-alive` above all. **Every** `Connection` line is checked
  rather than the first: a leaked one and the proxy's own announcement can
  both be present, and which lands first is the renderer's business rather
  than the oracle's.
- A `101` is exempt, checked by `UpgradePairMissing`, where the participating
  pair travels on purpose (#180).

## Verified by mutation

With the `isHopByHop` skip in `src/http/render.zig` disabled, the sweep fails
at **seed 7** with `ResponseHopByHopLeaked`. Re-run after the oracle was
amended, so both the passing gate and the failing mutation reflect the code
in this PR.

One earlier mutation attempt is worth recording because it *passed*:
re-applying the verbatim-forward spike did not fire, since the harness stamps
every 200 unconditionally (#175) and the spike was conditioned on
`edits.len == 0`. Mutating the stripping logic directly is what actually
proved the oracle.

## Scope, stated plainly

- **Reach is the final response.** The walk settles interim `1xx` before the
  oracles run. No interim constant carries a hop-by-hop header today, and the
  strip runs for interims via `forwardInterim`, so this is a narrower name
  than "nothing hop-by-hop reaches the client".
- **A response with no filter edits is still unwitnessed** — and that is the
  reason this gap survived. The harness stamps every 200, so any future fast
  path conditioned on `edits.len == 0` would need its own listener to be
  exercised here.
- `walkResponses` is now 119 lines against the 70-line limit. It was 115
  before; this adds the four-line call. Pre-existing, and left alone rather
  than folding an unrelated refactor into a gate fix.

`zig build ci` and `zig fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)