### PR TITLE
budget: the startup closed form is the library's, and §13 names the seam

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2185,9 +2185,11 @@ data path" from prose into CI.
 
 ```
 src/
-  main.zig            // startup: config → reserve pools → print memory → run loop
+  main.zig            // the application: argv, files, rlimit, signals, run loop
   Server.zig          // composition root: pools, listeners, admission, teardown;
                       // generic over Io so the simulator instantiates it whole
+  budget.zig          // §5/§8 closed form: pool sizes, fd and ring demands, banner;
+                      // generic over Io like Server, so an embedder inherits it (§13)
   constants.zig       // every static limit; pool memory is f(these)
   config.zig          // strict JSON → arena-owned immutable Config
   io/
@@ -2324,3 +2326,56 @@ and proxies and diffs the parses; it is how most of the recent
 request-smuggling class was found, and it tests exactly the property
 §7's strictness claims. h2spec answers the same question for #173 and
 arrives with it.
+
+## 13. Embedding — the library seam
+
+zoxy is a Zig module before it is a binary, and that is not an
+aspiration: `build.zig` publishes `zoxy`, and the serving path takes a
+`Config` **struct**, never a config *file*. `Server(Io).init` is handed
+`*const Config`, so JSON is one way to produce one and not the only way.
+
+The seam already carries its own proof. `sim/Harness.zig` builds a
+`Config` field by field from a seeded PRNG — listeners, clusters, picks,
+filters, TLS, error pages — and instantiates `Server(SimIo)` whole, with
+no JSON anywhere; the directed suites do the same over `SimIo`, and
+`main.zig` does it over `XevIo`. §9's entire claim rests on that being a
+real seam rather than a described one: the simulator runs the *real*
+data path because it is an embedder.
+
+**What the module offers** is what `src/root.zig` exports: `config.Config`
+and its loader, `Server(Io)`, `Budget(Io)` (§5's closed form, the fd and
+ring demands, the banner), the `Io` seam with both backends, and the
+parsing/rendering/routing pieces the phases are built from. `Server`
+carries many other `pub` declarations; those are module visibility for
+`http/proxy.zig` and `shed.zig`, not surface — pool acquires and static-
+send claims are mechanics an embedder has no business holding.
+
+**What stays in `main.zig` is the application**, and the split is drawn
+at what only a program owning a process may do: interpret argv, read the
+filesystem, raise `RLIMIT_NOFILE`, install signal dispositions. That is
+also why the fd-boundary lint's allowlist (§9) still names exactly one
+file. `Budget` moved out from under it because the closed form has to
+price precisely what `Server.init` reserves — a second derivation in an
+embedder's tree would break §5's promise while still looking right —
+whereas an `rlimit` call is twelve lines an application should own.
+
+**Extension stays compile-time**, which §7 already states as the phase
+model: `admit`, `route`, `upstream_pick`, `settle` are plain calls into
+the owning modules, and programmability means adding a Zig function
+there, not registering a callback. A runtime hook seam is deliberately
+**not** offered, and the reasons are this document's own promises rather
+than taste. §1's zero-allocation guarantee is proven by a gate over
+*this* code, and a hook can allocate. §9's coverage census — every
+counter fired at least once across a sweep — is a claim about the
+simulator's build, which an embedder's is not. TIGER_STYLE's bounded
+loops and assertion density do not cross a seam either. Pingora makes
+the opposite trade and is right to: it has years of production
+consumers, and it does not promise what §1 promises.
+
+So the seam is **published, not frozen**. There is no external consumer
+yet, and #173 will change the exchange model from one request per
+connection to multiplexed streams — the exact internal shape a stability
+promise would pin. Naming it here is what stops it being rediscovered,
+not a commitment that it cannot move. The related idea — specializing a
+`Config` at comptime to buy performance — is a **settled no**, measured
+three ways in `IMPLEMENTATION_NOTES.md`.

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1038,6 +1038,55 @@ work disappearing. compiler_rt's own dispatch is already good; the call
 around it is not worth beating by hand. Do not re-propose without a
 workload whose header values are genuinely short.
 
+## Comptime config — rejected as a performance lever (2026-08-17, #261)
+
+The proposal was Pingora-shaped: expose a library API for building
+relays, make the JSON config one consumer of it, and specialize the
+config at comptime — filters named as the example — to harvest
+performance. The API half is a separate question with a separate
+justification (§13). The performance half is answered *no*, and it is
+answered by three measurements already in this file rather than by a new
+one.
+
+- **zoxy user code is 1.26% of cycles** ("Loop profile at the Tier-1
+  band", above): 98.6% sit inside one `io_uring_enter`, and the profile's
+  own conclusion is "do not optimize the Zig side". Constant-folding
+  config takes a fraction of that fraction.
+- **The head pipeline has already been made faster to no effect**
+  ("Hand-rolled short copy in the head render", directly above). That
+  change measured 8.3–8.8% faster on `bench/micro/l7_head_pipeline` — the
+  same code a comptime config would specialize — and 3149 ± 194 against
+  3193 ± 68 cycles/request at the proxy level, overlapping bands. A
+  comptime win would have to beat a real 8% micro win that vanished.
+- **The reverse experiment is already run and priced** ("Config shape is
+  the operator's to size", below). Eight compile-time ceilings became
+  runtime shape for **0.055%** of the printed budget, and the recorded
+  finding was that they were a capability ceiling, not a memory cost.
+  Reintroducing comptime config for speed reverses that decision against
+  its own evidence.
+
+What would be specialized is already the cheap shape: `filter.firstVerdict`
+and `router.route` are bounded scans over arena slices, called once per
+request each, inside the 1.26%. On the TLS path the bound is asymmetric
+crypto (~47% of the profile, "Profile share is not throughput headroom"),
+which comptime config does not touch at all.
+
+The cost side is not zero either, which is what makes this a rejection
+rather than a shelving. The JSON path is the product and cannot go away,
+so a comptime path is additive — and it would put a second comptime
+dimension on a `Server` already generic over `Io`. That hazard is
+measured too: the admin-listener bug ("What a ceiling was quietly holding
+up", below) was invisible to the whole suite because `Server(XevIo)` is
+instantiated only by `main.zig` while `admin_test` runs over `SimIo`.
+Doubling the matrix doubles the surface that no gate walks.
+
+Revisit condition, and it is deliberately a profile rather than an
+opinion: a workload in which zoxy user code is not a rounding error —
+which today means after `splice`/`send_zc` (§4, "Open questions") or
+#173 changes the shape of the data path. Even then the verdict is a
+proxy-level band, never a micro-bench delta; that mistake is what the
+section above this one is about.
+
 ## io_uring op upgrades — evaluated, deferred (2026-07-16)
 
 §4's "plain ops only" holds: on the loop profile above (latency-bound,

--- a/src/budget.zig
+++ b/src/budget.zig
@@ -1,0 +1,352 @@
+//! The startup budget (DESIGN.md §5, §8): the closed form that prices
+//! every pool this process holds for its life, the fd and ring demands
+//! the *effective* config makes, and the banner that prints both.
+//!
+//! It lives beside `Server` rather than inside `main` because it is the
+//! one part of startup an embedder (§13) cannot reasonably rewrite: the
+//! closed form has to price exactly what `Server.init` reserves, and a
+//! second derivation that drifted would break §5's promise — that the
+//! printed total covers everything this process holds — while still
+//! looking correct. `main.zig` keeps what is genuinely the application's:
+//! reading files, raising `RLIMIT_NOFILE`, installing signal handlers.
+//!
+//! Generic over the Io backend for the same reason `Server` is: a conn
+//! slot's size and an upstream slot's size are properties of the backend,
+//! so the closed form cannot be stated without one.
+
+const std = @import("std");
+
+const config_module = @import("config.zig");
+const constants = @import("constants.zig");
+const Io = @import("io/io.zig");
+const RelayBuffer = @import("net/relay.zig").RelayBuffer;
+const Server = @import("Server.zig").Server;
+const TlsEngine = @import("tls/Engine.zig");
+const upstream_module = @import("net/upstream.zig");
+
+const assert = std.debug.assert;
+
+pub fn Budget(comptime IoType: type) type {
+    Io.assertIoInterface(IoType);
+
+    return struct {
+        const ServerType = Server(IoType);
+        const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
+
+        /// What the effective config demands of the process before a
+        /// single connection is admitted (§8): both are pre-budgeted
+        /// rather than shed, so both are known here and neither is ever
+        /// a ladder rung.
+        pub const Demands = struct {
+            /// Listeners + conn slots + upstream slots + the ring, async
+            /// and signal fds, asserted against `RLIMIT_NOFILE` by
+            /// whoever can raise it.
+            fds: u32,
+            /// The depth the ring must be *created* with, so the
+            /// worst-case in-flight ops stay within the configured fill
+            /// (§4). Not the SQ, which is `constants.ring_entries`.
+            cq_entries: u32,
+        };
+
+        /// What the banner's first line stamps. The name on it is zoxy's
+        /// either way — what follows is the budget of zoxy's pools, and
+        /// `bench/run.zig` parses these lines from outside the process —
+        /// so an embedder names itself on a line of its own rather than
+        /// through this.
+        pub const Build = struct {
+            version: []const u8,
+            /// `main`'s `git describe` suffix, or empty where the build
+            /// cannot say what it is. Printed verbatim, separator
+            /// included.
+            id_suffix: []const u8 = "",
+        };
+
+        /// The §5/§8 demands of the *effective* config, not the compiled
+        /// ceilings — a lean deployment neither demands the c10k
+        /// `RLIMIT_NOFILE` nor asks the kernel for a 65536-deep ring.
+        pub fn demandsFor(config: *const config_module.Config) Demands {
+            assert(config.listeners.len >= 1);
+            const listeners_count: u32 = @intCast(config.listeners.len);
+            const access_log_files: u32 = if (config.access_log_sink) |sink|
+                @intFromBool(sink == .file)
+            else
+                0;
+            const demands: Demands = .{
+                .fds = constants.fdsRequired(
+                    config.limits.conn_slots,
+                    config.limits.upstream_slots,
+                    listeners_count,
+                    access_log_files,
+                ),
+                .cq_entries = constants.completionQueueDepthFor(
+                    config.limits.conn_slots,
+                    config.limits.upstream_slots,
+                    listeners_count,
+                    config.limits.cq_fill_eighths,
+                ),
+            };
+            // The effective config never exceeds the compiled ceilings
+            // (§8): the pools, the ring and the fd demand all fit what
+            // the constants proved. A demand of zero would mean a proxy
+            // that reserved nothing — the closed form broke.
+            assert(demands.cq_entries <= constants.completion_queue_entries);
+            assert(demands.fds > 0);
+            return demands;
+        }
+
+        /// The §5 pool-size vector for the effective config: every term
+        /// the closed form takes, sourced from the limit or `@sizeOf`
+        /// that owns it.
+        pub fn poolSizesFor(config: *const config_module.Config) constants.PoolSizes {
+            const limits = config.limits;
+            // The head-sized side buffers (§5): Server owns the closed
+            // form and asserts its own allocations against it, so
+            // pricing it here cannot drift from what init reserves.
+            const head_scratch_bytes = ServerType.headScratchBytes(limits);
+            assert(head_scratch_bytes >= limits.head_buffer_bytes);
+            assert(limits.conn_slots >= 1);
+            return .{
+                .conn_slots = limits.conn_slots,
+                .conn_bytes = @sizeOf(ServerType.ConnType),
+                .relay_buffers = limits.relay_buffers,
+                .relay_buffer_pair_bytes = @sizeOf(RelayBuffer),
+                .upstream_slots = limits.upstream_slots,
+                .upstream_bytes = @sizeOf(UpstreamType),
+                .access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes),
+                .log_header_bytes = ServerType.logHeaderBytes(config, limits.conn_slots),
+                .endpoint_table_bytes = ServerType.endpointTableBytes(config),
+                .metrics_bytes = ServerType.metricsBytes(config),
+                .head_buffers = limits.head_buffers,
+                .head_buffer_bytes = limits.head_buffer_bytes,
+                .upstream_head_buffers = limits.upstream_head_buffers,
+                // The pool element (the free-list header and the slab
+                // slice) plus its share of the slab itself.
+                .upstream_head_buffer_bytes = @sizeOf(upstream_module.HeadBuffer) +
+                    limits.head_buffer_bytes,
+                .head_scratch_bytes = head_scratch_bytes,
+                // Zero unless a listener allows an upgrade, on the same
+                // terms as the TLS terms below: a feature nobody asked
+                // for costs nothing. Same element as a shared relay
+                // buffer, reserved apart from it (§5) — the point of the
+                // pool, not an accident of it.
+                .tunnels = limits.tunnels,
+                .tunnel_buffer_pair_bytes = if (limits.tunnels == 0)
+                    0
+                else
+                    @sizeOf(RelayBuffer),
+                // Zero unless a listener terminates TLS, which is what
+                // makes the whole feature free to a deployment that did
+                // not ask for it. The three terms move together:
+                // `limits.tls_engines` is zero exactly when no listener
+                // has a `tls` block.
+                .tls_engines = limits.tls_engines,
+                .tls_engine_bytes = if (limits.tls_engines == 0) 0 else @sizeOf(TlsEngine),
+                .tls_plaintext_bytes = if (limits.tls_engines == 0)
+                    0
+                else
+                    TlsEngine.plaintextBytesFor(limits.head_buffer_bytes),
+                // The whole compiled reservation, not this config's
+                // share of it: the storage is one static array sized at
+                // `tls_engines_max` (it must outlive the arena — see
+                // `main.zig`'s `libcrypto_heap_storage`), so that is what
+                // the process holds for its life whatever `tls_engines`
+                // says, and §5 prices what is held.
+                .libcrypto_heap_bytes = if (limits.tls_engines == 0)
+                    0
+                else
+                    constants.libcrypto_heap_bytes,
+            };
+        }
+
+        /// Everything this process holds for its life, in bytes.
+        ///
+        /// The config arena is a term because it is never freed, and it
+        /// is the one term *measured* rather than derived: there is no
+        /// constant bounding a config file's size, so what the operator
+        /// writes is what it costs and the only honest thing the budget
+        /// can do is report it (§5).
+        pub fn totalBytes(
+            config: *const config_module.Config,
+            config_arena_bytes: u64,
+        ) u64 {
+            const sizes = poolSizesFor(config);
+            return totalBytesFor(&sizes, config_arena_bytes);
+        }
+
+        /// The same total for a caller that already holds the vector —
+        /// the banner does, and deriving it twice would price one config
+        /// through two evaluations of a form that must have exactly one.
+        pub fn totalBytesFor(
+            sizes: *const constants.PoolSizes,
+            config_arena_bytes: u64,
+        ) u64 {
+            const total = constants.memoryBytesTotal(sizes) + config_arena_bytes;
+            // A total of zero would be a proxy that reserved nothing.
+            assert(total > 0);
+            assert(total >= config_arena_bytes);
+            return total;
+        }
+
+        /// The §5 banner, to **stderr**: the banner is diagnostics, and
+        /// stdout belongs to the data an operator may point there — the
+        /// access log's `stdout` sink must stay one uncontaminated JSON
+        /// line per event. Stderr is where the counter dump already
+        /// goes, and via the same `std.debug.print` plain-write path, so
+        /// the two interleave whole-lines even when both land in one
+        /// redirected file (a positional writer here would be silently
+        /// overwritten by the dump's shared-offset writes).
+        pub fn print(
+            config: *const config_module.Config,
+            demands: Demands,
+            /// What the config text and its parsed structures took from
+            /// the startup arena, measured (§5).
+            config_arena_bytes: u64,
+            build: Build,
+        ) void {
+            assert(config.listeners.len >= 1);
+            assert(demands.fds > 0);
+            // Every budget reflects the *effective* config (§5, §8): the
+            // config may shrink the pools, the fd demand and the
+            // requested ring below the compiled ceilings, and all three
+            // are shown as actually sized.
+            const limits = config.limits;
+            const in_flight = constants.inFlightOps(
+                limits.conn_slots,
+                limits.upstream_slots,
+                @intCast(config.listeners.len),
+            );
+            const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
+            const sizes = poolSizesFor(config);
+            const memory_total = totalBytesFor(&sizes, config_arena_bytes);
+            printMemoryBanner(config, &sizes, memory_total, access_log_bytes, config_arena_bytes, build);
+            std.debug.print(
+                \\  fds     {d} required (asserted against RLIMIT_NOFILE)
+                \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
+                \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}
+                \\
+            , .{
+                demands.fds,
+                constants.ring_entries,
+                demands.cq_entries,
+                in_flight,
+                config.listeners.len,
+                config.clusters.len,
+                // Their rendered bytes live in the config arena term
+                // above — read and pre-rendered at load (#159), so the
+                // measured number already covers them; this count is
+                // what says why it grew.
+                config.error_pages.len,
+                if (config.access_log_sink) |sink| @tagName(sink) else "off",
+            });
+        }
+
+        /// The banner's version and memory lines — the §5 closed form
+        /// itemized. Split from `print` for the length limit; the two
+        /// prints are sequential same-thread writes to stderr, so
+        /// nothing interleaves.
+        fn printMemoryBanner(
+            config: *const config_module.Config,
+            sizes: *const constants.PoolSizes,
+            memory_total: u64,
+            access_log_bytes: u64,
+            config_arena_bytes: u64,
+            build: Build,
+        ) void {
+            assert(memory_total > 0);
+            assert(config.listeners.len >= 1);
+            const limits = config.limits;
+            // The version leads, because this banner is what a bug
+            // report pastes and `--version` is what it does not think to
+            // run.
+            std.debug.print(
+                \\zoxy {s}{s}
+                \\budgets (DESIGN.md §5/§8; closed-form except where marked):
+                \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
+                \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
+                \\          + upstream head buffers {d} x {d} B + head scratch {d} B
+                \\          + access log {d} KiB (+ logged headers {d} B)
+                \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
+                \\          + labeled metrics {d} B (tables, labels and render buffers)
+                \\          + tunnels {d} x {d} B (their own relay buffers, never HTTP's)
+                \\          + tls engines {d} x {d} B (+ plaintext {d} B each, libcrypto heap {d} KiB)
+                \\          + config arena {d} KiB (measured, not closed-form)
+                \\
+            , .{
+                build.version,
+                build.id_suffix,
+                memory_total / 1024,
+                limits.conn_slots,
+                sizes.conn_bytes,
+                limits.relay_buffers,
+                sizes.relay_buffer_pair_bytes,
+                limits.upstream_slots,
+                sizes.upstream_bytes,
+                limits.head_buffers,
+                // The +1 ownership byte stays out of the banner's
+                // per-unit figure; the closed-form total above carries it.
+                limits.head_buffer_bytes,
+                constants.bufferGroupDescriptorBytes(limits.head_buffers),
+                limits.upstream_head_buffers,
+                sizes.upstream_head_buffer_bytes,
+                sizes.head_scratch_bytes,
+                access_log_bytes / 1024,
+                sizes.log_header_bytes,
+                sizes.endpoint_table_bytes,
+                config.clusters.len,
+                ServerType.endpointKeysFor(config).stride,
+                sizes.metrics_bytes,
+                // Both read zero unless a listener allows an upgrade —
+                // printed rather than omitted, on the same terms as the
+                // TLS line below.
+                limits.tunnels,
+                sizes.tunnel_buffer_pair_bytes,
+                // All four read zero on a plaintext deployment, which is
+                // the line saying "you are not paying for this" rather
+                // than omitting itself and leaving the reader to wonder.
+                limits.tls_engines,
+                sizes.tls_engine_bytes,
+                sizes.tls_plaintext_bytes,
+                sizes.libcrypto_heap_bytes / 1024,
+                config_arena_bytes / 1024,
+            });
+        }
+    };
+}
+
+const testing = std.testing;
+
+test "demandsFor: the effective config sizes both demands, not the ceilings" {
+    const SimIo = @import("io/SimIo.zig");
+    const BudgetSim = Budget(SimIo);
+
+    var arena_instance = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_instance.deinit();
+    const config = try config_module.parse(arena_instance.allocator(), @embedFile("example_config"));
+
+    const demands = BudgetSim.demandsFor(&config);
+    // Both demands are the config's, so both must sit under what the
+    // constants compiled — the assert `demandsFor` itself makes, restated
+    // here against a config the loader actually accepted.
+    try testing.expect(demands.cq_entries <= constants.completion_queue_entries);
+    try testing.expect(demands.fds > config.limits.conn_slots);
+    // A lean config must not demand the c10k ring: that is the whole
+    // reason the depth is derived from the effective config (§4).
+    try testing.expect(demands.cq_entries < constants.completion_queue_entries);
+}
+
+test "totalBytes: the measured arena joins the closed form" {
+    const SimIo = @import("io/SimIo.zig");
+    const BudgetSim = Budget(SimIo);
+
+    var arena_instance = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_instance.deinit();
+    const config = try config_module.parse(arena_instance.allocator(), @embedFile("example_config"));
+
+    const pools_only = BudgetSim.totalBytes(&config, 0);
+    const with_arena = BudgetSim.totalBytes(&config, 4096);
+    // §5's promise is that the printed total covers everything held for
+    // the process's life, the arena included — so the arena is a term,
+    // not a rounding.
+    try testing.expectEqual(pools_only + 4096, with_arena);
+    try testing.expect(pools_only > 0);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,13 @@
 //! sigaction allowlist by lint), then hand the process to the event loop
 //! until a drain completes. `--help` and `--version` are answered before any
 //! of that and exit immediately.
+//!
+//! This file is the *application* — the CLI, the filesystem, and the two
+//! process-level syscalls. Everything an embedder would need identically
+//! is the library's (§13): the budget's closed form and banner live in
+//! `budget.zig`, the serving path in `Server`. What is left here is what
+//! only a program owning a process may do — raise a resource limit,
+//! install a signal disposition, decide what argv means.
 
 const std = @import("std");
 
@@ -13,6 +20,7 @@ const build_options = @import("build_options");
 
 const XevIo = zoxy.Io.XevIo;
 const ServerXev = zoxy.Server(XevIo);
+const BudgetXev = zoxy.Budget(XevIo);
 
 const assert = std.debug.assert;
 
@@ -128,40 +136,27 @@ pub fn main(init: std.process.Init) !void {
     server.dumpMetrics();
 }
 
-/// The §5/§8 startup budget gauntlet: fds and the ring are sized to the
-/// *effective* config, not the compiled ceilings — a lean deployment
-/// neither demands the c10k RLIMIT_NOFILE nor asks the kernel for a
-/// 65536-deep ring. Derives both demands, raises RLIMIT_NOFILE to the
-/// fd one, prints the banner, and returns the CQ depth the ring must be
+/// The §5/§8 startup budget gauntlet. The closed form and the banner are
+/// the library's (`budget.zig`, §13) — they have to price exactly what
+/// `Server.init` reserves, and a second derivation here would be a copy
+/// that could drift. What stays is what only an application may do: raise
+/// `RLIMIT_NOFILE` to the demand. Returns the CQ depth the ring must be
 /// created with.
 fn resolveBudgets(
     config: *const zoxy.config.Config,
     config_arena_bytes: u64,
 ) !u32 {
-    const listeners_count: u32 = @intCast(config.listeners.len);
-    assert(listeners_count >= 1);
-    const access_log_files: u32 = if (config.access_log_sink) |sink|
-        @intFromBool(sink == .file)
-    else
-        0;
-    const fds_required = zoxy.constants.fdsRequired(
-        config.limits.conn_slots,
-        config.limits.upstream_slots,
-        listeners_count,
-        access_log_files,
-    );
-    const cq_entries = zoxy.constants.completionQueueDepthFor(
-        config.limits.conn_slots,
-        config.limits.upstream_slots,
-        listeners_count,
-        config.limits.cq_fill_eighths,
-    );
-    // The effective config never exceeds the compiled ceilings (§8): the
-    // pools, the ring, and the fd demand all fit what the constants proved.
-    assert(cq_entries <= zoxy.constants.completion_queue_entries);
-    try ensureFdBudget(fds_required);
-    printBudgets(config, fds_required, cq_entries, config_arena_bytes);
-    return cq_entries;
+    assert(config.listeners.len >= 1);
+    const demands = BudgetXev.demandsFor(config);
+    try ensureFdBudget(demands.fds);
+    BudgetXev.print(config, demands, config_arena_bytes, .{
+        .version = build_options.version,
+        .id_suffix = build_id_suffix,
+    });
+    // What the ring is created with, so a zero would be a loop that can
+    // complete nothing — the closed form broke upstream of here.
+    assert(demands.cq_entries > 0);
+    return demands.cq_entries;
 }
 
 /// The §8 access-log sink as the fd `XevIo` will write: the inherited
@@ -464,193 +459,6 @@ fn ensureFdBudget(fds_required: u32) !void {
     }
     limits.cur = required;
     try std.posix.setrlimit(.NOFILE, limits);
-}
-
-/// The §5 pool-size vector for the effective config — split from
-/// `printBudgets` for the length limit, and so the composition reads as
-/// one thing: every term the closed form takes, sourced from the limit
-/// or `@sizeOf` that owns it.
-fn poolSizesFor(config: *const zoxy.config.Config) zoxy.constants.PoolSizes {
-    const limits = config.limits;
-    const UpstreamType = zoxy.UpstreamPool(XevIo).Upstream;
-    // The head-sized side buffers (§5): Server owns the closed form and
-    // asserts its own allocations against it, so printing it here cannot
-    // drift from what init actually reserves.
-    const head_scratch_bytes = ServerXev.headScratchBytes(limits);
-    assert(head_scratch_bytes >= limits.head_buffer_bytes);
-    return .{
-        .conn_slots = limits.conn_slots,
-        .conn_bytes = @sizeOf(ServerXev.ConnType),
-        .relay_buffers = limits.relay_buffers,
-        .relay_buffer_pair_bytes = @sizeOf(zoxy.RelayBuffer),
-        .upstream_slots = limits.upstream_slots,
-        .upstream_bytes = @sizeOf(UpstreamType),
-        .access_log_bytes = zoxy.constants.accessLogBytes(limits.access_log_buffer_bytes),
-        .log_header_bytes = ServerXev.logHeaderBytes(config, limits.conn_slots),
-        .endpoint_table_bytes = ServerXev.endpointTableBytes(config),
-        .metrics_bytes = ServerXev.metricsBytes(config),
-        .head_buffers = limits.head_buffers,
-        .head_buffer_bytes = limits.head_buffer_bytes,
-        .upstream_head_buffers = limits.upstream_head_buffers,
-        // The pool element (the free-list header and the slab slice) plus
-        // its share of the slab itself.
-        .upstream_head_buffer_bytes = @sizeOf(zoxy.UpstreamHeadBuffer) + limits.head_buffer_bytes,
-        .head_scratch_bytes = head_scratch_bytes,
-        // Zero unless a listener allows an upgrade, on the same terms as
-        // the TLS terms below: a feature nobody asked for costs nothing.
-        // Same element as a shared relay buffer, reserved apart from it
-        // (§5) — the point of the pool, not an accident of it.
-        .tunnels = limits.tunnels,
-        .tunnel_buffer_pair_bytes = if (limits.tunnels == 0)
-            0
-        else
-            @sizeOf(zoxy.RelayBuffer),
-        // Zero unless a listener terminates TLS, which is what makes the
-        // whole feature free to a deployment that did not ask for it. The
-        // three terms move together: `limits.tls_engines` is zero exactly
-        // when no listener has a `tls` block.
-        .tls_engines = limits.tls_engines,
-        .tls_engine_bytes = if (limits.tls_engines == 0) 0 else @sizeOf(zoxy.tls.Engine),
-        .tls_plaintext_bytes = if (limits.tls_engines == 0)
-            0
-        else
-            zoxy.tls.Engine.plaintextBytesFor(limits.head_buffer_bytes),
-        // The whole compiled reservation, not this config's share of it:
-        // the storage is one static array sized at `tls_engines_max` (it
-        // must outlive the arena — see `libcrypto_heap_storage`), so that
-        // is what the process holds for its life whatever `tls_engines`
-        // says, and §5 prices what is held.
-        .libcrypto_heap_bytes = if (limits.tls_engines == 0)
-            0
-        else
-            zoxy.constants.libcrypto_heap_bytes,
-    };
-}
-
-/// The §5 banner, to **stderr**: the banner is diagnostics, and stdout
-/// belongs to the data an operator may point there — the access log's
-/// `stdout` sink must stay one uncontaminated JSON line per event.
-/// Stderr is where the counter dump already goes, and via the same
-/// `std.debug.print` plain-write path, so the two interleave whole-lines
-/// even when both land in one redirected file (a positional writer here
-/// would be silently overwritten by the dump's shared-offset writes).
-fn printBudgets(
-    config: *const zoxy.config.Config,
-    fds_required: u32,
-    cq_entries: u32,
-    /// What the config text and its parsed structures took from the
-    /// startup arena, measured (§5). Not closed-form like the pools —
-    /// it is whatever the operator's config file needed — which is
-    /// exactly why it is reported rather than derived.
-    config_arena_bytes: u64,
-) void {
-    const constants = zoxy.constants;
-    // Every budget reflects the *effective* config (§5, §8): the config may
-    // shrink the pools, the fd demand, and the requested ring below the
-    // compiled ceilings, and all three are shown as actually sized.
-    const limits = config.limits;
-    const in_flight = constants.inFlightOps(
-        limits.conn_slots,
-        limits.upstream_slots,
-        @intCast(config.listeners.len),
-    );
-    const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
-    const sizes = poolSizesFor(config);
-    // §5's promise is that the printed total covers everything this
-    // process holds for its life. The config arena qualifies — it is
-    // never freed — so it joins the total even though it is the one term
-    // measured rather than derived from constants.
-    const memory_total = constants.memoryBytesTotal(&sizes) + config_arena_bytes;
-    // A banner that could print a zero total or zero fd demand would be
-    // reporting a proxy that reserved nothing — the closed form broke.
-    assert(memory_total > 0);
-    assert(fds_required > 0);
-    printMemoryBanner(config, &sizes, memory_total, access_log_bytes, config_arena_bytes);
-    std.debug.print(
-        \\  fds     {d} required (asserted against RLIMIT_NOFILE)
-        \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
-        \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}
-        \\
-    , .{
-        fds_required,
-        constants.ring_entries,
-        cq_entries,
-        in_flight,
-        config.listeners.len,
-        config.clusters.len,
-        // Their rendered bytes live in the config arena term above —
-        // read and pre-rendered at load (#159), so the measured number
-        // already covers them; this count is what says why it grew.
-        config.error_pages.len,
-        if (config.access_log_sink) |sink| @tagName(sink) else "off",
-    });
-}
-
-/// The banner's version and memory lines — the §5 closed form itemized.
-/// Split from `printBudgets` for the length limit; the two prints are
-/// sequential same-thread writes to stderr, so nothing interleaves.
-fn printMemoryBanner(
-    config: *const zoxy.config.Config,
-    sizes: *const zoxy.constants.PoolSizes,
-    memory_total: u64,
-    access_log_bytes: u64,
-    config_arena_bytes: u64,
-) void {
-    assert(memory_total > 0);
-    assert(config.listeners.len >= 1);
-    const limits = config.limits;
-    // The version leads, because this banner is what a bug report pastes
-    // and `--version` is what it does not think to run.
-    std.debug.print(
-        \\zoxy {s}{s}
-        \\budgets (DESIGN.md §5/§8; closed-form except where marked):
-        \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
-        \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
-        \\          + upstream head buffers {d} x {d} B + head scratch {d} B
-        \\          + access log {d} KiB (+ logged headers {d} B)
-        \\          + endpoint tables {d} B ({d} cluster(s) x {d} wide)
-        \\          + labeled metrics {d} B (tables, labels and render buffers)
-        \\          + tunnels {d} x {d} B (their own relay buffers, never HTTP's)
-        \\          + tls engines {d} x {d} B (+ plaintext {d} B each, libcrypto heap {d} KiB)
-        \\          + config arena {d} KiB (measured, not closed-form)
-        \\
-    , .{
-        build_options.version,
-        build_id_suffix,
-        memory_total / 1024,
-        limits.conn_slots,
-        @sizeOf(ServerXev.ConnType),
-        limits.relay_buffers,
-        @sizeOf(zoxy.RelayBuffer),
-        limits.upstream_slots,
-        sizes.upstream_bytes,
-        limits.head_buffers,
-        // The +1 ownership byte stays out of the banner's per-unit figure;
-        // the closed-form total above carries it.
-        limits.head_buffer_bytes,
-        zoxy.constants.bufferGroupDescriptorBytes(limits.head_buffers),
-        limits.upstream_head_buffers,
-        sizes.upstream_head_buffer_bytes,
-        sizes.head_scratch_bytes,
-        access_log_bytes / 1024,
-        sizes.log_header_bytes,
-        ServerXev.endpointTableBytes(config),
-        config.clusters.len,
-        ServerXev.endpointKeysFor(config).stride,
-        ServerXev.metricsBytes(config),
-        // Both read zero unless a listener allows an upgrade — printed
-        // rather than omitted, on the same terms as the TLS line below.
-        limits.tunnels,
-        sizes.tunnel_buffer_pair_bytes,
-        // All four read zero on a plaintext deployment, which is the line
-        // saying "you are not paying for this" rather than omitting itself
-        // and leaving the reader to wonder.
-        limits.tls_engines,
-        sizes.tls_engine_bytes,
-        sizes.tls_plaintext_bytes,
-        sizes.libcrypto_heap_bytes / 1024,
-        config_arena_bytes / 1024,
-    });
 }
 
 fn installSignalHandlers() void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -6,6 +6,11 @@ const std = @import("std");
 
 pub const access_log = @import("access_log.zig");
 pub const balancer = @import("balancer.zig");
+/// The §5/§8 startup budget: pool sizes, fd and ring demands, the banner.
+/// Generic over the Io backend like `Server`, and the reason it is here
+/// rather than in `main` is §13 — the closed form must price exactly what
+/// `Server.init` reserves, so an embedder inherits it instead of copying it.
+pub const Budget = @import("budget.zig").Budget;
 pub const config = @import("config.zig");
 pub const config_schema = @import("config_schema.zig");
 pub const constants = @import("constants.zig");
@@ -61,6 +66,7 @@ pub const testing = struct {
 test {
     _ = access_log;
     _ = balancer;
+    _ = @import("budget.zig");
     _ = config;
     _ = config_schema;
     _ = constants;


### PR DESCRIPTION
Research on #261 concluded that the issue's first half — "expose an API for building relays and make JSON config use it" — was largely already true, and its second half — harvest performance from comptime config — was already answered *no* by three measurements in `IMPLEMENTATION_NOTES.md`. This lands the cheap real part of the first and records the second as settled.

## `budget:` — the startup closed form is the library's, not main's

The §5/§8 budget — the pool-size closed form, the fd and ring demands, the banner — moves out of `main.zig` into a new `budget.zig`, generic over the `Io` backend the way `Server` is, and exported from `root.zig`.

It is the one piece of startup an embedder cannot reasonably rewrite: the closed form has to price exactly what `Server.init` reserves, so inheriting it is the difference between §5's promise holding and a second derivation that drifts while still looking right. An `rlimit` call, by contrast, is twelve lines an application should own — so `main.zig` keeps what only a program owning a process may do (argv, the filesystem, `RLIMIT_NOFILE`, signal dispositions), and the fd-boundary lint's allowlist still names exactly one file.

Same commit adds **DESIGN.md §13, "Embedding — the library seam"**, which names the seam rather than inventing it: `sim/Harness.zig` already builds a `Config` field by field and instantiates `Server(SimIo)` with no JSON anywhere, which is what makes §9's claim to run the *real* data path true rather than described. §13 also states what is deliberately not offered — a runtime hook seam — in this document's own terms: §1's zero-allocation guarantee is proven by a gate over *this* code and a hook can allocate; §9's coverage census is a claim about the simulator's build, which an embedder's is not. The seam is published, not frozen — #173 will move the exchange model.

## `notes:` — comptime config is not a performance lever

Recorded as a settled rejection with its revisit condition, so it is not re-chased:

| measurement | finding |
|---|---|
| Loop profile at the Tier-1 band | zoxy user code is **1.26% of cycles**; 98.6% sit inside one `io_uring_enter` |
| Hand-rolled short copy in the head render | **8.3–8.8% faster** on `bench/micro/l7_head_pipeline` — the same code comptime filters would specialize — and 3149 ± 194 vs 3193 ± 68 cycles/request at the proxy level, overlapping bands |
| Config shape is the operator's to size | the reverse experiment, already run: eight comptime ceilings became runtime shape for **0.055%** of the printed budget |

## Verification

- `zig build ci` green — 4096 sim seeds, census ok (71 counters fired, 17 exempt), smoke's 146 exchanges, counters reconcile, clean drain. `zig fmt --check` clean.
- **The banner's bytes are unchanged, verified rather than inspected**: HEAD built in a throwaway worktree, both binaries run against a config where every banner term is non-zero (tls engines, tunnels, head buffers, error pages, file sink, two clusters), output diffed byte-for-byte. This matters because `bench/run.zig:readBanner` parses `"  memory  total "`, `"+ head buffers "` and `"  config  "` off it from outside the process.
- `tiger-style-reviewer` on the slice: no violations. Two of its three judgement calls applied — a duplicated `poolSizesFor` evaluation in `print` (now `totalBytesFor` takes the vector the caller already holds) and a thin assertion density in the new `resolveBudgets`.

## Not in scope, on purpose

A comptime-hook API (`Server(Io, Hooks)`) — the genuinely Pingora-shaped half — stays parked behind two gates named in §13: a real external consumer, and #173 landing.

Closes #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
