### PR TITLE
http: a chunked trailer is a field section, not relay bytes (#244)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -868,6 +868,30 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   ways; `Connection: close` injected when the proxy will close — announced,
   not silent, or a client pipelines into the close and reads the reset as
   an error instead of a clean end.
+- **A chunked trailer is a field section, not relay bytes** (#244). RFC
+  9112 §7.1.2 spells it `*( field-line CRLF )`, and the scanner holds it
+  to exactly that: a token name, a colon, a forwardable value. So the
+  `X-Bad : v` shape a head earns a 400 for is refused here too, and a
+  line that is no field-line at all never reaches the far side. A
+  trailer *naming* a header §7 decides — protected, hop-by-hop, or one
+  the render writes itself (`X-Forwarded-For`, `Max-Forwards`) — is
+  refused outright; RFC 9110 §6.5.1 already forbids the sender to
+  generate one. Refused rather than stripped, and that is the design
+  point rather than a shortcut: the relay forwards a *prefix* of what
+  framing consumed, so there is no seam at which a trailer could be
+  removed instead — stripping would mean a compacting transform in both
+  body legs, over the TLS transform already in each, to suppress a field
+  the sender was told not to send. One scanner serves both directions,
+  so one verdict covers both: a client cannot hand the origin a
+  `Content-Length` this proxy never committed to, and an origin cannot
+  hand one to the client. Ordinary trailers — the checksums and
+  signatures the section exists for — still forward untouched. The
+  visible shape follows §7's usual rule that a status needs a leg which
+  has not committed: a request body arriving with its head earns a 400
+  and a streamed one a teardown; a response earns a 502 while nothing
+  has reached the client, and past that the client's connection ends
+  with the chunked body unterminated, which is how a truncation is
+  meant to read.
 - **Path routing on the canonical path only** (settled 2026-07-19). An
   `http` listener maps the request path to a cluster through a
   per-listener longest-prefix route table (`"routes": [{ "prefix":
@@ -2264,8 +2288,8 @@ is a trap rather than a synonym.
 
 | spec | what binds a gateway | here |
 |---|---|---|
-| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §5.6.7 date format; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §10.2.1 `Allow`; §15.2.1 `100 Continue` | §7, §8's `Date`, with one deviation below |
-| **9112** HTTP/1.1 | §3.2 target forms; §6.3 body length; §7 transfer codings; §9 connection management | §7 framing, §8 close announcement |
+| **9110** Semantics | §3.7 roles; §4.2.3 host comparison; §5.6.7 date format; §6.5.1 trailer limits; §6.6.1 `Date`; §7.6.1 hop-by-hop; §7.6.2 `Max-Forwards`; §7.6.3 `Via`; §10.2.1 `Allow`; §15.2.1 `100 Continue` | §7, §8's `Date`, with one deviation below |
+| **9112** HTTP/1.1 | §3.2 target forms; §6.3 body length; §7 transfer codings and §7.1.2's trailer section; §9 connection management | §7 framing, §8 close announcement |
 | **6585** additional statuses | defines `429` and `431` — **9110 did not absorb these**, the registry still points here | §8's static set |
 | **8297** early hints | defines `103` | §7's interim relay (#232) |
 | **3986** URI syntax | §2.3 unreserved, §5.2.4 dot-segments | §7 canonical path |
@@ -2324,8 +2348,10 @@ agreeing with everyone else's. The external counterpart is
 differential fuzzer that runs adversarial requests through many servers
 and proxies and diffs the parses; it is how most of the recent
 request-smuggling class was found, and it tests exactly the property
-§7's strictness claims. h2spec answers the same question for #173 and
-arrives with it.
+§7's strictness claims — the first differential run against it produced
+#244, the one payload in twenty-one where this proxy was the permissive
+side, and §7's trailer rule above is that run's verdict. h2spec answers
+the same question for #173 and arrives with it.
 
 ## 13. Embedding — the library seam
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -3587,13 +3587,10 @@ fn validateHeaderValue(value: []const u8) ParseError!void {
     }
 }
 
-fn isTokenByte(byte: u8) bool {
-    return switch (byte) {
-        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
-        '0'...'9', 'a'...'z', 'A'...'Z' => true,
-        else => false,
-    };
-}
+/// The parser owns the token alphabet, so a name this config accepts and
+/// a name the wire accepts can never drift apart (#244 moved the one
+/// definition there, beside `isForwardableByte`).
+const isTokenByte = parser.isTokenByte;
 
 /// Resolve a listener's route table (§7). `"cluster": "x"` is sugar for a
 /// single catch-all route; `"routes": [...]` is the explicit table.

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -477,6 +477,30 @@ pub fn parseResponseHead(
     };
 }
 
+/// One past the longest name `HeaderName` spells. That "one past" is what
+/// makes a truncated trailer name safe to classify: a name that fills the
+/// buffer is already longer than every managed spelling, so it and the
+/// prefix kept for it both classify `.other` — the same answer, which is
+/// why no "this name was truncated" flag is needed anywhere.
+const trailer_name_bytes_max: u8 = trailer_name_bytes: {
+    var longest: u8 = 0;
+    for (@typeInfo(HeaderName).@"enum".fields) |field| {
+        const tag: HeaderName = @enumFromInt(field.value);
+        longest = @max(longest, tag.text().len);
+    }
+    break :trailer_name_bytes longest + 1;
+};
+
+comptime {
+    // The property above, said where a reviewer can check it: every
+    // managed spelling fits with a byte to spare, so "the buffer filled"
+    // and "longer than any managed name" are the same statement.
+    for (@typeInfo(HeaderName).@"enum".fields) |field| {
+        const tag: HeaderName = @enumFromInt(field.value);
+        assert(tag.text().len < trailer_name_bytes_max);
+    }
+}
+
 /// Incremental delimiter for chunked bodies (RFC 9112 §7.1) relayed
 /// verbatim: zoxy forwards the encoded bytes untouched and only needs to
 /// know where the message ends, so this scanner validates framing and
@@ -484,6 +508,13 @@ pub fn parseResponseHead(
 /// be forwarded, in any split; whole-buffer and byte-at-a-time feeding
 /// reach identical outcomes. CRLF-strict everywhere: a bare LF anywhere in
 /// the framing is malformed (§7's smuggling posture).
+///
+/// The trailer section is held to `trailer-section = *( field-line CRLF )`
+/// (RFC 9112 §7.1.2) rather than scanned as bytes, and a field naming a
+/// header §7 decides is refused (#244). Both halves are here, in the one
+/// place both directions share, because the relay forwards a *prefix* of
+/// what it consumed — there is no seam at which a trailer could be
+/// stripped instead.
 pub const ChunkedScanner = struct {
     state: State = .size,
     /// Chunk-data bytes still to pass through in the current chunk.
@@ -506,6 +537,11 @@ pub const ChunkedScanner = struct {
     /// Bytes consumed by the trailer section, bounded by
     /// `constants.chunked_trailer_bytes_max`.
     trailer_bytes: u32 = 0,
+    /// The trailer field name being read, kept only as far as
+    /// `trailer_name_bytes_max` reaches. Reset at each field, so no name
+    /// can carry into the next one.
+    name_bytes: [trailer_name_bytes_max]u8 = undefined,
+    name_len: u8 = 0,
 
     pub const State = enum(u8) {
         size,
@@ -515,7 +551,8 @@ pub const ChunkedScanner = struct {
         data_cr,
         data_lf,
         trailer_start,
-        trailer_field,
+        trailer_name,
+        trailer_value,
         trailer_lf,
         final_lf,
         done,
@@ -566,7 +603,12 @@ pub const ChunkedScanner = struct {
             .size, .extension, .size_lf => scanner.stepSizeLine(bytes[0]),
             .data => scanner.stepData(bytes),
             .data_cr, .data_lf => scanner.stepDataEnd(bytes[0]),
-            .trailer_start, .trailer_field, .trailer_lf, .final_lf => scanner.stepTrailer(bytes[0]),
+            .trailer_start,
+            .trailer_name,
+            .trailer_value,
+            .trailer_lf,
+            .final_lf,
+            => scanner.stepTrailer(bytes[0]),
             .done => unreachable, // feed() never steps a finished scanner.
         };
     }
@@ -667,13 +709,36 @@ pub const ChunkedScanner = struct {
             .trailer_start => switch (byte) {
                 '\r' => scanner.state = .final_lf,
                 else => {
-                    if (!isForwardableByte(byte)) {
+                    // A trailer line starts with a field name or it ends
+                    // the section; RFC 9112 §7.1.2's grammar has no third
+                    // production. That is what refuses an obs-fold
+                    // continuation and the empty name in `: value`.
+                    if (!isTokenByte(byte)) {
                         return error.Malformed;
                     }
-                    scanner.state = .trailer_field;
+                    scanner.name_len = 0;
+                    scanner.appendNameByte(byte);
+                    scanner.state = .trailer_name;
                 },
             },
-            .trailer_field => switch (byte) {
+            .trailer_name => switch (byte) {
+                ':' => {
+                    if (scanner.nameIsManaged()) {
+                        return error.Malformed;
+                    }
+                    scanner.state = .trailer_value;
+                },
+                else => {
+                    // A space here is `X-Bad : v`, the smuggling shape the
+                    // head parser already refuses — the trailer section is
+                    // held to the same syntax, not a looser one (#244).
+                    if (!isTokenByte(byte)) {
+                        return error.Malformed;
+                    }
+                    scanner.appendNameByte(byte);
+                },
+            },
+            .trailer_value => switch (byte) {
                 '\r' => scanner.state = .trailer_lf,
                 else => {
                     if (!isForwardableByte(byte)) {
@@ -712,6 +777,32 @@ pub const ChunkedScanner = struct {
         if (scanner.trailer_bytes > constants.chunked_trailer_bytes_max) {
             return error.Oversize;
         }
+    }
+
+    /// Keeps the trailer name as far as the buffer reaches and drops the
+    /// rest, which `trailer_name_bytes_max` explains is free: the verdict
+    /// on a name that long is `.other` either way.
+    fn appendNameByte(scanner: *ChunkedScanner, byte: u8) void {
+        assert(isTokenByte(byte));
+        assert(scanner.name_len <= trailer_name_bytes_max);
+        if (scanner.name_len == trailer_name_bytes_max) {
+            return;
+        }
+        scanner.name_bytes[scanner.name_len] = byte;
+        scanner.name_len += 1;
+        assert(scanner.name_len <= trailer_name_bytes_max);
+    }
+
+    /// True when the trailer names a header §7 makes a decision about —
+    /// protected, hop-by-hop, or one this proxy writes itself. RFC 9110
+    /// §6.5.1 forbids a sender to generate any of them in a trailer (no
+    /// such definition permits it), and forwarding one would hand the far
+    /// side a framing, routing or address field this proxy already
+    /// settled in the header section (#244).
+    fn nameIsManaged(scanner: *const ChunkedScanner) bool {
+        assert(scanner.name_len >= 1);
+        assert(scanner.name_len <= trailer_name_bytes_max);
+        return classifyHeaderName(scanner.name_bytes[0..scanner.name_len]) != .other;
     }
 };
 
@@ -1493,6 +1584,19 @@ pub fn isForwardableByte(byte: u8) bool {
     return byte == '\t' or (byte >= ' ' and byte != 0x7f);
 }
 
+/// True for a byte legal in an RFC 9110 token — a field name, a method, a
+/// `Connection` nomination. Public for the same reason
+/// `isForwardableByte` is: the config compiler validates the names an
+/// operator writes against the exact set the parser enforces on the wire,
+/// one definition for both.
+pub fn isTokenByte(byte: u8) bool {
+    return switch (byte) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        '0'...'9', 'a'...'z', 'A'...'Z' => true,
+        else => false,
+    };
+}
+
 fn hexDigitValue(byte: u8) u4 {
     return @intCast(hexNibble(byte) orelse unreachable); // Caller matched a hex digit.
 }
@@ -1965,6 +2069,82 @@ test "chunked: extensions and trailers are forwarded, bounded, and end cleanly" 
     }
 }
 
+test "chunked: a trailer naming a header §7 decides is refused (#244)" {
+    // Every managed name, in a spelling no header-section rule would let
+    // a client choose either: `Connection` may not nominate the protected
+    // three away, a filter edit may not name them, and the render writes
+    // `X-Forwarded-For` and `Max-Forwards` itself. A trailer was the one
+    // path to the far side that checked none of it.
+    const names = [_][]const u8{
+        "Content-Length",
+        "transfer-encoding", // Case is not a way around it.
+        "Host",
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Connection",
+        "TE",
+        "Upgrade",
+        "X-Forwarded-For",
+        "Max-Forwards",
+    };
+    inline for (names) |name| {
+        const body = "0\r\n" ++ name ++ ": v\r\n\r\n";
+        for ([_]usize{ 1, body.len }) |feed_bytes_max| {
+            const outcome = chunkedOutcome(body, feed_bytes_max);
+            try testing.expectEqual(
+                @as(?ChunkedScanner.Error, error.Malformed),
+                outcome.failure,
+            );
+        }
+    }
+}
+
+test "chunked: a trailer field is held to the header field's syntax (#244)" {
+    const refused = [_][]const u8{
+        "0\r\nX-Bad : v\r\n\r\n", // Space before the colon.
+        "0\r\nX-Bad\t: v\r\n\r\n", // …and the tab spelling of it.
+        "0\r\nnocolon\r\n\r\n", // Not a field-line at all.
+        "0\r\n: novalue\r\n\r\n", // An empty field name.
+        "0\r\n X-Fold: v\r\n\r\n", // An obs-fold continuation.
+        "0\r\nX(Bad): v\r\n\r\n", // A non-token byte in the name.
+    };
+    for (refused) |body| {
+        for ([_]usize{ 1, body.len }) |feed_bytes_max| {
+            const outcome = chunkedOutcome(body, feed_bytes_max);
+            try testing.expectEqual(
+                @as(?ChunkedScanner.Error, error.Malformed),
+                outcome.failure,
+            );
+        }
+    }
+}
+
+test "chunked: an ordinary trailer still forwards, however long its name (#244)" {
+    // The right-hand case is what `trailer_name_bytes_max` is for: a name
+    // past the buffer keeps only a prefix, and the prefix must classify
+    // `.other` exactly as the whole name does — a truncation that could
+    // collide with a managed spelling would refuse a legal trailer.
+    const long_name = "X-" ++ ("a" ** (trailer_name_bytes_max * 2));
+    const bodies = [_][]const u8{
+        "0\r\nX-Checksum: 3f21\r\n\r\n",
+        "0\r\nX-Checksum: 3f21\r\nX-Signature: ab\r\n\r\n",
+        "0\r\nX-Empty:\r\n\r\n",
+        "0\r\n" ++ long_name ++ ": v\r\n\r\n",
+        // The managed names are the whole names, not substrings of them:
+        // a longer name that merely starts with one is nobody's framing.
+        "0\r\nContent-Length-Hint: 9\r\n\r\n",
+        "0\r\nX-Host: a\r\n\r\n",
+    };
+    for (bodies) |body| {
+        for ([_]usize{ 1, body.len }) |feed_bytes_max| {
+            const outcome = chunkedOutcome(body, feed_bytes_max);
+            try testing.expectEqual(@as(?ChunkedScanner.Error, null), outcome.failure);
+            try testing.expect(outcome.done);
+            try testing.expectEqual(@as(u64, body.len), outcome.consumed);
+        }
+    }
+}
+
 test "chunked: pipelined bytes after the terminator are left unconsumed" {
     const body = "1\r\na\r\n0\r\n\r\n";
     const stream = body ++ "GET";
@@ -2072,6 +2252,10 @@ const fuzz_corpus_request = "POST /submit HTTP/1.1\r\nHost: origin\r\nContent-Le
 const fuzz_corpus_extension = "PROPFIND /dav HTTP/1.1\r\nHost: origin\r\nDepth: 1\r\n\r\n";
 const fuzz_corpus_response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
 const fuzz_corpus_chunked = "5\r\nhello\r\n0\r\nX-Trailer: v\r\n\r\n";
+/// The refused trailer shapes (#244), seeded beside the accepted one so
+/// the fuzzer starts either side of the verdict rather than having to
+/// discover a whole trailer section byte by byte.
+const fuzz_corpus_chunked_trailer = "0\r\nContent-Length: 100\r\nX-Bad : v\r\n\r\n";
 
 test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
     try std.testing.fuzz({}, fuzzParserInputs, .{
@@ -2080,6 +2264,7 @@ test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
             fuzz_corpus_extension,
             fuzz_corpus_response,
             fuzz_corpus_chunked,
+            fuzz_corpus_chunked_trailer,
         },
     });
 }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -881,6 +881,36 @@ test "l7: a malformed chunked body coalesced with the head is answered 400" {
     try bed.expectDrained();
 }
 
+test "l7: a trailer naming a framing header is answered 400, never forwarded (#244)" {
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 7,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    // The shape HTTP Garden found: framing this proxy committed to in the
+    // head, restated by the client in the trailer section, where no §7
+    // rule used to look. It is refused as framing rather than stripped,
+    // because the relay forwards a prefix of what it consumed and has no
+    // seam at which a trailer could be removed instead — so the verdict is
+    // the parser's, and this is the operator-visible half of it: a body
+    // that arrives with its head still earns a status.
+    try bed.exchange(
+        "POST /x HTTP/1.1\r\nHost: o\r\nTransfer-Encoding: chunked\r\n\r\n" ++
+            "0\r\nContent-Length: 100\r\n\r\n",
+    );
+
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++ "Connection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_request"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
+    try bed.expectDrained();
+}
+
 test "l7: oversize request line is 414, oversize header section is 431" {
     {
         var bed: Http1Bed = undefined;


### PR DESCRIPTION
Closes #244.

The chunked trailer section was scanned as bytes and forwarded verbatim:
CRLF structure, a forwardable-byte alphabet, a size bound, and no colon
ever looked for. There was therefore no field *name* at any point, and
none of §7's header-section rules could apply to one.

## What reached the far side

Measured through the built binary against a real origin, before this
change:

```
0\r\nContent-Length: 100\r\n\r\n     forwarded verbatim
0\r\nX-Bad : v\r\n\r\n               forwarded verbatim  (a 400 in the head)
0\r\nnocolon\r\n\r\n                 forwarded verbatim
```

Two consequences, one root cause, and the second one is not in the issue.

**Framing names.** `protected_names` bars a `Connection` from nominating
`Content-Length`, `Transfer-Encoding` or `Host` away, and bars a filter
edit from naming them, because desynchronizing the receiver from the
framing this proxy committed to is a smuggling vector. The trailer was an
unguarded path to the same end from the other side.

**Addresses, which is worse in kind.** `X-Forwarded-For` and
`Max-Forwards` are headers the render writes *itself*, suppressing the
inbound copy precisely so the two spellings can never both reach the
origin. A trailer walked past that. `Content-Length` needs a
non-conforming origin to be worth anything; so does this, but the payoff
is a spoofed source address rather than a desync, and deciding that
address is a job §7 already claimed.

**And the response direction has the identical hole** — one
`ChunkedScanner` serves both framings, so an origin's trailer reached the
*client* the same way. The issue is written entirely request-side.

## Refused, not stripped

This is the design point rather than a shortcut, and it is why the
issue's ranking of the options inverts.

The relay forwards a **prefix** of what framing consumed:
`state.owe(fr.consumed)` then `state.pending(buffer(conn))`. "Consume
twenty bytes, forward three" is not expressible in that contract.
Dropping the trailer — nginx's effective behaviour, and the issue's
"cheapest" option — would need `FeedResult` to grow a `forwarded` count
distinct from `consumed`, in-place compaction of the field lines (the
scanner mutating its input, against its own stated contract that it never
decodes or copies), and composition with the TLS transform seam already
occupying `recvBuffer`/`transformIn`/`sendSlice` on the request leg and
`transformOut`/`sendSlice`/`creditSend` on the response leg — separately
on each. All to suppress a field RFC 9110 §6.5.1 forbids the sender to
generate in the first place.

A parser-only verdict costs none of that and covers both directions at
once, because there is one scanner.

## What changed

The section is held to `trailer-section = *( field-line CRLF )` (RFC 9112
§7.1.2) — a token name, a colon, a forwardable value — and a field whose
name classifies as anything but `.other` is refused. That is one
predicate that already exists and is already comptime-pinned to
`protected_names` and `hop_by_hop_names`, so there is no second list to
drift.

The name buffer is sized **one past** the longest managed spelling, and
that "one past" is the whole argument: a name that fills it is already
longer than every managed name, so it and the prefix kept for it classify
alike. No "this name was truncated" flag exists anywhere because none is
needed. `classifyHeaderName` dispatching on length first is what makes
the collision impossible rather than merely unlikely.

`isTokenByte` moves to the parser as the one definition, beside
`isForwardableByte` and for the reason that one already gives: the names
an operator writes in config are then validated against the exact
alphabet the wire is held to.

Ordinary trailers — the checksums and signatures the section exists for —
still forward untouched, which options (1) and (3)-as-written both lose.

## After

```
0\r\nContent-Length: 100\r\n\r\n     400, and the origin sees no body at all
0\r\nX-Bad : v\r\n\r\n               400
0\r\nnocolon\r\n\r\n                 400
0\r\nX-Checksum: 3f21\r\n\r\n         forwarded, unchanged
origin trailer -> client            502, or a truncated body once streaming
```

The visible shape follows §7's usual rule that a status needs a leg which
has not committed. A request body arriving with its head earns the 400; a
streamed one can only be a teardown. A response earns a 502 while nothing
has reached the client, and past that the client's connection ends with
the chunked body unterminated — which is how a truncation is meant to
read, rather than a silently complete message.

## Gates

`zig build ci` green: unit tests, boundary lint, 4096 sim seeds, and the
live gate (144 http + 2 l4 exchanges, counters reconcile, clean drain).

Parser tests pin every managed name (including a lowercase spelling, so
case is not a way around it), the six refused syntax shapes, and the
accepted side — a name past the buffer, and `Content-Length-Hint` and
`X-Host`, which must **not** trip the match. All of them at both feed
splits, so the verdict stays split-invariant. One proxy-level test takes
the request-direction 400 end to end with its counters. A corpus seed
carrying both refused shapes joins the parser fuzz target.

Two things worth knowing, neither introduced here:

- **`zig build test --fuzz` does not build on this toolchain** — the
  Zig 0.16 `StackTrace` mismatch already recorded at `config.zig`'s fuzz
  block. The new seed runs under plain `zig build test`; coverage-guided
  mode is unavailable to every seed until that unblocks.
- `ChunkedScanner` grows ~20 bytes, twice per `Conn`, so ~40 bytes per
  connection slot against the approximate "~17.7 KiB per conn slot" note
  in `constants.zig`. That figure is explicitly not comptime-derived and
  nothing asserts on it; it matters only if `conn_slots_default`'s
  ~33 MiB target is re-measured.

§7 records the rule and its visible shape; §12 adds 9110 §6.5.1 and 9112
§7.1.2 to what binds, and notes that Garden's first differential run is
what produced this.

Left for a separate slice, flagged on the issue: `ChunkedScanner.Error`
documents `Oversize` as having a counter distinct from `Malformed`, and
`feedFraming` discards the error kind, so no counter tells them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
