### PR TITLE
health: eject an endpoint that real traffic reports dead (#230)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1366,7 +1366,9 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
 - **A pick chooses among the endpoints that are both healthy and under
   capacity**, in that order, and the two filters differ in what an empty
   result means. Health fails **open**: a cluster with every endpoint
-  ejected balances as if none were. `max_inflight` (§8) fails **closed**:
+  ejected balances as if none were — and since #230 that rung is
+  reachable in a config with no prober at all, because real traffic can
+  eject too. `max_inflight` (§8) fails **closed**:
   every endpoint at its cap refuses the request rather than dialing one.
   The asymmetry is the point — an ejection says *we do not know whether
   these work*, so trying beats refusing, while a cap says *we know they
@@ -1549,13 +1551,91 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   it. Endpoints start healthy — probing demotes, it never gates startup
   — and the pick **fails open**: a cluster with every endpoint ejected
   balances as if none were, because routing nowhere would turn a probe
-  verdict into an outage of its own. Circuit breakers, outlier ejection
-  and *aggregate* retry budgets stay deferred — the previous iteration
-  proved them buildable in this architecture; simplicity says they wait
-  for a demonstrated need. The per-request dial retry above is not one
-  of them: it bounds itself per request and per connect deadline, where
-  a retry budget is the cluster-wide cap that keeps a partial outage
-  from pushing its whole load onto the endpoints still answering.
+  verdict into an outage of its own.
+
+- **Passive ejection** (a `passive_ejection` block, #230) ejects an
+  endpoint that *real traffic* reports dead, and it is the load-bearing
+  detector rather than an optimisation over probes. A `tcp` check passes
+  whenever the kernel accepts — which it does from the backlog even when
+  the application never calls `accept()` — so a wedged process, an
+  exhausted thread pool and a GC-stalled backend all look perfectly
+  healthy to it while every real request against them times out. An
+  `http` check catches that but cannot be a default: there is no path to
+  guess. Real traffic is the only ground truth, and a probe tests one
+  path with one method.
+
+  ```json
+  "api": { "endpoints": ["10.0.0.1:80", "10.0.0.2:80"],
+           "passive_ejection": { "fall": 5, "recovery_ms": 30000 } }
+  ```
+
+  Two signals, both the endpoint's own fault: a **dial that failed** for
+  its reasons rather than ours, and an exchange that produced **no
+  response byte**. An origin `5xx` is never a signal — a bad deploy
+  answering 500s is a software bug, not an unhealthy endpoint, and
+  conflating the two ejects healthy backends for it. That exclusion is
+  structural rather than a rule to remember: this proxy will not answer
+  `504` once a response has started, so a status that arrived cannot
+  reach the path. `error.Unexpected` is excluded for the mirror-image
+  reason — that is *this* process out of sockets or memory, and ejecting
+  a backend for it turns our exhaustion into their outage.
+
+  An **absolute consecutive count** suffices where Envoy needs
+  success-rate outlier detection with a panic threshold, and fail-open
+  is why: a cluster with every endpoint ejected balances as if none
+  were, so the correlated-failure objection is already answered. That is
+  what keeps this two numbers rather than a windowed statistics model.
+
+  **Recovery is where active checks earn their place.** Passive
+  detection needs traffic and an ejected endpoint receives none, so it
+  cannot observe its own recovery: `recovery_ms` is a cooldown, after
+  which traffic is let back to judge the endpoint again and `fall` more
+  failures put it straight out. The cooldown is checked once per health
+  interval, so it is honoured to within one interval and never expires
+  early. A cluster that would rather spend one probe than up to `fall`
+  requests re-testing a still-dead backend configures `check` as well,
+  and its `rise` restores from probe traffic. Hence the division of
+  labour: **passive detects failure, active detects recovery** — not
+  redundant, and why a deployment wants both without either being a
+  workaround for the other.
+
+  Both verdicts write one mask through one ejection path, so an endpoint
+  is out or it is not and `health_endpoint_down` counts either, with a
+  cause partition saying which. A **drained** endpoint (weight `0`)
+  accrues no passive verdict at all: it is never picked, so it sees no
+  traffic to be judged by — the drain filter running before health is
+  what makes that true rather than a special case.
+
+  Opt-in, like `check`, and for a reason worth stating: passive ejection
+  removes capacity by *inference*. The failure it prevents is visible
+  and diagnosable; the failure it can cause — ejecting a healthy backend
+  during a blip — is subtle and worse. That is an operator's call. The
+  consequence is that a default deployment still has the gap, so the §5
+  banner **states** it as a fact rather than warning about it:
+
+  ```
+  config  1 listener(s), 3 cluster(s), 0 error page(s), access log off, 1 cluster(s) without failure detection
+  ```
+
+  A cluster counts only if two of its endpoints are actually reachable
+  — undrained, weight non-zero. One reachable endpoint means nowhere to
+  eject *to*, fail-open makes the ejection a no-op, and flagging it
+  would be noise on the config the number has nothing to tell; weights
+  are final because config never reloads (§1), so `[1, 0]` is the
+  single-endpoint case under a longer spelling. A warning on a valid
+  config would decay into noise and take the rest of stderr with it;
+  the banner is what a bug report pastes, so "why did traffic keep going
+  to a dead backend?" becomes answerable without a round trip.
+
+- **Still deferred**: circuit breakers, Envoy-style *outlier detection*
+  (success-rate and stddev maths, panic thresholds) and *aggregate*
+  retry budgets. The previous iteration proved them buildable here;
+  simplicity says they wait for a demonstrated need, and fail-open plus
+  a consecutive count is why the simple thing sufficed. The per-request
+  dial retry above is not one of them: it bounds itself per request and
+  per connect deadline, where a retry budget is the cluster-wide cap
+  that keeps a partial outage from pushing its whole load onto the
+  endpoints still answering.
 
 ## 8. Load shedding — the exhaustion ladder
 

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1088,6 +1088,76 @@ which today means after `splice`/`send_zc` (§4, "Open questions") or
 proxy-level band, never a micro-bench delta; that mistake is what the
 section above this one is about.
 
+## Passive ejection — three of four questions answered by the code (2026-08-21, #230)
+
+#230 listed four "points to settle" before any code. Reading the tree
+answered three of them, and that is worth recording so nobody re-opens
+them as design work.
+
+**Retry double-counting — impossible by construction.** The worry was
+that one bad request could count several times against one endpoint.
+`candidateEndpoints` skips `alreadyTried`, so a request can never dial
+the same endpoint twice; `beginRetry` reassigns `conn.upstream` to an
+untried one before the next dial. A first-endpoint failure is credited
+once, a retry's failure credits the *second* endpoint, and neither can
+credit the first twice.
+
+**Drained endpoints — impossible by construction.** A weight-`0`
+endpoint is filtered before health is even consulted, so it sees no
+traffic and can accrue no passive verdict. Nothing to build.
+
+**Fail-open — no code change.** The balancer already fails open when the
+healthy set empties. Passive ejection only makes that rung reachable in
+a config with no prober, which wanted stating in §7 rather than
+implementing.
+
+**Mask ownership — the one real question**, and `counters.zig` already
+had the answer. Kernel pressure runs a total with two partitions, both
+asserted against it in `reconcile`. Ejection took the same shape: one
+event, `health_endpoint_down`, with `_probe`/`_passive` partitioning it.
+The mask is one bit and the balancer reads one thing, so *how* an
+endpoint left rotation is a fact about the verdict rather than about the
+state. `reconcile`'s `health_endpoint_down <= health_probes_failed` —
+which *was* the assertion "ejections come only from probes" — narrowed
+to `_probe` and still holds.
+
+**The signals needed less work than the issue expected.** Both are
+already precisely delimited: `expiryAnswerable` refuses to answer `504`
+once a response has started, so every `504` is already a
+no-response-byte `504`, and the issue's hard requirement that origin
+`5xx` never be a signal holds without a status check —
+`commitResponse` sets `response_started` before the status is looked at.
+
+**Half-open probation — considered, not built.** Recovery could admit
+exactly one request after the cooldown and restore on success, costing
+one request per cooldown instead of up to `fall`. It was rejected for
+its blast radius rather than its benefit: it needs a third endpoint
+state the balancer must understand plus in-flight tracking to admit
+exactly one, which is a change to `candidateEndpoints` and the pick
+path. A plain cooldown keeps the mask one bool and the balancer
+untouched, and the cost it trades away is bounded and stated at
+`passive_ejection_recovery_ms_default`. A cluster that wants the cheaper
+re-test configures `check`, whose `rise` already does exactly this from
+probe traffic.
+
+**Recovery rides the existing loop.** A dedicated re-admission timer
+would have cost two ring ops — unlike the prober's rest timer it can
+co-arm with probes, so it is disjoint from nothing — plus a state
+machine running while the prober is `.off`. Instead the health loop runs
+for a passive-only config, where a sweep dispatches nothing and rests
+immediately; `readmitExpired` runs at the top of each sweep. Zero new
+ops, zero budget change. The cost is that re-admission is granular to
+`health_interval_ms`.
+
+**What the sweep caught that the unit tests did not.** Seed 1918: a
+cluster configuring `check` *and* `passive_ejection` can have a cooldown
+expire while probes have a partial `rise` built up. `restore` cleared
+the passive residue but not `ok_streaks`, and the next passing probe met
+`witnessPass`'s "healthy implies no streak" invariant. The fix is the
+honest rule — every streak against an endpoint stops meaning anything
+the moment it is back in rotation — and the lesson is that the
+interleaving of two mask writers has two directions, not one.
+
 ## Health prober concurrency — the two options that were already answered (2026-08-21, #132)
 
 #132 offered three fixes for a serial sweep whose detection time scales

--- a/docs/README.md
+++ b/docs/README.md
@@ -519,9 +519,9 @@ rate means backends are flapping under a sticky population.
 
 ### Health checks
 
-Per-cluster and opt-in. A prober dials each endpoint in turn; `fall`
-consecutive failures eject it from balancing and close its pooled
-connections, and `rise` consecutive successes restore it.
+Per-cluster and opt-in. A prober sweeps every checked endpoint, several
+at a time; `fall` consecutive failures eject one from balancing and close
+its pooled connections, and `rise` consecutive successes restore it.
 
 ```json
 "api": {
@@ -537,6 +537,55 @@ budget of `timeouts.connect_ms` unless `timeout_ms` overrides it.
 
 If *every* endpoint in a cluster is ejected, zoxy fails open and uses them
 all — routing nowhere would turn a probe verdict into an outage of its own.
+
+### Detecting a dead backend from real traffic
+
+A `tcp` check passes whenever the kernel accepts, and the kernel accepts
+from the backlog even when the application behind it never does. A wedged
+process, an exhausted thread pool and a GC-stalled backend therefore look
+healthy to it while every real request against them times out. An `http`
+check catches that, but it needs a path you have to know.
+
+`passive_ejection` uses the traffic you already have.
+
+```json
+"api": {
+    "endpoints": ["10.0.0.1:8080", "10.0.0.2:8080"],
+    "passive_ejection": { "fall": 5, "recovery_ms": 30000 }
+}
+```
+
+`fall` consecutive **failed requests** eject the endpoint — a dial that
+failed, or an exchange that returned no response byte before its deadline.
+A response with a `5xx` status is *not* a failure: a bad deploy answering
+500s is a software bug, not an unhealthy backend, and ejecting for it would
+take out a whole cluster. Any response resets the count, so the failures
+must be consecutive.
+
+After `recovery_ms` the endpoint is let back in and traffic judges it
+again; if it is still dead, `fall` more failures eject it once more. That
+is why the two features compose rather than overlap — **passive detection
+finds the failure, active checks find the recovery** — and why a cluster
+that would rather re-test with one probe than with up to `fall` real
+requests should configure both.
+
+Defaults: `fall` 5 (higher than a probe's 3, because real traffic carries
+transient failures a probe never sees) and `recovery_ms` 30000. Ejection,
+fail-open and the closing of pooled connections work exactly as they do for
+active checks — it is the same rotation, reached by a different verdict.
+
+If no cluster has either kind of detection, the startup banner says so:
+
+```
+config  1 listener(s), 3 cluster(s), 0 error page(s), access log off, 1 cluster(s) without failure detection
+```
+
+It is a statement, not a warning — a multi-endpoint cluster with no checks
+is perfectly reasonable behind a service mesh, or when the endpoints are
+themselves load balancers. A cluster is counted only when two of its
+endpoints are reachable, so a single-endpoint cluster never is, and neither
+is one whose second endpoint is drained with `"weight": 0`. In both there is
+nowhere to eject to.
 
 ### Protecting a backend from overload
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -735,6 +735,7 @@ fn wireClusters(
             .weights = if (random.boolean()) &harness.weights_l4 else null,
             .pick = picks.l4,
             .check = health.check_l4,
+            .passive_ejection = health.passive_l4,
             .max_inflight = deriveMaxInflight(harness.clean, random),
             .proxy_protocol_send = harness.proxy_protocol_send_l4,
         },
@@ -748,6 +749,7 @@ fn wireClusters(
             .pick = picks.http,
             .hash_key = picks.http_hash_key,
             .check = health.check_http,
+            .passive_ejection = health.passive_http,
             .max_inflight = deriveMaxInflight(harness.clean, random),
             .retries = harness.retries_http,
         },
@@ -1000,11 +1002,44 @@ fn checkHttpDraw(
 const HealthDraw = struct {
     check_l4: ?Check,
     check_http: ?Check,
+    /// #230 passive ejection, drawn independently of the probes: the two
+    /// compose rather than overlap, so a scenario must be able to run
+    /// either alone as well as both.
+    passive_l4: ?PassiveEjection,
+    passive_http: ?PassiveEjection,
     interval_ms: u32,
     http_origin_stop_at_ns: u64,
 };
 
 const Check = zoxy.config.Config.Cluster.Check;
+const PassiveEjection = zoxy.config.Config.Cluster.PassiveEjection;
+
+/// A cluster's #230 passive-ejection draw. A third of adversary seeds
+/// opt in, and never a clean one: the signals are a failed dial and an
+/// exchange that answered nothing, and a clean seed produces neither —
+/// so configuring it there would cost every clean seed a stream shift to
+/// exercise a code path that cannot fire.
+///
+/// `fall` is drawn tight because a scenario is tens of virtual
+/// milliseconds long and the adversary refuses at most a fifth of dials:
+/// a threshold of five would leave the ejection unreachable on most
+/// seeds, which is the axis being unreachable rather than covered — the
+/// #258 lesson. `recovery_ms` is drawn short for the same reason, so the
+/// re-admission it gates is reachable inside a scenario too.
+fn derivePassiveEjection(clean: bool, random: std.Random) ?PassiveEjection {
+    if (clean) return null;
+    if (random.uintLessThan(u8, 3) != 0) return null;
+    const draw: PassiveEjection = .{
+        .fall = 1 + random.uintAtMost(u8, 2),
+        .recovery_ms = 1 + random.uintAtMost(u32, 20),
+    };
+    // The bounds the reachability argument above depends on, stated
+    // where they are drawn rather than only in prose.
+    assert(draw.fall >= 1 and draw.fall <= 3);
+    assert(draw.recovery_ms >= 1);
+    assert(draw.recovery_ms < health_interval_floor_ms);
+    return draw;
+}
 
 /// An eighth of adversarial seeds are outage seeds: the HTTP origin
 /// stops listening while clients are still live and parked connections
@@ -1045,6 +1080,8 @@ fn deriveHealthChecks(clean: bool, random: std.Random, timeout_ms: u32) HealthDr
         // the dial check is meaningful against it.
         .check_l4 = if (!outage and random.boolean()) tcp_check else null,
         .check_http = checkHttpDraw(checked_http, outage, random, tcp_check, http_check),
+        .passive_l4 = derivePassiveEjection(clean, random),
+        .passive_http = derivePassiveEjection(clean, random),
         .interval_ms = if (outage)
             5 + random.uintAtMost(u32, 10)
         else

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2756,6 +2756,17 @@ pub fn Server(comptime IoType: type) type {
                 // here — and wants the opposite response. The dial counter
                 // cannot tell them apart, so witness the pressure too (§8).
                 server.witnessKernelPressure(.connect, err);
+                // #230's dial signal, on the same split and for the same
+                // reason as the L7 path: an L4 cluster's endpoints share
+                // the one health mask, so a refusing backend an operator
+                // asked to have detected must be detected whichever
+                // protocol found it.
+                if (err != error.Unexpected) {
+                    server.health.witnessPassiveFailure(
+                        conn.charged_cluster,
+                        conn.charged_endpoint,
+                    );
+                }
                 server.beginTeardown(conn);
                 return;
             };
@@ -3133,6 +3144,7 @@ pub fn Server(comptime IoType: type) type {
                 .upstream_head_buffers_capacity = server.upstream_head_buffers.capacity(),
                 .kernel_pressure_last_errno = server.last_pressure_errno,
                 .health_endpoints_checked = server.health.checked_count,
+                .health_endpoints_ejectable = server.health.ejectable_count,
                 .health_endpoints_unhealthy = server.health.unhealthy_count,
             };
             // Asserted at the producer, not in the renderer: a level past

--- a/src/budget.zig
+++ b/src/budget.zig
@@ -227,10 +227,13 @@ pub fn Budget(comptime IoType: type) type {
             const sizes = poolSizesFor(config);
             const memory_total = totalBytesFor(&sizes, config_arena_bytes);
             printMemoryBanner(config, &sizes, memory_total, access_log_bytes, config_arena_bytes, build);
+            // A stack temporary in a function that runs once at startup,
+            // not a reservation (§5).
+            var fact_buffer: [failure_detection_fact_bytes]u8 = undefined;
             std.debug.print(
                 \\  fds     {d} required (asserted against RLIMIT_NOFILE)
                 \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
-                \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}
+                \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}{s}
                 \\
             , .{
                 demands.fds,
@@ -245,7 +248,56 @@ pub fn Budget(comptime IoType: type) type {
                 // what says why it grew.
                 config.error_pages.len,
                 if (config.access_log_sink) |sink| @tagName(sink) else "off",
+                failureDetectionFact(config, &fact_buffer),
             });
+        }
+
+        /// The rendering `failure_detection_fact_bytes` is the width of.
+        /// One literal, used by the format below *and* by the buffer that
+        /// holds it, so a reworded fact cannot silently outgrow its
+        /// buffer — the two used to agree only by a copied string.
+        const failure_detection_fact_format = ", {d} cluster(s) without failure detection";
+
+        /// The widest that fact can render: the literal with a `u32` at
+        /// full width in place of `{d}`.
+        const failure_detection_fact_bytes =
+            failure_detection_fact_format.len - "{d}".len +
+            std.fmt.count("{d}", .{std.math.maxInt(u32)});
+
+        /// The §7 failure-detection fact (#230), appended to the config
+        /// line: how many clusters could lose an endpoint and never
+        /// notice.
+        ///
+        /// Empty when there are none, which is deliberately unlike the
+        /// tunnel and TLS terms above — those print their zeros to say
+        /// "you are not paying for this", where a *pool* at zero is a
+        /// standing fact about the deployment. This is not a pool; it is
+        /// a count of a gap, and a gap that does not exist has nothing to
+        /// report rather than a zero worth reading.
+        ///
+        /// This is the whole visibility answer #230 asked for, and it is
+        /// deliberately not a warning. The banner is what a bug report
+        /// pastes, so "why did traffic keep going to a dead backend?"
+        /// becomes answerable without a round trip; a warning on a valid
+        /// config would decay into noise and take the rest of stderr with
+        /// it. §8's own line for the same idea: the budget is printed,
+        /// not hoped for.
+        fn failureDetectionFact(
+            config: *const config_module.Config,
+            buffer: []u8,
+        ) []const u8 {
+            // The claim the `catch unreachable` below rests on, checked
+            // rather than argued: this buffer is the one `print` sized.
+            assert(buffer.len == failure_detection_fact_bytes);
+            const count = config.clustersWithoutFailureDetection();
+            if (count == 0) return "";
+            const rendered = std.fmt.bufPrint(
+                buffer,
+                failure_detection_fact_format,
+                .{count},
+            ) catch unreachable; // The assert above covers every u32.
+            assert(rendered.len <= failure_detection_fact_bytes);
+            return rendered;
         }
 
         /// The banner's version and memory lines — the §5 closed form

--- a/src/config.zig
+++ b/src/config.zig
@@ -133,6 +133,55 @@ pub const Config = struct {
         return constants.healthProbeConcurrency(config.checkedEndpoints());
     }
 
+    /// Clusters that could lose an endpoint and would never notice: more
+    /// than one endpoint, and neither `check` nor `passive_ejection`
+    /// (§7, #230). The §5 banner states this as a fact, not a warning,
+    /// and that is the point — a multi-endpoint cluster with no failure
+    /// detection is legitimate behind a mesh, or when the endpoints are
+    /// themselves VIPs, so warning every startup would teach operators
+    /// to ignore the stream the banner and the `SIGUSR1` dump share.
+    ///
+    /// Clusters with fewer than two endpoints a request could actually
+    /// be sent to are excluded deliberately: there is nowhere to eject
+    /// *to*, and §7 fail-open makes the ejection a no-op there, so
+    /// counting them would make the number noise on exactly the configs
+    /// it has nothing to say about.
+    ///
+    /// "Could be sent to" means weight, not list length. A weight of `0`
+    /// **drains** an endpoint — it never enters the eligible set — and
+    /// config is loaded once and never reloaded, so a two-endpoint
+    /// cluster at weights `[1, 0]` has exactly one reachable endpoint
+    /// for the life of the process. That is the single-endpoint case
+    /// under a different spelling, and flagging it would be the same
+    /// noise by a longer route.
+    pub fn clustersWithoutFailureDetection(config: *const Config) u32 {
+        var total: u32 = 0;
+        for (config.clusters) |cluster| {
+            if (cluster.check != null or cluster.passive_ejection != null) continue;
+            if (reachableEndpoints(&cluster) < 2) continue;
+            total += 1;
+        }
+        assert(total <= config.clusters.len);
+        return total;
+    }
+
+    /// Endpoints of a cluster that any pick may return — those left
+    /// undrained by a non-zero weight (§7). An absent `weights` list is
+    /// the homogeneous case, where every endpoint carries weight one.
+    fn reachableEndpoints(cluster: *const Cluster) u32 {
+        const weights = cluster.weights orelse return @intCast(cluster.endpoints.len);
+        assert(weights.len == cluster.endpoints.len);
+        var reachable: u32 = 0;
+        for (weights) |weight| {
+            if (weight != 0) reachable += 1;
+        }
+        // The loader rejects an all-zero cluster, so a cluster always
+        // has somewhere to send a request even if not somewhere to eject
+        // to (`EndpointWeightsAllZero`).
+        assert(reachable >= 1);
+        return reachable;
+    }
+
     /// Where the access log writes (§8). `stdout` is the process's own
     /// standard output, inherited rather than opened, so it costs no file
     /// descriptor and carries no rotation story of its own — an operator
@@ -5180,6 +5229,37 @@ test "config: an http check resolves its request and expected status" {
         try std.testing.expectEqual(@as(?[]const u8, null), http.host);
         try std.testing.expectEqual(@as(u16, 200), http.expect_status);
     }
+}
+
+test "config: the failure-detection fact counts only clusters it can be true of" {
+    // What the §5 banner states (#230). The rule has two halves and both
+    // are judgement calls worth pinning: detection of *either* kind
+    // clears a cluster, and a single-endpoint cluster is never counted
+    // however undetected it is — there is nowhere to eject to, and §7
+    // fail-open makes the ejection a no-op, so counting it would put
+    // noise on exactly the configs the number has nothing to say about.
+    const json =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"bare"}],
+        \\ "clusters":{
+        \\  "bare":{"endpoints":["127.0.0.1:2","127.0.0.1:3"]},
+        \\  "alone":{"endpoints":["127.0.0.1:4"]},
+        \\  "probed":{"endpoints":["127.0.0.1:5","127.0.0.1:6"],"check":{"type":"tcp"}},
+        \\  "watched":{"endpoints":["127.0.0.1:7","127.0.0.1:8"],"passive_ejection":{}},
+        \\  "both":{"endpoints":["127.0.0.1:9","127.0.0.1:10"],
+        \\          "check":{"type":"tcp"},"passive_ejection":{}},
+        \\  "drained":{"endpoints":[{"address":"127.0.0.1:11","weight":1},
+        \\                          {"address":"127.0.0.1:12","weight":0}]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const config = try expectParseOk(&arena_state, json);
+
+    // Only `bare`. `alone` is single-endpoint; three have a detector of
+    // one kind or the other; and `drained` has two endpoints but only
+    // one a request can reach, which is the single-endpoint case wearing
+    // a longer spelling — config never reloads, so that weight is final.
+    try std.testing.expectEqual(@as(u32, 1), config.clustersWithoutFailureDetection());
 }
 
 test "config: a passive_ejection block rejects the thresholds it cannot act on" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -418,6 +418,14 @@ pub const Config = struct {
         /// cluster, so absent means the balancer never skips anything
         /// here and the prober never dials it.
         check: ?Check = null,
+        /// §7 passive ejection for this cluster (#230), or null to leave
+        /// it off. Independent of `check`: the two compose rather than
+        /// overlap, since real traffic is the only signal that catches a
+        /// backend whose kernel still completes the handshake while the
+        /// application behind it never answers — a wedged process, an
+        /// exhausted thread pool, a GC stall. That is precisely what a
+        /// `tcp` probe cannot see, because the backlog accepts for it.
+        passive_ejection: ?PassiveEjection = null,
         /// The §8 concurrency cap protecting each of this cluster's
         /// endpoints, or null for uncapped. **Per endpoint, not per
         /// cluster**: it is a statement about what one origin can carry,
@@ -541,6 +549,36 @@ pub const Config = struct {
                 expect_status: u16 = 200,
             };
         };
+
+        /// One cluster's resolved passive-ejection policy (§7, #230):
+        /// eject an endpoint that real traffic says is dead, rather than
+        /// only one a probe caught.
+        ///
+        /// Opt-in for the same reason `check` is. It removes capacity by
+        /// inference: the failure it prevents is visible and diagnosable,
+        /// while the failure it can cause — ejecting a healthy backend
+        /// during a blip — is subtle and worse. That is an operator's
+        /// call, not a default.
+        ///
+        /// The two signals it acts on are the endpoint's own fault in a
+        /// way a `5xx` is not: a dial that failed, and an exchange that
+        /// produced no response byte before the deadline. A bad deploy
+        /// answering 500s is a software bug, not an unhealthy endpoint,
+        /// and conflating them would eject a whole cluster for it.
+        pub const PassiveEjection = struct {
+            /// Consecutive failed requests that eject. An absolute count
+            /// is sufficient here where Envoy needs success-rate
+            /// outlier detection, because §7 fail-open already answers
+            /// the correlated-failure objection: a cluster with every
+            /// endpoint ejected balances as if none were.
+            fall: u8 = constants.passive_ejection_fall_default,
+            /// How long an ejected endpoint stays out before traffic is
+            /// admitted again to re-judge it. Passive detection needs
+            /// traffic to learn anything and an ejected endpoint gets
+            /// none, so recovery cannot be passive too — this cooldown
+            /// is what makes it observable at all.
+            recovery_ms: u32 = constants.passive_ejection_recovery_ms_default,
+        };
     };
 };
 
@@ -566,6 +604,8 @@ pub const ValidationError = error{
     ClusterCheckPathNotCanonical,
     ClusterCheckHostInvalid,
     ClusterCheckStatusInvalid,
+    ClusterPassiveEjectionFallOutOfRange,
+    ClusterPassiveEjectionRecoveryOutOfRange,
     ClusterMaxInflightOutOfRange,
     ClusterRetriesOutOfRange,
     ClusterPickKeyMissing,
@@ -2172,6 +2212,8 @@ pub const ClusterJson = struct {
     /// Optional §7 active health checks; absent means off, so an
     /// unprobed cluster reserves nothing and is never skipped.
     check: ?CheckJson = null,
+    /// Optional §7 passive ejection (#230); absent leaves it off.
+    passive_ejection: ?PassiveEjectionJson = null,
     /// Optional §8 per-endpoint concurrency cap; absent means uncapped.
     max_inflight: ?u32 = null,
     /// Optional #181 dial retries across this cluster's endpoints;
@@ -2197,6 +2239,9 @@ pub const ClusterJson = struct {
         },
         .check = .{
             .desc = "Active health checks for every endpoint in this cluster; absent leaves them off.",
+        },
+        .passive_ejection = .{
+            .desc = "Eject endpoints that real traffic reports dead; absent leaves passive ejection off.",
         },
         .max_inflight = .{
             .desc = "Cap on concurrent in-flight work per endpoint; absent leaves the cluster uncapped.",
@@ -2577,6 +2622,33 @@ pub const CheckJson = struct {
     };
 };
 
+/// One cluster's passive-ejection block (§7, #230). Two numbers and no
+/// mode switch: what the signals are is settled by the design, not by
+/// the operator, because the choice worth making is *whether* to remove
+/// capacity by inference — not which inference to draw.
+pub const PassiveEjectionJson = struct {
+    fall: u8 = constants.passive_ejection_fall_default,
+    recovery_ms: u32 = constants.passive_ejection_recovery_ms_default,
+
+    pub const schema_doc =
+        "Eject an endpoint that real traffic reports as dead — a failed dial, " ++
+        "or an exchange that produced no response byte before the deadline. " ++
+        "Absent leaves it off. Origin 5xx responses are never a signal: a bad " ++
+        "deploy is a software bug, not an unhealthy endpoint.";
+    pub const schema_fields = .{
+        .fall = .{
+            .desc = "Consecutive failed requests that eject an endpoint from balancing.",
+            .minimum = 1,
+            .maximum = constants.health_probe_threshold_max,
+        },
+        .recovery_ms = .{
+            .desc = "How long an ejected endpoint stays out before traffic re-judges it.",
+            .minimum = 1,
+            .maximum = constants.timeout_ms_max,
+        },
+    };
+};
+
 pub const TimeoutsJson = struct {
     /// Optional: nginx ships 60 s for the same budget and HAProxy's
     /// `timeout connect` is conventionally single-digit seconds, so a
@@ -2784,13 +2856,13 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// block below runs `assert_meta_matches` on each at comptime, so the
 /// metadata cannot drift from the fields whether or not the emitter builds.
 pub const dto_types = .{
-    ConfigJson,         ListenerJson,      RouteJson,                FilterJson,
-    MatchJson,          HeaderMatchJson,   ActionJson,               HeaderEditJson,
-    RewriteJson,        ClusterJson,       TimeoutsJson,             LimitsJson,
-    AdminJson,          AccessLogJson,     CheckJson,                PickJson,
-    ForwardedJson,      ProxyProtocolJson, ClusterProxyProtocolJson, EndpointJson,
-    ResponseFilterJson, ResponseMatchJson, RedirectJson,             BodyJson,
-    TlsJson,
+    ConfigJson,         ListenerJson,        RouteJson,                FilterJson,
+    MatchJson,          HeaderMatchJson,     ActionJson,               HeaderEditJson,
+    RewriteJson,        ClusterJson,         TimeoutsJson,             LimitsJson,
+    AdminJson,          AccessLogJson,       CheckJson,                PickJson,
+    ForwardedJson,      ProxyProtocolJson,   ClusterProxyProtocolJson, EndpointJson,
+    ResponseFilterJson, ResponseMatchJson,   RedirectJson,             BodyJson,
+    TlsJson,            PassiveEjectionJson,
 };
 
 comptime {
@@ -2853,6 +2925,7 @@ fn resolveClusters(
             .weights = endpoints.weights,
             .pick = picked.pick,
             .check = try resolveCheck(entry.cluster.check, connect_timeout_ms),
+            .passive_ejection = try resolvePassiveEjection(entry.cluster.passive_ejection),
             .hash_key = picked.hash_key,
             .max_inflight = try resolveMaxInflight(entry.cluster.max_inflight),
             .retries = try resolveRetries(entry.cluster.retries),
@@ -3788,6 +3861,28 @@ fn validateRoutePrefix(prefix: []const u8, head_buffer_bytes: u32) ParseError!vo
 /// path for a check that will never request it is describing something
 /// the process is not doing, which is exactly the negative space this
 /// loader exists to refuse.
+/// Resolve one cluster's §7 passive-ejection block (#230). Absent leaves
+/// it off, the same shape `check` uses: a feature nobody asked for costs
+/// nothing and changes nothing.
+///
+/// A single-endpoint cluster is *allowed* to configure this even though
+/// §7 fail-open makes the ejection a no-op there. Rejecting it would
+/// punish the config that is about to grow a second endpoint, and the
+/// operator's intent is unambiguous either way. The banner is where that
+/// shows up as a fact, not the loader as an error.
+fn resolvePassiveEjection(passive_ejection_json: ?PassiveEjectionJson) ParseError!?Config.Cluster.PassiveEjection {
+    const passive_ejection = passive_ejection_json orelse return null;
+    if (passive_ejection.fall < 1 or passive_ejection.fall > constants.health_probe_threshold_max) {
+        return error.ClusterPassiveEjectionFallOutOfRange;
+    }
+    // Zero would re-admit inside the same tick that ejected, which is not
+    // a fast recovery but an ejection that never happened.
+    if (passive_ejection.recovery_ms < 1 or passive_ejection.recovery_ms > constants.timeout_ms_max) {
+        return error.ClusterPassiveEjectionRecoveryOutOfRange;
+    }
+    return .{ .fall = passive_ejection.fall, .recovery_ms = passive_ejection.recovery_ms };
+}
+
 fn resolveCheck(
     check_json: ?CheckJson,
     connect_timeout_ms: u32,
@@ -5085,6 +5180,46 @@ test "config: an http check resolves its request and expected status" {
         try std.testing.expectEqual(@as(?[]const u8, null), http.host);
         try std.testing.expectEqual(@as(u16, 200), http.expect_status);
     }
+}
+
+test "config: a passive_ejection block rejects the thresholds it cannot act on" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"],"passive_ejection":
+    ;
+    const tail =
+        \\}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    // Zero would eject on no evidence; the ceiling is what keeps the u8
+    // streak from wrapping, shared with the probe thresholds.
+    try expectParseError(error.ClusterPassiveEjectionFallOutOfRange, head ++ "{\"fall\":0}" ++ tail);
+    try expectParseError(error.ClusterPassiveEjectionFallOutOfRange, head ++ "{\"fall\":65}" ++ tail);
+    // A zero cooldown re-admits in the tick that ejected — not a fast
+    // recovery but an ejection that never happened.
+    try expectParseError(error.ClusterPassiveEjectionRecoveryOutOfRange, head ++ "{\"recovery_ms\":0}" ++ tail);
+
+    // The defaults are what an operator who writes `"passive_ejection":{}` gets,
+    // and they are the whole point of the block being two optional
+    // numbers: opting in should not require picking them.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const config = try expectParseOk(&arena_state, head ++ "{}" ++ tail);
+    const passive_ejection = config.clusters[0].passive_ejection.?;
+    try std.testing.expectEqual(constants.passive_ejection_fall_default, passive_ejection.fall);
+    try std.testing.expectEqual(constants.passive_ejection_recovery_ms_default, passive_ejection.recovery_ms);
+
+    // Absent is off, and off is not "defaults" — an unconfigured cluster
+    // must be distinguishable from one that opted in and took them.
+    const bare =
+        \\{"listeners":[{"bind":"127.0.0.1:1","cluster":"a"}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    var bare_arena: std.heap.ArenaAllocator = undefined;
+    defer bare_arena.deinit();
+    const bare_config = try expectParseOk(&bare_arena, bare);
+    try std.testing.expect(bare_config.clusters[0].passive_ejection == null);
 }
 
 test "config: a check block rejects every shape it cannot run" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -657,11 +657,34 @@ pub const health_probe_fall_default: u8 = 3;
 /// HAProxy's `rise` default: recovery must prove itself twice.
 pub const health_probe_rise_default: u8 = 2;
 
-/// Upper bound on a configured `fall`/`rise`. The streak counters are
-/// `u8`, so this is what keeps them from wrapping; it is also far past
-/// any useful tuning — a threshold in the dozens means the *interval* is
-/// the wrong knob, since detection latency is `fall × interval`.
+/// Upper bound on a configured `fall`/`rise`, and on passive ejection's
+/// own `fall` (#230) — one bound because all three are streaks counted
+/// in a `u8`, and this is what keeps them from wrapping. It is also far
+/// past any useful tuning: a probe threshold in the dozens means the
+/// *interval* is the wrong knob, since detection latency is
+/// `fall × interval`.
 pub const health_probe_threshold_max: u8 = 64;
+
+/// Consecutive failed *requests* that passively eject an endpoint (§7,
+/// #230), when a cluster's `passive_ejection` block omits `fall`.
+/// Higher than the probe's three on purpose: a probe is one synthetic
+/// request the operator chose, where this counts real traffic, which
+/// carries transient failures a probe never sees. Envoy's
+/// `consecutive_5xx` default is the same five.
+pub const passive_ejection_fall_default: u8 = 5;
+
+/// How long a passively-ejected endpoint stays out before traffic is let
+/// back to judge it again (§7, #230), when `passive_ejection` omits
+/// `recovery_ms`. Envoy's `base_ejection_time`.
+///
+/// Recovery is a plain cooldown rather than a half-open probation, and
+/// the cost of that choice is bounded and lives here: each cooldown ends
+/// with up to `fall` requests spent on an endpoint that may still be
+/// dead. Thirty seconds keeps that rate negligible against any real
+/// traffic level while still restoring a recovered backend promptly. A
+/// cluster that wants a single request spent instead of `fall` configures
+/// `check`, whose `rise` restores from probe traffic rather than real.
+pub const passive_ejection_recovery_ms_default: u32 = 30_000;
 
 /// Default `timeouts.health_interval_ms`: the pause between health-probe
 /// sweeps when the config omits it (§7). HAProxy's `inter` default. What
@@ -1388,6 +1411,17 @@ comptime {
     assert(health_probe_rise_default >= 1);
     assert(health_probe_fall_default <= health_probe_threshold_max);
     assert(health_probe_rise_default <= health_probe_threshold_max);
+    // Passive ejection's threshold shares the bound for the same reason
+    // (a `u8` streak), and its cooldown is a configurable duration like
+    // any other, so it sits inside `timeout_ms_max` — the ceiling that
+    // exists to catch a units mistake, not a §8 shedding rung.
+    assert(passive_ejection_fall_default >= 1);
+    assert(passive_ejection_fall_default <= health_probe_threshold_max);
+    // Real traffic is noisier than a probe, so the passive threshold
+    // should never be the *twitchier* of the two.
+    assert(passive_ejection_fall_default >= health_probe_fall_default);
+    assert(passive_ejection_recovery_ms_default >= 1);
+    assert(passive_ejection_recovery_ms_default <= timeout_ms_max);
     assert(health_interval_ms_default >= 1);
     assert(health_interval_ms_default <= timeout_ms_max);
     // The rendered probe request must fit its buffer whatever a config

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -841,6 +841,18 @@ pub const Labeled = struct {
     /// like-named process total — see `reconciles`.
     connect_failed: []Value,
     responses: []Value,
+    /// Exchanges this endpoint was picked for that produced **no response
+    /// byte** before the deadline — the `504` path, per endpoint (#230).
+    ///
+    /// The pair `connect_failed`/`no_response` is what tells a wedged
+    /// backend from a refusing one: a refused dial is answered in a round
+    /// trip, where an accepted-but-silent origin costs a whole budget and
+    /// is exactly what a `tcp` probe cannot see. Both are the endpoint's
+    /// own fault in a way a `5xx` is not, which is why *this* is the
+    /// signal passive ejection may act on: `expiryAnswerable` refuses to
+    /// answer `504` once a response has started, so an origin that
+    /// returned 500s can never land here.
+    no_response: []Value,
     health_down: []Value,
     health_up: []Value,
     /// Per-cluster counters: the inflight sheds fire precisely because
@@ -876,6 +888,7 @@ pub const Labeled = struct {
     pub const EndpointFamily = enum {
         connect_failed,
         responses,
+        no_response,
         health_down,
         health_up,
 
@@ -885,6 +898,7 @@ pub const Labeled = struct {
             return switch (family) {
                 .connect_failed => "endpoint_connect_failed",
                 .responses => "endpoint_responses",
+                .no_response => "endpoint_no_response",
                 .health_down => "endpoint_health_down",
                 .health_up => "endpoint_health_up",
             };
@@ -928,6 +942,7 @@ pub const Labeled = struct {
         labeled.cluster_checked = try arena.alloc(bool, cluster_count);
         labeled.connect_failed = try allocValues(arena, keys.count);
         labeled.responses = try allocValues(arena, keys.count);
+        labeled.no_response = try allocValues(arena, keys.count);
         labeled.health_down = try allocValues(arena, keys.count);
         labeled.health_up = try allocValues(arena, keys.count);
         labeled.l7_shed_inflight = try allocValues(arena, cluster_count);
@@ -1307,6 +1322,10 @@ pub const Labeled = struct {
     pub fn reconciles(labeled: *const Labeled, counters: *const Counters) void {
         assert(tableTotal(labeled.connect_failed) == counters.get("upstream_connect_failed"));
         assert(tableTotal(labeled.responses) == counters.get("l7_responses"));
+        // Both `504` sites — the dial that outlived its budget and the
+        // exchange that did — know the endpoint they were dialling, so
+        // the partition is total (#230).
+        assert(tableTotal(labeled.no_response) == counters.get("l7_gateway_timeout"));
         assert(tableTotal(labeled.health_down) == counters.get("health_endpoint_down"));
         assert(tableTotal(labeled.health_up) == counters.get("health_endpoint_up"));
         assert(tableTotal(labeled.l7_shed_inflight) ==
@@ -1687,7 +1706,7 @@ test "counters: labeled render speaks the exposition dialect" {
         type_lines += 1;
         search = at + "# TYPE ".len;
     }
-    try std.testing.expectEqual(@as(usize, 8), type_lines);
+    try std.testing.expectEqual(@as(usize, 9), type_lines);
 }
 
 test "counters: labeled render bound is exact at the maximum values" {
@@ -1700,8 +1719,9 @@ test "counters: labeled render bound is exact at the maximum values" {
 
     for ([_][]Counters.Value{
         labeled.connect_failed,   labeled.responses,
-        labeled.health_down,      labeled.health_up,
-        labeled.l7_shed_inflight, labeled.l4_shed_inflight,
+        labeled.no_response,      labeled.health_down,
+        labeled.health_up,        labeled.l7_shed_inflight,
+        labeled.l4_shed_inflight,
     }) |table| {
         for (table) |*value| value.store(std.math.maxInt(u64), .monotonic);
     }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -295,12 +295,32 @@ pub const Counters = struct {
     /// case also lands in `kernel_pressure_connect`, same as a data-path
     /// dial.
     health_probes_failed: Value = Value.init(0),
-    /// Endpoints ejected from balancing after `health_probe_fall`
-    /// consecutive failed probes (§7). Their parked connections are
-    /// closed at the transition (§5, `health_parked_closed`).
+    /// Endpoints ejected from balancing (§7), whatever decided it. Their
+    /// parked connections are closed at the transition (§5,
+    /// `health_parked_closed`).
+    ///
+    /// The **total**; the two `_probe`/`_passive` counters below
+    /// partition it by cause, the same shape `kernel_pressure_errors`
+    /// takes. One event with two causes rather than two events, because
+    /// the mask is one bit and the balancer reads one thing: an endpoint
+    /// is out or it is not, and how it got there is a question about the
+    /// verdict, not about the state.
     health_endpoint_down: Value = Value.init(0),
-    /// Ejected endpoints restored to balancing after `health_probe_rise`
-    /// consecutive successful probes (§7).
+    /// Ejections a probe decided, after `check.fall` consecutive failed
+    /// probes (§7). This is the claim `reconcile` used to make of
+    /// `health_endpoint_down` itself, before passive ejection gave the
+    /// mask a second writer (#230).
+    health_endpoint_down_probe: Value = Value.init(0),
+    /// Ejections real traffic decided, after `passive_ejection.fall`
+    /// consecutive failed requests (#230). The signals are a dial that
+    /// failed for the endpoint's own reasons and an exchange that
+    /// produced no response byte — never an origin `5xx`, which is a
+    /// software bug rather than an unhealthy endpoint.
+    health_endpoint_down_passive: Value = Value.init(0),
+    /// Ejected endpoints restored to balancing (§7): after `check.rise`
+    /// consecutive successful probes, or — for a passively ejected one —
+    /// when its `recovery_ms` cooldown expires and traffic is let back to
+    /// judge it again.
     health_endpoint_up: Value = Value.init(0),
     /// Parked upstream connections closed because their endpoint was
     /// ejected (§5): a parked socket to a dead origin is a stale replay
@@ -561,12 +581,21 @@ pub const Counters = struct {
         /// `other_cause` diagnosable instead of merely counted.
         kernel_pressure_last_errno: u32,
         /// Endpoints under §7 active checks — static per config (the
-        /// sum of `endpoints` over every `check` cluster). The capacity
-        /// the unhealthy level below is read against.
+        /// sum of `endpoints` over every `check` cluster).
         health_endpoints_checked: u32,
-        /// Checked endpoints currently ejected from balancing (§7). A
-        /// level, not a counter: `health_endpoint_down`/`_up` carry the
-        /// history; a scrape wants how many are out *now*.
+        /// Endpoints any failure detection may remove — the sum of
+        /// `endpoints` over every cluster with `check`, `passive_ejection`
+        /// or both (#230). The capacity the unhealthy level is read
+        /// against, and no longer the same number as `checked`: passive
+        /// ejection can remove an endpoint no probe ever dialled.
+        ///
+        /// Kept beside `checked` rather than replacing it, so a dashboard
+        /// that has always read "how many are probed" keeps reading
+        /// exactly that.
+        health_endpoints_ejectable: u32,
+        /// Endpoints currently ejected from balancing (§7). A level, not
+        /// a counter: `health_endpoint_down`/`_up` carry the history; a
+        /// scrape wants how many are out *now*.
         health_endpoints_unhealthy: u32,
 
         /// The invariant every producer owes: a level never exceeds its
@@ -576,7 +605,11 @@ pub const Counters = struct {
             if (gauges.relay_buffers_in_use > gauges.relay_buffers_capacity) return false;
             if (gauges.head_buffers_in_use > gauges.head_buffers_capacity) return false;
             if (gauges.upstream_head_buffers_in_use > gauges.upstream_head_buffers_capacity) return false;
-            if (gauges.health_endpoints_unhealthy > gauges.health_endpoints_checked) return false;
+            // Against `ejectable`, not `checked`: a passively ejected
+            // endpoint need never have been probed (#230). `checked` is
+            // still a subset of it, which is its own claim worth holding.
+            if (gauges.health_endpoints_checked > gauges.health_endpoints_ejectable) return false;
+            if (gauges.health_endpoints_unhealthy > gauges.health_endpoints_ejectable) return false;
             const upstream_in_use = @as(u64, gauges.upstream_slots_leased) +
                 gauges.upstream_slots_parked;
             return upstream_in_use <= gauges.upstream_slots_capacity;
@@ -790,7 +823,18 @@ pub const Counters = struct {
         // one failed probe; a restore needs a prior ejection (endpoints
         // start healthy, §7).
         assert(counters.get("health_probes_failed") <= counters.get("health_probes_sent"));
-        assert(counters.get("health_endpoint_down") <= counters.get("health_probes_failed"));
+        // The cause split partitions the ejection total exactly (#230),
+        // the same identity the kernel-pressure split carries. This is
+        // what replaced `health_endpoint_down <= health_probes_failed`:
+        // that assert *was* the claim "ejections come only from probes",
+        // and passive ejection is precisely the thing that makes it
+        // false. Narrowed to the cause it was always about, it still
+        // holds — and now says something the total no longer can.
+        assert(counters.get("health_endpoint_down_probe") +
+            counters.get("health_endpoint_down_passive") ==
+            counters.get("health_endpoint_down"));
+        assert(counters.get("health_endpoint_down_probe") <=
+            counters.get("health_probes_failed"));
         assert(counters.get("health_endpoint_up") <= counters.get("health_endpoint_down"));
         // The op split partitions the total exactly: a witness that
         // incremented one without the other would make the split lie about
@@ -1368,6 +1412,7 @@ const test_gauges: Counters.Gauges = .{
     .upstream_head_buffers_capacity = 6,
     .kernel_pressure_last_errno = 105, // ENOBUFS on Linux
     .health_endpoints_checked = 4,
+    .health_endpoints_ejectable = 6,
     .health_endpoints_unhealthy = 1,
 };
 

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1377,6 +1377,7 @@ pub fn Proxy(comptime IoType: type) type {
                     conn.upstream.?.socket = socket;
                     conn.upstream_socket = socket;
                 } else |_| {}
+                witnessNoResponse(server, conn);
                 respond(server, conn, 504, "l7_gateway_timeout");
                 return;
             }
@@ -3425,6 +3426,22 @@ pub fn Proxy(comptime IoType: type) type {
             return true;
         }
 
+        /// The labeled twin of a `504` (#179, #230): this endpoint was
+        /// dialled and produced no response byte before the deadline.
+        ///
+        /// Called at both `504` sites and only there, which is what makes
+        /// the family a *partition* of `l7_gateway_timeout` rather than a
+        /// sample of it (`Labeled.reconciles`). The endpoint is always
+        /// known: a deadline can only be answered against a try, and a
+        /// try is a pick.
+        fn witnessNoResponse(server: *ServerType, conn: *const ConnType) void {
+            assert(conn.upstream != null);
+            server.labeled.incrementEndpoint(.no_response, server.upstreams.keys.key(
+                conn.upstream.?.cluster_index,
+                conn.upstream.?.endpoint_index,
+            ));
+        }
+
         /// Begin the §8 request-deadline verdict. Ops are never canceled
         /// (§5) — they are *forced*: shutting the upstream socket down
         /// makes each armed op on it complete with an error its handler
@@ -3460,7 +3477,10 @@ pub fn Proxy(comptime IoType: type) type {
             conn.l7.pending_verdict = .none;
             switch (verdict) {
                 .none => unreachable,
-                .gateway_timeout => respond(server, conn, 504, "l7_gateway_timeout"),
+                .gateway_timeout => {
+                    witnessNoResponse(server, conn);
+                    respond(server, conn, 504, "l7_gateway_timeout");
+                },
                 .replay => beginReplay(server, conn),
             }
         }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1395,6 +1395,18 @@ pub fn Proxy(comptime IoType: type) type {
                 // Same split as the L4 dial: the origin's verdict arrives
                 // typed, our own resource exhaustion does not (§8).
                 server.witnessKernelPressure(.connect, err);
+                // #230's first signal, and it rides that same split: a
+                // refusal or an unreachable host is the endpoint's own
+                // verdict, where `error.Unexpected` is this process
+                // running out of something. Ejecting a backend because
+                // *we* hit ENOBUFS would turn our exhaustion into their
+                // outage.
+                if (err != error.Unexpected) {
+                    server.health.witnessPassiveFailure(
+                        conn.upstream.?.cluster_index,
+                        conn.upstream.?.endpoint_index,
+                    );
+                }
                 if (retryEligible(server, conn, err)) {
                     beginRetry(server, conn);
                     return;
@@ -3269,6 +3281,14 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream.?.cluster_index,
                 conn.upstream.?.endpoint_index,
             ));
+            // #230: a served response ends whatever passive streak was
+            // building. Any response — the status is deliberately not
+            // read, because an origin answering 500 is a software bug
+            // and this counts endpoints, not deployments.
+            server.health.witnessPassiveSuccess(
+                conn.upstream.?.cluster_index,
+                conn.upstream.?.endpoint_index,
+            );
             // The whole response reached the client: the line goes out
             // now, before the turnaround below clears what it reports.
             // This is also the only place `ok` is earned — nothing between
@@ -3440,6 +3460,14 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream.?.cluster_index,
                 conn.upstream.?.endpoint_index,
             ));
+            // #230's second signal. This is the wedged-application case a
+            // `tcp` probe is blind to — the kernel completed a handshake
+            // the application never got to — so it is the one passive
+            // ejection exists for more than any other.
+            server.health.witnessPassiveFailure(
+                conn.upstream.?.cluster_index,
+                conn.upstream.?.endpoint_index,
+            );
         }
 
         /// Begin the §8 request-deadline verdict. Ops are never canceled
@@ -3643,6 +3671,19 @@ pub fn Proxy(comptime IoType: type) type {
                 server.beginTeardown(conn);
                 return;
             }
+            // #230, the third and last shape of "this endpoint said
+            // nothing": the exchange leg failed outright — an RST on the
+            // head send, a hangup mid-request — with no response byte and
+            // no replay left to spend. The two 504 sites reach the same
+            // conclusion by deadline where this one reaches it by
+            // transport error, and an endpoint is no healthier for
+            // failing fast.
+            assert(!conn.l7.response_started);
+            assert(conn.upstream != null);
+            server.health.witnessPassiveFailure(
+                conn.upstream.?.cluster_index,
+                conn.upstream.?.endpoint_index,
+            );
             respond(server, conn, 502, "l7_bad_gateway");
         }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -28,6 +28,7 @@ const expected_date = "Date: Wed, 01 Jan 2020 00:00:00 GMT\r\nServer: zoxy\r\n";
 /// silently replaced.
 const origin_date = "Date: Tue, 31 Dec 2019 23:59:59 GMT\r\nServer: origin/1.0\r\n";
 const constants = @import("constants.zig");
+const counters_module = @import("counters.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
 const Io = @import("io/io.zig");
@@ -503,6 +504,22 @@ const HttpOrigin = struct {
 
 /// Single-listener L7 harness: one http listener, a scripted origin, one
 /// client.
+/// One per-endpoint labeled value (#179). `Labeled`'s read path is the
+/// exposition, so nothing exposes a single value — a test that wants
+/// *attribution* rather than a total has to index the table. Named here
+/// so the passive-ejection work (#230), which asks "which endpoint" of
+/// nearly every signal it adds, does not spread raw field access through
+/// these tests.
+fn endpointCounter(
+    server: anytype,
+    comptime family: counters_module.Labeled.EndpointFamily,
+    cluster_index: u16,
+    endpoint_index: u16,
+) u64 {
+    const table = @field(server.labeled, @tagName(family));
+    return table[server.upstreams.keys.key(cluster_index, endpoint_index)].load(.monotonic);
+}
+
 const Http1Bed = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
@@ -3148,6 +3165,14 @@ test "l7: a hung dial fires 504 at the connect budget, not the idle timeout" {
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // The labeled twin (#230) names *which* endpoint answered nothing.
+    // `reconciles` already holds the family's total equal to the counter
+    // above on every seed; what it cannot say is that the credit landed
+    // on the endpoint the request actually dialled, which is the whole
+    // basis a passive verdict would rest on. This is the *dial* budget's
+    // 504; the exchange deadline's is covered separately, because "both
+    // sites" is the claim the partition identity rests on.
+    try std.testing.expectEqual(@as(u64, 1), endpointCounter(&bed.server, .no_response, 0, 0));
     // A timeout is not a dial failure: the counters stay orthogonal.
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_connect_failed"));
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_bad_gateway"));
@@ -3340,6 +3365,11 @@ test "l7: the request deadline fires 504 ahead of the connect and idle budgets" 
     );
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    // The other half of #230's signal: an origin that accepted and then
+    // said nothing is attributed to the endpoint that accepted, exactly
+    // as a dial that never completed is. Both 504 sites credit an
+    // endpoint or the family is a sample rather than a partition.
+    try std.testing.expectEqual(@as(u64, 1), endpointCounter(&bed.server, .no_response, 0, 0));
     // The dial *worked*: this is a slow exchange, not a hung or refused
     // one, which is exactly the case no other rung covers.
     try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("upstream_connect_failed"));

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -3408,6 +3408,43 @@ test "l7: one failure is a blip, and a served response ends the streak" {
     try bed.expectDrained();
 }
 
+test "l7: a passive ejection ends when its cooldown does, with nothing probing" {
+    // #230's recovery half, on the config the feature exists for: no
+    // `check` block, so nothing probes and only the cooldown can bring
+    // the endpoint back. Passive detection needs traffic and an ejected
+    // endpoint gets none — which is exactly why recovery cannot also be
+    // passive, and why the health loop runs here despite having nothing
+    // to probe. It costs no ring op beyond the rest timer the prober
+    // already reserved.
+    //
+    // The client must not drain on finish, or the scenario would end at
+    // the 504 and never reach the cooldown.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 235,
+        .origin_mute = true,
+        .request_timeout_ms = 20,
+        .passive_ejection = .{ .fall = 1, .recovery_ms = 40 },
+        .health_interval_ms = 10,
+    });
+    defer bed.tearDown();
+
+    bed.client.drain_on_finish = false;
+    bed.armDrainTimer(200);
+    try bed.exchange("GET /mute HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down_passive"));
+    // Back exactly once — not once per sweep, which is what `restore`
+    // clearing the deadline buys, and the reason the sweep can be a plain
+    // scan rather than a queue.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_up"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.unhealthy_count);
+    // The recovery was the cooldown's, not a `rise`: nothing probed at all.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_probes_sent"));
+    try bed.expectDrained();
+}
+
 test "l7: a cluster that did not opt in is never passively ejected" {
     // The opt-in claim, stated as a test rather than trusted: the same
     // scenario that ejects above must leave the mask untouched with no

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -660,6 +660,9 @@ const Http1Bed = struct {
         /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
         check: ?config_module.Config.Cluster.Check = null,
+        /// §7 passive ejection on the one cluster (#230); null by default
+        /// so no pre-existing scenario can have an endpoint removed under it.
+        passive_ejection: ?config_module.Config.Cluster.PassiveEjection = null,
         /// §8 per-endpoint concurrency cap; null leaves the cluster
         /// uncapped, which is what every pre-existing scenario wants.
         max_inflight: ?u32 = null,
@@ -701,7 +704,7 @@ const Http1Bed = struct {
         else
             .{ originAddress(), originAddress() };
         bed.endpoints_count = if (options.refusing_endpoint_first) 2 else 1;
-        bed.clusters = .{.{ .name = "origin", .endpoints = bed.endpoints[0..bed.endpoints_count], .check = options.check, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key, .retries = options.retries }};
+        bed.clusters = .{.{ .name = "origin", .endpoints = bed.endpoints[0..bed.endpoints_count], .check = options.check, .passive_ejection = options.passive_ejection, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key, .retries = options.retries }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
             .bind_address = bindAddress(),
@@ -3333,6 +3336,99 @@ test "l7: a dial re-basing an already-expired deadline defers past the cancel" {
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
         try bed.expectDrained();
     }
+}
+
+test "l7: passive ejection removes an endpoint real traffic reports dead" {
+    // #230's core: an origin that accepts and then answers nothing is the
+    // wedged-application case a `tcp` probe is blind to, because the
+    // kernel completes the handshake on the application's behalf. Here
+    // nothing probes at all — `check` is absent — which is the default
+    // deployment the issue was opened about.
+    // `fall` is one because a 504 answers `Connection: close`, so one
+    // client connection carries one failure — the threshold's *counting*
+    // is what the next test covers, on a connection that survives.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 230,
+        .origin_mute = true,
+        .request_timeout_ms = 20,
+        .passive_ejection = .{ .fall = 1, .recovery_ms = 60_000 },
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(!bed.server.health.healthy[0]);
+
+    // The cause partition, which is the whole reason `reconcile` could
+    // keep asserting anything about ejections once the mask grew a second
+    // writer: this one was traffic's verdict, and no probe was involved.
+    try std.testing.expectEqual(
+        @as(u64, 1),
+        bed.server.counters.get("health_endpoint_down_passive"),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        bed.server.counters.get("health_endpoint_down_probe"),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_probes_sent"));
+    // Ejectable without being checked — the gap #230 exists to fill, and
+    // the reason the gauge capacity could not stay `checked`.
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.checked_count);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.ejectable_count);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.unhealthy_count);
+    try bed.expectDrained();
+}
+
+test "l7: one failure is a blip, and a served response ends the streak" {
+    // The other half of the threshold's meaning, on a keep-alive
+    // connection so both requests fit one scenario: the origin answers
+    // the first and goes mute for the second. That is a flapping backend,
+    // not a dead one, and `fall` of two must not be reached — neither by
+    // the single failure alone, nor by counting it against a streak the
+    // served response should already have cleared.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 231,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        .origin_mute_after_served = 1,
+        .request_timeout_ms = 20,
+        .passive_ejection = .{ .fall = 2, .recovery_ms = 60_000 },
+    });
+    defer bed.tearDown();
+
+    bed.client.second_request = "GET /mute HTTP/1.1\r\nHost: o\r\n\r\n";
+    try bed.exchange("GET /served HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_responses"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    try bed.expectDrained();
+}
+
+test "l7: a cluster that did not opt in is never passively ejected" {
+    // The opt-in claim, stated as a test rather than trusted: the same
+    // scenario that ejects above must leave the mask untouched with no
+    // `passive_ejection` block, however many requests answer nothing.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 232,
+        .origin_mute = true,
+        .request_timeout_ms = 20,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /one HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_gateway_timeout"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_down"));
+    try std.testing.expect(bed.server.health.healthy[0]);
+    // Not merely un-ejected: not even a candidate, which is what keeps a
+    // deployment that never asked for this paying nothing for it.
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.ejectable_count);
+    try bed.expectDrained();
 }
 
 test "l7: the request deadline fires 504 ahead of the connect and idle budgets" {

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -88,13 +88,18 @@ pub fn Checker(comptime IoType: type) type {
         eject_deadline_ns: []u64,
         /// Endpoints under checks — static after `init` (the sum of
         /// `endpoints.len` over every `check` cluster); zero leaves the
-        /// prober `.off` forever.
+        /// prober `.off` forever unless some cluster opted into passive
+        /// ejection, which needs the loop for its cooldowns (#230).
         checked_count: u32,
         /// Endpoints any failure detection may remove — `check`,
         /// `passive_ejection`, or both (#230). The bound `unhealthy_count`
         /// is held against, and no longer `checked_count`: passive
         /// ejection can remove an endpoint no probe ever dialled.
         ejectable_count: u32,
+        /// Whether any cluster opted into passive ejection. Distinct from
+        /// `ejectable_count > checked_count`, which a cluster configuring
+        /// both would make false while still needing the loop to run.
+        passive_configured: bool,
         /// Endpoints currently ejected; the gauge level (§8).
         unhealthy_count: u32,
         state: State,
@@ -129,7 +134,8 @@ pub fn Checker(comptime IoType: type) type {
         const Self = @This();
 
         pub const State = enum(u8) {
-            /// Not started, or no cluster sets `check`: nothing ever arms.
+            /// Not started, or no cluster configures `check` or
+            /// `passive_ejection`: nothing ever arms.
             off,
             /// A sweep is running: up to `probes.len` of them in flight,
             /// each against an endpoint the cursor has already handed out.
@@ -732,6 +738,7 @@ pub fn Checker(comptime IoType: type) type {
             @memset(checker.eject_deadline_ns, 0);
             checker.checked_count = 0;
             checker.ejectable_count = 0;
+            checker.passive_configured = false;
             checker.unhealthy_count = 0;
             checker.state = .off;
             checker.cursor_cluster = 0;
@@ -760,8 +767,17 @@ pub fn Checker(comptime IoType: type) type {
             // the prober sizes itself from it, and §5's closed form is
             // only closed while there is exactly one reading of it.
             checker.checked_count = server.config.checkedEndpoints();
+            const ejectable = ejectableEndpoints(clusters);
+            checker.ejectable_count = ejectable.count;
+            checker.passive_configured = ejectable.passive_configured;
+            checker.assertSized(probe_count);
+        }
+
+        /// What `init` must leave true about the tables it just sized —
+        /// split out because it is the part that grows every time a new
+        /// verdict learns to write the mask, and `init` has no room left.
+        fn assertSized(checker: *const Self, probe_count: u32) void {
             assert(checker.checked_count <= checker.healthy.len);
-            checker.ejectable_count = ejectableEndpoints(clusters);
             // Every checked endpoint is ejectable; the reverse does not
             // hold, and that gap is exactly what #230 adds.
             assert(checker.checked_count <= checker.ejectable_count);
@@ -769,25 +785,39 @@ pub fn Checker(comptime IoType: type) type {
             // What `Server.initHeadBuffers` priced the prober's scratch
             // at, checked where the probes are actually allocated.
             assert(probe_count == constants.healthProbeConcurrency(checker.checked_count));
-            // Never more probes than there are endpoints to hand them:
-            // an idle probe would be a reservation nothing can spend.
-            // The floor of one is the exception, and only when nothing
-            // is checked at all — the prober stays `.off` then.
+            assert(checker.probes.len == probe_count);
+            // Never more probes than there are endpoints to hand them: an
+            // idle probe is a reservation nothing can spend. The floor of
+            // one is the exception, and it goes unused whether the prober
+            // stays `.off` or runs for cooldowns alone (#230).
             assert(checker.probes.len <= @max(1, checker.checked_count));
             assert(checker.armedCount() == 0);
         }
 
-        /// Endpoints any failure detection may remove: `check`,
-        /// `passive_ejection`, or both (#230). The union rather than
-        /// either count, because one mask serves both verdicts and it is
-        /// the mask's capacity `unhealthy_count` is bounded by.
-        fn ejectableEndpoints(clusters: []const config_module.Config.Cluster) u32 {
-            var total: u32 = 0;
+        /// What one walk of the cluster table tells the checker about
+        /// what it may remove (#230).
+        const Ejectable = struct {
+            /// Endpoints any failure detection may remove: `check`,
+            /// `passive_ejection`, or both. The union rather than either
+            /// count, because one mask serves both verdicts and it is
+            /// the mask's capacity `unhealthy_count` is bounded by.
+            count: u32,
+            /// Whether the loop must run at all for passive ejection's
+            /// cooldowns — which `count` cannot answer, since a cluster
+            /// configuring both check and passive contributes to it
+            /// either way.
+            passive_configured: bool,
+        };
+
+        fn ejectableEndpoints(clusters: []const config_module.Config.Cluster) Ejectable {
+            var ejectable: Ejectable = .{ .count = 0, .passive_configured = false };
             for (clusters) |cluster| {
+                if (cluster.passive_ejection != null) ejectable.passive_configured = true;
                 if (cluster.check == null and cluster.passive_ejection == null) continue;
-                total += @intCast(cluster.endpoints.len);
+                ejectable.count += @intCast(cluster.endpoints.len);
             }
-            return total;
+            assert(!ejectable.passive_configured or ejectable.count >= 1);
+            return ejectable;
         }
 
         /// Begin probing, or stay `.off` when no cluster opted in. The
@@ -797,7 +827,14 @@ pub fn Checker(comptime IoType: type) type {
         pub fn start(checker: *Self) void {
             assert(checker.state == .off);
             assert(checker.armedCount() == 0);
-            if (checker.checked_count == 0) return;
+            // Passive ejection needs the loop even with nothing to probe
+            // (#230). Its cooldowns expire on wall-clock time, and an
+            // ejected endpoint receives no traffic to notice with — so
+            // something must tick, and the loop that already ticks is
+            // cheaper than a second one. A sweep with no checked endpoint
+            // dispatches nothing and rests immediately, which makes this
+            // the rest timer alone, on the interval it already had.
+            if (checker.checked_count == 0 and !checker.passive_configured) return;
             checker.startSweep();
         }
 
@@ -814,7 +851,10 @@ pub fn Checker(comptime IoType: type) type {
             // Live states always hold work: probing keeps probe ops armed,
             // resting keeps the rest timer armed.
             assert(checker.armedCount() >= 1);
-            assert(checker.checked_count >= 1);
+            // The same condition `start` runs on: a passive-only config
+            // has a live loop with nothing to probe, ticking the rest
+            // timer for its cooldowns alone (#230).
+            assert(checker.checked_count >= 1 or checker.passive_configured);
             checker.state = .stopping;
             for (checker.probes) |*probe| {
                 probe.pending_verdict = .none;
@@ -854,11 +894,51 @@ pub fn Checker(comptime IoType: type) type {
 
         fn startSweep(checker: *Self) void {
             assert(checker.armedCount() == 0);
-            assert(checker.checked_count >= 1);
+            assert(checker.checked_count >= 1 or checker.passive_configured);
             checker.state = .probing;
+            // Before the probes, because a re-admitted endpoint should be
+            // probed on the sweep that readmitted it rather than wait a
+            // whole interval to be looked at.
+            checker.readmitExpired();
             checker.cursor_cluster = 0;
             checker.cursor_endpoint = 0;
             checker.dispatchNext();
+        }
+
+        /// Return passively ejected endpoints whose cooldown has run out
+        /// (#230). Recovery cannot be passive — an ejected endpoint gets
+        /// no traffic to be judged by — so the cooldown expiring is the
+        /// whole mechanism: traffic is let back and judges it again, and
+        /// `fall` more failures put it straight back out.
+        ///
+        /// Checked once per sweep rather than on its own timer, which
+        /// costs the §8 budget nothing and makes `health_interval_ms` the
+        /// granularity of re-admission as well as of probing. So a
+        /// cooldown is honoured to within one interval and never expires
+        /// early — the same "never move a timer earlier" rule every other
+        /// deadline here follows (§4). An operator who wants a 1 s
+        /// cooldown observed to the second wants a 1 s interval too, and
+        /// that is one knob rather than two that can disagree.
+        ///
+        /// A bounded scan of the endpoint table, on a tick that already
+        /// walks every cluster.
+        fn readmitExpired(checker: *Self) void {
+            assert(checker.state == .probing);
+            if (checker.unhealthy_count == 0) return;
+            const now = checker.server.io.nowNs();
+            var restored: u32 = 0;
+            for (checker.eject_deadline_ns, 0..) |deadline_ns, index| {
+                if (deadline_ns == 0) continue; // Not passively ejected.
+                if (deadline_ns > now) continue;
+                const key: u32 = @intCast(index);
+                // A passive ejection is the only writer of a non-zero
+                // deadline, and `restore` clears it — so a deadline
+                // standing means the endpoint is still out.
+                assert(!checker.healthy[key]);
+                checker.restore(key);
+                restored += 1;
+                assert(restored <= checker.ejectable_count);
+            }
         }
 
         /// One endpoint of a sweep, claimed from the cursor.
@@ -966,21 +1046,29 @@ pub fn Checker(comptime IoType: type) type {
             checker.ok_streaks[key] += 1;
             assert(checker.ok_streaks[key] <= rise);
             if (checker.ok_streaks[key] < rise) return;
-            checker.ok_streaks[key] = 0;
             checker.restore(key);
         }
 
         /// Return an endpoint to balancing (§7). The one writer of the
         /// mask's rising edge, for the same reason `eject` is of the
-        /// falling one — and the reason it takes no cause: a restore is
-        /// a restore, and the passive residue must be cleared whichever
-        /// verdict lifted it. A probe's `rise` can lift an endpoint that
-        /// real traffic ejected, and leaving its cooldown behind would
-        /// let the re-admission sweep "restore" an endpoint that is
-        /// already in rotation.
+        /// falling one — and the reason it takes no cause: a restore is a
+        /// restore, and **every** streak against this endpoint stops
+        /// meaning anything the moment it is back in rotation.
+        ///
+        /// That completeness is load-bearing, not tidiness. A cluster may
+        /// configure `check` and `passive_ejection` together, and then the
+        /// two verdicts interleave: a cooldown can expire while probes
+        /// have a partial `rise` built up, and a probe's `rise` can lift
+        /// an endpoint that traffic ejected while a cooldown is still
+        /// standing. Leaving either behind desynchronises the next cycle
+        /// — found by the simulator at seed 1918, where a cooldown
+        /// restored an endpoint mid-`rise` and the next passing probe met
+        /// `witnessPass`'s "healthy implies no streak" invariant.
         fn restore(checker: *Self, key: u32) void {
             assert(!checker.healthy[key]);
             checker.healthy[key] = true;
+            checker.fail_streaks[key] = 0;
+            checker.ok_streaks[key] = 0;
             checker.passive_streaks[key] = 0;
             checker.eject_deadline_ns[key] = 0;
             assert(checker.unhealthy_count >= 1);

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -74,11 +74,28 @@ pub fn Checker(comptime IoType: type) type {
         /// Consecutive passed probes toward `health_probe_rise`; tracked
         /// only while the endpoint is ejected, reset by any fail.
         ok_streaks: []u8,
+        /// Consecutive failed *requests* toward `passive_ejection.fall`
+        /// (#230), tracked only while the endpoint is healthy and reset
+        /// by any success — the passive twin of `fail_streaks`, kept
+        /// apart because the two are denominated in different thresholds
+        /// and a cluster may configure either without the other.
+        passive_streaks: []u8,
+        /// When a passively ejected endpoint may be let back, on the §4
+        /// coarse clock; zero for an endpoint that is not passively
+        /// ejected. Recorded at the ejection and consumed by the
+        /// re-admission sweep — recovery cannot itself be passive,
+        /// because an ejected endpoint receives no traffic to learn from.
+        eject_deadline_ns: []u64,
         /// Endpoints under checks — static after `init` (the sum of
         /// `endpoints.len` over every `check` cluster); zero leaves the
         /// prober `.off` forever.
         checked_count: u32,
-        /// Checked endpoints currently ejected; the gauge level (§8).
+        /// Endpoints any failure detection may remove — `check`,
+        /// `passive_ejection`, or both (#230). The bound `unhealthy_count`
+        /// is held against, and no longer `checked_count`: passive
+        /// ejection can remove an endpoint no probe ever dialled.
+        ejectable_count: u32,
+        /// Endpoints currently ejected; the gauge level (§8).
         unhealthy_count: u32,
         state: State,
         /// The sweep cursor: the *next* endpoint to hand out, not the one
@@ -706,10 +723,15 @@ pub fn Checker(comptime IoType: type) type {
             checker.healthy = try arena.alloc(bool, keys.count);
             checker.fail_streaks = try arena.alloc(u8, keys.count);
             checker.ok_streaks = try arena.alloc(u8, keys.count);
+            checker.passive_streaks = try arena.alloc(u8, keys.count);
+            checker.eject_deadline_ns = try arena.alloc(u64, keys.count);
             @memset(checker.healthy, true);
             @memset(checker.fail_streaks, 0);
             @memset(checker.ok_streaks, 0);
+            @memset(checker.passive_streaks, 0);
+            @memset(checker.eject_deadline_ns, 0);
             checker.checked_count = 0;
+            checker.ejectable_count = 0;
             checker.unhealthy_count = 0;
             checker.state = .off;
             checker.cursor_cluster = 0;
@@ -739,6 +761,11 @@ pub fn Checker(comptime IoType: type) type {
             // only closed while there is exactly one reading of it.
             checker.checked_count = server.config.checkedEndpoints();
             assert(checker.checked_count <= checker.healthy.len);
+            checker.ejectable_count = ejectableEndpoints(clusters);
+            // Every checked endpoint is ejectable; the reverse does not
+            // hold, and that gap is exactly what #230 adds.
+            assert(checker.checked_count <= checker.ejectable_count);
+            assert(checker.ejectable_count <= checker.healthy.len);
             // What `Server.initHeadBuffers` priced the prober's scratch
             // at, checked where the probes are actually allocated.
             assert(probe_count == constants.healthProbeConcurrency(checker.checked_count));
@@ -748,6 +775,19 @@ pub fn Checker(comptime IoType: type) type {
             // is checked at all — the prober stays `.off` then.
             assert(checker.probes.len <= @max(1, checker.checked_count));
             assert(checker.armedCount() == 0);
+        }
+
+        /// Endpoints any failure detection may remove: `check`,
+        /// `passive_ejection`, or both (#230). The union rather than
+        /// either count, because one mask serves both verdicts and it is
+        /// the mask's capacity `unhealthy_count` is bounded by.
+        fn ejectableEndpoints(clusters: []const config_module.Config.Cluster) u32 {
+            var total: u32 = 0;
+            for (clusters) |cluster| {
+                if (cluster.check == null and cluster.passive_ejection == null) continue;
+                total += @intCast(cluster.endpoints.len);
+            }
+            return total;
         }
 
         /// Begin probing, or stay `.off` when no cluster opted in. The
@@ -927,7 +967,22 @@ pub fn Checker(comptime IoType: type) type {
             assert(checker.ok_streaks[key] <= rise);
             if (checker.ok_streaks[key] < rise) return;
             checker.ok_streaks[key] = 0;
+            checker.restore(key);
+        }
+
+        /// Return an endpoint to balancing (§7). The one writer of the
+        /// mask's rising edge, for the same reason `eject` is of the
+        /// falling one — and the reason it takes no cause: a restore is
+        /// a restore, and the passive residue must be cleared whichever
+        /// verdict lifted it. A probe's `rise` can lift an endpoint that
+        /// real traffic ejected, and leaving its cooldown behind would
+        /// let the re-admission sweep "restore" an endpoint that is
+        /// already in rotation.
+        fn restore(checker: *Self, key: u32) void {
+            assert(!checker.healthy[key]);
             checker.healthy[key] = true;
+            checker.passive_streaks[key] = 0;
+            checker.eject_deadline_ns[key] = 0;
             assert(checker.unhealthy_count >= 1);
             checker.unhealthy_count -= 1;
             checker.server.counters.increment("health_endpoint_up");
@@ -949,19 +1004,127 @@ pub fn Checker(comptime IoType: type) type {
             checker.fail_streaks[key] += 1;
             if (checker.fail_streaks[key] < fall) return;
             checker.fail_streaks[key] = 0;
+            checker.eject(cluster_index, endpoint_index, .probe);
+        }
+
+        /// What decided an ejection. One event, two causes (#230): the
+        /// mask is a single bit and the balancer reads a single thing, so
+        /// *how* an endpoint left the rotation is a fact about the
+        /// verdict rather than about the state.
+        pub const Cause = enum(u8) { probe, passive };
+
+        /// Remove an endpoint from balancing (§7). The one writer of the
+        /// mask's falling edge, whichever verdict reached it, which is
+        /// what keeps the §5 obligation below from being forgotten on a
+        /// path that grew later: a parked socket to a dead origin is a
+        /// stale replay waiting to be spent.
+        fn eject(
+            checker: *Self,
+            cluster_index: u16,
+            endpoint_index: u16,
+            cause: Cause,
+        ) void {
+            const key = checker.server.upstreams.keys.key(cluster_index, endpoint_index);
+            assert(checker.healthy[key]);
             checker.healthy[key] = false;
             checker.unhealthy_count += 1;
-            assert(checker.unhealthy_count <= checker.checked_count);
+            assert(checker.unhealthy_count <= checker.ejectable_count);
             checker.server.counters.increment("health_endpoint_down");
+            switch (cause) {
+                // A partial passive streak is deliberately left where it
+                // is: it is inert while the endpoint is out (every
+                // passive witness returns early on an unhealthy key), and
+                // `restore` clears it on the way back in. Clearing here
+                // as well would be two owners for one reset.
+                .probe => checker.server.counters.increment("health_endpoint_down_probe"),
+                .passive => {
+                    checker.server.counters.increment("health_endpoint_down_passive");
+                    // The cooldown starts here, not at the first failure:
+                    // what it bounds is how long the endpoint stays out,
+                    // and a streak that took a minute to build should not
+                    // shorten that.
+                    const passive = checker.passiveOf(cluster_index).?;
+                    checker.eject_deadline_ns[key] = checker.server.io.nowNs() +
+                        @as(u64, passive.recovery_ms) * std.time.ns_per_ms;
+                    assert(checker.eject_deadline_ns[key] > 0);
+                },
+            }
             // The labeled twin (#179), same key the mask just flipped.
+            // Unlabelled by cause: a dashboard asking "which backend is
+            // out" is asking about the endpoint, not about who said so.
             checker.server.labeled.incrementEndpoint(.health_down, key);
             checker.closeParked(cluster_index, endpoint_index);
+        }
+
+        /// The cluster's passive-ejection policy, or null where the
+        /// operator did not opt in — which is the common case, and the
+        /// reason every passive witness below starts by asking.
+        fn passiveOf(
+            checker: *const Self,
+            cluster_index: u16,
+        ) ?*const config_module.Config.Cluster.PassiveEjection {
+            assert(cluster_index < checker.server.config.clusters.len);
+            const passive = &checker.server.config.clusters[cluster_index].passive_ejection;
+            return if (passive.* == null) null else &passive.*.?;
+        }
+
+        /// Real traffic reported this endpoint dead (#230): a dial that
+        /// failed for the endpoint's own reasons, or an exchange that
+        /// produced no response byte before its deadline.
+        ///
+        /// Silently ignored for a cluster that did not opt in, rather
+        /// than asserted against: the call sites are on the data path and
+        /// know nothing about which clusters configured what, and making
+        /// them ask first would put this policy in two places.
+        pub fn witnessPassiveFailure(
+            checker: *Self,
+            cluster_index: u16,
+            endpoint_index: u16,
+        ) void {
+            const passive = checker.passiveOf(cluster_index) orelse return;
+            assert(passive.fall >= 1);
+            const key = checker.server.upstreams.keys.key(cluster_index, endpoint_index);
+            // Already out: a request in flight when the ejection landed
+            // can still fail afterwards, and counting it would deepen a
+            // streak that no longer means anything.
+            if (!checker.healthy[key]) return;
+            assert(checker.passive_streaks[key] < passive.fall);
+            checker.passive_streaks[key] += 1;
+            if (checker.passive_streaks[key] < passive.fall) return;
+            checker.passive_streaks[key] = 0;
+            checker.eject(cluster_index, endpoint_index, .passive);
+        }
+
+        /// This endpoint served a response (#230), so whatever streak was
+        /// building against it is not a pattern. Consecutive means
+        /// consecutive: one success is the whole reset.
+        pub fn witnessPassiveSuccess(
+            checker: *Self,
+            cluster_index: u16,
+            endpoint_index: u16,
+        ) void {
+            const passive = checker.passiveOf(cluster_index) orelse return;
+            const key = checker.server.upstreams.keys.key(cluster_index, endpoint_index);
+            // A streak that had reached the threshold would already have
+            // ejected and reset, so anything a success lands on is
+            // sub-threshold by construction.
+            assert(checker.passive_streaks[key] < passive.fall);
+            checker.passive_streaks[key] = 0;
         }
 
         /// The §5 obligation: ejection closes the endpoint's parked
         /// pooled connections. Synchronous closes — a parked slot holds
         /// no armed op (§5), so checkout + close + release is one step,
         /// the reap discipline `Server.reapParked` set.
+        ///
+        /// Private, with exactly one caller — `eject` — and that is the
+        /// invariant the obligation's coverage rests on rather than a
+        /// tidiness preference. No directed test proves the *passive*
+        /// verdict discharges it (the signal needs traffic, and that
+        /// traffic leases the very connection that would otherwise be
+        /// parked), so what makes it true for both causes is that there
+        /// is one ejection path and the probe test already walks it.
+        /// A second call site would quietly end that argument.
         fn closeParked(checker: *Self, cluster_index: u16, endpoint_index: u16) void {
             // Only an ejection reaches here: the endpoint was just marked
             // unhealthy by the caller.

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -286,6 +286,9 @@ pub const TestBed = struct {
         /// §7 active health checks on the one cluster; null by default so
         /// existing scenarios see no probe traffic.
         check: ?config_module.Config.Cluster.Check = null,
+        /// §7 passive ejection on the one cluster (#230); null by default,
+        /// so no pre-existing scenario can lose an endpoint under it.
+        passive_ejection: ?config_module.Config.Cluster.PassiveEjection = null,
         /// §8 per-endpoint concurrency cap; null leaves the cluster
         /// uncapped, which is what every pre-existing scenario wants.
         max_inflight: ?u32 = null,
@@ -368,6 +371,7 @@ pub const TestBed = struct {
             .name = "origin",
             .endpoints = bed.endpoints[0..bed.endpoints_count],
             .check = options.check,
+            .passive_ejection = options.passive_ejection,
             .max_inflight = options.max_inflight,
             .proxy_protocol_send = options.proxy_protocol_send,
         }};
@@ -979,6 +983,38 @@ test "server: refused upstream tears the connection down and is counted" {
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try std.testing.expectEqual(@as(u8, 1), bed.scenario.outcomeCount(.eof));
+    try bed.expectDrained();
+}
+
+test "l4: a refused dial passively ejects the endpoint it was for" {
+    // #230 on the L4 path. The two "answered nothing" signals are L7
+    // shapes — there is no response head to be missing from a byte relay
+    // — but a *dial* fails identically whichever protocol asked for it,
+    // and both protocols pick through the one health mask. An operator
+    // who configures `passive_ejection` on a cluster an l4 listener
+    // routes to must get detection, not a knob that quietly does
+    // nothing.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .server = .{ .conn_slots = 2, .relay_buffers = 1 },
+        .sim = .{ .seed = 234 },
+        .origin_listens = false, // every dial is refused
+        .passive_ejection = .{ .fall = 1, .recovery_ms = 60_000 },
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, false);
+    try bed.sim_io.run();
+
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("upstream_connect_failed"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("health_endpoint_down_passive"));
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("health_endpoint_down_probe"));
+    try std.testing.expect(!bed.server.health.healthy[0]);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.unhealthy_count);
+    // Nothing probes here, and the endpoint is still ejectable — the
+    // whole point of the feature for a cluster with no `check` block.
+    try std.testing.expectEqual(@as(u32, 0), bed.server.health.checked_count);
+    try std.testing.expectEqual(@as(u32, 1), bed.server.health.ejectable_count);
     try bed.expectDrained();
 }
 


### PR DESCRIPTION
Closes #230.

A `tcp` check passes whenever the kernel accepts — and the kernel accepts from the backlog even when the application behind it never calls `accept()`. A wedged process, an exhausted thread pool and a GC-stalled backend therefore look perfectly healthy to it while every real request against them times out. An `http` check catches that but cannot be a default: there is no path to guess.

So "just turn health checks on" does not close the gap, and the default deployment — no `check` block — has **no failure detection at all**. Real traffic is the only ground truth; a probe tests one path with one method.

```json
"api": { "endpoints": ["10.0.0.1:80", "10.0.0.2:80"],
         "passive_ejection": { "fall": 5, "recovery_ms": 30000 } }
```

## Three of the issue's four questions were already answered by the code

#230 listed four "points to settle" before any code. Reading the tree answered three:

- **Retry double-counting** — impossible. `candidateEndpoints` skips `alreadyTried` and `beginRetry` reassigns to an untried endpoint, so one request credits each endpoint at most once.
- **Drained endpoints** — impossible. The weight-0 filter runs *before* health, so a drained endpoint sees no traffic and can accrue no verdict.
- **Fail-open** — no code change; it already fails open. Passive ejection only makes that rung reachable with no prober, which wanted stating in §7.

The fourth — **mask ownership** — had an exact precedent in `counters.zig`: kernel pressure already runs a total with two partitions, both asserted against it in `reconcile`. Ejection took the same shape. `health_endpoint_down` stays the total dashboards read; `_probe`/`_passive` partition it. The assert `health_endpoint_down <= health_probes_failed` — which *was* the claim "ejections come only from probes" — narrowed to `_probe` and still holds.

**Both signals were already precisely delimited**, which the issue assumed was still work: `expiryAnswerable` refuses to answer `504` once a response has started, so every `504` is already a no-response-byte `504` — and the hard requirement that origin `5xx` never be a signal holds *structurally*, since `commitResponse` sets `response_started` before the status is read.

## Design

**One ejection path, two verdicts.** `eject(cluster, endpoint, cause)` is the single writer of the mask's falling edge, which is what keeps §5's obligation — close the endpoint's parked connections — from being skipped on the new path. `restore` owns the rising edge and clears *every* streak.

**An absolute consecutive count**, where Envoy needs success-rate outlier detection with a panic threshold. Fail-open is why: a cluster with every endpoint ejected balances as if none were, so the correlated-failure objection is already answered.

**Recovery is a cooldown, on the loop that already ticks.** Passive detection needs traffic and an ejected endpoint gets none, so recovery cannot also be passive. A dedicated re-admission timer would have cost 2 ring ops (unlike the rest timer it can co-arm with probes) plus a state machine running while the prober is `.off`; instead the health loop runs for a passive-only config and `readmitExpired` runs at the top of each sweep. **Zero new ops, zero budget change.** Cost: granularity is `health_interval_ms`, so a cooldown is honoured to within one interval and never expires early.

Half-open probation was considered and rejected on blast radius rather than benefit — it needs a third endpoint state threaded through `candidateEndpoints` and the pick path. A cluster wanting the cheaper re-test configures `check`, whose `rise` already does this from probe traffic. Hence: **passive detects failure, active detects recovery.**

**Four signal sites**, all "this endpoint said nothing": the L7 dial, the **L4** dial (a dial fails identically whichever protocol asked, and both pick through one mask — a knob that silently did nothing for an l4-fronted cluster would be worse than no knob), both `504` sites, and the plain `502`. Each rides the split `witnessKernelPressure` already draws: `error.Unexpected` is *this* process out of something, and ejecting a backend for it would turn our exhaustion into their outage.

## Visibility

The default deployment still has the gap, so the banner states it:

```
config  1 listener(s), 3 cluster(s), 0 error page(s), access log off, 1 cluster(s) without failure detection
```

A fact, not a warning — a multi-endpoint cluster with no checks is legitimate behind a mesh, and warning every startup teaches operators to ignore stderr. A cluster counts only when two endpoints are *reachable*: weight-0 drains an endpoint and config never reloads, so `[1, 0]` is the single-endpoint case under a longer spelling.

## What the gates caught

**Seed 1918.** A cluster configuring `check` *and* `passive_ejection` can have a cooldown expire while probes have a partial `rise` built up; `restore` cleared the passive residue but not `ok_streaks`, and the next passing probe met `witnessPass`'s "healthy implies no streak" invariant. The unit tests were green throughout — only the 4096-seed sweep saw it. The lesson: two mask writers interleave in **two** directions, and I had reasoned about one.

Two invariants moved that the plan had not anticipated: the gauge bound `unhealthy <= checked` breaks the moment an unprobed endpoint can be ejected (now `health_endpoints_ejectable`, with `checked` keeping its meaning), and `reconcile`'s ejection assert.

## Commits

| | |
|---|---|
| `7dcf50d` | the missing per-endpoint `no_response` signal — observability only |
| `0252347` | the `passive_ejection` config block, validated, no consumer |
| `97d4fbd` | ejection: the mask's second writer |
| `9c74c22` | re-admission on the existing loop |
| `6eb14a1` | the banner fact |
| `f5bb2b3` | §7, README, notes |

Each slice was reviewed against `docs/TIGER_STYLE.md` before commit.

## Gates

`zig build ci` green (4096 seeds; census 72 → 74, both new counters firing unexempted), 551 unit tests, `zig fmt --check` and `zig build lint` clean. The simulator draws the block on a third of adversary seeds and never a clean one, with thresholds drawn tight so the axis is actually reachable in a short scenario rather than covered in appearance only (#258's lesson).

## One coverage limitation, recorded not hidden

No directed test proves the *passive* verdict discharges §5's parked-close obligation: the signal needs traffic, and that traffic leases the very connection that would otherwise be parked, so the bed cannot hold both states. What makes it true is that `closeParked` is private with exactly one caller and the probe test already walks that path — an invariant now written at its declaration, because a second call site would quietly end the argument.

## Not in scope

Circuit breakers and Envoy-style outlier detection (success-rate and stddev maths, panic thresholds) stay deferred per §7, and the §7 text now says so explicitly rather than reading as though passive ejection had been ruled out with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)