### PR TITLE
sim: a slowloris the sweep can reach, and an oracle for when it is reaped (#258)

### DIFF
--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -784,9 +784,12 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
     );
     harness.listeners_count = if (harness.tls_clients >= 1) 3 else 2;
     for (&harness.tls_scripts) |*script| {
-        script.* = l7.scripts.terminating_scripts[
+        const drawn = l7.scripts.terminating_scripts[
             random.uintLessThan(usize, l7.scripts.terminating_scripts.len)
         ];
+        // The same clean-seed exclusion the plaintext draw makes, and
+        // for the same reason — see `drawScript`.
+        script.* = if (harness.clean and drawn == .dribbled_head) .get else drawn;
     }
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
     harness.drop_mode = deriveDropMode(harness.clean, random);
@@ -1543,6 +1546,27 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
 /// A plaintext seed draws nothing here, which is what keeps its stream
 /// position — and so the whole sweep's plaintext coverage — exactly
 /// where it was before TLS existed.
+/// One client's script, drawn uniformly except that a clean seed never
+/// gets `dribbled_head` (#258).
+///
+/// That script exists to leave a request unfinished, which *is* an
+/// abort — and `verifyAccessLog`'s sharpest claim is that a clean seed
+/// aborts nothing. The claim is worth more than the coverage would be:
+/// it is an equality rather than a bound, and it is what fails on seed
+/// 10 when #129's phantom-line bug is put back. Teaching it an
+/// exception would blunt it on every seed to reach one axis on some.
+///
+/// The axis is reached on adversary seeds instead, where an abort is
+/// already ordinary and the surrounding equality still holds. `.get` is
+/// the substitute because it is the canonical script; the small bias it
+/// adds to clean populations is the price, and it is stated rather than
+/// hidden in a re-draw loop that could in principle spin.
+fn drawScript(random: std.Random, clean: bool) l7.Script {
+    const drawn = random.enumValue(l7.Script);
+    if (clean and drawn == .dribbled_head) return .get;
+    return drawn;
+}
+
 fn populateTlsClients(harness: *Harness, random: std.Random) void {
     harness.tls_clients_storage = @splat(undefined);
     harness.tls_clients_live = harness.tls_clients;
@@ -1599,7 +1623,10 @@ fn populateClients(harness: *Harness, random: std.Random) void {
             client.prepare(
                 &harness.io,
                 httpBindAddress(),
-                if (forced_upgrade) .upgrade_request else random.enumValue(l7.Script),
+                if (forced_upgrade)
+                    .upgrade_request
+                else
+                    drawScript(random, harness.clean),
                 harness.clean,
                 harness.upgrades_http,
                 harness.sticky_http,
@@ -2445,7 +2472,7 @@ fn verifyTlsSessions(harness: *Harness) !void {
             // asked to send, so what went out cannot exceed it — the check
             // that catches the two drifting apart, since a wider send
             // would be judged against a transcript that never mentions it.
-            assert(client.requestsSent() <= entry.expected_responses);
+            assert(client.requestsSent() <= entry.payloadsSent());
             const walk = HttpClient.walkResponses(
                 back,
                 entry,

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -823,19 +823,12 @@ fn deriveServerConfig(
         // loader rejects the other order (§5), so an independent draw would
         // spend seeds on a config production cannot load.
         .idle_timeout_ms = idle_timeout_ms,
-        // Mirrors the idle window (#235), which is also what the loader
-        // would derive at this scale: the sim draws its timeouts in tens
-        // of milliseconds, and `defaultHeadMs` clamps its ten seconds down
-        // to `idle_ms` for exactly such a config.
-        //
-        // A known gap, stated rather than left implicit: equal values mean
-        // no seed exercises the first-byte re-base under a *tighter* head
-        // budget, so that call site's randomized coverage is deferred to
-        // the two scripted tests in `src/http_proxy_test.zig`. Drawing the
-        // two apart is a scenario for the split, and wants the head budget
-        // to be a drawn value the response oracles can still live with —
-        // more than this line.
-        .head_timeout_ms = idle_timeout_ms,
+        .head_timeout_ms = deriveHeadTimeoutMs(
+            harness.clean,
+            random,
+            connect_timeout_ms,
+            idle_timeout_ms,
+        ),
         .drain_deadline_ms = deriveDrainDeadlineMs(harness.drain_at_ns, random),
         // The §6 age cap: measured from the connection's birth, so the
         // clamp sometimes reaps an actively-relaying connection.
@@ -977,6 +970,44 @@ fn deriveKeepaliveRequests(clean: bool, random: std.Random) u32 {
     if (clean) return 0;
     if (random.uintLessThan(u8, 3) != 0) return 0;
     return 1 + random.uintLessThan(u32, 2);
+}
+
+/// The #235 head budget, drawn *apart* from the idle window on a third
+/// of adversary seeds (#258).
+///
+/// It was pinned equal to `idle_timeout_ms` until the sweep had a client
+/// that could reach it, and that was the right call at the time rather
+/// than an oversight: with every head arriving whole, the two values
+/// being equal cost nothing, while drawing them apart shifted every
+/// seed's random stream to exercise an axis no seed could observe. The
+/// issue measured exactly that — forcing every adversary seed to the
+/// tightest legal budget changed nothing at all.
+///
+/// What changed is that `dribbled_head` now holds a head open and
+/// `l7_head_budget_expired` witnesses the reap, so a tighter budget is a
+/// genuinely different schedule rather than the same one wearing a
+/// different number.
+///
+/// The band is the loader's own invariant, restated: strictly above
+/// `connect_ms`, because a dial re-bases the deadline to that and a
+/// budget beneath it would be spent before the hand-off; and never wider
+/// than the window it exists to narrow.
+fn deriveHeadTimeoutMs(
+    clean: bool,
+    random: std.Random,
+    connect_ms: u32,
+    idle_ms: u32,
+) u32 {
+    assert(connect_ms >= 1);
+    assert(connect_ms < idle_ms);
+    if (clean) return idle_ms;
+    if (random.uintLessThan(u8, 3) != 0) return idle_ms;
+    const span = idle_ms - connect_ms;
+    assert(span >= 1);
+    const drawn = connect_ms + 1 + random.uintLessThan(u32, span);
+    assert(drawn > connect_ms);
+    assert(drawn <= idle_ms);
+    return drawn;
 }
 
 fn deriveMaxInflight(clean: bool, random: std.Random) ?u32 {

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -67,6 +67,20 @@ pub const Script = enum(u8) {
     /// Connects and sends nothing: the head-read deadline reaps it;
     /// any response byte is a violation.
     silent,
+    /// Begins a head and never finishes it — a request line and one
+    /// header, no terminating blank line — then holds the connection
+    /// open. Any response byte is a violation, exactly as for `silent`.
+    ///
+    /// The two are not the same wait, and the difference is the whole
+    /// reason this exists (#258). `silent` says nothing at all, so it
+    /// sits on the *idle* window; the #235 head budget starts at the
+    /// client's first byte, so only a client mid-sentence is ever under
+    /// it. Before this script no seed in the sweep had a head
+    /// outstanding at all — the axis was unreachable, which is why
+    /// forcing every adversary seed to a one-millisecond head budget
+    /// changed nothing and two defects in that budget reached 0.4.0 by
+    /// way of a reader rather than the gate.
+    dribbled_head,
     /// A GET whose path only reaches the routable resource after
     /// canonicalization — an encoded `..` that collapses a segment away
     /// (`/deep/%2e%2e/sim` → `/sim`). It must route and forward exactly as
@@ -168,6 +182,17 @@ pub const Spec = struct {
     /// Statuses a complete response may legally carry under the
     /// adversary. Empty means any complete response is a violation.
     allowed_statuses: []const u16,
+    /// Application-data payloads this script puts on the wire, where
+    /// that differs from `expected_responses`. Null means the two are
+    /// equal, which is true of every script that *finishes* what it
+    /// starts: one request earns one answer.
+    ///
+    /// `dribbled_head` is why the override exists (#258). It sends a
+    /// payload and is owed nothing, so the terminating oracle's "what
+    /// went out cannot exceed what the spec describes" check needs to
+    /// be told about the request rather than about the answer — the two
+    /// having always coincided is what let one number stand for both.
+    payloads_sent: ?u8 = null,
     /// Append a second GET once the first response settles reusable —
     /// the §5 parked-connection checkout under schedule fuzz. Such a
     /// script degrades to a single-exchange transcript when its first
@@ -211,6 +236,13 @@ pub const Spec = struct {
     /// way, because one spec cannot describe both halves. Held to its
     /// meaning by the comptime block below rather than trusted.
     routed_canonical: bool = false,
+
+    /// How many application-data payloads this script puts on the wire.
+    /// The same number as `expected_responses` unless a script overrides
+    /// it, which only one does — see `payloads_sent`.
+    pub fn payloadsSent(entry: Spec) u8 {
+        return entry.payloads_sent orelse entry.expected_responses;
+    }
 };
 
 const post_body = "request-body-24-bytes-ab";
@@ -515,6 +547,34 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .method = .get,
         .allowed_statuses = &.{},
     },
+    .dribbled_head = .{
+        // A request line and one header, and deliberately no terminating
+        // blank line: the parser returns Incomplete and the proxy waits
+        // under the head budget rather than the idle window. The client
+        // sends exactly this and never sends more, so what ends the
+        // connection is always a deadline of the proxy's.
+        //
+        // Zero responses today, and that is a claim about behaviour
+        // rather than a shrug: a head-read timeout tears down silently
+        // (#247). Should this proxy ever learn to answer `408`, this is
+        // the spec that fails and has to be told about it.
+        .request = "GET /sim HTTP/1.1\r\nHost: sim\r\n",
+        .expected_responses = 0,
+        // An adversary seed may show exactly one, and only a `503`: the
+        // head never completes, so nothing routes and neither 200, 502
+        // nor 504 is reachable — but the *first byte* of a partial head
+        // still meets §8's head-buffer rung, which answers 503 before
+        // the parse. That is the whole difference from `silent`, which
+        // sends no byte and so meets no rung at all. Found by seed 778
+        // rather than reasoned out in advance.
+        .transcript_cap = 1,
+        .golden_status = 0,
+        .method = .get,
+        .allowed_statuses = &.{503},
+        // One payload out, no answer owed — the coincidence every
+        // other script relies on, broken on purpose.
+        .payloads_sent = 1,
+    },
     .confusion = .{
         // Canonicalizes to /sim (the `/deep` segment is popped by the
         // decoded `..`), so it routes and forwards as /sim.
@@ -763,6 +823,14 @@ pub const terminating_scripts = [_]Script{
     .forwarded_oversize,
     .sticky_follow,
     .sticky_repick,
+    // Drawn here deliberately, where `silent` is not (#258). The two
+    // 0.4.0 defects were both about *where* the head budget is
+    // installed, and one of them was that the terminating arm installed
+    // it somewhere else — so a slowloris that only ever ran plaintext
+    // would miss the half that was actually broken. Unlike `silent` this
+    // one sends bytes, so the session it opens is a real one that the
+    // proxy's own deadline ends.
+    .dribbled_head,
 };
 
 comptime {
@@ -843,6 +911,26 @@ comptime {
             // cannot be paired. GET and POST share theirs; HEAD does not,
             // and would have its bodiless responses read as truncated.
             assert(entry.method != .head);
+        }
+    }
+
+    // `payloads_sent` held to its meaning too (#258), rather than left
+    // as the one conditional field on trust. Two claims:
+    //
+    // A script is never owed more answers than it asks questions — that
+    // is what the terminating oracle reads it for, and an entry
+    // declaring otherwise would make a *wider* transcript legal than the
+    // session could produce.
+    //
+    // And an override equal to the default is noise: it would read as a
+    // deliberate statement while saying exactly what null already says,
+    // which is how a field like this quietly spreads to entries that do
+    // not need it.
+    for (std.enums.values(Script)) |script| {
+        const entry = specs.get(script);
+        assert(entry.payloadsSent() >= entry.expected_responses);
+        if (entry.payloads_sent) |override| {
+            assert(override != entry.expected_responses);
         }
     }
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -3538,6 +3538,20 @@ pub fn Server(comptime IoType: type) type {
                 server.armConnectCancel(conn);
                 return;
             }
+            // The #235 head budget's own reap, witnessed (#258). Every
+            // path above answers *something*; this one tears down
+            // silently, so without a counter the budget firing and the
+            // idle window firing are the same event to every oracle the
+            // simulator has — which is exactly how two defects in that
+            // budget reached 0.4.0.
+            //
+            // `head_budget_installed` is the discriminator rather than
+            // the state: a connection in `.l7_reading_head` may still be
+            // on the idle window, because the budget is installed at the
+            // first `Incomplete` and not at the first byte.
+            if (conn.state == .l7_reading_head and conn.l7.head_budget_installed) {
+                server.counters.increment("l7_head_budget_expired");
+            }
             server.beginTeardown(conn);
         }
 

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -273,6 +273,23 @@ pub const Counters = struct {
     /// so a rising count is the cap doing its job rather than churn it
     /// merely coincided with.
     l7_keepalive_requests_capped: Value = Value.init(0),
+    /// Connections reaped by the #235 head-read budget — a client that
+    /// began a request and stopped mid-sentence (#258).
+    ///
+    /// It exists because that reap is otherwise *invisible*. Every other
+    /// deadline verdict answers something a transcript can show; this one
+    /// tears down silently (#247), so a budget that fired at the wrong
+    /// moment, or that was never installed at all, produces a run
+    /// indistinguishable from one where the idle window did the work.
+    /// Both of #235's defects reached 0.4.0 that way, found by reading
+    /// rather than by the gate.
+    ///
+    /// A witness, not a health signal: a proxy on a hostile network
+    /// should see this rise. What it protects is the *reachability* of
+    /// the axis — the census fails if no seed ever gets a head
+    /// outstanding long enough to be reaped, which was true of every
+    /// sweep before `dribbled_head` existed.
+    l7_head_budget_expired: Value = Value.init(0),
     /// Interim `1xx` responses relayed to the client (#232). Forwarded
     /// rather than absorbed, which is what both references do: a `103` is
     /// worthless to a client that never sees it, and a `100` the client is

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -103,6 +103,12 @@ const HttpClient = struct {
     fn onConnect(client: *HttpClient, result: Io.ConnectError!SimIo.Socket) void {
         client.socket = result catch unreachable;
         client.armRecv();
+        // An empty request is a client that connects and says nothing —
+        // a legal shape the proxy has its own answer for (the idle
+        // window, never the #235 head budget), and one the simulator's
+        // own l7 client has always been able to express. Guarded here
+        // rather than asserted against, so a bed can state that boundary.
+        if (client.request.len == 0) return;
         if (client.send_delay_ms == 0) {
             client.armSend();
             return;
@@ -5629,6 +5635,108 @@ test "l7: a partial head is reaped at the head budget, not the idle window" {
     // state this fix found.
     try std.testing.expect(elapsed_ms >= 100);
     try std.testing.expect(elapsed_ms < 500);
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    try bed.expectDrained();
+}
+
+test "l7: a partial head is reaped at min(head budget, effective idle window)" {
+    // #258's second half. The three tests below this one each pin one
+    // *shape* of the #235 budget with a hand-written band; this states
+    // the rule itself, across the space, and checks the reap instant as
+    // an **equality** rather than a bound.
+    //
+    // The equality is what makes it an oracle rather than a sanity
+    // check. `elapsed_ms >= 100 and < 500` — the shape the point tests
+    // use — passes just as happily on a budget that fires four times
+    // late, and "fires late" is precisely the defect class no counter or
+    // transcript can see (§9). Measured rather than hoped for: every
+    // case below lands on its predicted millisecond exactly, and does so
+    // across four unrelated seed bases, because the deadline is a timer
+    // the virtual clock advances *to* rather than past.
+    //
+    // The rule is `min(head_timeout_ms, idleTimeoutMs())`, and the second
+    // term is the awkward one — it divides by `pressure_idle_divisor`
+    // under downstream pressure (§8), so which of the pair binds changes
+    // with load rather than with config alone. Both orders appear here.
+    const Case = struct {
+        head_ms: u32,
+        pressured: bool,
+        /// `min(head_ms, effective idle)`, restated per case rather than
+        /// computed: a helper sharing the implementation's arithmetic
+        /// would agree with a wrong implementation.
+        reaped_at_ms: u64,
+    };
+    const cases = [_]Case{
+        // The budget binds, an order of magnitude under the window.
+        .{ .head_ms = 100, .pressured = false, .reaped_at_ms = 100 },
+        // Still the budget, but close enough to the window that an
+        // off-by-one in which term wins would be invisible at 100.
+        .{ .head_ms = 800, .pressured = false, .reaped_at_ms = 800 },
+        // Pressure shrinks the window (1000/4) *under* a budget that was
+        // legal at rest, so the window binds — the inversion #235 shipped.
+        .{ .head_ms = 400, .pressured = true, .reaped_at_ms = 250 },
+        // Pressured, but the budget is tighter still: the min must not
+        // simply prefer whichever term pressure touched.
+        .{ .head_ms = 100, .pressured = true, .reaped_at_ms = 100 },
+    };
+    comptime assert(Http1Bed.idle_timeout_ms == 1000);
+    for (cases, 0..) |case, index| {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = @intCast(320 + index),
+            .head_timeout_ms = case.head_ms,
+        });
+        defer bed.tearDown();
+        bed.server.relay_pressure = case.pressured;
+
+        const start_ns = bed.sim_io.nowNs();
+        try bed.exchange("GET /slow HTTP/1.1\r\nHost: o\r\n");
+        const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+        try std.testing.expectEqual(case.reaped_at_ms, elapsed_ms);
+        // *Which* deadline reaped it, which no instant can say on its
+        // own: at case 2 the budget and the window are both plausible
+        // explanations of 250 ms until this names one (#258).
+        try std.testing.expectEqual(
+            @as(u64, 1),
+            bed.server.counters.get("l7_head_budget_expired"),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+        try bed.expectDrained();
+    }
+}
+
+test "l7: silence waits out the idle window, because the budget starts mid-head" {
+    // The boundary the whole axis rests on, and the reason it went
+    // unreachable for so long (#258). The head budget is installed on the
+    // first `Incomplete` — a client *mid-sentence* — not on connect and
+    // not on the first byte. A connection that says nothing at all has
+    // begun no head, so it is the idle window's to reap, and the sweep's
+    // `silent` script therefore never touched the budget however tight
+    // the config made it.
+    //
+    // Stated as a test because it is indistinguishable from a bug: a
+    // budget that did start at connect would reap this at 100 ms and
+    // look like a tighter, better slowloris defence, while actually
+    // capping how long any client may stay connected before speaking.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 324,
+        .head_timeout_ms = 100,
+    });
+    defer bed.tearDown();
+
+    const start_ns = bed.sim_io.nowNs();
+    try bed.exchange("");
+    const elapsed_ms = (bed.sim_io.nowNs() - start_ns) / std.time.ns_per_ms;
+
+    try std.testing.expectEqual(@as(u64, Http1Bed.idle_timeout_ms), elapsed_ms);
+    // And the budget was never installed, so its witness stays silent —
+    // the categorical half of the same claim.
+    try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_head_budget_expired"));
+    // The client's own view, so the claim does not rest on the proxy's
+    // account of itself: it was reaped, not answered.
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try bed.expectDrained();
 }


### PR DESCRIPTION
Closes #258.

Two defects in #235's head-read budget reached 0.4.0 and were found by *reading* rather than by the sweep. #258 diagnosed why, in two parts, and measured the first: forcing every adversary seed to a one-millisecond head budget **changed nothing at all**. No seed ever had a head outstanding, so no budget could ever fire.

## 1. A client that begins a head and stops

`dribbled_head` sends a request line and one header, no terminating blank line, then holds. It is not `silent` with fewer bytes: `silent` says nothing, so it waits on the *idle* window. The budget starts at the first `Incomplete` and only ever bounds a client **mid-sentence**.

Drawn on the terminating population as well as the plaintext one, because one of the two 0.4.0 defects was precisely that the two arms installed the budget in different places — a slowloris that only ran plaintext would have missed the half that was broken.

Reachability is now **enforced** rather than argued: `l7_head_budget_expired` counts the reap and the census fails if no seed reaches it (74 → 75, unexempted). Every other deadline verdict answers something a transcript can show; this one tears down silently (#247), so without a witness the budget firing and the idle window firing are the same event to every oracle the simulator has.

Two things the sweep taught rather than confirmed:

- **A dribbled head may legally earn a `503`, and only that** (seed 778). Its *first byte* meets §8's head-buffer rung, which `silent` never reaches because it sends no byte at all.
- **`requestsSent() <= expected_responses` held only by coincidence.** Every script until now finished what it started, so one number stood for both the questions asked and the answers owed.

The script is kept off *clean* seeds. An unfinished request is by definition an abort, and `verifyAccessLog`'s clean-seed claim is that nothing aborts — an equality, and the one that fails on seed 10 when #129's phantom-line bug is put back. Teaching it an exception would blunt it on every seed to reach one axis on some.

## 2. The oracle: an equality, not a band

The sweep cannot bound *when* a deadline fires — its schedule is the randomised thing. A scripted scenario can, because the clock is virtual; that is the split §9 already records for #132. What is new is how tight it goes.

The three pre-existing tests each pin one *shape* of the budget with a hand-written band. This states the rule — `min(head_timeout_ms, idleTimeoutMs())` — across four cases covering both orders of the min, and checks the reap instant as an **equality**. Measured, not hoped for: every case lands on its predicted millisecond exactly, across four unrelated seed bases, because a virtual clock advances *to* a timer rather than past it.

| mutant | table oracle | silence test | the 3 old tests |
|---|---|---|---|
| budget unclamped (0.4.0's pressure inversion) | fail | pass | fail |
| budget never installed | fail | pass | fail |
| **budget fires 2× late** | **fail** | pass | **pass** |
| **silent conn credited to the budget** | pass | **fail** | pass |

Row three is the issue's thesis made concrete: doubling the budget sails through `>= 100 and < 500`, which is what the old bands say. Only an equality catches it.

Row four is the boundary the whole axis rests on — a client that says nothing has begun no head, so the idle window reaps it and the budget's witness stays at zero. A budget that *did* start at connect would look like a tighter slowloris defence while quietly capping how long any client may stay connected before speaking.

## 3. Drawing the budget apart, and what it actually buys

The issue made this conditional — *"only then is drawing `head_timeout_ms` apart worth its stream shift"* — so it was measured, and **the first measurement was the wrong one.**

Totalling `l7_head_budget_expired` across the sweep: **120 pinned, 110 drawn, 117 at the tightest legal budget** — all passing, all firing. By that measure the draw adds nothing but noise; the *script* made the axis reachable, not the draw.

The number that moves is one layer down. `narrowDeadline` returns early unless the new deadline is genuinely earlier, so with the budget pinned equal to the idle window the rebase — cancel the armed timer, re-arm it tighter — almost never runs from this path: **90 times across 4096 seeds, every one of them through `storeDeadline`'s max-lifetime clamp** rather than through the head budget being tighter at all. Drawn, it runs **1112 times**. Twelve times the traffic through a timer rebase racing resets, drops and partial deliveries — a defect class this tree has already shipped once (#253, a retry racing its own deadline rebase).

That is schedule coverage, not new detection. The sweep's oracles still cannot see a budget that fires late, and nothing here changes that — what catches a wrong instant is the scripted equality above. This makes the code path it guards actually run under a hostile schedule.

Clean seeds keep the pin: they draw no `dribbled_head`, so a tighter budget there would shift every clean seed's stream to vary a number no client can observe.

## Commits

| | |
|---|---|
| `4da9311` | the slowloris script, both arms, and the witness that makes reachability enforceable |
| `a7bddce` | the timing oracle, as an equality, plus the boundary case |
| `d9a897c` | the draw, with what it buys measured |

Reviewed against `docs/TIGER_STYLE.md` before commit.

## Gates

`zig build ci` green (4096 seeds, census 75), 553 unit tests, `zig fmt --check` and `zig build lint` clean.

## What this does not do

It does not make the *sweep* able to catch a late deadline — that remains impossible for the reason the issue gives, and the scripted tests are where that property lives. And it leaves #247 exactly where it was: a head-read timeout still tears down silently, and `dribbled_head`'s spec says so in a way that will fail loudly if a `408` ever arrives without the spec being told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)