### PR TITLE
http: answer 408 when a client stops mid-head, instead of resetting (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/zoxy-io/zoxy/actions/workflows/ci.yml/badge.svg)](https://github.com/zoxy-io/zoxy/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/zoxy-io/zoxy/badge.svg?branch=main)](https://coveralls.io/github/zoxy-io/zoxy?branch=main)
+[![Discord](https://img.shields.io/discord/1530882611159760956)](https://discord.gg/BGbb7VtYA)
 [![Project stage: Experimental][project-stage-badge: Experimental]][project-stage-page]
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -292,8 +292,9 @@ primitives trusted institutionally.
   a "quick" direct `write` could stall the whole loop. That choice is
   kept: O_NONBLOCK is never set. The control ops the design needs are
   seam methods instead — `setNodelay`, `setLingerRst` (§8's
-  accept-and-RST), `shutdown(.both)` (which must bypass
-  `xev.TCP.shutdown`, hardcoded to SHUT_WR, for the low-level op) —
+  accept-and-RST), `shutdown(.both)` and `shutdown(.read)` (both of
+  which must bypass `xev.TCP.shutdown`, hardcoded to SHUT_WR, for the
+  low-level op) —
   direct non-blocking syscalls in `XevIo`, virtual-socket state changes
   in `SimIo`, so the simulator can witness RST-on-shed and half-close
   (§9). A build-time lint enforces the boundary (§9).
@@ -1287,7 +1288,17 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   transparency is that leg's whole claim.
 - **Resilience is minimal by design:** per-request and per-try deadlines
   (head-read gets its own deadline, so a slowloris meets the clock or
-  `limits.head_buffer_bytes`, whichever comes first; each dial — the
+  `limits.head_buffer_bytes`, whichever comes first — the buffer answers
+  `431`, and the clock is **answered `408`** rather than reset, §8's
+  rule being that a client reading a reset
+  where a status was due reports an error it cannot attribute. That
+  answer is why §4 has a read-half shutdown at all: the op in the way is
+  a recv on the socket the answer goes out on, ops are never cancelled
+  but forced (§5), and `.both` would take the write half the verdict
+  needs. A connection that said *nothing* is owed no status and gets
+  none — it was never under the budget, which starts mid-head, and that
+  is the distinction HAProxy needed `option http-ignore-probes` to make
+  after monitoring agents earned a `408` apiece; each dial — the
   first try and the replay's — runs under its own connect deadline);
   one free replay of a request that hit a stale pooled connection —
   only when the
@@ -1655,6 +1666,7 @@ the loop thread.
 | **origin capacity** — every endpoint at its `max_inflight` | endpoint pick | static `503` (L7) / close (L4) |
 | tunnels | the upgrade request, **before** it is forwarded | static `503`, then keep or close per pressure |
 | request deadline | timer completion | `504` if no response byte was sent — a timed-out dial included; teardown once a response byte is on the wire or the stall is the client's own body |
+| head-read budget | timer completion | `408` for a client that began a head and stopped; **silence earns none** — a connection that said nothing was never under the budget |
 | kernel memory pressure (ENOBUFS/ENOMEM from ring) | any completion | treat as that op's failure → teardown that connection; counter |
 
 Most rungs shed on a *resource of this proxy's* running out. That was

--- a/docs/README.md
+++ b/docs/README.md
@@ -886,7 +886,7 @@ guessed from a filename. Files are read at startup like the rest of the
 config, so **changing one needs a restart**.
 
 `error_pages` accepts only the statuses zoxy actually sends — `400`,
-`403`, `404`, `414`, `429`, `431`, `501`, `502`, `503`, `504` — and a
+`403`, `404`, `408`, `413`, `414`, `429`, `431`, `501`, `502`, `503`, `504` — and a
 page for anything else is refused at load.
 
 Every response zoxy answers *itself* — those pages, the empty defaults,
@@ -960,7 +960,7 @@ dial or idle budget is a mistake rather than a policy.
 | field | default | meaning |
 |---|---|---|
 | `connect_ms` | `5000` | per-try upstream connect budget |
-| `head_ms` | derived | budget for reading one request head — what a slowloris meets. 10 s, clamped between `connect_ms` and `idle_ms` so it never changes a config that predates it |
+| `head_ms` | derived | budget for reading one request head — what a slowloris meets, and is answered `408` for. A connection that has said nothing at all is not under it, so a monitoring probe that connects and leaves earns silence. 10 s, clamped between `connect_ms` and `idle_ms` so it never changes a config that predates it |
 | `idle_ms` | `60000` | how long a connection may stay quiet — between requests, or before its first byte |
 | `drain_deadline_ms` | `0` | how long a `SIGTERM` drain waits before reaping stragglers; `0` waits for the last connection |
 | `max_lifetime_ms` | `0` | absolute connection-age cap regardless of activity; `0` disables |

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -787,8 +787,8 @@ fn deriveTerminatingDraws(harness: *Harness, random: std.Random) void {
         const drawn = l7.scripts.terminating_scripts[
             random.uintLessThan(usize, l7.scripts.terminating_scripts.len)
         ];
-        // The same clean-seed exclusion the plaintext draw makes, and
-        // for the same reason — see `drawScript`.
+        // The same clean-seed exclusion the plaintext draw makes, and for
+        // the same reason — see `drawScript`.
         script.* = if (harness.clean and drawn == .dribbled_head) .get else drawn;
     }
     harness.clock_jump_wanted = deriveClockJump(harness.tls_clients, random);
@@ -1578,20 +1578,22 @@ fn startServerAndOrigins(harness: *Harness, arena: std.mem.Allocator, random: st
 /// position — and so the whole sweep's plaintext coverage — exactly
 /// where it was before TLS existed.
 /// One client's script, drawn uniformly except that a clean seed never
-/// gets `dribbled_head` (#258).
+/// gets `dribbled_head`.
 ///
-/// That script exists to leave a request unfinished, which *is* an
-/// abort — and `verifyAccessLog`'s sharpest claim is that a clean seed
-/// aborts nothing. The claim is worth more than the coverage would be:
-/// it is an equality rather than a bound, and it is what fails on seed
-/// 10 when #129's phantom-line bug is put back. Teaching it an
-/// exception would blunt it on every seed to reach one axis on some.
+/// The *original* reason is gone. #258 excluded it because an unfinished
+/// request was an abort, and `verifyAccessLog`'s sharpest claim is that
+/// a clean seed aborts nothing — an equality, and the one that fails on
+/// seed 10 when #129's phantom-line bug is put back. #247 made the reap
+/// answer `408`, so a dribbled head is now an ordinary answered exchange
+/// and that objection no longer applies.
 ///
-/// The axis is reached on adversary seeds instead, where an abort is
-/// already ordinary and the surrounding equality still holds. `.get` is
-/// the substitute because it is the canonical script; the small bias it
-/// adds to clean populations is the price, and it is stated rather than
-/// hidden in a re-draw loop that could in principle spin.
+/// A different one does, and it was measured rather than assumed: clean
+/// seeds pin the head budget to the idle window (`deriveHeadTimeoutMs`),
+/// which can outlast the scenario's own backstop — so the reap does not
+/// reliably land inside the run and seed 486 misses its golden `408`.
+/// Including it here would want the clean budget drawn tight enough to
+/// observe, which is a change to a value every clean seed shares for the
+/// benefit of one script. Adversary seeds reach the axis already.
 fn drawScript(random: std.Random, clean: bool) l7.Script {
     const drawn = random.enumValue(l7.Script);
     if (clean and drawn == .dribbled_head) return .get;
@@ -2818,6 +2820,12 @@ fn l7OutcomeTotal(counters: *const zoxy.counters.Counters) u64 {
         "l7_shed_endpoint_inflight",
         "l7_bad_gateway",
         "l7_gateway_timeout",
+        // The #247 head-read verdict. It answers `408` and so owes a
+        // line, exactly like the `504` above it — the difference between
+        // them is which side ran out of time, which the status says and
+        // this sum does not care about. Before #247 the same reap wrote
+        // an *abort* line and belonged on the other side of the equality.
+        "l7_request_timeout",
     };
     var total: u64 = 0;
     inline for (answered) |name| {

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -69,14 +69,15 @@ pub const Script = enum(u8) {
     silent,
     /// Begins a head and never finishes it — a request line and one
     /// header, no terminating blank line — then holds the connection
-    /// open. Any response byte is a violation, exactly as for `silent`.
+    /// open. Earns the #247 `408`.
     ///
-    /// The two are not the same wait, and the difference is the whole
+    /// Not `silent` with fewer bytes, and the difference is the whole
     /// reason this exists (#258). `silent` says nothing at all, so it
-    /// sits on the *idle* window; the #235 head budget starts at the
-    /// client's first byte, so only a client mid-sentence is ever under
-    /// it. Before this script no seed in the sweep had a head
-    /// outstanding at all — the axis was unreachable, which is why
+    /// sits on the *idle* window and is owed nothing; the #235 head
+    /// budget starts at the client's first byte, so only a client
+    /// mid-sentence is ever under it — and only such a client is owed a
+    /// status. Before this script no seed in the sweep had a head
+    /// outstanding at all: the axis was unreachable, which is why
     /// forcing every adversary seed to a one-millisecond head budget
     /// changed nothing and two defects in that budget reached 0.4.0 by
     /// way of a reader rather than the gate.
@@ -369,19 +370,19 @@ comptime {
 /// stall any of them) earns the 504 once the deadline expires with no
 /// response byte sent. Clean seeds pin the origin to `sized` and never
 /// stall, so `golden_status` still demands exact outcomes there.
-const statuses_routed: []const u16 = &.{ 200, 502, 503, 504 };
+const statuses_routed: []const u16 = &.{ 200, 408, 502, 503, 504 };
 /// The routed set plus the #236 body cap's `413`, for the scripts that
 /// carry a body. Only an adversarial seed draws a cap — a clean seed's
 /// script asked for a `200` and a refusal is not it — so the golden
 /// outcome is unchanged and this only widens what a cut seed may legally
 /// show.
-const statuses_routed_body: []const u16 = &.{ 200, 413, 502, 503, 504 };
+const statuses_routed_body: []const u16 = &.{ 200, 408, 413, 502, 503, 504 };
 /// The head routes and forwards before its body is validated, so several
 /// outcomes can precede the 400: the §8 rungs, a killed dial, and — the
 /// subtlety — an early origin response. An instant origin answers 200
 /// before the proxy ever pumps the malformed body (which it then
 /// contains, never forwarding it: the origin's §7 oracle still holds).
-const statuses_body_reject: []const u16 = &.{ 400, 200, 502, 503, 504 };
+const statuses_body_reject: []const u16 = &.{ 400, 200, 408, 502, 503, 504 };
 
 const specs = std.enums.EnumArray(Script, Spec).init(.{
     .get = .{
@@ -460,7 +461,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 400,
         .method = .get,
-        .allowed_statuses = &.{ 400, 503 },
+        .allowed_statuses = &.{ 400, 408, 503 },
     },
     .oversize_uri = .{
         // The request line alone must overflow the proxy's 8 KiB head
@@ -472,7 +473,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 414,
         .method = .get,
-        .allowed_statuses = &.{ 414, 503 },
+        .allowed_statuses = &.{ 414, 408, 503 },
     },
     .connect_method = .{
         // The 501 verdict precedes routing. The method context maps to
@@ -485,7 +486,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 501,
         .method = .get,
         // Only the §5 head ring's 503 precedes the parse the 501 rides on.
-        .allowed_statuses = &.{ 501, 503 },
+        .allowed_statuses = &.{ 501, 408, 503 },
     },
     .upgrade_request = .{
         .request = "GET /ws HTTP/1.1\r\nHost: origin\r\n" ++
@@ -509,7 +510,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         // saw. A clean seed's origin always reads first and always
         // answers `101`, which is why the golden above can still be
         // exact.
-        .allowed_statuses = &.{ 101, 200, 501, 502, 503, 504 },
+        .allowed_statuses = &.{ 101, 200, 408, 501, 502, 503, 504 },
     },
     .keepalive_pair = .{
         // The second GET is appended at run time, only after the first
@@ -559,21 +560,22 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         // (#247). Should this proxy ever learn to answer `408`, this is
         // the spec that fails and has to be told about it.
         .request = "GET /sim HTTP/1.1\r\nHost: sim\r\n",
-        .expected_responses = 0,
-        // An adversary seed may show exactly one, and only a `503`: the
-        // head never completes, so nothing routes and neither 200, 502
-        // nor 504 is reachable — but the *first byte* of a partial head
-        // still meets §8's head-buffer rung, which answers 503 before
-        // the parse. That is the whole difference from `silent`, which
-        // sends no byte and so meets no rung at all. Found by seed 778
-        // rather than reasoned out in advance.
+        // One, and it is the point: the head-read budget answers `408`
+        // rather than resetting (#247). This entry read zero until that
+        // landed, with a note saying it would have to be told — and it
+        // was, by seed 796, which is the spec doing its job rather than
+        // the change being caught late.
+        .expected_responses = 1,
         .transcript_cap = 1,
-        .golden_status = 0,
+        .golden_status = 408,
         .method = .get,
-        .allowed_statuses = &.{503},
-        // One payload out, no answer owed — the coincidence every
-        // other script relies on, broken on purpose.
-        .payloads_sent = 1,
+        // `503` remains legal beside it: the *first byte* of a partial
+        // head meets §8's head-buffer rung, which answers before the
+        // parse and so before any budget is installed. That is the whole
+        // difference from `silent`, which sends no byte and meets no rung
+        // at all — and it is why this script has two legal answers where
+        // most have one.
+        .allowed_statuses = &.{ 408, 503 },
     },
     .confusion = .{
         // Canonicalizes to /sim (the `/deep` segment is popped by the
@@ -596,7 +598,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .golden_status = 501,
         .method = .get,
         // Only the §5 head ring's 503 precedes the parse the 501 rides on.
-        .allowed_statuses = &.{ 501, 503 },
+        .allowed_statuses = &.{ 501, 408, 503 },
     },
     .options_final = .{
         // Answered here, so the only rung that can precede it is the head
@@ -607,7 +609,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 200,
         .method = .options,
-        .allowed_statuses = &.{ 200, 503 },
+        .allowed_statuses = &.{ 200, 408, 503 },
         // A `200` from this proxy's own memory, not from an origin: it
         // crosses neither response-side render, and carries no body.
         .answered_here = true,
@@ -647,7 +649,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 403,
         .method = .get,
-        .allowed_statuses = &.{ 403, 503 },
+        .allowed_statuses = &.{ 403, 408, 503 },
     },
     .filter_redirect = .{
         // `filter_reject`'s timing exactly — answered before any
@@ -660,7 +662,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 301,
         .method = .get,
-        .allowed_statuses = &.{ 301, 503 },
+        .allowed_statuses = &.{ 301, 408, 503 },
     },
     .filter_respond = .{
         // `filter_reject`'s timing exactly — the answer precedes every
@@ -671,7 +673,7 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .transcript_cap = 1,
         .golden_status = 200,
         .method = .get,
-        .allowed_statuses = &.{ 200, 503 },
+        .allowed_statuses = &.{ 200, 408, 503 },
         .respond_page = true,
     },
     .filter_edit = .{

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -3549,8 +3549,26 @@ pub fn Server(comptime IoType: type) type {
             // the state: a connection in `.l7_reading_head` may still be
             // on the idle window, because the budget is installed at the
             // first `Incomplete` and not at the first byte.
-            if (conn.state == .l7_reading_head and conn.l7.head_budget_installed) {
+            if (conn.state == .l7_reading_head and conn.l7.head_budget_installed and
+                conn.l7.pending_verdict == .none)
+            {
+                // Gated on the verdict, not merely on the state: the
+                // grace window this branch installs could in principle
+                // fire again before the forced recv's completion lands,
+                // and counting that would be two reaps for one. The same
+                // re-entrancy the exchange and dial branches above guard,
+                // guarded the same way.
                 server.counters.increment("l7_head_budget_expired");
+                if (Proxy.headExpiryAnswerable(conn)) {
+                    // The same fixed grace the other two verdicts take:
+                    // the pressure-biased window can collapse toward 1 ms
+                    // and tear the verdict down before its forced
+                    // completion lands.
+                    server.storeDeadline(conn, server.config.idle_timeout_ms);
+                    server.armDeadline(conn);
+                    Proxy.beginHeadExpiry(server, conn);
+                    return;
+                }
             }
             server.beginTeardown(conn);
         }

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -290,6 +290,13 @@ pub const Counters = struct {
     /// outstanding long enough to be reaped, which was true of every
     /// sweep before `dribbled_head` existed.
     l7_head_budget_expired: Value = Value.init(0),
+    /// Head-budget reaps answered `408` rather than reset (#247) — a
+    /// client that began a request and stopped, told why it is being
+    /// closed. A subset of `l7_head_budget_expired`: the reaps it does
+    /// *not* count are the ones no status was due for, which today is
+    /// none of them, and `reconcile` holds the inequality so a future
+    /// unanswerable shape cannot pass unnoticed.
+    l7_request_timeout: Value = Value.init(0),
     /// Interim `1xx` responses relayed to the client (#232). Forwarded
     /// rather than absorbed, which is what both references do: a `103` is
     /// worthless to a client that never sees it, and a `100` the client is
@@ -821,6 +828,13 @@ pub const Counters = struct {
         // Every 504 verdict rides a deadline expiry (§8) — the verdict
         // path increments both, the teardown path only the expiry.
         assert(counters.get("l7_gateway_timeout") <= counters.get("deadline_expired"));
+        // Every `408` rides a head-budget reap (#247): the verdict is
+        // reached from that expiry and nowhere else. The inequality
+        // rather than an equality, because a reap that cannot be
+        // answered is legal — today none exist, and this is what would
+        // notice if one arrived.
+        assert(counters.get("l7_request_timeout") <=
+            counters.get("l7_head_budget_expired"));
         // Every §7 replay rides a checkout: only a reused connection's
         // early failure is blamed on staleness.
         assert(counters.get("upstream_replayed") <= counters.get("upstream_reused"));

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -216,6 +216,18 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_reading_head);
+            // The head budget's verdict forced this op (#247) — the same
+            // divert `onHeadRecv` makes, and it must be here too because
+            // a terminated connection reads *only* through this arm.
+            // #235 shipped its budget into the plaintext arm alone and
+            // left HTTPS slowlorises the whole idle window; answering in
+            // one arm and resetting in the other would be that defect
+            // again, wearing the fix's clothes.
+            if (conn.l7.pending_verdict != .none) {
+                assert(conn.l7.pending_verdict == .request_timeout);
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const received = result catch |err| {
                 // A client that leaves before finishing its head has
                 // nothing to be answered; the §7 head deadline handles the
@@ -533,6 +545,18 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_reading_head);
+            // The head budget's verdict forced this op (#247): the read
+            // half was shut down precisely to end it, so its result is
+            // accounting rather than news — an EndOfStream we caused, or
+            // a delivery that raced the shutdown. Diverted before the
+            // error handling below so a forced EOF never reaches the
+            // kernel-pressure witness, the same order `settlePendingVerdict`
+            // relies on for the upstream verdicts.
+            if (conn.l7.pending_verdict != .none) {
+                assert(conn.l7.pending_verdict == .request_timeout);
+                settlePendingVerdict(server, conn);
+                return;
+            }
             const received = result catch |err| {
                 // A client that closes or resets mid-head simply leaves —
                 // there is nothing to answer. The §7 head-read deadline
@@ -3470,6 +3494,52 @@ pub fn Proxy(comptime IoType: type) type {
             );
         }
 
+        /// Whether the #235 head budget's expiry can be *answered* rather
+        /// than reset (#247).
+        ///
+        /// Only a client mid-sentence is owed one. A connection that has
+        /// said nothing at all was never under the budget — it sits on
+        /// the idle window — so `head_budget_installed` already draws the
+        /// line HAProxy needed `option http-ignore-probes` to draw: a
+        /// monitoring agent that opens a connection and closes it without
+        /// speaking earns silence, not a `408` per probe.
+        ///
+        /// The head recv is the one op that must be armed, since it is
+        /// what the verdict forces. A response leg cannot be, because
+        /// nothing has been answered yet in this state.
+        pub fn headExpiryAnswerable(conn: *const ConnType) bool {
+            assert(conn.state == .l7_reading_head);
+            // Stated positively rather than tested: `response_started` is
+            // set only inside `.l7_exchanging` and cleared on every entry
+            // to this state, so a conditional here would read as live and
+            // never be.
+            assert(!conn.l7.response_started);
+            if (!conn.l7.head_budget_installed) return false;
+            return conn.armed.data_client_to_upstream;
+        }
+
+        /// Begin the #247 head-read verdict: force the armed head recv and
+        /// answer `408` once it settles.
+        ///
+        /// The force is a **read-half** shutdown, which is the whole
+        /// reason §4 grew a variant for it. `.both` would end the recv and
+        /// take with it the write half the answer needs; `.write` would
+        /// leave the recv armed on a client that has already stopped
+        /// speaking. This ends exactly the op in the way, and leaves the
+        /// connection able to say why it is closing — §8's own rule, that
+        /// a client reading a reset where a status was due reports an
+        /// error it cannot attribute.
+        ///
+        /// The connection never survives the answer: a shut read half
+        /// cannot carry another request, so the `408` announces close.
+        pub fn beginHeadExpiry(server: *ServerType, conn: *ConnType) void {
+            assert(conn.state == .l7_reading_head);
+            assert(conn.l7.pending_verdict == .none);
+            assert(headExpiryAnswerable(conn));
+            conn.l7.pending_verdict = .request_timeout;
+            server.io.shutdown(conn.client_socket, .read);
+        }
+
         /// Begin the §8 request-deadline verdict. Ops are never canceled
         /// (§5) — they are *forced*: shutting the upstream socket down
         /// makes each armed op on it complete with an error its handler
@@ -3494,7 +3564,14 @@ pub fn Proxy(comptime IoType: type) type {
         /// divert runs before any error handling, a forced EPIPE never
         /// pollutes the kernel-pressure witness.
         fn settlePendingVerdict(server: *ServerType, conn: *ConnType) void {
-            assert(conn.state == .l7_exchanging);
+            // The #247 verdict settles from `.l7_reading_head`, where the
+            // op it forced is the head recv; the other two settle from an
+            // exchange. One function because the discipline is identical —
+            // act only once every forced op has drained — and splitting it
+            // would be two copies of that rule to keep in step.
+            assert(conn.state == .l7_exchanging or
+                (conn.state == .l7_reading_head and
+                    conn.l7.pending_verdict == .request_timeout));
             assert(conn.l7.pending_verdict != .none);
             if (conn.armed.data_client_to_upstream or
                 conn.armed.data_upstream_to_client)
@@ -3510,6 +3587,7 @@ pub fn Proxy(comptime IoType: type) type {
                     respond(server, conn, 504, "l7_gateway_timeout");
                 },
                 .replay => beginReplay(server, conn),
+                .request_timeout => respond(server, conn, 408, "l7_request_timeout"),
             }
         }
 
@@ -4223,6 +4301,13 @@ pub fn Proxy(comptime IoType: type) type {
             if (std.mem.eql(u8, counter, "l7_shed_tunnels")) return .shed;
             if (std.mem.eql(u8, counter, "l7_bad_gateway")) return .upstream_failed;
             if (std.mem.eql(u8, counter, "l7_gateway_timeout")) return .timed_out;
+            // A head that never finished is a timeout like the exchange
+            // deadline's, and reads as one (#247). Which side ran out of
+            // time is the status's to say — `408` names the client, `504`
+            // the origin — where the log line is about the outcome, and
+            // the outcome is the same: nothing was served, because time
+            // ran out.
+            if (std.mem.eql(u8, counter, "l7_request_timeout")) return .timed_out;
             @compileError("static-response counter with no access-log outcome: " ++ counter);
         }
 

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -3222,7 +3222,24 @@ test "l7: the head-read deadline reaps a slowloris that never completes" {
     // goes silent, so only the head-read deadline can end the connection.
     try bed.exchange("GET / HTTP/1.1\r\nHost: a\r\n");
 
-    try std.testing.expectEqual(@as(usize, 0), bed.client.response().len);
+    // Answered, not reset (#247). This assertion read `len == 0` until
+    // the seam grew a read-half shutdown: the budget's reap could not
+    // say anything, because the recv it had to force was on the socket
+    // the answer goes out on. §8's rule is that a client reading a reset
+    // where a status was due reports an error it cannot attribute.
+    try std.testing.expectEqual(HttpClient.Outcome.fin, bed.client.outcome);
+    // The `Date` is a second past every other scenario's and spelled out
+    // rather than shared, for the reason the 504 test gives: the budget
+    // this waits out is a virtual second long, so the stamp moving with
+    // it is the cheapest proof the slot reads a live clock (#234).
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 408 Request Timeout\r\nContent-Length: 0\r\n" ++
+            "Date: Wed, 01 Jan 2020 00:00:01 GMT\r\nServer: zoxy\r\n" ++
+            "Connection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_request_timeout"));
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_head_budget_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try bed.expectDrained();
@@ -5810,6 +5827,15 @@ test "l7: a terminated listener's partial head meets the head budget too" {
     try std.testing.expect(elapsed_ms >= 100);
     try std.testing.expect(elapsed_ms < 500);
     try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("deadline_expired"));
+    // And it is *answered*, through the transform, not reset (#247). This
+    // arm needed saying separately: a terminated connection reads only
+    // through `onTlsHeadRecv`, so the verdict's divert has to be in two
+    // places, and the first version of #247 put it in one — which is
+    // #235's own defect repeated, the budget wired into the plaintext arm
+    // alone. The sweep could not have caught it: `dribbled_head` is drawn
+    // on the terminating population by adversary seeds only, and there
+    // the lenient oracle reads zero bytes as a legal cut.
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_request_timeout"));
     try bed.expectDrained();
 }
 

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -1013,13 +1013,13 @@ fn takeSetOptionError(io: *SimIo) ?Io.SetOptionError {
 
 pub fn shutdown(io: *SimIo, socket: Socket, how: Io.ShutdownHow) void {
     const entry = io.socketEntry(socket);
-    if (!entry.write_shutdown) {
+    if (how != .read and !entry.write_shutdown) {
         entry.write_shutdown = true;
         if (entry.peer != peer_none) {
             io.peerEntry(entry).fin_received = true;
         }
     }
-    if (how == .both) {
+    if (how != .write) {
         entry.read_shutdown = true;
     }
 }

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1354,6 +1354,7 @@ pub fn setLingerRst(io: *XevIo, socket: Socket) Io.SetOptionError!void {
 pub fn shutdown(io: *XevIo, socket: Socket, how: Io.ShutdownHow) void {
     _ = io;
     const posix_how: i32 = switch (how) {
+        .read => posix.SHUT.RD,
         .write => posix.SHUT.WR,
         .both => posix.SHUT.RDWR,
     };

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -1458,3 +1458,79 @@ test "xevio: the listener table reserves a slot for the admin listener" {
     // And the reservation is exactly one — not open-ended.
     try std.testing.expectError(error.AddressUnavailable, xev_io.listen(loopback));
 }
+
+/// The §4 contract a head-read verdict rests on (#247): a read-half
+/// shutdown forces an armed recv to completion **and leaves the socket
+/// writable**.
+///
+/// Both halves matter and neither is obvious. Answering `408` to a client
+/// that stopped mid-head means writing on the very socket a recv is armed
+/// on, and §5 never cancels a data op — it forces one. `.both` would
+/// force it and take the write half with it, which is the one thing the
+/// verdict cannot afford; `.write` leaves the recv armed forever. So the
+/// whole feature turns on a variant that does exactly one of the two, and
+/// on both backends agreeing about it.
+///
+/// Asked of the kernel rather than reasoned about: on io_uring the armed
+/// recv completes `EndOfStream`, which is the shape `SimIo` already
+/// modelled for a FIN.
+fn runReadShutdownContract(comptime IoType: type, io: *IoType) !void {
+    const Contract = GroupContract(IoType);
+    var c: Contract = .{ .io = io };
+    const listener = try io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
+    defer io.listenClose(listener);
+    const client, const server = try c.pair(listener);
+    defer io.closeNow(client);
+    defer io.closeNow(server);
+
+    // Armed with the peer silent, so nothing but the shutdown can end it.
+    var buffer: [64]u8 = undefined;
+    var recv_outcome: ?Io.RecvError!u32 = null;
+    var recv_completion: IoType.Completion = .{};
+    io.recv(client, &buffer, &recv_completion, @TypeOf(recv_outcome), &recv_outcome, (struct {
+        fn onRecv(state: *?Io.RecvError!u32, result: Io.RecvError!u32) void {
+            state.* = result;
+        }
+    }).onRecv);
+
+    io.shutdown(client, .read);
+    try io.run();
+
+    const recv_result = recv_outcome orelse return error.RecvNeverCompleted;
+    try std.testing.expectError(error.EndOfStream, recv_result);
+
+    // And the half the verdict answers through is still open. Without
+    // this the first half would be satisfied by `.both`, which is the
+    // variant #247 could not use.
+    var send_outcome: ?Io.SendError!u32 = null;
+    var send_completion: IoType.Completion = .{};
+    const payload = "still-writable";
+    io.send(client, payload, &send_completion, @TypeOf(send_outcome), &send_outcome, (struct {
+        fn onSend(state: *?Io.SendError!u32, result: Io.SendError!u32) void {
+            state.* = result;
+        }
+    }).onSend);
+    try io.run();
+    const sent = try (send_outcome orelse return error.SendNeverCompleted);
+    try std.testing.expect(sent >= 1);
+    try std.testing.expect(sent <= payload.len);
+}
+
+test "contract: a read-half shutdown forces an armed recv on SimIo" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var sim_io: SimIo = undefined;
+    try sim_io.init(arena_state.allocator(), .{ .seed = 247 });
+    try runReadShutdownContract(SimIo, &sim_io);
+}
+
+test "contract: a read-half shutdown forces an armed recv on XevIo" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    var xev_io: XevIo = undefined;
+    try initTestIo(&xev_io, arena_state.allocator(), 0);
+    defer xev_io.deinit();
+    try runReadShutdownContract(XevIo, &xev_io);
+}

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -82,6 +82,11 @@ pub const Signal = enum(u8) {
 };
 
 pub const ShutdownHow = enum(u8) {
+    /// Force an armed *recv* to completion while the connection stays
+    /// writable (#247). The write half is untouched, which is the whole
+    /// point: a verdict that must answer cannot shut the socket it is
+    /// answering on.
+    read,
     write,
     both,
 };

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -700,6 +700,14 @@ pub fn Conn(comptime IoType: type) type {
                 none,
                 gateway_timeout,
                 replay,
+                /// The #235 head budget expired on a client mid-sentence,
+                /// and it is owed a `408` (#247). The odd one out: the
+                /// armed op it waits on is a recv on the **client**
+                /// socket, so the force is a read-half shutdown rather
+                /// than the upstream teardown the other two use — the
+                /// connection has to survive writable to carry the
+                /// answer.
+                request_timeout,
             };
         };
 

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -315,7 +315,7 @@ fn writeTwoDigits(out: *[2]u8, value: u32) void {
 /// (§7) send as static responses — the statuses `error_pages` may
 /// configure a body for (#159): a page for a status this proxy never
 /// sends is a config the operator misread, refused at load.
-pub const static_statuses = [_]u16{ 400, 403, 404, 413, 414, 429, 431, 501, 502, 503, 504 };
+pub const static_statuses = [_]u16{ 400, 403, 404, 408, 413, 414, 429, 431, 501, 502, 503, 504 };
 
 /// Every status a configured page may carry (#159): the error set
 /// above, plus `200` — which no rung raises, but a `respond` filter
@@ -394,6 +394,7 @@ pub fn reasonPhrase(status: u16) []const u8 {
         400 => "Bad Request",
         403 => "Forbidden",
         404 => "Not Found",
+        408 => "Request Timeout",
         413 => "Content Too Large",
         414 => "URI Too Long",
         429 => "Too Many Requests",


### PR DESCRIPTION
Closes #247.

When #235's head budget fires, the connection was reset with nothing said. Both references answer `408` first, and §8's own rule applies exactly: *a client that reads a reset where a status was due reports an error it cannot attribute.*

The issue documented this as blocked on a §4 seam change and said recording a decision either way was the point. The decision is **yes**, and what settled it was measuring the unknown rather than reasoning about it.

## The seam, and why the contract test is the whole argument

Answering means writing on the socket an armed recv is sitting on. Ops are never cancelled, they are *forced* (§5) — and neither existing variant fits: `.both` forces the recv and takes the write half the answer needs; `.write` leaves the recv armed on a client that has already stopped talking.

So `ShutdownHow` grows `read`, and the contract test asks the kernel two questions instead of assuming them — does a read-half shutdown complete an armed recv, and is the socket still writable afterwards. It runs both against **both backends** through the harness the buffer-group contract already uses. The second question is the one an obvious test forgets, and forgetting it leaves `.both` passing.

On io_uring: the recv completes `EndOfStream` — the shape `SimIo` already modelled for a FIN — and a following send succeeds.

**`SimIo` needed a fix, not a case.** Its `shutdown` set `write_shutdown` *unconditionally* and reached `read_shutdown` only through `.both`: it assumed every shutdown includes the write half. Adding `.read` naively would have shut the write half too, and the simulator would have agreed with itself while modelling the opposite of the variant's purpose.

## The verdict

Follows the shape the dial-timeout `504` already uses — a `pending_verdict`, the armed op forced rather than cancelled, the answer sent once it drains — with the one difference that made #247 blocked: the op is a recv on the *client* socket, so the force is the read-half shutdown and the connection survives writable to carry its own reason.

**Silence earns nothing, and that falls out rather than being special-cased.** The budget starts at the first `Incomplete` — a client mid-sentence — so a connection that never spoke is on the idle window and `headExpiryAnswerable` is false for it. That is the distinction HAProxy needed `option http-ignore-probes` for, after monitoring agents that open and close without speaking earned a `408` each.

`408` joins `static_statuses`, so it renders from static memory like every other verdict and can carry a #159 configured page. `l7_request_timeout` counts the answers, held at or under `l7_head_budget_expired` by `reconcile` — an inequality, because a reap that cannot be answered is legal even though none exist today.

## The bug the review caught, which was mine

**The first version wired the plaintext arm only.** A terminated connection reads exclusively through `onTlsHeadRecv`, so an HTTPS slowloris still got a silent reset — which is **#235's own defect repeated**, the budget installed into the plaintext arm alone, wearing the fix's clothes.

The sweep could not have caught it: `dribbled_head` is drawn on the terminating population by adversary seeds only, and there the lenient prefix oracle reads zero bytes as a legal cut. "4096 seeds pass" established nothing about that arm. There is now a directed test on it, and removing the divert fails with `expected 1, found 0`.

Three smaller review findings, all fixed: a dead `response_started` branch that read as live (now an assert), a counter that could double-increment across the new grace window (now gated on the verdict, matching its sibling branches), and a §7 sentence implying `limits.head_buffer_bytes` is answered `408` when that path answers `431`.

## Consequences found by the gates, not predicted

- **Every script's legal status set needed `408`** (seed 1675). Adversarial fragmentation can leave *any* request mid-head when the budget fires, so a new response shape in a state every request passes through widens the whole table, not one row.
- **The `408` owes an access-log line** where the old reset was an abort, so `l7_request_timeout` joins `l7OutcomeTotal` (seed 264).
- **#258's spec did its job**: `dribbled_head` was written to fail loudly if a `408` ever appeared unannounced, and seed 796 did exactly that.
- **`dribbled_head` stays off clean seeds, for a new reason.** #258 excluded it because an unfinished request was an abort; #247 makes it an ordinary answered exchange, so that objection is gone. Lifting it still fails at seed 486 — clean seeds pin the head budget to the idle window, which can outlast the scenario backstop. The comment now says that rather than the stale reason.

## Commits

| | |
|---|---|
| `be34390` | the seam + the two-question contract test, both backends |
| `d8c8d8e` | the verdict, both head-recv arms, `408` wiring |
| `c927d1a` | sim specs, the outcome sum, §7/§8 and README |

Reviewed against `docs/TIGER_STYLE.md` before commit.

## Gates

`zig build ci` green (4096 seeds, census 76), 555 unit tests, fmt and lint clean.

## What CI will settle

The read-half shutdown is **proven on io_uring only**. macOS uses kqueue, and the contract test deliberately does not skip there — the neighbouring EPIPE test skips on kqueue for a real reason, and this one should not inherit that by default. If kqueue does not complete an armed recv on `SHUT_RD`, that is a finding about the seam and this PR should not merge as-is.

Separately: the 4M-seed nightly soak that passed today ran against `43e693d`, which is this branch's base and does not include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)