### PR TITLE
release: make this file testable, and stop the dispatch path lying

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
       tag:
         description: 'Release tag (e.g. v0.1.0)'
         required: true
+      dry_run:
+        description: 'Build and package only — publish nothing, touch no tap'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -75,7 +79,12 @@ jobs:
             static: false
     runs-on: ${{ matrix.os }}
     steps:
+      # A dispatch defaults to the branch it was launched from, which would
+      # build one commit and then label it — and smoke-test it — as another's
+      # version. Build the tag that is being released.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v35
@@ -193,7 +202,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # A dispatch defaults to the branch it was launched from, which would
+      # build one commit and then label it — and smoke-test it — as another's
+      # version. Build the tag that is being released.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v35
@@ -216,6 +230,19 @@ jobs:
           ref="${{ github.event.inputs.tag || github.ref_name }}"
           echo "tag=$ref" >> "$GITHUB_OUTPUT"
           echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+          # On `push` there are no inputs at all, so this is empty and the
+          # release is real. Only an explicit dispatch can ask for a rehearsal.
+          #
+          # The steps below gate on `dry == 'false'` rather than `!= 'true'`,
+          # so this going missing blocks a release instead of publishing one
+          # that was asked to be a rehearsal: a release that did not happen is
+          # a re-run away, one that did cannot be unpublished.
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            echo "dry=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::dry run — building $ref, publishing nothing"
+          else
+            echo "dry=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/download-artifact@v4
         with:
@@ -249,13 +276,41 @@ jobs:
           ls -la dist
 
       - name: Publish GitHub Release
+        if: steps.ver.outputs.dry == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           files: dist/*
           generate_release_notes: true
 
+      # A guard that fails closed can fail *silently*: if `dry` were ever
+      # anything but the 'false' those two steps test for, a real release would
+      # skip both and still report success — a green run that shipped nothing.
+      # So check the outcome rather than trusting the condition.
+      #
+      # Deliberately `!= 'true'`: erring towards running a check is the safe
+      # direction, the opposite of erring towards publishing.
+      - name: Verify the release was published
+        if: steps.ver.outputs.dry != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.ver.outputs.tag }}"
+          version="${{ steps.ver.outputs.version }}"
+          gh release view "$tag" --json assets --jq '.assets[].name' | tee assets.txt
+          for label in x86_64-linux aarch64-linux aarch64-macos; do
+            grep -qx "zoxy-$version-$label.tar.gz" assets.txt \
+              || { echo "::error::$tag is missing the $label archive"; exit 1; }
+          done
+          grep -qx 'SHA256SUMS.txt' assets.txt \
+            || { echo "::error::$tag has no SHA256SUMS.txt"; exit 1; }
+          grep -qx "zoxy-$version-config.schema.json" assets.txt \
+            || { echo "::error::$tag has no config schema"; exit 1; }
+          echo "$tag published complete"
+
       - name: Update Homebrew formula
+        if: steps.ver.outputs.dry == 'false'
         env:
           HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
         run: |
@@ -339,6 +394,7 @@ jobs:
       # reason — a red step is how an expired token gets noticed, and the site's
       # weekly refresh catches the page up in the meantime.
       - name: Notify zoxy-io/site
+        if: steps.ver.outputs.dry == 'false'
         env:
           GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
           TAG: ${{ steps.ver.outputs.tag }}
@@ -350,3 +406,18 @@ jobs:
           jq -n --arg tag "$TAG" \
             '{event_type: "zoxy-release", client_payload: {tag: $tag}}' |
             gh api repos/zoxy-io/site/dispatches --input -
+
+      - name: Dry run summary
+        if: steps.ver.outputs.dry == 'true'
+        run: |
+          {
+            echo "### Dry run — nothing was published"
+            echo
+            echo "Built \`${{ steps.ver.outputs.tag }}\`, smoke-tested each binary on"
+            echo "its own platform, packaged everything, and stopped before the"
+            echo "release and the tap."
+            echo
+            echo '```'
+            cat dist/SHA256SUMS.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`release.yml` only ever runs on a tag, so every edit to it is unverifiable
except by cutting a release — and a broken release tag is public and
half-published. This repository does not need convincing of that: the 0.2.0 tag
is the reason the file builds natively at all.

`dry_run` closes the gap. Dispatch with an existing tag and it builds every
target, smoke-tests each binary on its own platform, packages, checksums and
generates the config schema exactly as a real release does, then stops before
the steps that reach outside this repository.

Validated by doing it —
[dry run against v0.5.1](https://github.com/zoxy-io/zoxy/actions/runs/32616073981):
all three builds green, artifacts collected and checksummed, and every
outward-facing step skipped. No release, and the tap untouched.

### There are three irreversible steps, not one

The release and the Homebrew tap are the obvious ones. `Notify zoxy-io/site`
fires a `repository_dispatch` and would have announced a rehearsal as a real
release — the kind of step that is easy to miss precisely because it is not
what anyone pictures when they think "publish".

Verification now sits *between* publishing and the two steps that react to it,
so the tap and the site are never told about a release that did not land
completely.

### The guards fail closed, and then get checked anyway

They gate on `dry == 'false'` rather than `!= 'true'`, so a missing output
blocks a release instead of publishing one that was asked to be a rehearsal: a
release that did not happen is a re-run away, one that did cannot be
unpublished.

But a guard that fails closed can fail *silently* — if `dry` were ever anything
else, a real release would skip all three steps and still report success, a
green run that shipped nothing. So the new step stops testing the condition and
checks the outcome: after a real release the tag must carry all three archives,
`SHA256SUMS.txt` and the config schema, or the run fails.

### A latent bug in the dispatch path

It checked out whichever branch it was launched from, then labelled those
binaries — and smoke-tested them — as the supplied tag's version. A manual
re-release of `v0.4.0` from `main` would have shipped `main`'s code, and the
`--version` check would have *passed* it, because the version it compares
against comes from the same wrong tree. It now checks out the tag.

### Not in scope

The build matrix is unchanged. `x86_64-macos` is still absent, and the
cross-compile route back to it does not work: `allyourcodebase/openssl` builds
under Zig 0.16 for x86_64 after two mechanical fixes, but has no aarch64
support at all, and BoringSSL has no `CRYPTO_set_mem_functions`, so
`libcrypto_heap.install` fails and `main.zig` refuses to start. Native builds
here are load-bearing, not a workaround.