### PR TITLE
build: link a Zig-built libcrypto instead of the host's

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -75,11 +75,49 @@ pub fn build(b: *std.Build) void {
     // over libcrypto primitives, which is why every build below links
     // libcrypto: the §4 crypto-primitives exception, and the codebase's one
     // C surface.
-    const ztls_dependency = b.dependency("ztls", .{
+    // libcrypto, built by Zig for the *target* rather than resolved out of the
+    // build machine's nix store. See build.zig.zon for why it is OpenSSL and
+    // why this fork; the short version is that BoringSSL has no
+    // `CRYPTO_set_mem_functions` and `tls/libcrypto_heap.zig` cannot start
+    // without it.
+    //
+    // Two of them, because the ReleaseSafe twin below builds its own ztls at a
+    // different optimize mode and the archive has to match.
+    const openssl_dependency = b.dependency("openssl", .{
         .target = target,
         .optimize = optimize,
     });
+    const libcrypto = openssl_dependency.artifact("openssl");
+    const openssl_fast_dependency = b.dependency("openssl", .{
+        .target = target,
+        .optimize = std.builtin.OptimizeMode.ReleaseSafe,
+    });
+    const libcrypto_fast = openssl_fast_dependency.artifact("openssl");
+
+    // ztls asks the linker for `-lcrypto` by name and this package emits
+    // `libopenssl.a`. Linking the artifact resolves every symbol, but the
+    // linker must still *find* a file of that name or it fails before getting
+    // there — so publish a copy under it and point the search path at it. A
+    // copy rather than renaming the artifact, because the artifact's name is
+    // the package's API.
+    const crypto_alias = b.addWriteFiles();
+    _ = crypto_alias.addCopyFile(libcrypto.getEmittedBin(), "libcrypto.a");
+    const crypto_alias_dir = crypto_alias.getDirectory();
+    const crypto_fast_alias = b.addWriteFiles();
+    _ = crypto_fast_alias.addCopyFile(libcrypto_fast.getEmittedBin(), "libcrypto.a");
+    const crypto_fast_alias_dir = crypto_fast_alias.getDirectory();
+
+    const ztls_dependency = b.dependency("ztls", .{
+        .target = target,
+        .optimize = optimize,
+        // We supply libcrypto, so pkg-config must not. Left on, it injects the
+        // system OpenSSL's include path ahead of ours and the C import dies on
+        // typedef collisions — but only where pkg-config knows about OpenSSL,
+        // so it passes CI and breaks on a laptop.
+        .@"crypto-pkg-config" = false,
+    });
     const ztls_module = ztls_dependency.module("ztls");
+    ztls_module.linkLibrary(libcrypto);
 
     const zoxy_module = b.addModule("zoxy", .{
         .root_source_file = b.path("src/root.zig"),
@@ -91,7 +129,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ztls", .module = ztls_module },
         },
     });
-    linkLibcrypto(zoxy_module);
+    linkLibcrypto(zoxy_module, libcrypto, crypto_alias_dir);
     // `src/io/XevIo.zig` reads the backend choice from here.
     zoxy_module.addOptions("io_options", io_options);
     // The shipped example config is embedded so tests and the fuzz corpus
@@ -163,7 +201,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ztls", .module = ztls_module },
         },
     });
-    linkLibcrypto(tls_heap_proof_module);
+    linkLibcrypto(tls_heap_proof_module, libcrypto, crypto_alias_dir);
     const tls_heap_proof_tests = b.addRunArtifact(b.addTest(.{
         .root_module = tls_heap_proof_module,
     }));
@@ -281,7 +319,9 @@ pub fn build(b: *std.Build) void {
     const ztls_fast_dependency = b.dependency("ztls", .{
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseSafe,
+        .@"crypto-pkg-config" = false,
     });
+    ztls_fast_dependency.module("ztls").linkLibrary(libcrypto_fast);
     const zoxy_fast_module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
@@ -292,7 +332,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ztls", .module = ztls_fast_dependency.module("ztls") },
         },
     });
-    linkLibcrypto(zoxy_fast_module);
+    linkLibcrypto(zoxy_fast_module, libcrypto_fast, crypto_fast_alias_dir);
     // The ReleaseSafe twin of the library module needs the same backend
     // choice: it is the same `src/root.zig`, so `XevIo` asks it the same
     // question.
@@ -554,37 +594,39 @@ fn resolveBuildId(b: *std.Build) []const u8 {
 
 /// ztls's C surface: the protocol layer is Zig, the primitives are
 /// libcrypto's (DESIGN.md §4's crypto-primitives exception). Every module
-/// that reaches `src/tls/` needs both, and they always travel together —
-/// linking one without the other produces a link error a long way from
-/// here, so they are set in one place rather than repeated per module.
-fn linkLibcrypto(module: *std.Build.Module) void {
+/// that reaches `src/tls/` needs the archive and a search path that makes
+/// ztls's own `-lcrypto` resolvable; they always travel together, so they
+/// are set in one place rather than repeated per module.
+///
+/// Statically, always, and built for the target rather than found on the
+/// build machine. This used to be `linkSystemLibrary("crypto")` with
+/// pkg-config deciding which libcrypto that meant, which cost twice over.
+/// A *release* binary handed to strangers must not want a musl-ABI
+/// `libcrypto.so.3` at runtime — that shipped unnoticed the moment TLS
+/// termination (#125) gave zoxy a C dependency. And pkg-config answers only
+/// for the host, so every other target failed to link, which is why
+/// release.yml builds natively on one runner per target and why
+/// x86_64-macos has been absent since 0.2.0.
+fn linkLibcrypto(
+    module: *std.Build.Module,
+    lib: *std.Build.Step.Compile,
+    alias_dir: std.Build.LazyPath,
+) void {
     module.link_libc = true;
-    // Static where the caller asked for it (`-Dstatic-crypto`), which the
-    // release builds do and nothing else does.
-    //
-    // A dev or CI build links the shared libcrypto its shell provides and
-    // runs on that machine, which is all it needs. A *release* binary is
-    // handed to strangers, and a musl target that dynamically links
-    // libcrypto is not the artifact anyone thinks it is: it wants a musl
-    // loader and a musl-ABI `libcrypto.so.3` at runtime, so a stock
-    // Linux box cannot execute it at all. That shipped unnoticed the
-    // moment TLS termination (#125) gave zoxy a C dependency — before it,
-    // the musl target had nothing to link and was static by default.
-    module.linkSystemLibrary("crypto", .{});
+    module.addLibraryPath(alias_dir);
+    module.linkLibrary(lib);
 }
 
 /// Set from `-Dstatic` in `build`, read where the executable is declared.
 /// A file global because that is the only other place it is needed and a
 /// parameter would have to travel through code that does not care.
 ///
-/// *Which* libcrypto `-lcrypto` resolves to is not decided here. Zig
-/// asks pkg-config, so the answer is whatever `PKG_CONFIG_PATH` names —
-/// which is also the only lever that reaches **ztls's** own
-/// `linkSystemLibrary("crypto")`, since that lives in a pinned dependency
-/// this build cannot reach into. A release therefore points pkg-config at
-/// a static, target-ABI openssl and gets one everywhere; naming an
-/// archive here would have fixed only half the link and left ztls still
-/// pulling in the shared one.
+/// This no longer decides anything about libcrypto. It used to matter that
+/// `-Dstatic` and pkg-config agreed, because pkg-config was the only lever
+/// that reached **ztls's** own `linkSystemLibrary("crypto")` inside a
+/// pinned dependency. `linkLibcrypto` now hands both halves the same
+/// Zig-built archive, so libcrypto is static on every build and
+/// `PKG_CONFIG_PATH` reaches nothing.
 var static_link: bool = false;
 
 /// The `-Dio-backend` choice. `default` is what the platform picks

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -123,6 +123,33 @@
             .url = "git+https://github.com/zoxy-io/hparse#65521edfc09f19c5574a3360e2ce236c6dbc3be3",
             .hash = "hparse-0.2.0-IukW0rSOAQAmTPCaHzBakxuRRv6dfMds5OGdGU8nxlXw",
         },
+        // libcrypto, built by Zig rather than found on the system.
+        //
+        // This is what buys back cross-compilation. `linkSystemLibrary("crypto")`
+        // resolved libcrypto out of the *host's* nix store, so every target but
+        // the host's own failed to link — the reason release.yml builds natively
+        // on one runner per target, and the reason x86_64-macos has been absent
+        // since 0.2.0 for want of an Intel runner.
+        //
+        // OpenSSL, not BoringSSL: the BoringSSL family has no
+        // `CRYPTO_set_mem_functions`, so `tls/libcrypto_heap.zig`'s `install`
+        // would return false and `main.zig` would refuse to start (§5's
+        // zero-allocation budget cannot be kept without it). That rules out the
+        // package zrk was using and made this fork the shared answer.
+        //
+        // The fork carries allyourcodebase/openssl#5 — pre-generated perlasm for
+        // aarch64, which upstream has only for x86_64 — on top of a bump from
+        // 3.3.2 to 3.5.7. 3.5 is the LTS line, supported to April 2030. 3.6.3
+        // was measured and rejected: it restructured the provider tree, leaving
+        // 62 sources and 2 templates without a home against 3 for 3.5.7.
+        //
+        // Versus what this build linked before: nixpkgs supplies 3.6.3, so the
+        // libcrypto version steps back one minor release onto a supported LTS
+        // branch, and forward two years from the package's own 3.3.2.
+        .openssl = .{
+            .url = "git+https://github.com/zoxy-io/openssl?ref=openssl-3.5.7#546ec9845fa43013021609a8590e03678cc0fb20",
+            .hash = "openssl-3.5.7-TC9C3eDHfwHNGqKQk63LrMZg6g-YSvctDN8wNP1uktMX",
+        },
         // Audited fork: zoxy-io/ztls branch zoxy-tls = upstream
         // mattrobenolt/ztls 7c5049ec (the audited snapshot) plus four
         // commits of ours:
@@ -214,9 +241,20 @@
         // tests that pinned the old mapping moved with it; zero is the
         // "draw again" case they describe. Still open upstream, so this
         // rides the fork like the other four.
+        // Re-audit for 03c2464, the one commit new since the pin above:
+        // build plumbing only. `git diff 634567a..03c2464` touches build.zig,
+        // build.zig.zon and integrations/ztls-std/src/root.zig and nothing
+        // else — `src/` is byte-identical, so the audited crypto surface is
+        // unchanged and the four commits below still describe it exactly.
+        //
+        // It adds `-Dcrypto-pkg-config`, which is why the pin moves at all.
+        // Default true, i.e. the behaviour this build had before; zoxy now
+        // passes false because it supplies libcrypto itself (see build.zig).
+        // The other two changes — exposing `ztls_std` as a module and shipping
+        // its source — are for zoxy-io/zrk and inert here.
         .ztls = .{
-            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#634567aedb66ed7c8abcd0d6b2e4fefdba6b6cb5",
-            .hash = "ztls-0.0.0-SHHDXm2kFQB_YpgKnzsrxFllS1bq1WTSN-HTr8fAdAYr",
+            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#03c246477370d83bfc38d5168250e10fb235f358",
+            .hash = "ztls-0.0.0-SHHDXrvzFgAxDlPTWEEam3B2YclV_S0hHpOrD3qGFnEp",
         },
     },
     .paths = .{


### PR DESCRIPTION
`linkSystemLibrary("crypto")` resolved libcrypto out of the **build machine's**
nix store, and that one line is why this repository builds the way it does:

- every target but the host's own failed to link, so `release.yml` builds
  natively on one runner per target;
- `x86_64-macos` has been absent since 0.2.0 for want of an Intel runner —
  documented in the matrix as deliberate, because cross-compiling it would have
  meant the wrong architecture's libcrypto;
- the release has to resolve `nixpkgs#pkgsStatic.openssl` and thread
  `PKG_CONFIG_PATH` through `devenv shell -- env` to avoid shipping a binary
  that wants a musl-ABI `libcrypto.so.3` it cannot find.

Linking a Zig-built artifact removes the premise. libcrypto is built **for the
target, statically, on every build** — dev, CI and release alike.

### Why OpenSSL and not BoringSSL

zoxy-io/zrk took the BoringSSL route for the same problem. It is not available
here: the BoringSSL family has no `CRYPTO_set_mem_functions`, so
`tls/libcrypto_heap.zig`'s `install` returns false and `main.zig` refuses to
start rather than run without §5's zero-allocation budget. So the shared pin
had to be OpenSSL, and zrk moves to it too
([zoxy-io/zrk#53](https://github.com/zoxy-io/zrk/pull/53)).

The fork carries
[allyourcodebase/openssl#5](https://github.com/allyourcodebase/openssl/pull/5)
— pre-generated perlasm for aarch64 — on top of a 3.3.2 → **3.5.7** bump onto
the LTS line (supported to April 2030). Versus what this build linked before,
nixpkgs supplies 3.6.3, so the version steps back one minor release onto a
supported LTS branch and forward two years from the package's own 3.3.2. 3.6.3
was measured and rejected: it restructured the provider tree, leaving 62
sources and 2 templates without a home against 3 for 3.5.7.

### Three things the diff does not explain itself

- **The ztls pin has to move.** `634567a` predates `-Dcrypto-pkg-config`, and
  without it pkg-config injects the system OpenSSL's include path ahead of ours
  and the C import dies on typedef collisions — but only where pkg-config knows
  about OpenSSL, so it would pass CI and break on a laptop. `03c2464` is build
  plumbing only: `git diff 634567a..03c2464` touches `build.zig`,
  `build.zig.zon` and `integrations/ztls-std/src/root.zig` and nothing else, so
  `src/` is byte-identical and the audited crypto surface does not move. The
  re-audit note is in `build.zig.zon` in the usual form.
- **Two libcryptos**, because the ReleaseSafe twin builds its own ztls at a
  different optimize mode and the archive has to match it.
- **An alias.** ztls asks the linker for `-lcrypto` by name and the package
  emits `libopenssl.a`; linking the artifact resolves every symbol, but the
  linker must find a file of that name first.

### Verification

- **`zig build tls-heap-proof` passes** — the load-bearing one. A real
  handshake ran entirely on the fixed heap, so `CRYPTO_set_mem_functions`
  installed and libcrypto's allocations landed in memory we own.
- **`zig build ci` green** — 4096 simulation seeds, smoke clean (144 http + 2
  l4 exchanges), counters reconcile.
- **`otool -L`** on the binary shows `libSystem` and nothing else: zero
  nix-store references, now by construction rather than by aiming pkg-config at
  `pkgsStatic`.

### Not in scope

`release.yml` is untouched. Its `PKG_CONFIG_PATH` machinery is now **inert
rather than wrong**, and taking the native matrix apart — and adding back
`x86_64-macos`, which an ARM runner can now both cross-compile and run under
Rosetta — is its own change, and one that should ride on the `dry_run` added in
#278.