### PR TITLE
deps: zrk v2.1.0, and the zio it carries

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -22,7 +22,7 @@ const affinity = @import("affinity.zig");
 const zrk = @import("zrk");
 const zio = @import("zio");
 const spawn_path = @import("spawn_path.zig");
-const constants = @import("zoxy").constants;
+const constants = @import("zoxy_constants");
 
 const assert = std.debug.assert;
 

--- a/build.zig
+++ b/build.zig
@@ -421,7 +421,29 @@ pub fn build(b: *std.Build) void {
                 // *lowered* ceiling loudly (the config is rejected at
                 // startup) but a *raised* one silently — a profile aimed at
                 // the new maximum would cap below it and say nothing.
-                .{ .name = "zoxy", .module = zoxy_fast_module },
+                //
+                // `src/constants.zig` directly rather than the whole `zoxy`
+                // module, which imports ztls: this executable also imports
+                // zrk, which reaches the same ztls through ztls_std, and the
+                // two instantiations differ in optimize mode — ReleaseSafe
+                // for the zoxy under test, ReleaseFast for the load
+                // generator. Zig treats those as two modules rooted at one
+                // file and refuses to compile:
+                //
+                //     error: file exists in modules 'ztls' and 'ztls0'
+                //     note: files must belong to only one module
+                //
+                // Importing a leaf that depends on nothing but `std` keeps
+                // both of those optimize choices, which are deliberate, and
+                // takes the shared C dependency out of the question. It only
+                // became possible to hit once libcrypto stopped being one
+                // system-wide shared object and became a per-configuration
+                // artifact (#279).
+                .{ .name = "zoxy_constants", .module = b.createModule(.{
+                    .root_source_file = b.path("src/constants.zig"),
+                    .target = target,
+                    .optimize = .ReleaseFast,
+                }) },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -79,18 +79,34 @@
         // come off the same generator; runs on mismatched versions are not
         // comparable, which is a trap this pin exists to close.
         //
-        // v1.4.1, matching zoxy-io/benchmark's `bench/build.zig.zon`
-        // verbatim — including the `?ref=` form, which the other three pins
-        // here do not use: zrk is the one dependency whose *version* the
-        // comparability rule above is stated in, so the tag is carried in
-        // the URL where a reader sees it without resolving the sha.
-        // Since v1.3.1 it carries three UB/panic guards
-        // found in review (zoxy-io/zrk#46) and two dashboard fixes that the
-        // harness does not reach; what matters to a band is the zio pin
-        // below, which #46 moved and v1.4.1 settled.
+        // v2.1.0, matching zoxy-io/benchmark's `bench/build.zig.zon`
+        // verbatim — including the `?ref=` form, which the other pins here do
+        // not use: zrk is the one dependency whose *version* the comparability
+        // rule above is stated in, so the tag is carried in the URL where a
+        // reader sees it without resolving the sha.
+        //
+        // 2.x is major for reasons that do not reach this harness — dropped
+        // Windows targets, `--http2` — and one that does: zrk links C now,
+        // having swapped `std.crypto.tls` for ztls over a Zig-built libcrypto.
+        // The band is plaintext, so no measurement changes; what changes is
+        // that `zig build bench` builds libcrypto for zrk's ReleaseFast
+        // instantiation as well as zoxy's own.
+        //
+        // **2.1.0 and not 2.0.0**, and the difference is load-bearing. v2.0.0
+        // predates zoxy-io/zrk#53 and pins *BoringSSL*, while this file pins
+        // OpenSSL — and `zoxy-profile-harness` imports both the `zrk` and
+        // `zoxy` modules, so that tag would put two libcryptos with
+        // overlapping symbol sets into the one binary whose job is producing
+        // trustworthy measurements. 2.1.0 is the swap, so both sides resolve
+        // to the `openssl` pin below: one source, built per optimize mode.
+        //
+        // The zio bump beside it is not optional. zrk 2.0.0 carries
+        // zio 0.17.0 at df666c2, and the rule below — that this file's zio must
+        // be *exactly* zrk's — is what keeps the harness and zrk's runner on
+        // one runtime.
         .zrk = .{
-            .url = "git+https://github.com/zoxy-io/zrk?ref=v1.4.1#b2b7ddaa0b125817ea105f258710563f65d42bdc",
-            .hash = "zrk-1.4.1-WqdFO0rIBAABbP3sI9jkhfqcIn4ZQM2zQ2HL9eh4KaAP",
+            .url = "git+https://github.com/zoxy-io/zrk?ref=v2.1.0#a47c02d628064dc1d6285fb5d42bdf90ce407b41",
+            .hash = "zrk-2.1.0-WqdFO1rQBQA9vPHaywTYs1dBhnCIP_h2Wn06dGSD3uxa",
         },
         // zrk embeds its load off a zio (io_uring) runtime, not the default
         // std.Io.Threaded backend — plain Threaded is missing pieces zrk
@@ -103,18 +119,22 @@
         // not patch is a second thing to keep in sync with zrk's pin, and
         // the only way it can differ from upstream is by being wrong.
         //
-        // b822fda is lalinsky/zio#628, "flush a full submission queue
-        // instead of dropping SQEs". Before it, zio dropped a cancel when
-        // the io_uring SQ was full, leaving the target completion stuck
-        // `.running` forever and the awaiting task blocked with it — which a
-        // c10k load reaches reliably, since ten thousand per-operation
-        // timeouts expiring together submit thousands of cancels at once
-        // (lalinsky/zio#623). It postdates the v0.16.0 tag, so there is no
-        // release to name and this pins the bare commit — as zrk's own zio
-        // entry does, which is what makes the two identical.
+        // df666c2 is v0.17.0 plus lalinsky/zio#699, and it is what zrk v2.0.0
+        // carries — which is the only reason this line has that value.
+        //
+        // It is 121 commits ahead of the b822fda this used to pin, and zero
+        // behind, so the fix that pin existed for is contained rather than
+        // lost: zio#628, "flush a full submission queue instead of dropping
+        // SQEs". Before it, zio dropped a cancel when the io_uring SQ was
+        // full, leaving the target completion stuck `.running` forever and the
+        // awaiting task blocked with it — which a c10k load reaches reliably,
+        // since ten thousand per-operation timeouts expiring together submit
+        // thousands of cancels at once (lalinsky/zio#623). Checked with
+        // `compare/b822fda...df666c2` before moving, because "the fix is still
+        // in there" is exactly the assumption a bump is where you lose.
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio#b822fda55af546ce47918776950338cdf23315c0",
-            .hash = "zio-0.16.0-xHbVVJqoJADE1sz0O0ssHXOjaYODH86TWCUG9Pg4N69C",
+            .url = "git+https://github.com/lalinsky/zio?ref=main#df666c286380bf513dfe843f65a8133207ad7373",
+            .hash = "zio-0.17.0-xHbVVJPWJwBY3c_AkOFjUCF_pTIMnMc7ia9ujTjAfsbk",
         },
         // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
         // hardening-gate merge (PR #3: CRLF-only line terminators +


### PR DESCRIPTION
The band's generator moves to zrk 2.1.0. `zio` moves with it because this
file's own rule requires it: the harness builds its own `zio.Runtime` to drive
zrk's runner, so two zio copies would be two runtimes and zrk would be handed
an `Io` from the wrong one.

### v2.1.0 and not v2.0.0

The tag one would reach for **predates the OpenSSL swap** (zoxy-io/zrk#53
landed after it) and pins BoringSSL, while this repository pins OpenSSL.
`zoxy-profile-harness` imports both the `zrk` and `zoxy` modules, so `v2.0.0`
puts two libcryptos with overlapping symbol sets into the one binary whose job
is producing trustworthy measurements. 2.1.0 is the swap; both sides now
resolve to a single `openssl` pin.

Confirmed by the package graph: `boringssl`, `nasm` and `patch` are gone.

### The zio bump carries its fix rather than losing it

`df666c2` is 121 commits ahead of `b822fda` and **zero behind**, so zio#628 —
"flush a full submission queue instead of dropping SQEs", the reason that pin
existed — is contained. Checked with `compare/b822fda...df666c2` before moving,
because *"the fix is still in there"* is exactly the assumption a bump is where
you lose.

### The gate then found something real

`zig build ci` failed:

```
error: file exists in modules 'ztls' and 'ztls0'
note: files must belong to only one module
```

`zoxy-profile-harness` imports zrk, which reaches ztls through `ztls_std` at
**ReleaseFast**, *and* the whole zoxy module, which imports ztls at
**ReleaseSafe**. One file, two modules, which Zig refuses.

Both optimize choices are deliberate and documented — ReleaseSafe for the zoxy
under test, ReleaseFast for a load generator that must not become the
bottleneck — so neither should move. What made them collide is #279: libcrypto
stopped being one system-wide shared object and became a per-configuration
artifact, which forked ztls into two instantiations of the same file. The
collision was created this morning and only surfaces in the one binary linking
both modules.

**The fix removes work rather than adding it.** The harness was importing the
entire zoxy module — ztls, libcrypto and all — for a single line,
`@import("zoxy").constants`. `src/constants.zig` depends on nothing but `std`,
so it now imports that leaf directly. Both optimize choices survive, the reason
the import exists survives (track the compiled ceiling rather than duplicate
the number), and the shared C dependency leaves the question entirely.

### Verification

`zig build ci` green locally: 4096 sim seeds, smoke clean (144 http + 2 l4,
counters reconcile), census ok, and **both** zrk-linking harnesses compiled —
which is the check that matters here, and the one that caught the above.

zoxy-io/benchmark takes the identical pins in lockstep; a local band and a
fleet number off different generators are not comparable, which is the trap
that pin exists to close.