### PR TITLE
build: stop UBSan-trapping the vendored libcrypto, and gate the mode that ships (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,10 @@ direnv activates the shell). Read before writing code:
   `zig build sim -- <seed>` replays the exact schedule. The live gate
   (`zig build smoke` alone) runs the real binary against a real origin
   and asserts equalities on what it wrote; a failing one prints the
-  proxy's own output from `.zig-cache/zoxy-smoke/`.
+  proxy's own output from `.zig-cache/zoxy-smoke/`. It runs twice — once
+  against the default build and once against the ReleaseSafe twin
+  (`zig build smoke-release`), because the configuration release.yml
+  ships has failure modes a Debug build cannot reproduce (#283).
 - `zig fmt --check src scripts smoke build.zig build.zig.zon` — the format
   gate (a PostToolUse hook auto-formats files as they are edited).
 - `zig build bench` (Tier 1: zrk against an nginx origin) runs at merge,

--- a/build.zig
+++ b/build.zig
@@ -88,11 +88,38 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const libcrypto = openssl_dependency.artifact("openssl");
+    // Zig's C sanitizers off for the vendored C, in every mode — #283, and
+    // not a preference. `sanitize_c` defaults to `.full` in Debug and
+    // `.trap` in ReleaseSafe, and only the `.full` arm passes
+    // `-fno-sanitize=function` (Zig's src/Compilation.zig), whose comment
+    // there calls the pattern it flags "very common, and well-defined" and
+    // whose handler `lib/zig/ubsan_rt.zig` leaves commented out for the same
+    // reason. So the one check Zig deliberately disables is armed *only* in
+    // the mode release.yml ships, as a `ud1` trap: 17242 of them in the
+    // archive, 3499 of those the function check, and the first one a `tls`
+    // listener reaches is `OPENSSL_sk_pop_free` calling its `free_func`
+    // through a cast pointer — the idiom the check exists to flag and
+    // OpenSSL has always used. v0.6.0 SIGILLs there at key load, before
+    // serving anything, on every target it ships.
+    //
+    // `.off` rather than `.full`, and rather than dropping the one check:
+    // libcrypto is built without UBSan everywhere else (0.5.1 shipped
+    // nixpkgs' gcc-built one), the other 13743 traps are a crash surface on
+    // attacker-reachable paths rather than a diagnostic anyone acts on, and
+    // one setting for every mode is what stops the shipped artifact from
+    // differing from the tested one again — which is what this bug *was*,
+    // not a detail of it. Costs no Zig safety: the package gives this module
+    // no root source file, so it is C and nothing else. `smoke-release`
+    // below is the gate for the class.
+    libcrypto.root_module.sanitize_c = .off;
     const openssl_fast_dependency = b.dependency("openssl", .{
         .target = target,
         .optimize = std.builtin.OptimizeMode.ReleaseSafe,
     });
     const libcrypto_fast = openssl_fast_dependency.artifact("openssl");
+    // Same reason, and this is the archive that matters most: the twin
+    // linking it is the one built the way the release is.
+    libcrypto_fast.root_module.sanitize_c = .off;
 
     // ztls asks the linker for `-lcrypto` by name and this package emits
     // `libopenssl.a`. Linking the artifact resolves every symbol, but the
@@ -258,8 +285,12 @@ pub fn build(b: *std.Build) void {
     // one the bench uses: its verdicts are correctness equalities on real
     // output, so what a Debug build's extra checks add is worth more here
     // than the shipped binary's code generation, which Tier 1 is the gate
-    // for. The origin and the load generator both live inside the harness
-    // (smoke/), so the step needs nothing from the dev shell.
+    // for. That reasoning holds for what this leg *tests* and did not
+    // survive #283 as a reason to test only this one — the shipped build
+    // has failure modes a Debug build cannot reproduce, so `smoke-release`
+    // below runs the same harness against the ReleaseSafe twin. The origin
+    // and the load generator both live inside the harness (smoke/), so the
+    // step needs nothing from the dev shell.
     const smoke_exe = b.addExecutable(.{
         .name = "zoxy-smoke",
         .root_module = b.createModule(.{
@@ -349,6 +380,35 @@ pub fn build(b: *std.Build) void {
         }),
     });
     release_zoxy.root_module.addOptions("build_options", build_options);
+
+    // The same Tier-0.5 harness against the ReleaseSafe twin: the gate #283
+    // needed and did not have. `smoke` above drives the *default* build,
+    // which is Debug for every developer and every CI run, and the
+    // `sanitize_c` comment on `libcrypto` above is one worked example of
+    // what that leaves unwatched — a defect visible only in the mode the
+    // artifact is built in, which no amount of *scenario* coverage on the
+    // Debug leg could reach. So this leg runs the same requests, TLS
+    // included, and what it adds is the build configuration release.yml
+    // ships. Cheap: the micro binaries already make `ci` compile the
+    // ReleaseSafe libcrypto, so this is a link and a run on top.
+    //
+    // Ordered after the Debug leg rather than beside it: both harness runs
+    // are the same program and it keeps its work directory at a fixed path
+    // (`.zig-cache/zoxy-smoke`), so left free to run in parallel they would
+    // write each other's config and logs.
+    const smoke_release_run = b.addRunArtifact(smoke_exe);
+    smoke_release_run.addArg("--zoxy");
+    smoke_release_run.addArtifactArg(release_zoxy);
+    if (b.args) |args| {
+        smoke_release_run.addArgs(args);
+    }
+    smoke_release_run.step.dependOn(&smoke_run.step);
+    const smoke_release_step = b.step(
+        "smoke-release",
+        "Tier-0.5 live gate against the ReleaseSafe twin (the shipped build's configuration)",
+    );
+    smoke_release_step.dependOn(&smoke_release_run.step);
+
     // The harness itself (drives zrk against release_zoxy over the wire)
     // stays ReleaseFast for the same reason zrk/zio do above.
     const bench_exe = b.addExecutable(.{
@@ -485,6 +545,12 @@ pub fn build(b: *std.Build) void {
     // every other syscall here. This unconditional line is that fix's
     // acceptance test — kqueue's failure modes only surface at runtime.
     ci_step.dependOn(smoke_step);
+    // And once more against the configuration that ships. This list ran
+    // green on the change that gave zoxy a Zig-built libcrypto (#279) and
+    // on every change after it, while the release those changes produced
+    // had no working TLS at all (#283) — because every gate above builds
+    // at `-Doptimize`'s default and the artifact does not.
+    ci_step.dependOn(smoke_release_step);
     // Compile — never run — every measurement binary. Their verdicts are
     // human-read A/Bs and profiles, so running them here would buy nothing
     // and cost minutes; but they call the same internal APIs the proxy

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -228,6 +228,16 @@ zoxy's own tree never names a C symbol and `@cImport` stays lint-forbidden
 (§9) — a second C surface opened here would not be behind anyone's audited
 Zig. libcrypto's internal allocations are routed to a fixed startup arena
 (`CRYPTO_set_mem_functions`) so §5's zero-allocation gate keeps its teeth.
+What does *not* backstop this surface, deliberately, is Zig's C
+undefined-behaviour sanitizer: libcrypto is built with `sanitize_c` off in
+every mode (build.zig). Left on, ReleaseSafe compiles ~17000 trap sites
+into it, and the one OpenSSL cannot satisfy — an indirect call through a
+cast function pointer, the idiom `OPENSSL_sk_pop_free` has always used —
+killed v0.6.0 at key load (#283). Every other libcrypto on earth is built
+without it too, which is the point of trusting these primitives
+institutionally rather than instrumenting them; the safety this surface
+does get is the audited Zig above it, the fixed heap beside it, and §9's
+`smoke-release` running the mode that ships.
 And the pinned hash is an *audited commit*, never a branch tip — libxev's
 Zig 0.16 support is a self-described compatibility shim (PR #220) with
 real fixes still unmerged behind it — so a pin moves only after re-audit;
@@ -2275,6 +2285,24 @@ equalities a shared runner's noise cannot move.
    different piece of work from building one. `zig build smoke` runs
    everywhere regardless, and restoring the `ci` wiring on macOS is that
    issue's acceptance test.
+   The harness runs a second time against the ReleaseSafe twin
+   (`zig build smoke-release`), and the difference between the two legs is
+   the build's *configuration*, not its scenario — the same requests, the
+   same TLS listener, the same equalities. It exists because "the shipped
+   binary" above was true of the code and false of the build: every gate
+   in this list builds at `-Doptimize`'s default, which is Debug, and the
+   two modes did not agree about the vendored C. Zig compiled libcrypto
+   against UBSan's runtime handlers in one and against traps in the other,
+   and only the trap set carried a check OpenSSL has never satisfied, so
+   v0.6.0 passed this gate green and then died in libcrypto at key load
+   for anyone who configured a `tls` listener (#283). That particular
+   divergence is closed at its source — §4 records that libcrypto is now
+   built with Zig's C sanitizers off in every mode — and this leg is not
+   here to watch it. It is here because no amount of scenario coverage on
+   the Debug leg could have found it, which is the general shape: a gate
+   that never runs what ships is evidence about a different program. The
+   cost is a link and a run — `ci` already compiles the ReleaseSafe
+   libcrypto for the Tier-0 micro binaries.
 4. **Benchmarks — [zrk](https://github.com/zoxy-io/zrk), three tiers.**
    The load generator is zrk — a pure-Zig wrk2 rewrite: *constant-throughput*
    (open-loop) pacing with coordinated-omission-corrected HdrHistogram


### PR DESCRIPTION
Fixes #283.

## What was wrong

v0.6.0's release binaries SIGILL inside libcrypto the moment a listener has a `tls` block — before serving anything, at the first `PEM_read_bio_PrivateKey`, on every target it ships.

It is not an unsupported instruction and not an OpenSSL bug. Zig's `Module.sanitize_c` defaults to `.full` in Debug and `.trap` in ReleaseSafe. Both emit `-fsanitize=undefined`, but only the `.full` arm goes on to pass `-fno-sanitize=function` (Zig's `src/Compilation.zig`), whose comment there explains that a pointer with a different-but-compatible element type across a C ABI is "very common, and well-defined" — and `lib/zig/ubsan_rt.zig` leaves the matching handler commented out for the same reason.

So the one check Zig deliberately disables is armed **only** in the mode `release.yml` ships, as a `ud1` trap, and `OPENSSL_sk_pop_free` calling its `free_func` through a cast pointer is the first one a TLS listener reaches.

## Why not the minimal fix

The issue suggests `-fno-sanitize=function`. Measured on the shipped archive: 17242 traps, 3499 of them that check. Dropping only that one leaves 13743 armed — and the case for keeping those is weak in both directions: the Debug gate has been running every one of them as a runtime handler through real handshakes without a hit, so they are catching nothing, while each stays a way for the proxy to die with no diagnostic. It would also have to be spelled as a cflag inside the pinned openssl fork, moving an audited pin for a build-flag change.

`.off` instead, set from `build.zig` on both archives. No pin move, and no Zig safety lost: the package gives that module no root source file, so it is C and nothing else. The stripped x86_64-linux binary loses 596 KiB.

## Why `ci` was green while this shipped

Every gate in `ci` builds at `-Doptimize`'s default, which is Debug, and the Debug libcrypto carries UBSan's runtime handlers instead of traps — 4133 handler references, zero traps. So `tls-heap-proof` completed real handshakes and `smoke` terminated real TLS against a libcrypto that was never going to fail this way.

The gap is the build's *configuration*, not its scenario, so `smoke-release` runs the **same** harness against the ReleaseSafe twin and `ci` depends on it. Ordered after the Debug leg because both are the same program and it keeps its work directory at a fixed path. Cheap: the Tier-0 micro binaries already make `ci` compile the ReleaseSafe libcrypto, so this is a link and a run on top.

## Verification

- With `sanitize_c` set back to `.trap`, `zig build smoke-release` **fails** at `Credentials.load` → `privateKeyFromPem`. The reported crash is a gate now, not an argument.
- With the fix, `zig build ci` green: 52/52 steps, 593/593 tests, 4096 sim seeds, both smoke legs. The release leg reports rss 9156 KiB against the Debug leg's 17112 KiB, so it is demonstrably the other binary.
- A release-invocation build (`-Dtarget=x86_64-linux-musl -Dcpu=x86_64_v3 -Dstatic -Doptimize=ReleaseSafe`) has zero trap sites, boots the reporter's config, and completes an `openssl s_client` handshake.

Scope note: the defect is target-independent — `sanitize_c` defaults are a function of optimize mode, not target, confirmed by building the same probe for aarch64-linux and aarch64-macos. All four v0.6.0 artifacts are affected, not just x86_64-linux.

## Not done here

- `release.yml` still only runs `--version` on each artifact, so the four published tarballs are covered by this gate's configuration argument rather than by being run. Whether it should boot each one is its own change.
- zrk shares the openssl pin and sets no `sanitize_c`, but builds ReleaseFast everywhere, so it is unaffected today and one flag from not being.

🤖 Generated with [Claude Code](https://claude.com/claude-code)