### PR TITLE
release: run the artifact, over TLS, before packaging it (#283)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,22 @@ jobs:
             *) echo "::error::binary reports '$reported', expected $version"; exit 1 ;;
           esac
 
+          # And it proxies, over TLS, on the platform it was built for.
+          #
+          # Every check above passed for v0.6.0 — static, no nix-store
+          # references, right version — and that release could not terminate
+          # TLS at all: it died in libcrypto at key load for anyone who
+          # configured a `tls` listener (#283). The binary was correct; the
+          # build was not, and `--version` exits before the difference can
+          # show. `zig build ci`'s `smoke-release` leg covers the build
+          # *configuration*; this is the only thing that runs the artifact
+          # being published, which is a separate claim and the one a release
+          # is for.
+          #
+          # Before packaging rather than after, so a binary that cannot serve
+          # never becomes a tarball.
+          bash scripts/release-tls-check.sh ./out/bin/zoxy
+
           tar czf "dist/zoxy-$version-${{ matrix.label }}.tar.gz" -C out/bin zoxy
 
       - uses: actions/upload-artifact@v4

--- a/scripts/release-tls-check.sh
+++ b/scripts/release-tls-check.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Boot a zoxy binary with a `tls` listener and drive one request through each
+# listener it declares. Run against a *built artifact*, on the platform that
+# artifact is for — release.yml calls it on every leg, before packaging.
+#
+# It exists because `--version` cannot see #283. v0.6.0 passed every other
+# check in that workflow — static, no nix-store references, right version —
+# and then died in libcrypto at key load for anyone who configured a `tls`
+# listener. The binary was fine; the build was not, and nothing in the release
+# ran it far enough to notice. `zig build ci`'s `smoke-release` leg now covers
+# the build *configuration*; this covers the artifact that is actually
+# published.
+#
+# Deliberately depends on bash and curl and nothing else. The TLS fixture is
+# the one already in the tree (src/tls/testdata, an EC keypair good to 2036),
+# so there is no openssl invocation to differ between a Linux runner and a
+# macOS one, and no generated material whose algorithm choice could drift away
+# from what the smoke harness exercises.
+#
+# Usage: release-tls-check.sh <zoxy-binary>
+set -eu
+
+readonly bin="${1:?usage: release-tls-check.sh <zoxy-binary>}"
+readonly root="$(cd "$(dirname "$0")/.." && pwd)"
+readonly cert="$root/src/tls/testdata/cert.pem"
+readonly key="$root/src/tls/testdata/key.pem"
+
+# High and unremarkable: a released binary is checked on shared runners, and
+# the low ports are where other people's services live (a system nginx on 9000
+# has cost this project a debugging session before).
+readonly port_http=41080
+readonly port_tls=41443
+readonly port_admin=41101
+
+[ -x "$bin" ] || { echo "::error::not executable: $bin"; exit 1; }
+[ -f "$cert" ] && [ -f "$key" ] || { echo "::error::missing TLS fixture under $root/src/tls/testdata"; exit 1; }
+
+work="$(mktemp -d)"
+log="$work/zoxy.log"
+pid=""
+
+cleanup() {
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+    rm -rf "$work"
+}
+trap cleanup EXIT
+
+# The endpoint deliberately points at a closed port. What is under test is that
+# the process starts, terminates TLS and answers; whether it can reach an
+# origin is a different gate's business, and standing up one here would add a
+# dependency for no verdict.
+cat > "$work/zoxy.json" <<JSON
+{
+  "listeners": [
+    { "bind": "127.0.0.1:$port_http", "cluster": "origin", "protocol": "http" },
+    { "bind": "127.0.0.1:$port_tls", "cluster": "origin", "protocol": "http",
+      "tls": { "cert": "$cert", "key": "$key" } }
+  ],
+  "clusters": { "origin": { "endpoints": ["127.0.0.1:1"], "pick": "rr" } },
+  "admin": { "bind": "127.0.0.1:$port_admin" }
+}
+JSON
+
+fail() {
+    echo "::error::$1"
+    echo "--- proxy output ---"
+    cat "$log" 2>/dev/null || echo "(none)"
+    exit 1
+}
+
+"$bin" "$work/zoxy.json" > "$log" 2>&1 &
+pid=$!
+
+# Startup is where #283 lands, so a death here is reported as itself rather
+# than as a connection failure thirty seconds later.
+waited=0
+until curl -sf -o /dev/null --max-time 2 "http://127.0.0.1:$port_admin/metrics"; do
+    kill -0 "$pid" 2>/dev/null || fail "died during startup (this is the #283 signature)"
+    waited=$((waited + 1))
+    [ "$waited" -lt 30 ] || fail "admin plane never answered after ${waited}s"
+    sleep 1
+done
+echo "startup: ok (admin plane answering after ${waited}s)"
+
+# Plaintext first, as the control. If this passes and TLS does not, the fault
+# is in the TLS path specifically — which is exactly what #283 looked like.
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$port_http/" || echo 000)"
+[ "$code" != "000" ] || fail "plaintext listener answered nothing"
+echo "plaintext: ok (HTTP $code)"
+
+# -k because the fixture is self-signed: this asserts that a TLS 1.3 handshake
+# completed and the request was proxied, not that anyone trusts the cert.
+code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 10 "https://127.0.0.1:$port_tls/" || echo 000)"
+[ "$code" != "000" ] || fail "TLS handshake or request failed"
+echo "tls: ok (HTTP $code over TLS 1.3)"
+
+kill -0 "$pid" 2>/dev/null || fail "exited while serving"
+
+# A clean SIGTERM shutdown, because #283's neighbour was a libcrypto atexit
+# handler that segfaulted *after* a correct drain — a failure only a real
+# process teardown can show.
+kill -TERM "$pid"
+wait "$pid" 2>/dev/null && status=0 || status=$?
+pid=""
+[ "$status" -eq 0 ] || fail "unclean shutdown: exit $status"
+echo "shutdown: ok"
+
+echo "release TLS check passed: $bin"


### PR DESCRIPTION
Closes the last gap from #283.

`release.yml` proved four things about each binary — static, no nix-store references, right version, and that it starts long enough to print one. **v0.6.0 passed all four and could not terminate TLS at all.** `--version` exits before the difference can show.

`smoke-release` in `zig build ci` (#284) covers the build *configuration*, which is what made v0.6.0 wrong. This covers the artifact being published, which is a different claim: the configuration argument reasons that all four targets are equivalent because Zig's `sanitize_c` defaults follow optimize mode and not target — and reasoning is not the same as having run the thing.

## What it does

Boots the binary with a plaintext listener and a TLS listener, waits for the admin plane, drives one request through each, and shuts down with SIGTERM asserting a clean exit. Plaintext first as the control, because "plaintext fine, TLS dead" is exactly what #283 looked like from outside. A death during startup is reported as itself rather than as a connection failure thirty seconds later.

Runs before packaging, so a binary that cannot serve never becomes a tarball.

## Verified in both directions, before wiring it in

Against the **published v0.6.0** tarball:

```
::error::died during startup (this is the #283 signature)
--- proxy output ---
...
Illegal instruction at address 0x1318255
  crypto/stack/stack.c:440   OPENSSL_sk_pop_free
  ...
  ztls/src/crypto/backend_openssl.zig:598  privateKeyFromPem
```

Against the **published v0.6.1** tarball:

```
startup: ok (admin plane answering after 1s)
plaintext: ok (HTTP 502)
tls: ok (HTTP 502 over TLS 1.3)
shutdown: ok
```

(502 is the deliberately-closed origin; what is under test is that TLS terminated and the L7 path answered.)

## Design notes

- **In `scripts/` rather than inline**, so it can be pointed at any binary without cutting a release — which is how the above was produced.
- **Depends on bash and curl and nothing else.** The TLS fixture is the EC keypair already in `src/tls/testdata` (good to 2036), so there is no openssl invocation whose behaviour could differ between a Linux runner and a macOS one, and sharing the smoke harness's fixture means the two gates cannot drift apart on key format.
- That the fixture is SEC1 rather than PKCS#8 does not soften the check — the trap is the first EVP fetch, not anything format-specific, which the v0.6.0 run above confirms.

## Rehearsal

Dispatched as a `dry_run` against this branch, which builds all four targets and runs this check on each while publishing nothing — the mechanism #278 added for exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)