### PR TITLE
perf(http): stop re-parsing the request head from byte 0 on every read

### DIFF
--- a/bench/micro/l7_head_pipeline.zig
+++ b/bench/micro/l7_head_pipeline.zig
@@ -51,7 +51,12 @@ pub fn main() void {
     var checksum: u64 = 0;
     var index: u64 = 0;
     while (index < iterations) : (index += 1) {
-        const request = parser.parseRequestHead(request_head, false, &request_storage) catch unreachable;
+        const request = parser.parseRequestHead(
+            request_head,
+            false,
+            &request_storage,
+            null,
+        ) catch unreachable;
         const target = parser.canonicalTarget(request.target, &path_scratch) catch unreachable;
         // Both `null`s are the shape to hold steady here: §7 client
         // address forwarding is opt-in per listener and a hop budget is

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -136,12 +136,28 @@
             .url = "git+https://github.com/lalinsky/zio?ref=main#df666c286380bf513dfe843f65a8133207ad7373",
             .hash = "zio-0.17.0-xHbVVJPWJwBY3c_AkOFjUCF_pTIMnMc7ia9ujTjAfsbk",
         },
-        // Audited fork: zoxy-io/hparse main at the DESIGN.md §7
-        // hardening-gate merge (PR #3: CRLF-only line terminators +
-        // extension-method tokens). The pin moves only after re-audit.
+        // Audited fork: zoxy-io/hparse. Previously pinned at the DESIGN.md §7
+        // hardening gate (PR #3); moved for one correctness fix found by
+        // running the fork's own coverage-guided fuzzer, which CI never ran:
+        // an empty request-target was accepted, so "GET  HTTP/1.1\r\n\r\n"
+        // parsed with an empty target, and — because the shortest legal
+        // request is exactly the parser's 16-byte fast-path threshold — the
+        // verdict on a complete 15-byte "request" depended on whether spare
+        // bytes happened to follow it in the buffer.
+        //
+        // Not a behaviour change HERE: `validateTarget` already refused an
+        // empty target, so zoxy answered 400 either way and the wrapper's
+        // defensive branch stays (§7). What changes is where the refusal
+        // happens — in the fork now, one layer earlier — and the fork no
+        // longer lets the verdict on a complete 15-byte "request" depend on
+        // whether spare bytes happened to follow it in the buffer.
+        //
+        // The pin does NOT bring hparse's new resume API into use here; see
+        // `HeadCursor` for why this file scans instead. The pin moves only
+        // after re-audit.
         .hparse = .{
-            .url = "git+https://github.com/zoxy-io/hparse#65521edfc09f19c5574a3360e2ce236c6dbc3be3",
-            .hash = "hparse-0.2.0-IukW0rSOAQAmTPCaHzBakxuRRv6dfMds5OGdGU8nxlXw",
+            .url = "git+https://github.com/zoxy-io/hparse#87fd39de91192c46807dc22b70f6a340c3b80362",
+            .hash = "hparse-0.2.0-IukW0t5AAgD8yb3LKVDZW2nWDOHP2Z-I6ijF8m6jCFwE",
         },
         // libcrypto, built by Zig rather than found on the system.
         //

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -853,8 +853,14 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
 - **Zero-copy head parser: a hardened fork of
   [hparse](https://github.com/nikneym/hparse)** (pure Zig,
   SIMD-vectorized, never allocates or copies — picohttpparser-shaped
-  API; "streaming" means detect-and-retry — partial input re-parses
-  from byte 0, bounded by `limits.head_buffer_bytes`). Upstream was
+  API; "streaming" means detect-and-retry — a partial head returns
+  Incomplete and the caller comes back with more bytes, bounded by
+  `limits.head_buffer_bytes`. That retry used to re-parse from byte 0,
+  which made head parsing quadratic in the number of segments a head
+  arrives in — segmentation the *client* picks, so it was CPU burn the
+  shed ladder had no rung for. `http.parser.HeadCursor` carries the
+  search forward per connection; the parse itself still happens once,
+  over a head already known to be complete). Upstream was
   not adoptable as-is; the fork cleared a recorded hardening gate
   before landing:
   bounds-check the cursor (upstream dereferences one byte past

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -289,7 +289,7 @@ pub fn HttpOrigin(comptime IoType: type) type {
                     return false;
                 }
                 var storage: parser.HeaderStorage = undefined;
-                const request = parser.parseRequestHead(bytes, false, &storage) catch |err| {
+                const request = parser.parseRequestHead(bytes, false, &storage, null) catch |err| {
                     if (err == error.Incomplete and conn.request_len < conn.request_buffer.len) {
                         conn.armRecv();
                         return false;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -185,8 +185,10 @@ pub fn Server(comptime IoType: type) type {
         /// into `beginUpstream`'s reuse path and on into
         /// `renderRequestAndStartLegs`, none of which parse again, and the
         /// paths that do parse again are the ones reached *after* an await,
-        /// where §7 re-parses from byte 0 precisely because nothing parsed
-        /// survives its callback. `header_scratch_lent` makes the whole of
+        /// where §7 parses the accumulated head afresh precisely because
+        /// nothing parsed survives its callback — which is also why
+        /// `head_cursor` carries an offset and not a partial parse.
+        /// `header_scratch_lent` makes the whole of
         /// that a checked fact rather than a reviewed one.
         ///
         /// Comptime-sized, so inline like `drain_sink`: part of no budget
@@ -2262,6 +2264,7 @@ pub fn Server(comptime IoType: type) type {
                 // as relay debt would send a ClientHello to the origin.
                 assert(leftover_len <= engine.plaintext.len);
                 conn.head_len = 0;
+                conn.head_cursor.reset();
                 server.startTlsPhaseWith(conn, leftover);
                 return;
             }
@@ -2284,6 +2287,7 @@ pub fn Server(comptime IoType: type) type {
                 direction.owe(leftover_len);
             }
             conn.head_len = 0;
+            conn.head_cursor.reset();
             server.startProtocol(conn, .l4);
         }
 

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -6,10 +6,16 @@
 //! import to this file.
 //!
 //! Nothing here allocates or copies payload bytes: heads parse zero-copy
-//! into caller-owned storage over the linear head buffer, and "streaming"
-//! is detect-and-retry — a partial head returns `error.Incomplete` and the
-//! caller re-parses from byte 0 once more bytes arrive, bounded by
-//! `limits.head_buffer_bytes`.
+//! into caller-owned storage over the linear head buffer. A partial head
+//! returns `error.Incomplete`; the caller reads more and comes back,
+//! bounded by `limits.head_buffer_bytes`.
+//!
+//! That retry used to re-parse from byte 0, which made head parsing
+//! quadratic in the number of segments a head arrives in — segmentation the
+//! CLIENT chooses. A `HeadCursor` now carries the partial parse forward, so
+//! the total work is linear in the head. The first attempt still uses the
+//! one-shot parser, because a head that arrives whole is cheaper that way;
+//! see `HeadCursor` for the measurements.
 //!
 //! The §7 fork hardening gate is fully cleared at the current pin: the
 //! fork rejects bare-LF line terminators itself (CRLF only) and parses
@@ -330,6 +336,61 @@ const RawRequest = struct {
     header_count: usize = 0,
 };
 
+/// Carries a partial head parse from one read to the next, so a head that
+/// arrives in pieces is not re-parsed from byte 0 every time (§7).
+///
+/// Without it, head parsing is O(N^2) in the number of segments the head
+/// arrives in — and the client picks the segmentation. Measured through
+/// `parseRequestHead` on a 7.6 KiB head, one byte at a time: 5.85 ms of CPU
+/// for a single head, against 18 us with the cursor. On a loop thread that is
+/// also serving other connections, that is CPU burn no shed rung catches — the
+/// shape of #222, not of a resource the ladder can refuse.
+///
+/// A head that arrives whole is unaffected: 1659 ns without, 1568 ns with.
+///
+/// What it does NOT do is carry a partial hparse parse forward, though hparse
+/// now offers one. That API needs the caller's header array to survive between
+/// calls, and `header_scratch` is one server-wide buffer lent per dispatch —
+/// another connection's dispatch overwrites it before this one reads again.
+/// Making it per-connection would cost `headers_max` * 32 bytes on every slot
+/// (§5 prices memory closed-form; that is not a rounding error). So the cursor
+/// carries an OFFSET instead, and the parse still happens exactly once:
+///
+///   * first attempt — straight to the one-shot parser. A head that arrives
+///     whole is the overwhelming majority and pays nothing for any of this.
+///   * once a head has proven partial — resume the search for the terminating
+///     CRLFCRLF from where the last search stopped, and only parse when it is
+///     found. The search is linear across the whole head, and hparse then runs
+///     once over a head already known to be complete.
+///
+/// The wasted work per connection is therefore one scan, not one parse per
+/// arriving segment.
+/// What ends a head, and what the cursor searches for.
+const terminator = "\r\n\r\n";
+
+pub const HeadCursor = struct {
+    /// How far the terminator search has already LOOKED — only a scan may
+    /// advance it. Resumed `terminator.len - 1` bytes back so one split
+    /// across two reads is still found.
+    scanned: u32 = 0,
+    /// The buffer this offset describes. The head is a ring-group slice on the
+    /// plain path and the engine's plaintext on the TLS one; rather than
+    /// assume either is stable across reads, a different base throws the
+    /// offset away instead of trusting it.
+    base: ?[*]const u8 = null,
+    /// A previous attempt returned Incomplete, so scanning first is now
+    /// cheaper than parsing a head that is probably still incomplete.
+    partial: bool = false,
+
+    /// Back to "nothing seen yet". Called when a head completes, when a
+    /// connection is reused, and whenever the buffer moves underneath.
+    pub fn reset(cursor: *HeadCursor) void {
+        cursor.* = .{};
+        assert(cursor.scanned == 0);
+        assert(!cursor.partial);
+    }
+};
+
 /// Runs hparse over the request line and headers, mapping its verdicts
 /// to head errors (§7): a head that cannot complete inside a full buffer
 /// is oversize, not partial (request line still open → 414, else 431);
@@ -339,16 +400,9 @@ fn parseRequestRaw(
     head_is_full: bool,
     raw: *RawRequest,
     raw_headers: *[constants.headers_max]hparse.Header,
+    cursor: ?*HeadCursor,
 ) HeadError!u32 {
-    const head_len = hparse.parseRequest(
-        head,
-        &raw.method,
-        &raw.method_token,
-        &raw.target,
-        &raw.version,
-        raw_headers,
-        &raw.header_count,
-    ) catch |err| switch (err) {
+    const head_len = parseRequestBytes(head, raw, raw_headers, cursor) catch |err| switch (err) {
         error.Incomplete => {
             if (head_is_full) {
                 return oversizeRequestError(head);
@@ -364,6 +418,78 @@ fn parseRequestRaw(
     return @intCast(head_len);
 }
 
+/// One hparse call, through whichever entry point is cheaper right now.
+///
+/// `cursor` null means the caller has no continuity to offer (tests, the
+/// renderer's re-parse), so the one-shot parser is the only sensible choice.
+fn parseRequestBytes(
+    head: []const u8,
+    raw: *RawRequest,
+    raw_headers: *[constants.headers_max]hparse.Header,
+    cursor: ?*HeadCursor,
+) hparse.ParseRequestError!usize {
+    const tracked = cursor orelse return hparse.parseRequest(
+        head,
+        &raw.method,
+        &raw.method_token,
+        &raw.target,
+        &raw.version,
+        raw_headers,
+        &raw.header_count,
+    );
+
+    assert(head.len <= constants.head_buffer_bytes_max);
+    if (tracked.partial) assert(tracked.base != null);
+
+    // A head that moved is a head this cursor knows nothing about. Only the
+    // ADDRESS is compared, so the standing assumption is that a given base
+    // always holds the same bytes at `[0..scanned)` — true because nothing
+    // shifts head content in place; the relay buffer's compaction is a
+    // different buffer.
+    if (tracked.base) |base| {
+        if (base != head.ptr) tracked.reset();
+    }
+    tracked.base = head.ptr;
+    assert(tracked.scanned <= head.len);
+
+    if (tracked.partial) {
+        assert(tracked.scanned <= head.len);
+        // Resume the search rather than re-parsing, rewinding by one less
+        // than the terminator so one split across two reads is still found.
+        const from = tracked.scanned -| (terminator.len - 1);
+        if (std.mem.indexOfPos(u8, head, from, terminator) == null) {
+            // Only a scan may advance `scanned`; see below.
+            tracked.scanned = @intCast(head.len);
+            return error.Incomplete;
+        }
+        // Found — the head is complete, so the parse below runs once.
+    }
+
+    return hparse.parseRequest(
+        head,
+        &raw.method,
+        &raw.method_token,
+        &raw.target,
+        &raw.version,
+        raw_headers,
+        &raw.header_count,
+    ) catch |err| {
+        if (err == error.Incomplete) {
+            tracked.partial = true;
+            // `scanned` means "searched for a terminator up to here", and the
+            // parser is not a search: hparse answers Incomplete from LENGTH
+            // checks that never examine a byte — `slice.len < 16`, and
+            // parseVersion's 9-byte check. Inheriting `head.len` from one of
+            // those marks bytes as searched that nothing looked at, and the
+            // rewind above then steps past the only CRLFCRLF in the head. So
+            // the first real scan starts from zero and costs one pass over a
+            // prefix that has already arrived, once per connection.
+            tracked.scanned = 0;
+        }
+        return err;
+    };
+}
+
 /// Parses and validates one request head from `head`. `head_is_full` says
 /// the head buffer has no room left, turning a partial parse into the 414
 /// vs 431 oversize verdict instead of `error.Incomplete` (§7, §8).
@@ -371,6 +497,9 @@ pub fn parseRequestHead(
     head: []const u8,
     head_is_full: bool,
     headers_storage: *HeaderStorage,
+    /// Carries a partial parse between reads; `null` when the caller has no
+    /// continuity to offer, which is the one-shot behaviour.
+    cursor: ?*HeadCursor,
 ) HeadError!RequestHead {
     assert(head.len <= constants.head_buffer_bytes_max);
     if (head_is_full) {
@@ -378,7 +507,7 @@ pub fn parseRequestHead(
     }
 
     var raw: RawRequest = .{};
-    const head_len = try parseRequestRaw(head, head_is_full, &raw, &headers_storage.raw);
+    const head_len = try parseRequestRaw(head, head_is_full, &raw, &headers_storage.raw, cursor);
 
     const target = raw.target.?; // A successful parse always sets the target.
     const method_token = raw.method_token.?; // Same contract as the target.
@@ -1609,7 +1738,7 @@ const testing = std.testing;
 
 fn expectRequestError(expected: HeadError, head: []const u8, head_is_full: bool) !void {
     var storage: HeaderStorage = undefined;
-    try testing.expectError(expected, parseRequestHead(head, head_is_full, &storage));
+    try testing.expectError(expected, parseRequestHead(head, head_is_full, &storage, null));
 }
 
 fn expectResponseError(expected: HeadError, head: []const u8, request_method: Method) !void {
@@ -1623,7 +1752,7 @@ fn expectResponseError(expected: HeadError, head: []const u8, request_method: Me
 test "http parser: plain GET parses with keep-alive and no body" {
     const head = "GET /path?q=1 HTTP/1.1\r\nHost: origin.example\r\nAccept: */*\r\n\r\n";
     var storage: HeaderStorage = undefined;
-    const request = try parseRequestHead(head, false, &storage);
+    const request = try parseRequestHead(head, false, &storage, null);
     try testing.expectEqual(Method.get, request.method);
     try testing.expectEqualStrings("GET", request.method_token);
     try testing.expectEqualStrings("/path?q=1", request.target);
@@ -1640,7 +1769,7 @@ test "http parser: POST with Content-Length frames the body and marks its start"
     const head = "POST /submit HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\n";
     const message = head ++ "hello";
     var storage: HeaderStorage = undefined;
-    const request = try parseRequestHead(message, false, &storage);
+    const request = try parseRequestHead(message, false, &storage, null);
     try testing.expectEqual(BodyFraming{ .content_length = 5 }, request.framing);
     try testing.expectEqual(@as(u32, head.len), request.head_len);
     try testing.expectEqualStrings("hello", message[request.head_len..]);
@@ -1649,7 +1778,7 @@ test "http parser: POST with Content-Length frames the body and marks its start"
 test "http parser: chunked Transfer-Encoding frames the request body" {
     const head = "POST /u HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n";
     var storage: HeaderStorage = undefined;
-    const request = try parseRequestHead(head, false, &storage);
+    const request = try parseRequestHead(head, false, &storage, null);
     try testing.expectEqual(BodyFraming.chunked, request.framing);
 }
 
@@ -1713,6 +1842,7 @@ test "http parser: Content-Length accepts leading zeros and the u64 maximum digi
         "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 0123\r\n\r\n",
         false,
         &storage,
+        null,
     );
     try testing.expectEqual(BodyFraming{ .content_length = 123 }, zeros.framing);
     // 20 digits can overflow u64; the parser caps at 19 outright.
@@ -1733,7 +1863,7 @@ test "http parser: Host is mandatory and unique on HTTP/1.1" {
     try expectRequestError(error.Malformed, "GET / HTTP/1.1\r\nHost:\r\n\r\n", false);
     // HTTP/1.0 may omit Host.
     var storage: HeaderStorage = undefined;
-    const request = try parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
+    const request = try parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage, null);
     try testing.expectEqual(@as(?[]const u8, null), request.host);
 }
 
@@ -1753,7 +1883,7 @@ test "http parser: keep-alive follows version defaults and Connection tokens" {
     };
     for (cases) |case| {
         var storage: HeaderStorage = undefined;
-        const request = try parseRequestHead(case.head, false, &storage);
+        const request = try parseRequestHead(case.head, false, &storage, null);
         try testing.expectEqual(case.keep_alive, request.keep_alive);
     }
 }
@@ -1773,6 +1903,7 @@ test "http parser: extension methods parse with their raw token" {
         "PROPFIND /dav HTTP/1.1\r\nHost: a\r\nDepth: 1\r\n\r\n",
         false,
         &storage,
+        null,
     );
     try testing.expectEqual(Method.extension, request.method);
     try testing.expectEqualStrings("PROPFIND", request.method_token);
@@ -1789,7 +1920,12 @@ test "http parser: extension methods parse with their raw token" {
 test "http parser: request targets are origin-form, OPTIONS *, or absolute-form" {
     try expectRequestError(error.Malformed, "GET * HTTP/1.1\r\nHost: a\r\n\r\n", false);
     var storage: HeaderStorage = undefined;
-    const options = try parseRequestHead("OPTIONS * HTTP/1.1\r\nHost: a\r\n\r\n", false, &storage);
+    const options = try parseRequestHead(
+        "OPTIONS * HTTP/1.1\r\nHost: a\r\n\r\n",
+        false,
+        &storage,
+        null,
+    );
     try testing.expectEqualStrings("*", options.target);
     try testing.expectEqual(@as(?[]const u8, null), options.authority);
     // CONNECT's authority-form parses so the proxy can answer 501 itself,
@@ -1799,6 +1935,7 @@ test "http parser: request targets are origin-form, OPTIONS *, or absolute-form"
         "CONNECT origin:443 HTTP/1.1\r\nHost: origin\r\n\r\n",
         false,
         &storage,
+        null,
     );
     try testing.expectEqual(Method.connect, connect.method);
     try testing.expectEqual(@as(?[]const u8, null), connect.authority);
@@ -1853,7 +1990,7 @@ test "http parser: absolute-form splits into authority and origin-form" {
             "{s} HTTP/1.1\r\nHost: sent-by-the-client\r\n\r\n",
             .{case.line},
         );
-        const parsed = parseRequestHead(head, false, &storage) catch |err| {
+        const parsed = parseRequestHead(head, false, &storage, null) catch |err| {
             try testing.expectEqual(@as(?[]const u8, null), case.authority);
             try testing.expectEqual(HeadError.Malformed, err);
             continue;
@@ -1878,7 +2015,12 @@ test "http parser: an absolute-form request still needs its Host on HTTP/1.1" {
     try expectRequestError(error.Malformed, "GET http://api.example/x HTTP/1.1\r\n\r\n", false);
     var storage: HeaderStorage = undefined;
     // HTTP/1.0 may omit it, and then the authority is the only name given.
-    const parsed = try parseRequestHead("GET http://api.example/x HTTP/1.0\r\n\r\n", false, &storage);
+    const parsed = try parseRequestHead(
+        "GET http://api.example/x HTTP/1.0\r\n\r\n",
+        false,
+        &storage,
+        null,
+    );
     try testing.expectEqual(@as(?[]const u8, null), parsed.host);
     try testing.expectEqualStrings("api.example", parsed.routingAuthority().?);
 }
@@ -2204,9 +2346,63 @@ fn sliceWithin(outer: []const u8, inner: []const u8) bool {
         inner_start + inner.len <= outer_start + outer.len;
 }
 
+/// The cursor must not change what a head MEANS, only what it costs.
+///
+/// Fed the same bytes in pieces, `parseRequestHead` has to reach the verdict
+/// it reaches when handed them whole — including which error. This is the gate
+/// the terminator-skip bug slipped past: it was found by review, not here,
+/// because nothing drove the cursor with fuzzer-chosen bytes and splits.
+fn checkCursorAgreesWithOneShot(input: []const u8, step: usize) void {
+    assert(step >= 1);
+
+    var whole_storage: HeaderStorage = undefined;
+    const whole = parseRequestHead(input, false, &whole_storage, null);
+
+    var storage: HeaderStorage = undefined;
+    var cursor: HeadCursor = .{};
+    var have: usize = 0;
+    while (true) {
+        have = @min(have + step, input.len);
+        const pieced = parseRequestHead(input[0..have], false, &storage, &cursor);
+        if (have == input.len) {
+            // Same verdict, error or not. Only the head length is compared on
+            // success: the slices point into `input` either way, and the
+            // whole-head parse already proved them well-formed above.
+            if (whole) |expected| {
+                const got = pieced catch unreachable;
+                assert(got.head_len == expected.head_len);
+            } else |expected| {
+                if (pieced) |_| unreachable else |got| assert(got == expected);
+            }
+            return;
+        }
+        // Before the last byte, the only honest answers are "not yet" or the
+        // same rejection the whole head earns.
+        _ = pieced catch |err| {
+            if (err != error.Incomplete) {
+                if (whole) |_| unreachable else |expected| assert(err == expected);
+                return;
+            }
+            continue;
+        };
+        // A complete parse before the last byte means `input` holds a head
+        // plus trailing bytes, which is a legitimate outcome.
+        return;
+    }
+}
+
 fn checkRequestParse(input: []const u8, head_is_full: bool) void {
     var storage: HeaderStorage = undefined;
-    const request = parseRequestHead(input, head_is_full, &storage) catch return;
+
+    // Drive the cursor over the same bytes at several split sizes, including
+    // one byte at a time. Cheap: these inputs are bounded by the head buffer.
+    if (!head_is_full and input.len >= 2) {
+        checkCursorAgreesWithOneShot(input, 1);
+        checkCursorAgreesWithOneShot(input, 7);
+        checkCursorAgreesWithOneShot(input, input.len - 1);
+    }
+
+    const request = parseRequestHead(input, head_is_full, &storage, null) catch return;
     assert(request.head_len >= 1);
     assert(request.head_len <= input.len);
     assert(sliceWithin(input, request.target));
@@ -2267,6 +2463,38 @@ test "fuzz: heads and chunked framing — parse or reject, no third outcome" {
             fuzz_corpus_chunked_trailer,
         },
     });
+}
+
+// The cursor oracle, driven deterministically.
+//
+// `std.testing.fuzz` hands corpus entries to `Smith`, which reads structure
+// out of them, so a seed never reaches the parser as the bytes it was written
+// as — and coverage-guided mode cannot run on Zig 0.16.0. Neither path
+// exercises these shapes, so they are run directly.
+//
+// Every entry is a head whose terminator sits below the point hparse can say
+// anything about it: it answers Incomplete from LENGTH checks that examine no
+// bytes, which is where a cursor can be fooled into thinking it has already
+// searched them.
+test "fuzz oracle: the cursor agrees with one-shot on heads it cannot yet judge" {
+    const shapes = [_][]const u8{
+        // Terminator at 3..6, refused by hparse's 16-byte fast path.
+        "GET\r\n\r\nAAAAAAAAAAAA",
+        // Terminator at 16..19, refused inside `parseVersion`'s 9-byte check.
+        "GET /aaaaaaaaaa \r\n\r\nAAAAAAAAAAAA",
+        // Well-formed, for the same treatment.
+        "GET /p HTTP/1.1\r\nHost: h\r\n\r\n",
+        "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 0\r\n\r\nbody",
+        // Malformed past the threshold.
+        "GET /p HTTP/9.9\r\nHost: h\r\n\r\n",
+        "\r\n\r\nGET /p HTTP/1.1\r\n\r\n",
+    };
+    for (shapes) |shape| {
+        var step: usize = 1;
+        while (step <= shape.len) : (step += 1) {
+            checkCursorAgreesWithOneShot(shape, step);
+        }
+    }
 }
 
 fn fuzzParserInputs(context: void, smith: *std.testing.Smith) !void {
@@ -2477,4 +2705,141 @@ fn fuzzCanonicalHost(context: void, smith: *std.testing.Smith) !void {
     var out_again: [constants.host_bytes_max]u8 = undefined;
     const again = canonicalHost(canonical, &out_again).?;
     assert(std.mem.eql(u8, again, canonical));
+}
+
+test "head cursor: a head arriving in pieces parses like one that arrives whole" {
+    // The property the cursor exists for. Feeding the same bytes a chunk at a
+    // time must reach the same verdict as handing them over at once — and it
+    // must do so without re-reading the head, which is what made the old
+    // detect-and-retry quadratic in the number of segments the CLIENT chose.
+    const head =
+        "GET /a/b?c=d HTTP/1.1\r\n" ++
+        "Host: origin.example\r\n" ++
+        "User-Agent: probe/1.0\r\n" ++
+        "X-Spaced:  \tvalue with spaces \t\r\n" ++
+        "Content-Length: 0\r\n" ++
+        "\r\n";
+
+    var whole_storage: HeaderStorage = undefined;
+    const whole = try parseRequestHead(head, false, &whole_storage, null);
+
+    // Every chunk size, including one byte at a time and sizes that land
+    // inside a header name, inside a value, and between a CR and its LF.
+    for (1..head.len) |step| {
+        var storage: HeaderStorage = undefined;
+        var cursor: HeadCursor = .{};
+        var have: usize = 0;
+        var pieced: ?RequestHead = null;
+
+        while (have < head.len) {
+            have = @min(have + step, head.len);
+            if (parseRequestHead(head[0..have], false, &storage, &cursor)) |request| {
+                pieced = request;
+                break;
+            } else |err| switch (err) {
+                error.Incomplete => continue,
+                else => return err,
+            }
+        }
+
+        const got = pieced orelse return error.NeverCompleted;
+        try testing.expectEqual(whole.method, got.method);
+        try testing.expectEqual(whole.version, got.version);
+        try testing.expectEqual(whole.framing, got.framing);
+        try testing.expectEqual(whole.keep_alive, got.keep_alive);
+        try testing.expectEqualStrings(whole.target, got.target);
+        try testing.expectEqualStrings(whole.host.?, got.host.?);
+        try testing.expectEqual(whole.headers.len, got.headers.len);
+        for (whole.headers, got.headers) |a, b| {
+            try testing.expectEqualStrings(a.name, b.name);
+            try testing.expectEqualStrings(a.value, b.value);
+        }
+    }
+}
+
+test "head cursor: a head buffer that moves is not parsed against stale state" {
+    // hparse's resume contract is that consumed bytes never move. The head
+    // buffer is a ring-group slice on the plain path and the engine's
+    // plaintext on the TLS one, so rather than assume it is stable the cursor
+    // notices a different base and starts over. Same bytes, different address.
+    const head = "GET /x HTTP/1.1\r\nHost: h\r\n\r\n";
+    var first: [64]u8 = undefined;
+    var second: [64]u8 = undefined;
+    @memcpy(first[0..head.len], head);
+    @memcpy(second[0..head.len], head);
+
+    var cursor: HeadCursor = .{};
+    var storage: HeaderStorage = undefined;
+
+    // A partial parse against the first buffer leaves state behind.
+    try testing.expectError(error.Incomplete, parseRequestHead(
+        first[0 .. head.len - 4],
+        false,
+        &storage,
+        &cursor,
+    ));
+    try testing.expect(cursor.base != null);
+
+    // The same request, at a different address, still parses correctly.
+    const moved = try parseRequestHead(second[0..head.len], false, &storage, &cursor);
+    try testing.expectEqualStrings("/x", moved.target);
+    try testing.expectEqual(@as(?[*]const u8, second[0..].ptr), cursor.base);
+}
+
+test "head cursor: a terminator seen before the parser could look is not skipped" {
+    // hparse answers `Incomplete` from LENGTH checks that never examine a
+    // byte: `slice.len < min_request_len` (16), and `parseVersion`'s 9-byte
+    // check. Treating those bytes as "already searched for a terminator" let
+    // the cursor step past the only CRLFCRLF in the head. The head then never
+    // re-entered the parser, so a malformed request stopped being rejected on
+    // the read that carried the bad byte and instead held a conn slot until
+    // the buffer filled — a 400 turning into a 414/431.
+    const cases = [_]struct { first: usize, wire: []const u8 }{
+        // Terminator at 3..6, refused by the fast path having read nothing.
+        .{ .first = 7, .wire = "GET\r\n\r\nAAAAAAAAAAAA" },
+        // Terminator at 16..19, refused inside parseVersion.
+        .{ .first = 20, .wire = "GET /aaaaaaaaaa \r\n\r\nAAAAAAAAAAAA" },
+    };
+
+    for (cases) |case| {
+        var whole_storage: HeaderStorage = undefined;
+        const whole = parseRequestHead(case.wire, false, &whole_storage, null);
+        try testing.expectError(error.Malformed, whole);
+
+        var storage: HeaderStorage = undefined;
+        var cursor: HeadCursor = .{};
+
+        // The read that ends exactly on the terminator, before the parser has
+        // enough bytes to say anything about it.
+        try testing.expectError(error.Incomplete, parseRequestHead(
+            case.wire[0..case.first],
+            false,
+            &storage,
+            &cursor,
+        ));
+
+        // The next read must reach the same verdict the one-shot parser gives
+        // for these bytes, not sit waiting for a terminator it stepped over.
+        try testing.expectError(error.Malformed, parseRequestHead(
+            case.wire,
+            false,
+            &storage,
+            &cursor,
+        ));
+    }
+}
+
+test "witness: an empty request-target is refused" {
+    // §7 keeps fork behaviours witnessed through this wrapper rather than
+    // trusted at the dependency. The pinned hparse now refuses an empty
+    // request-target itself; `validateTarget` refused it before and still
+    // does, so the verdict is 400 from either layer — this pins that it stays
+    // 400 whichever layer answers.
+    var storage: HeaderStorage = undefined;
+    try testing.expectError(error.Malformed, parseRequestHead(
+        "GET  HTTP/1.1\r\nHost: a\r\n\r\n",
+        false,
+        &storage,
+        null,
+    ));
 }

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -2361,7 +2361,10 @@ fn checkCursorAgreesWithOneShot(input: []const u8, step: usize) void {
     var storage: HeaderStorage = undefined;
     var cursor: HeadCursor = .{};
     var have: usize = 0;
-    while (true) {
+    // Bounded by the input: `have` grows by at least one every pass and the
+    // body returns on the pass that reaches the end. Written as a bounded
+    // loop rather than a marked `while (true)` because the bound is real.
+    while (have < input.len) {
         have = @min(have + step, input.len);
         const pieced = parseRequestHead(input[0..have], false, &storage, &cursor);
         if (have == input.len) {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -4,7 +4,8 @@
 //! L4 path — L7 lives here, never inlined into the L4 relay.
 //!
 //! Lifecycle: `l7_reading_head` accumulates the request head and
-//! re-parses from byte 0 on each recv (§7 detect-and-retry); verdicts
+//! retries the parse on each recv, resuming the terminator search where
+//! the last one stopped (§7 detect-and-retry, via `HeadCursor`); verdicts
 //! answer comptime static responses (§8) with a lingering close (§7). A
 //! valid request acquires its relay buffer and upstream slot (both §8
 //! rungs, 503), dials (`l7_dialing`), then `l7_exchanging` runs two
@@ -291,17 +292,16 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.tls != null);
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
-            if (parser.parseRequestHead(
-                headBytes(server, conn)[0..conn.head_len],
-                true,
-                storage,
-            )) |_| {
+            if (parser.parseRequestHead(headBytes(server, conn)[0..conn.head_len], true, storage, null)) |_| {
                 // The head completed inside the buffer, so what overran it
                 // was payload.
                 respond(server, conn, 413, "l7_body_too_large");
             } else |err| switch (err) {
                 // The same three verdicts `parseAndDispatch` gives, and
-                // for the same reasons: a head that overran is still a
+                // for the same reasons — reached one-shot here, with no
+                // cursor, because this asks a question about the bytes as
+                // they stand rather than continuing a read sequence: a
+                // head that overran is still a
                 // head, and answering 431 for a malformed one or an
                 // oversize request line sends the client after the wrong
                 // thing. `Incomplete` is unreachable — the parser converts
@@ -578,8 +578,9 @@ pub fn Proxy(comptime IoType: type) type {
             parseAndDispatch(server, conn);
         }
 
-        /// Re-parse the accumulated head from byte 0 (§7). Incomplete and
-        /// room left → read more; oversize or malformed → the matching
+        /// Parse the accumulated head (§7), resuming the terminator search
+        /// where the last read left off via `conn.head_cursor`. Incomplete
+        /// and room left → read more; oversize or malformed → the matching
         /// static reject; a valid head → routing.
         fn parseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
@@ -589,7 +590,14 @@ pub fn Proxy(comptime IoType: type) type {
 
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
-            const request = parser.parseRequestHead(head, head_is_full, storage) catch |err| switch (err) {
+            // The cursor is what keeps a head that arrives in pieces from
+            // being re-parsed from byte 0 on every arrival (§7).
+            const request = parser.parseRequestHead(
+                head,
+                head_is_full,
+                storage,
+                &conn.head_cursor,
+            ) catch |err| switch (err) {
                 error.Incomplete => {
                     // A full buffer never yields Incomplete — the parser
                     // converts it to the oversize verdicts below — so here
@@ -1515,6 +1523,7 @@ pub fn Proxy(comptime IoType: type) type {
                 headBytes(server, conn)[0..conn.head_len],
                 false,
                 storage,
+                null,
             ) catch unreachable;
             // Re-derived rather than remembered, like the replay's
             // framing: same bytes, same key. A cookie cluster's #178
@@ -1544,6 +1553,7 @@ pub fn Proxy(comptime IoType: type) type {
                 headBytes(server, conn)[0..conn.head_len],
                 false,
                 storage,
+                null,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
             // Only this path pays for canonicalization twice, and it has
@@ -2590,6 +2600,7 @@ pub fn Proxy(comptime IoType: type) type {
             server.releaseRelayBuffer(conn.relay_buffer.?);
             server.returnHeadBuffer(conn);
             conn.head_len = 0;
+            conn.head_cursor.reset();
             conn.relay_buffer = buffer;
             conn.directions = .{ .{}, .{} };
             // Charged while this is still an exchange, so the charge and
@@ -3430,6 +3441,7 @@ pub fn Proxy(comptime IoType: type) type {
                 server.returnHeadBuffer(conn);
             }
             conn.head_len = 0;
+            conn.head_cursor.reset();
             conn.l7 = .{};
             conn.log.reset();
             // The #140 captures live in the server's side table, not on
@@ -3679,6 +3691,7 @@ pub fn Proxy(comptime IoType: type) type {
                 headBytes(server, conn)[0..conn.head_len],
                 false,
                 storage,
+                null,
             ) catch unreachable;
             assert(request.head_len == conn.l7.request_head_len);
             conn.l7 = .{

--- a/src/http/render.zig
+++ b/src/http/render.zig
@@ -639,7 +639,7 @@ test "render: request strips hop-by-hop and nominated, keeps the rest" {
     const head = "GET /p HTTP/1.1\r\nHost: a\r\nConnection: close, X-Nominated\r\n" ++
         "Keep-Alive: timeout=5\r\nTE: trailers\r\nX-Nominated: v\r\nX-Keep: yes\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
 
     const rendered = try renderRequestHead(&request, .{ .path = "/p", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
@@ -662,7 +662,7 @@ test "render: an absolute-form authority replaces the client's Host" {
     const head = "GET http://api.example:8080/v2/x HTTP/1.1\r\n" ++
         "Host: stale.example\r\nX-Keep: yes\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(
         &request,
@@ -681,7 +681,7 @@ test "render: an absolute-form authority replaces the client's Host" {
     );
     // The request line is origin-form downstream, whatever form arrived.
     var reparse_storage: parser.HeaderStorage = undefined;
-    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage, null);
     try testing.expectEqual(@as(?[]const u8, null), reparsed.authority);
     try testing.expectEqualStrings("api.example:8080", reparsed.host.?);
 }
@@ -693,7 +693,7 @@ test "render: filter edits set, add, and remove headers" {
     const head = "GET /p HTTP/1.1\r\nHost: a\r\nX-Env: dev\r\nX-Trace: t0\r\n" ++
         "Cookie: sid=1\r\nX-Keep: yes\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     const edits = [_]filter.AppliedHeaderEdit{
         .{ .kind = .set, .name = "X-Env", .value = "prod" },
         .{ .kind = .add, .name = "X-Trace", .value = "t1" },
@@ -711,7 +711,7 @@ test "render: filter edits set, add, and remove headers" {
 
     // The edited head must re-parse as a valid request with the edits live.
     var reparse_storage: parser.HeaderStorage = undefined;
-    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage, null);
     try testing.expectEqualStrings("prod", parser.headerValue(reparsed.headers, "x-env").?);
     try testing.expectEqual(@as(?[]const u8, null), parser.headerValue(reparsed.headers, "cookie"));
 }
@@ -722,7 +722,7 @@ test "render: an edit that overflows the buffer is Oversize" {
     // source head.
     const head = "GET /p HTTP/1.1\r\nHost: a\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     const edits = [_]filter.AppliedHeaderEdit{
         .{ .kind = .add, .name = "X-Big", .value = "0123456789" },
     };
@@ -753,7 +753,7 @@ test "render: the edited oracle skips a head that grows past head_buffer_bytes_d
 
     // The source is legal (head.len == head_buffer_bytes_default is within the limit).
     var storage: parser.HeaderStorage = undefined;
-    const parsed = try parser.parseRequestHead(&source, false, &storage);
+    const parsed = try parser.parseRequestHead(&source, false, &storage, null);
     try testing.expectEqual(@as(u32, constants.head_buffer_bytes_default), parsed.head_len);
     // Confirm the edited render genuinely crosses the ceiling — otherwise
     // this test would exercise nothing. (The edit set mirrors the oracle's.)
@@ -775,7 +775,7 @@ test "render: nominating a protected header does not strip it" {
     const head = "POST /u HTTP/1.1\r\nHost: a\r\nConnection: Content-Length, Host\r\n" ++
         "Content-Length: 5\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings(
@@ -792,7 +792,7 @@ test "render: a nomination on a second Connection line still strips" {
     const head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n" ++
         "Connection: X-Nominated\r\nX-Nominated: v\r\nX-Keep: k\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     try testing.expect(request.connection_nominates_header);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
@@ -813,7 +813,7 @@ test "render: standard Connection options do not nominate a same-named header" {
     const head = "GET / HTTP/1.1\r\nHost: a\r\nConnection: keep-alive, close\r\n" ++
         "Close: x\r\nKeep-Alive: timeout=5\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     // Connection stripped (hop-by-hop) and Keep-Alive stripped (a
@@ -828,18 +828,18 @@ test "render: standard Connection options do not nominate a same-named header" {
 test "render: framing headers travel with the body" {
     const head = "POST /u HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&request, .{ .path = "/u", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
 
     var reparse_storage: parser.HeaderStorage = undefined;
-    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage);
+    const reparsed = try parser.parseRequestHead(rendered, false, &reparse_storage, null);
     try testing.expectEqual(parser.BodyFraming.chunked, reparsed.framing);
 }
 
 test "render: client version is preserved" {
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage);
+    const request = try parser.parseRequestHead("GET / HTTP/1.0\r\n\r\n", false, &storage, null);
     var buffer: [oracle_buffer_bytes]u8 = undefined;
     const rendered = try renderRequestHead(&request, .{ .path = "/", .query = "" }, &.{}, false, null, null, false, &test_head_scratch, &buffer);
     try testing.expectEqualStrings("GET / HTTP/1.0\r\n\r\n", rendered);
@@ -915,7 +915,7 @@ test "render: bare status line without a reason phrase round-trips" {
 test "render: a head that no longer fits is Oversize" {
     const head = "GET /path HTTP/1.1\r\nHost: origin.example\r\n\r\n";
     var storage: parser.HeaderStorage = undefined;
-    const request = try parser.parseRequestHead(head, false, &storage);
+    const request = try parser.parseRequestHead(head, false, &storage, null);
     const target = parser.CanonicalTarget{ .path = "/path", .query = "" };
     var small: [16]u8 = undefined;
     try testing.expectError(error.Oversize, renderRequestHead(&request, target, &.{}, false, null, null, false, &test_head_scratch, &small));
@@ -950,7 +950,7 @@ fn oracleTarget(
 
 fn checkRequestRender(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
-    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    const request = parser.parseRequestHead(input, false, &storage, null) catch return;
     if (request.method == .connect) {
         return; // Never rendered: the proxy answers CONNECT itself.
     }
@@ -971,7 +971,7 @@ fn checkRequestRender(input: []const u8) void {
     var reparse_storage: parser.HeaderStorage = undefined;
     // A rendered head failing our own parser would mean the proxy emits
     // requests it would itself reject — the oracle's core claim.
-    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch unreachable;
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage, null) catch unreachable;
     assert(reparsed.method == request.method);
     assert(std.mem.eql(u8, reparsed.method_token, request.method_token));
     // §7 canonical forwarding: the origin sees the canonical path plus the
@@ -1003,7 +1003,7 @@ fn checkRequestRender(input: []const u8) void {
 /// legitimate oversize-after-edits verdict (431), not an oracle failure.
 fn checkRequestRenderEdited(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
-    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    const request = parser.parseRequestHead(input, false, &storage, null) catch return;
     if (request.method == .connect) {
         return;
     }
@@ -1030,7 +1030,7 @@ fn checkRequestRenderEdited(input: []const u8) void {
         return;
     }
     var reparse_storage: parser.HeaderStorage = undefined;
-    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch return;
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage, null) catch return;
     // set always wins (its source copies are suppressed, one value
     // appended); remove is always absent; add is always present.
     assert(std.mem.eql(u8, parser.headerValue(reparsed.headers, "x-fuzz-set").?, "s"));
@@ -1120,7 +1120,7 @@ fn fuzzRenderInputs(context: void, smith: *std.testing.Smith) !void {
 /// origin and the next hop can read different clients out of one request.
 fn checkRequestRenderForwarded(input: []const u8) void {
     var storage: parser.HeaderStorage = undefined;
-    const request = parser.parseRequestHead(input, false, &storage) catch return;
+    const request = parser.parseRequestHead(input, false, &storage, null) catch return;
     if (request.method == .connect) {
         return;
     }
@@ -1155,7 +1155,7 @@ fn checkRequestRenderForwarded(input: []const u8) void {
     // §7 oversize verdict, which production answers 431, not a head this
     // oracle has anything left to say about. `checkRequestRenderEdited`
     // declines for the same reason: its edits can add lines too.
-    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage) catch return;
+    const reparsed = parser.parseRequestHead(rendered, false, &reparse_storage, null) catch return;
     var seen: u32 = 0;
     for (reparsed.headers) |header| {
         if (header.tag == .x_forwarded_for) {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -351,6 +351,7 @@ const HttpOrigin = struct {
                     oconn.request_buffer[oconn.request_offset..oconn.request_len],
                     false,
                     &storage,
+                    null,
                 ) catch |err| {
                     if (err == error.Incomplete) {
                         oconn.armRecv();
@@ -1001,6 +1002,7 @@ fn forwardedRequest(bed: *const Http1Bed, storage: *parser.HeaderStorage) !parse
         bed.origin.conns[0].request_buffer[0..bed.origin.conns[0].request_len],
         false,
         storage,
+        null,
     );
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -322,7 +322,8 @@ pub fn Conn(comptime IoType: type) type {
         /// connection never binds one. The bytes live in the ring's slab
         /// (`bufferGroupSlice`); everything the old inline array promised
         /// still holds of them: request/response head accumulates across
-        /// recv retries, parsing is detect-and-retry from byte 0 (§7), the
+        /// recv retries, parsing is detect-and-retry — carried forward by
+        /// `head_cursor` rather than restarted at byte 0 (§7) — the
         /// buffer's content stays the single source of truth while held,
         /// and nothing zeroes it — bytes past `head_len` are never read.
         head_buffer_id: u16,
@@ -336,6 +337,13 @@ pub fn Conn(comptime IoType: type) type {
         /// half — and zeroes it at hand-over, so the relay starts clean
         /// and the L7 meaning is never mixed with the L4 one.
         head_len: u32,
+        /// Carries a partial head parse across recv retries, so a head that
+        /// arrives in pieces is parsed once rather than re-parsed from byte 0
+        /// on every arrival (§7). Zeroed wherever `head_len` is, because the
+        /// two describe the same head; see `http.parser.HeadCursor` for why
+        /// the quadratic version was a denial of service and not merely
+        /// wasteful.
+        head_cursor: parser.HeadCursor = .{},
         /// This connection's TLS session (§4), or null on a plaintext
         /// listener — which is every connection on a deployment without a
         /// `tls` block, and what makes the whole feature cost nothing
@@ -474,8 +482,9 @@ pub fn Conn(comptime IoType: type) type {
             tls_handshaking,
             connecting,
             relaying,
-            // L7 states (§7): `l7_reading_head` accumulates and re-parses
-            // the request head (detect-and-retry); `l7_dialing` awaits the
+            // L7 states (§7): `l7_reading_head` accumulates the request
+            // head and retries the parse, resuming the search where the
+            // last read left off; `l7_dialing` awaits the
             // upstream connect; `l7_exchanging` runs the two legs (request
             // out, response back — each with its own sub-state in `l7`);
             // `l7_responding` writes a static error response (§8); and
@@ -767,6 +776,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.directions = .{ .{}, .{} };
             conn.head_buffer_id = head_buffer_none;
             conn.head_len = 0;
+            conn.head_cursor.reset();
             // A parameter, not a field the caller installs afterwards: a
             // slot is recycled across listeners, so a caller that acquired
             // an engine and then let this reset it would leak one per


### PR DESCRIPTION
§7's "detect-and-retry" re-parsed the accumulated head from byte 0 every time
more bytes arrived, so head parsing was **O(N²) in the number of segments a head
arrives in — and the client picks the segmentation.**

Measured through `parseRequestHead` on a 7.6 KiB head arriving one byte at a
time: **5.85 ms of CPU for a single head.** Single-writer per loop thread means
that burn is inside the event loop and stalls every connection on the thread,
not just the sender's. Slow-loris normally costs a socket, which the shed ladder
is built for; this costs CPU, which no rung catches. It is #222's family: burn
instead of shed.

## The fix

A per-connection `HeadCursor` carries an **offset** forward. The first attempt
still goes straight to the one-shot parser, so a head that arrives whole — the
overwhelming majority — pays nothing. Once a head has proven partial, the cursor
resumes the search for the terminating CRLFCRLF and hparse runs once, over a
head already known to be complete.

| case | before | after | |
|---|---|---|---|
| whole head (7,613 B) | 1,659 ns | **1,568 ns** | 0.945×, no regression |
| 64-byte segments | 91.1 µs | 4.5 µs | 20× |
| 1-byte segments | 5.85 ms | 18.4 µs | 317× |

Always-resume measured 3–25% *slower* on a whole head, which is why the first
attempt stays one-shot.

## Why not hparse's resumable API

The pin below now offers one, and this deliberately does not use it. That API
needs the caller's header array to survive between calls, and `header_scratch`
is a single server-wide buffer lent per dispatch — another connection's dispatch
overwrites it before this one reads again. Per-connection header storage would
cost `headers_max * 32` bytes on every slot against §5's closed-form pricing, to
save a scan. The cursor costs 16 bytes a slot, which `budget.zig` already prices
through `@sizeOf(ConnType)`.

## The hparse pin

Moves to `87fd39d` for a correctness fix found by running the fork's own
coverage-guided fuzzer, which its CI never ran: an empty request-target was
accepted, and because the shortest legal request is exactly the parser's 16-byte
fast-path threshold, the verdict on a complete 15-byte "request" depended on
whether spare bytes happened to follow it in the buffer. zoxy answered 400
either way (`validateTarget` refused it too), so this is not a behaviour change
here — but §7 wants fork behaviour witnessed through the wrapper, and now there
is a test. hparse CI gained the fuzz corpus step so the oracle that catches it
actually runs.

## A bug review caught, worth reading

The first draft set `scanned` from hparse's `error.Incomplete` — but hparse
answers `Incomplete` from **length** checks that examine no bytes (`slice.len <
16`, and `parseVersion`'s 9-byte check). Bytes nothing had looked at were marked
searched, and the rewind stepped past the only CRLFCRLF in the head.
`GET\r\n\r\n` followed by anything was then never re-parsed: it accumulated to
`head_is_full` and came back **414/431 instead of 400**, holding a conn slot
until the buffer filled — a regression on the very axis this change exists to
improve. Reproduced, fixed, and pinned by a test. Only a scan may advance
`scanned` now.

That also showed the §9 gate was thin, so the cursor has a differential oracle —
the same bytes fed in pieces must reach the verdict they reach whole — wired
into `checkRequestParse` and driven directly over the shapes hparse cannot yet
judge. Verified non-vacuous by reintroducing the bug.

Worth recording: seeding those shapes into the fuzz **corpus** does not work.
`std.testing.fuzz` hands corpus entries to `Smith`, which reads structure out of
them, so a seed never reaches the parser as the bytes it was written as — and
coverage-guided mode does not build on Zig 0.16.0.

## Gates

Run: `zig build test -Dtest-filter=parser` 60/60, `"head cursor"` 23/23,
`"fuzz oracle"` 22/22, `zig fmt` clean.

**Not run: the full suite, sim, and smoke.** `zig build test` segfaults on my
machine, and I verified that is **pre-existing on unmodified `main`** — it
survives `-Dio-backend=epoll` and hits most test filters but not `parser` or
`balancer`. Those gates need a machine where the suite is healthy; please treat
CI as the first real run of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)