### PR TITLE
profile: sample kernel mode too, and price the levers with it (§9)

### DIFF
--- a/bench/profile.zig
+++ b/bench/profile.zig
@@ -68,6 +68,30 @@ const Flags = struct {
     /// there to a low floor, so this leaves real margin rather than the
     /// 22 seconds the first version left.
     quiesce_timeout_s: u64 = 300,
+    /// Sample in kernel mode as well as user mode: drop the `u` modifier
+    /// from the cycles event so samples landing inside syscalls, softirq
+    /// and the TCP stack are recorded instead of discarded.
+    ///
+    /// Off by default, and that default is load-bearing: every number in
+    /// IMPLEMENTATION_NOTES.md is a userspace share, and a run that
+    /// silently included kernel time would not be comparable to any of
+    /// them. It is a separate question, so it gets a separate flag.
+    ///
+    /// It answers the gap that file records as unmeasured — what the ~52
+    /// points of kernel time on zoxy's core are doing, against the ~5 the
+    /// profiler can see today. Needs `kernel.perf_event_paranoid <= 1`
+    /// and, to resolve the symbols, `kernel.kptr_restrict = 0`; both are
+    /// checked before a window opens rather than discovered in the output.
+    ///
+    /// KERNEL STACKS ARE NOT UNWOUND. The recording keeps `--call-graph
+    /// lbr`, whose branch filter is user-only, so kernel frames arrive as
+    /// sample leaves with no callers above them. That is deliberate: the
+    /// flat top-symbols table is what answers "where is the time", and
+    /// the alternative — `fp` — would need frame pointers this ReleaseSafe
+    /// binary does not keep, trading the user stacks that do work for
+    /// kernel stacks that might. Read the symbol table, not the
+    /// flamegraph's kernel branches.
+    kernel: bool = false,
     zoxy_path: []const u8 = "zig-out/bin/zoxy-profile",
 
     const Protocol = enum { l4, http };
@@ -105,8 +129,7 @@ pub fn main(init: std.process.Init) !u8 {
     // `dedicate` yields null.
     const zoxy_cpu = affinity.dedicate(io, flags.zoxy_cpu).?;
 
-    const cycles_event = try preflight(io, &flags, zoxy_cpu) orelse
-        return refuseNoPtraceAttach();
+    const cycles_event = try preflight(io, &flags, zoxy_cpu) orelse return 1;
 
     var origin_child = try spawnNginx(arena, io, environ);
     defer origin_child.kill(io);
@@ -123,6 +146,7 @@ pub fn main(init: std.process.Init) !u8 {
         "profile: zoxy pid {d} pinned to cpu {d} ({s}); driving {s} listener; origin + load pinned off it\n",
         .{ zoxy_pid, zoxy_cpu, cycles_event, @tagName(flags.protocol) },
     );
+    if (flags.kernel) announceKernelMode();
 
     // Record only the zoxy pid for the load's duration while zrk saturates it.
     var perf_child = try spawnPerf(arena, io, environ, zoxy_pid, cycles_event, &flags);
@@ -200,6 +224,8 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
                 std.debug.print("profile: --protocol must be l4 or http\n", .{});
                 return error.InvalidArguments;
             }
+        } else if (std.mem.eql(u8, arg, "--kernel")) {
+            flags.kernel = true;
         } else if (!zoxy_path_set and !std.mem.startsWith(u8, arg, "--")) {
             // First bare argument is the zoxy binary (passed by `zig build`).
             flags.zoxy_path = arg;
@@ -208,7 +234,7 @@ fn parseFlags(args: []const [:0]const u8) !Flags {
             std.debug.print(
                 "usage: profile [zoxy-path] [--rate N] [--connections N] [--threads N] " ++
                     "[--seconds N] [--freq N] [--cpu N] [--quiesce-load F] [--request-ms N] " ++
-                    "[--protocol l4|http]\n",
+                    "[--protocol l4|http] [--kernel]\n",
                 .{},
             );
             return error.InvalidArguments;
@@ -367,7 +393,8 @@ fn cpuListContains(list: []const u8, cpu: u16) bool {
 }
 
 /// The cycles event to sample zoxy with, qualified by the PMU that owns
-/// the dedicated core.
+/// the dedicated core, and scoped to user mode unless `kernel` says
+/// otherwise.
 ///
 /// This matters on a hybrid part. An unqualified `cycles:u` binds to a
 /// single PMU — cpu_atom, as perf resolves it here — while `dedicate`
@@ -376,28 +403,132 @@ fn cpuListContains(list: []const u8, cpu: u16) bool {
 /// a measurement instead of the failure it is. Naming the PMU that owns
 /// the chosen cpu keeps the pairing correct whichever core is picked,
 /// including a `--cpu` override onto an E-core.
-fn cyclesEventFor(io: Io, cpu: u16) []const u8 {
+///
+/// The modifier is the `--kernel` axis: `cpu_core/cycles/u` counts user
+/// mode only, `cpu_core/cycles/` (empty modifier) counts both. Every
+/// figure recorded in IMPLEMENTATION_NOTES.md came off the former, so the
+/// default stays there and the two are never silently mixed.
+fn cyclesEventFor(io: Io, cpu: u16, kernel: bool) []const u8 {
     var buffer: [256]u8 = undefined;
     const event = event: {
         if (readSmallFile(io, "/sys/devices/cpu_core/cpus", &buffer)) |list| {
-            if (cpuListContains(list, cpu)) break :event "cpu_core/cycles/u";
+            if (cpuListContains(list, cpu)) {
+                break :event if (kernel) "cpu_core/cycles/" else "cpu_core/cycles/u";
+            }
         }
         if (readSmallFile(io, "/sys/devices/cpu_atom/cpus", &buffer)) |list| {
-            if (cpuListContains(list, cpu)) break :event "cpu_atom/cycles/u";
+            if (cpuListContains(list, cpu)) {
+                break :event if (kernel) "cpu_atom/cycles/" else "cpu_atom/cycles/u";
+            }
         }
-        break :event "cycles:u";
+        break :event if (kernel) "cycles" else "cycles:u";
     };
     // Every arm names a cycles event, PMU-qualified or plain. An empty or
     // unrelated event is what silently records nothing, which is the bug
     // this function exists to prevent.
     assert(event.len > 0);
     assert(std.mem.indexOf(u8, event, "cycles") != null);
+    // The `u` modifier and `--kernel` are the same decision spelled two
+    // ways; disagreeing would record the opposite of what was asked.
+    assert(kernel != (std.mem.endsWith(u8, event, ":u") or std.mem.endsWith(u8, event, "/u")));
     return event;
 }
 
-/// The remedy for a box whose `ptrace_scope` forbids the attach. Split
-/// out of `main` so the preflight costs it one line, not twelve.
-fn refuseNoPtraceAttach() u8 {
+/// Why a box cannot record kernel-mode samples, or null if it can.
+///
+/// Two independent sysctls, and the second is the one that costs an
+/// afternoon: `perf_event_paranoid` decides whether the samples are taken
+/// at all, `kptr_restrict` decides whether their addresses resolve to
+/// names. With paranoid granted and kptr_restrict left at 1, perf records
+/// a perfectly good profile in which every kernel symbol is `[unknown]` —
+/// a measurement-shaped output carrying no measurement, which is the
+/// failure mode this whole file is written against. Root reads kallsyms
+/// regardless, so it is exempt from the second check only.
+const KernelSampleBlocker = enum { paranoid, kptr_restrict };
+
+fn kernelSampleBlocker(io: Io) ?KernelSampleBlocker {
+    const root = std.os.linux.geteuid() == 0;
+    // `perf_event_paranoid` gates on CAPABILITY at every level, not on a
+    // ceiling: a root process that still holds CAP_PERFMON bypasses all of
+    // them, the Debian/Ubuntu level 3 included. Refusing root at the common
+    // default of 2 would refuse a run that would have worked.
+    if (!root) {
+        if (sysctlLevel(io, "/proc/sys/kernel/perf_event_paranoid")) |level| {
+            if (level > 1) return .paranoid;
+        }
+    }
+    // `kptr_restrict` does NOT work the same way, which is the trap. Level 1
+    // is capability-gated, so root reads real addresses; level 2 hides them
+    // from everyone, root included — `kallsyms_show_value` has no capability
+    // escape there. So root is exempt from 1 and not from 2.
+    if (sysctlLevel(io, "/proc/sys/kernel/kptr_restrict")) |level| {
+        if (level >= 2) return .kptr_restrict;
+        if (level != 0 and !root) return .kptr_restrict;
+    }
+    return null;
+}
+
+/// One small integer sysctl, or null when the box does not answer.
+///
+/// Null covers both ways of not answering, and they are the same answer
+/// here: the file is absent or unreadable, or it is readable and does not
+/// parse. Neither is EVIDENCE OF A RESTRICTION, and this function's
+/// callers refuse a run — so inventing a restriction from an unparseable
+/// file would block a measurement on a box that would have taken it.
+/// The cost of being wrong in this direction is bounded: perf itself
+/// refuses loudly, and `printTopSymbols` reports a zero-sample recording
+/// rather than rendering one.
+fn sysctlLevel(io: Io, path: []const u8) ?i8 {
+    var buffer: [16]u8 = undefined;
+    const content = readSmallFile(io, path, &buffer) orelse return null;
+    assert(content.len <= buffer.len);
+    const text = std.mem.trim(u8, content, " \n\t");
+    assert(text.len <= content.len);
+    if (text.len == 0) return null;
+    return std.fmt.parseInt(i8, text, 10) catch null;
+}
+
+/// The remedy for a box that cannot take kernel-mode samples. Refuses
+/// rather than downgrading to a user-only run: `--kernel` was asked for,
+/// and quietly answering a different question is what the output would
+/// then be.
+fn refuseNoKernelSamples(blocker: KernelSampleBlocker) void {
+    switch (blocker) {
+        .paranoid => std.debug.print(
+            \\profile: --kernel needs kernel.perf_event_paranoid <= 1, so kernel-mode
+            \\  samples would be dropped and the profile would be user-only anyway:
+            \\    sudo sysctl -w kernel.perf_event_paranoid=0
+            \\  (0 rather than 1 also unlocks the syscall tracepoints, which is the
+            \\  other measurement this box cannot currently take.)
+            \\
+        , .{}),
+        .kptr_restrict => std.debug.print(
+            \\profile: --kernel needs kernel.kptr_restrict = 0, or every kernel symbol
+            \\  resolves to [unknown] and the profile looks valid while naming nothing:
+            \\    sudo sysctl -w kernel.kptr_restrict=0
+            \\  or run this profile as root.
+            \\
+        , .{}),
+    }
+}
+
+/// Said in the run's own banner rather than left to whoever reads the
+/// flamegraph later: kernel mode changes what the output means, and what
+/// changes is which half of it can be trusted. The leaves are the answer;
+/// the branches above a kernel leaf are absent, not empty.
+fn announceKernelMode() void {
+    std.debug.print(
+        "profile: kernel-mode samples on — read the symbol table; " ++
+            "LBR does not unwind kernel stacks\n",
+        .{},
+    );
+}
+
+/// The remedy for a box whose `ptrace_scope` forbids the attach. Prints
+/// and returns; `preflight` turns it into the null that stops the run, so
+/// every refusal reaches `main` as one exit code rather than as a message
+/// each call site has to remember to print.
+fn refuseNoPtraceAttach() void {
     std.debug.print(
         \\profile: kernel.yama.ptrace_scope is not 0, so `perf record -p` cannot
         \\  attach to zoxy and the recording would come back empty. Either:
@@ -405,7 +536,6 @@ fn refuseNoPtraceAttach() u8 {
         \\  or run this profile as root.
         \\
     , .{});
-    return 1;
 }
 
 /// Whether `perf record -p` can attach to zoxy at all.
@@ -489,8 +619,20 @@ fn benchConfig(port: u16, rate: u64, connections: u32, threads: u8) zrk.cli.Conf
 /// never went quiet.
 fn preflight(io: Io, flags: *const Flags, zoxy_cpu: u16) !?[]const u8 {
     assert(flags.quiesce_load >= 0);
-    if (!ptraceScopeAllowsAttach(io)) return null;
-    const cycles_event = cyclesEventFor(io, zoxy_cpu);
+    if (!ptraceScopeAllowsAttach(io)) {
+        refuseNoPtraceAttach();
+        return null;
+    }
+    // Kernel samples asked for on a box that cannot take them, refused
+    // here rather than after nginx, zoxy and a whole load window have
+    // been spent producing a user-only profile nobody asked for.
+    if (flags.kernel) {
+        if (kernelSampleBlocker(io)) |blocker| {
+            refuseNoKernelSamples(blocker);
+            return null;
+        }
+    }
+    const cycles_event = cyclesEventFor(io, zoxy_cpu, flags.kernel);
     assert(cycles_event.len >= 1);
     // Before anything is spawned, so the wait is not itself adding load.
     try awaitQuietBox(io, flags);

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -616,6 +616,13 @@ chunked L7 bodies fall back to copy regardless. Revisit only under
 genuine CPU/memory-bandwidth saturation — the copy is not the bottleneck
 today (§3's envelope; the loop profile below).
 
+**Now priced, and the price argues against building it** ("What the kernel
+time is doing" below): the copy paths are 4.4% of all cycles and the two
+this op would remove are 2.7%, against skb lifecycle at 7.7% and tcp/ip at
+17.3% which it does not touch. Do not open this without a workload whose
+copy share is materially larger than 2.7% — and measure that share on a
+real NIC, not the loopback box those figures came from.
+
 ### libxev fork queue
 
 The §4 pin policy (DESIGN.md) makes fork changes deliberate, batched
@@ -788,12 +795,85 @@ Three caveats, each of which changes what the table above means.
 - Ops/req measured 4.00 flat at every rate, matching the 4.0 already
   recorded across a 156× connection sweep.
 
-Not measured, and the honest gap: what the 51.9 points of kernel time
-are actually doing. That needs kernel-mode samples, which needs a
-`perf_event_paranoid` this box does not grant by default and a profiler
-event without the `:u` suffix — two changes, neither of which the
-userspace question above required.
+That gap is now closed — see the next section.
 
+## What the kernel time is doing (2026-08-24)
+
+The gap above, measured. `bench/profile.zig` grew a `--kernel` flag that
+drops the `u` modifier from the cycles event, and the box granted
+`perf_event_paranoid=0`, `kptr_restrict=0` and `yama.ptrace_scope=0`.
+L7, 100 k req/s offered, 64 connections, 20 s, zoxy alone on a P-core.
+**73 K samples, 0 lost.**
+
+    kernel  89.3%
+    user    10.5%
+
+**The 10:1 estimate above was right.** It was inferred from `/proc`
+(51.9 kernel against 5.2 user points of a 57.2%-busy core); sampling both
+modes directly says 89.3/10.5. Nothing about the userspace-share warnings
+changes — they were correctly calibrated, and every figure in this file
+that carries one still means what it said.
+
+Grouped, and the groups are what matter rather than any single symbol:
+
+| | share of all cycles |
+|---|---|
+| tcp/ip protocol work | 17.3% |
+| skb lifecycle (alloc, release, defer-free, slab) | 7.7% |
+| **nft + conntrack (this box's firewall)** | **7.2%** |
+| io_uring (`io_submit_sqes` and friends) | 7.0% |
+| spinlocks (`_raw_spin_lock_irqsave`/`_bh`) | 5.4% |
+| copy paths (`_copy_to_iter`, `__skb_datagram_iter`) | 4.4% |
+| all of zoxy's own code | 10.5% |
+
+Top single symbol is `nft_do_chain` at 3.23%, then
+`_raw_spin_lock_irqsave` 2.98%, `skb_release_data` 2.09%,
+`__alloc_skb` 2.05%, `__nf_conntrack_find_get` 1.77%.
+
+Three findings, in order of what they change.
+
+- **This is evidence AGAINST `splice`, not for it.** The copy it removes
+  is the 4.4% row, and `_copy_to_iter` + `__skb_datagram_iter` alone are
+  2.7% of it. Against +4 fds per L4 connection (tripling the fd budget),
+  a `Pool(Pipe)`, a SimIo primitive and a libxev re-audit, that is not a
+  trade worth making. The lever's own entry already said "the copy is not
+  the bottleneck today"; this is the number behind the sentence. What
+  dominates instead — skb lifecycle and TCP protocol work — `splice` does
+  not touch at all.
+- **The largest single cost is not zoxy's.** nft + conntrack is 7.2%,
+  more than every line of zoxy's own code but for a rounding error, and
+  more than any kernel subsystem except TCP itself. The nft loopback
+  bypass recorded above as "environmental work, not zoxy work" is now
+  priced: it would clean ~7 points out of every profile taken here.
+- **zoxy's own code is 10.5%, and the parser is ~2.2% of the total**
+  (`parseResponseHead` 0.75, `analyzeHeaders` 0.66, `parseRequest` 0.53,
+  `classifyHeaderName` 0.28). This is the closing argument for "do not
+  optimize the Zig side", now from the kernel's side of the fence rather
+  than by inference from a 1.26% userspace slice. It also prices the
+  same day's hparse work: a ~19% win on the parser is ~0.4% of total,
+  which is why nothing was expected to move at proxy level and nothing
+  did.
+
+**What it does NOT say, and the limit is severe.** This is loopback, so
+the sender pays the receiver's TCP stack too and the tcp/ip row is
+inflated by an amount nothing here measures; and nft/conntrack is this
+box's configuration, absent on a machine without it. Read the SHAPE —
+protocol and buffer management dominate, copying does not — and re-take
+it on the cloud fleet before any of the rows are quoted as a deployment
+profile. The tooling is in the tree; the sysctls are the only thing a
+fleet run needs that CI does not have.
+
+Reproducibility, since a single profile is not a measurement here: two
+independent 20 s runs gave 89.5/10.3 and 89.3/10.5 with `nft_do_chain`
+at 3.26% and 3.23%. That is tight enough to quote the groups to one
+decimal, and it is the only claim in this section resting on more than
+one run.
+
+The other honest gap is untouched and now matters more: at the 165 k
+req/s ceiling zoxy is at ~55% of its core, latency-bound with CPU
+headroom. Cutting CPU does not raise that ceiling, so the ~45% off-CPU
+residue is the measurement with the most left in it — `perf sched`, and
+the paranoid sysctl this section needed is the one it needs too.
 ## Multishot recv — measured and parked (2026-07-12), closed (2026-07-28)
 
 Best-case echo microbench (pinned cores, ABBA, single-shot vs multishot


### PR DESCRIPTION
Adds `--kernel` to `bench/profile.zig`, and writes up the measurement it
made possible. One slice, because the flag's justification *is* the number
it produced.

## The gap this closes

`cyclesEventFor` hard-coded the `u` modifier, so every performance figure in
`IMPLEMENTATION_NOTES.md` is a userspace share. That file records the
consequence as an open gap: what the 51.9 points of kernel time on zoxy's
core are doing, against the 5.2 the profiler could see.

## The flag

Off by default, deliberately — a run that silently included kernel time
would not be comparable to any number already recorded, so it is a separate
question with a separate flag.

Two preflight checks **refuse rather than downgrade**, beside the existing
ptrace check so every refusal reaches `main` as one exit code:

- `perf_event_paranoid > 1` — the samples would be dropped.
- `kptr_restrict != 0` — every kernel symbol resolves to `[unknown]`, i.e. a
  profile that looks valid while naming nothing. This is the one that costs
  an afternoon, and it is the failure mode the whole file is written against.

**Root exemption is asymmetric, and that is the subtle part.** Root bypasses
`perf_event_paranoid` at every level via `CAP_PERFMON` (the Debian level 3
included), so refusing it at the common default of 2 would refuse a run that
would have worked. But `kallsyms_show_value` has no capability escape at
`kptr_restrict = 2` — so root is exempt from level 1 and not from level 2.
An earlier revision of this branch got that wrong in the permissive
direction.

**LBR is kept on purpose.** Its branch filter is user-only, so kernel frames
arrive as leaves with no callers — but `printTopSymbols` already runs a flat
`-g none --no-children` report, which attributes by leaf IP, and that is what
"where does the time go" asks. The alternative, `fp`, needs frame pointers
this ReleaseSafe binary does not keep, and would trade working user stacks
for kernel stacks that might not unwind. The run banner says so rather than
leaving the flamegraph to be misread.

## The measurement

L7, 100 k req/s offered, 64 connections, 20 s, zoxy alone on a P-core.
**73 K samples, 0 lost.**

    kernel  89.3%      user  10.5%

    tcp/ip protocol      17.3%
    skb lifecycle         7.7%
    nft + conntrack       7.2%   <- this box's firewall
    io_uring              7.0%
    spinlocks             5.4%
    copy paths            4.4%

The 10:1 the `/proc` arithmetic inferred was right.

**It retires a lever rather than opening one.** `splice` removes 2.7% and
touches neither skb lifecycle nor tcp/ip, against +4 fds per L4 connection
(tripling the fd budget), a `Pool(Pipe)`, a SimIo primitive and a libxev
re-audit. The c10k entry now carries that price and the instruction not to
reopen it without a workload whose copy share is materially larger — measured
on a real NIC, not this box.

The largest single symbol is `nft_do_chain` at 3.23% — more than all of
zoxy's own code bar a rounding error, and already recorded as environmental
rather than zoxy work.

## Reading limits, stated in the section

Loopback: the sender pays the receiver's TCP stack, so tcp/ip is inflated by
an amount nothing here measures, and nft/conntrack is this box's config. Read
the *shape* — protocol and buffer management dominate, copying does not — and
re-take it on the fleet before quoting rows as a deployment profile.

Two independent runs gave 89.5/10.3 and 89.3/10.5 with `nft_do_chain` at
3.26% and 3.23%. That is what justifies quoting the groups to one decimal,
and it is the only claim in the section resting on more than one run.

## Gates

`zig build ci` green, `zig fmt --check` clean. The flag was exercised end to
end: both refusal paths, and a full 20 s window at `cpu_core/cycles/`.

Needs `perf_event_paranoid=0`, `kptr_restrict=0` and `yama.ptrace_scope=0` to
run — inert without them, which is why it refuses up front instead of after a
load window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)