### PR TITLE
conn/stream: split the exchange out of the conn slot (#274)

### DIFF
--- a/bench/micro/conn_touch_scaling.zig
+++ b/bench/micro/conn_touch_scaling.zig
@@ -2,13 +2,20 @@
 //! live connection count grows — the memory-hierarchy half of the c10k
 //! question, isolated from the network.
 //!
-//! `Conn.arm`/`Conn.delivered` are three instructions in ReleaseFast (the
-//! assertions compile out), so their cost is not the work — it is reaching
-//! `conn.armed` at all. One conn slot is ~9.5 KiB, so N live connections
-//! spread that byte over N distinct pages, and the completion order across
-//! them is effectively random. At 500 connections the touched set is a few
-//! MiB and lives in L3; at 10k it is over 100 MiB and every touch is a DRAM
-//! access plus a page walk.
+//! `Stream.arm`/`Stream.delivered` are three instructions in ReleaseFast
+//! (the assertions compile out), so their cost is not the work — it is
+//! reaching `stream.armed` at all. A conn slot is ~2 KiB and the stream
+//! slot beside it is small, but they are allocated in separate pools, so N
+//! live connections spread the pair over 2N distinct locations and the
+//! completion order across them is effectively random. At 500 connections
+//! the touched set lives in L3; at 10k every touch is a DRAM access plus a
+//! page walk.
+//!
+//! Since #274 a data completion arms on the *stream* — that is the object
+//! the ops moved to — and the peak accounting reaches its connection, so
+//! both are on the measured path. Comparing bands across that change is
+//! the point: the split traded one large object per completion for two
+//! smaller ones, and only a measurement says which way that goes.
 //!
 //! The permutation is the point: a sequential walk measures the prefetcher,
 //! not the proxy. A real loop services whichever connection the ring hands
@@ -28,7 +35,9 @@ const zoxy = @import("zoxy");
 
 const assert = std.debug.assert;
 
-const ConnType = zoxy.Server(zoxy.Io.XevIo).ConnType;
+const ServerType = zoxy.Server(zoxy.Io.XevIo);
+const ConnType = ServerType.ConnType;
+const StreamType = ServerType.StreamType;
 
 /// `std.time` carries only constants in 0.16 — `Instant`/`Timer` moved out —
 /// and this bench has no `Io` runtime to borrow a clock from, so it reads
@@ -106,10 +115,29 @@ const Measurement = struct {
 fn measure(arena: std.mem.Allocator, count: u32) !Measurement {
     assert(count >= 1);
     const conns = try arena.alloc(ConnType, count);
-    for (conns, 0..) |*conn, index| {
+    // One stream per connection, as the server pairs them (#274): a data
+    // completion's bookkeeping now lands on the stream slot, and the peak
+    // tracking inside `arm` reaches back through it to the conn. Both
+    // objects are therefore on the path this bench measures, which is the
+    // layout change worth watching — the arrays are allocated apart, so a
+    // touched pair is two distinct pages exactly as it is in the server.
+    const streams = try arena.alloc(StreamType, count);
+    // The peak counters `arm` writes under runtime safety (this binary is
+    // ReleaseSafe) are the only fields either type reads off the server,
+    // and they must be real storage: reaching them through an undefined
+    // pointer is what this loop used to do, quietly.
+    const server = try arena.create(ServerType);
+    server.armed_ops_peak = 0;
+    server.stream_armed_ops_peak = 0;
+    for (conns, streams, 0..) |*conn, *stream, index| {
         conn.generation = @intCast(index);
         conn.armed = .{};
-        conn.op_data_client_to_upstream = .{};
+        conn.server = server;
+        conn.stream = stream;
+        stream.generation = @intCast(index);
+        stream.conn = conn;
+        stream.armed = .{};
+        stream.op_data_client_to_upstream = .{};
     }
 
     // A random permutation, walked repeatedly: the completion order a ring
@@ -125,10 +153,10 @@ fn measure(arena: std.mem.Allocator, count: u32) !Measurement {
     var done: u64 = 0;
     while (done < ops_per_point) {
         for (order) |index| {
-            const conn = &conns[index];
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
-            checksum +%= conn.generation;
+            const stream = &streams[index];
+            stream.arm(&stream.op_data_client_to_upstream, "data_client_to_upstream");
+            stream.delivered(&stream.op_data_client_to_upstream, "data_client_to_upstream");
+            checksum +%= stream.conn.generation;
         }
         done += count;
     }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -19,6 +19,7 @@ const config_module = @import("config.zig");
 const constants = @import("constants.zig");
 const counters_module = @import("counters.zig");
 const conn_module = @import("net/Conn.zig");
+const stream_module = @import("net/Stream.zig");
 const health_module = @import("net/health.zig");
 const Io = @import("io/io.zig");
 const Pool = @import("mem/Pool.zig").Pool;
@@ -762,8 +763,9 @@ pub fn Server(comptime IoType: type) type {
         }
 
         /// The #140 capture table, sized by the config's named headers
-        /// times the connection slots that can each hold one request's
-        /// worth. Both allocations are empty when no header is named,
+        /// times the stream slots that can each hold one request's
+        /// worth (#274: the captures share `LogState`'s unit, and that
+        /// is the slot it lives on). Both allocations are empty when no header is named,
         /// which is what makes the feature free to a deployment that
         /// does not use it.
         fn initLogHeaders(
@@ -773,7 +775,12 @@ pub fn Server(comptime IoType: type) type {
         ) error{OutOfMemory}!void {
             const per_conn = logHeadersPerConn(server.config);
             server.log_headers_per_conn = per_conn;
-            const slots: usize = @as(usize, options.conn_slots) * per_conn;
+            // One slice per *stream* slot (#274): the captures share
+            // `LogState`'s unit, and that is the slot the line lives on.
+            // Pinned 1:1 to the conn count, so the reservation is the
+            // number the §5 banner has always printed.
+            const stream_slots = constants.streamSlotsFor(options.conn_slots);
+            const slots: usize = @as(usize, stream_slots) * per_conn;
             server.log_header_values = try arena.alloc(
                 u8,
                 slots * constants.access_log_header_bytes_max,
@@ -781,7 +788,7 @@ pub fn Server(comptime IoType: type) type {
             server.log_header_lens = try arena.alloc(u16, slots);
             @memset(server.log_header_lens, 0);
             assert(server.log_header_values.len ==
-                logHeaderBytes(server.config, options.conn_slots) -
+                logHeaderBytes(server.config, stream_slots) -
                     server.log_header_lens.len * @sizeOf(u16));
         }
 
@@ -1827,39 +1834,19 @@ pub fn Server(comptime IoType: type) type {
             shed.closeQuietly(IoType, server.io, client_socket);
         }
 
-        /// The shared admission tail (§8 single choke point): counting, slot
-        /// prepare, socket options, the routing tables, and the one deadline
-        /// timer this connection ever arms are identical across protocols —
-        /// the protocol only chooses which values go in, through
-        /// `entryState` and `entryTimeoutMs`.
-        fn finishAdmission(
+        /// What the listener decided, written onto the two slots it was
+        /// decided for (§5, §7). Split from `finishAdmission` for the
+        /// length limit, and the seam is the one the split of #274 made
+        /// natural: the caller owns the connection's *lifecycle* — the
+        /// count, the reset, the socket options, the one deadline it
+        /// arms — while this owns the values a listener contributes to
+        /// the connection and to the exchange starting on it.
+        fn installListenerState(
             server: *Self,
             conn: *ConnType,
-            client_socket: IoType.Socket,
             buffer: ?*relay.RelayBuffer,
-            engine: ?*TlsEngine,
             listener: *const ListenerState,
         ) void {
-            assert(!server.draining);
-            // Whatever a listener terminates, it terminates for every
-            // connection: an engine without a credentialed listener would
-            // be one this slot leaks, and a credentialed listener without
-            // one would serve ciphertext as if it were a request.
-            assert((engine != null) == (listener.credentials != null));
-            server.counters.increment("admitted");
-            conn.prepare(
-                server,
-                client_socket,
-                engine,
-                entryState(listener.protocol),
-                listener.protocol,
-                // Asked once, here, and kept: at log time the socket may
-                // already be closed (§8).
-                server.io.peerAddress(client_socket),
-            );
-            server.io.setNodelay(client_socket) catch |err| {
-                server.witnessKernelPressure(.set_option, err);
-            };
             // The L7 path routes and filters once the head parses (§7);
             // every connection gets its listener's tables and the protocol
             // decides whether it reads them — an l4 listener resolves to
@@ -1895,7 +1882,55 @@ pub fn Server(comptime IoType: type) type {
             // capture at all, and its line would otherwise report
             // whatever the slot's *previous* occupant sent.
             server.resetLogHeaders(conn);
+            // An L4 connection is its own log unit and starts its line
+            // here — the first point at which a listener has said it is
+            // one. An L7 exchange starts only when its first head byte
+            // lands, so an idle keep-alive connection reaped without ever
+            // being asked anything owes no line. Both are gated on the log
+            // being on, so a deployment without one reads no clock here.
+            if (listener.protocol == .l4 and server.access_log.sink != null) {
+                conn.stream.log.started_wall_ns = server.io.nowWallNs();
+            }
             assert(conn.routes.len >= 1);
+            assert(conn.stream.conn == conn);
+        }
+
+        /// The shared admission tail (§8 single choke point): counting,
+        /// slot prepare, socket options and the one deadline timer this
+        /// connection ever arms are identical across protocols — the
+        /// protocol only chooses which values go in, through `entryState`
+        /// and `entryTimeoutMs`. What a *listener* contributes to the two
+        /// slots is `installListenerState`'s, split out for the length
+        /// limit.
+        fn finishAdmission(
+            server: *Self,
+            conn: *ConnType,
+            client_socket: IoType.Socket,
+            buffer: ?*relay.RelayBuffer,
+            engine: ?*TlsEngine,
+            listener: *const ListenerState,
+        ) void {
+            assert(!server.draining);
+            // Whatever a listener terminates, it terminates for every
+            // connection: an engine without a credentialed listener would
+            // be one this slot leaks, and a credentialed listener without
+            // one would serve ciphertext as if it were a request.
+            assert((engine != null) == (listener.credentials != null));
+            server.counters.increment("admitted");
+            conn.prepare(
+                server,
+                client_socket,
+                engine,
+                entryState(listener.protocol),
+                listener.protocol,
+                // Asked once, here, and kept: at log time the socket may
+                // already be closed (§8).
+                server.io.peerAddress(client_socket),
+            );
+            server.io.setNodelay(client_socket) catch |err| {
+                server.witnessKernelPressure(.set_option, err);
+            };
+            server.installListenerState(conn, buffer, listener);
             server.storeDeadline(conn, server.entryTimeoutMs(listener.protocol));
             server.armDeadline(conn);
             assert(conn.deadline_ns > 0);
@@ -2080,20 +2115,28 @@ pub fn Server(comptime IoType: type) type {
         /// The #140 capture table's closed form — values plus their
         /// lengths — for the banner and for `initLogHeaders` to assert
         /// against. Zero for a config that names no headers.
-        pub fn logHeaderBytes(config: *const config_module.Config, conn_slots: u32) u64 {
-            const slots: u64 = @as(u64, conn_slots) * logHeadersPerConn(config);
+        pub fn logHeaderBytes(config: *const config_module.Config, stream_slots: u32) u64 {
+            const slots: u64 = @as(u64, stream_slots) * logHeadersPerConn(config);
             return slots * constants.access_log_header_bytes_max + slots * @sizeOf(u16);
         }
 
-        /// One connection's slice of the capture table: `per_conn` value
-        /// slots, addressed by the pool index — stable across reuse, and
-        /// the same index for the whole life of the connection holding
-        /// it. Split from the capture and the read so both speak one
-        /// piece of arithmetic.
+        /// One exchange's slice of the capture table: `per_conn` value
+        /// slots, addressed by the *stream* pool index — stable across
+        /// reuse, and the same index for the whole life of the slot
+        /// holding it. Split from the capture and the read so both speak
+        /// one piece of arithmetic.
+        ///
+        /// Keyed by the stream since #274, because these are the fields
+        /// `LogState` could not hold inline and they share its unit
+        /// exactly: one request on the L7 path, cleared at every
+        /// turnaround. Addressing them by the conn slot while the line
+        /// they belong to lives on the stream would be two units for one
+        /// log entry. The count is unchanged — the pools are pinned 1:1
+        /// (#274) — so the §5 budget term does not move.
         fn logHeaderSlot(server: *Self, conn: *const ConnType, index: u32) []u8 {
             assert(index < server.log_headers_per_conn);
-            const conn_index = server.conns.indexOf(conn);
-            const slot = conn_index * server.log_headers_per_conn + index;
+            const stream_index = server.streams.indexOf(conn.stream);
+            const slot = stream_index * server.log_headers_per_conn + index;
             assert(slot < server.log_header_lens.len);
             const bytes = constants.access_log_header_bytes_max;
             return server.log_header_values[slot * bytes ..][0..bytes];
@@ -2101,8 +2144,8 @@ pub fn Server(comptime IoType: type) type {
 
         fn logHeaderLen(server: *Self, conn: *const ConnType, index: u32) *u16 {
             assert(index < server.log_headers_per_conn);
-            const conn_index = server.conns.indexOf(conn);
-            const slot = conn_index * server.log_headers_per_conn + index;
+            const stream_index = server.streams.indexOf(conn.stream);
+            const slot = stream_index * server.log_headers_per_conn + index;
             assert(slot < server.log_header_lens.len);
             return &server.log_header_lens[slot];
         }
@@ -2230,13 +2273,13 @@ pub fn Server(comptime IoType: type) type {
             };
         }
 
-        /// Forget this connection's captured values, so a kept-alive
+        /// Forget this exchange's captured values, so a kept-alive
         /// turnaround cannot report the previous request's headers on
         /// the next one's line — `LogState.reset`'s rule for the fields
-        /// that live in the side table instead of on the conn.
+        /// that live in the side table instead of on the slot.
         pub fn resetLogHeaders(server: *Self, conn: *const ConnType) void {
             assert(server.log_header_lens.len ==
-                @as(usize, server.conns.capacity()) * server.log_headers_per_conn);
+                @as(usize, server.streams.capacity()) * server.log_headers_per_conn);
             var index: u32 = 0;
             while (index < server.log_headers_per_conn) : (index += 1) {
                 server.logHeaderLen(conn, index).* = 0;
@@ -2415,7 +2458,7 @@ pub fn Server(comptime IoType: type) type {
                 // access log's `bytes_in` unit (§8) — which the relay's
                 // own counting will never see; the header is metadata the
                 // origin never receives, so it stays uncounted.
-                conn.log.bytes_in += leftover_len;
+                conn.stream.log.bytes_in += leftover_len;
                 const direction = &conn.stream.directions[
                     @intFromEnum(StreamType.Direction.client_to_upstream)
                 ];
@@ -2744,7 +2787,7 @@ pub fn Server(comptime IoType: type) type {
                     bytes,
                 );
                 conn.tls_pending_len += @intCast(bytes.len);
-                conn.log.bytes_in += bytes.len;
+                conn.stream.log.bytes_in += bytes.len;
             }
 
             fn closed(ctx: *anyopaque) void {
@@ -2852,7 +2895,7 @@ pub fn Server(comptime IoType: type) type {
             // An L4 dial holds no slot to record the endpoint on, so the
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
-            conn.log.endpoint_index = dial.endpoint_index;
+            conn.stream.log.endpoint_index = dial.endpoint_index;
             server.chargeEndpoint(conn, cluster_index, dial.endpoint_index);
             if (server.config.clusters[cluster_index].proxy_protocol_send) |version| {
                 server.stageProxySendHeader(conn, version);
@@ -2886,7 +2929,7 @@ pub fn Server(comptime IoType: type) type {
                 // await, but the charge did — `chargeEndpoint` recorded the
                 // endpoint this dial was for, and the charge is released
                 // only at teardown, after this line.
-                assert(conn.charged_endpoint != conn_module.LogState.endpoint_none);
+                assert(conn.charged_endpoint != stream_module.LogState.endpoint_none);
                 server.labeled.incrementEndpoint(
                     .connect_failed,
                     server.upstreams.keys.key(conn.charged_cluster, conn.charged_endpoint),
@@ -3023,7 +3066,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.stream.relay_buffer == null);
             assert(conn.tunnel_buffer == null);
             assert(conn.stream.upstream == null);
-            assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
+            assert(conn.charged_endpoint == stream_module.LogState.endpoint_none);
         }
 
         /// Public for the relay: a completion delivered during teardown
@@ -3079,14 +3122,14 @@ pub fn Server(comptime IoType: type) type {
         /// the whole time it spent dribbling.
         pub fn beginLogRequest(server: *Self, conn: *ConnType) void {
             if (server.access_log.sink == null) return;
-            if (conn.log.started_wall_ns != 0) return;
-            conn.log.started_wall_ns = server.io.nowWallNs();
-            assert(conn.log.started_wall_ns != 0);
+            if (conn.stream.log.started_wall_ns != 0) return;
+            conn.stream.log.started_wall_ns = server.io.nowWallNs();
+            assert(conn.stream.log.started_wall_ns != 0);
         }
 
         /// Write the access-log line this connection owes, if any (§8).
         ///
-        /// The caller sets `conn.log.status` and `conn.log.outcome` when it
+        /// The caller sets `conn.stream.log.status` and `conn.stream.log.outcome` when it
         /// knows them; the defaults — status 0, outcome `aborted` — are
         /// deliberately the answer for the caller that does not, which is
         /// teardown. That is what lets one function serve both the path
@@ -3095,11 +3138,11 @@ pub fn Server(comptime IoType: type) type {
         /// took both.
         pub fn logExchange(server: *Self, conn: *ConnType) void {
             if (server.access_log.sink == null) return;
-            if (conn.log.emitted) return;
+            if (conn.stream.log.emitted) return;
             // Nothing was asked of this connection: an L7 slot that idled
             // out between requests, or one reaped before its first byte.
-            if (conn.log.started_wall_ns == 0) return;
-            conn.log.emitted = true;
+            if (conn.stream.log.started_wall_ns == 0) return;
+            conn.stream.log.emitted = true;
             const now_wall_ns = server.io.nowWallNs();
             // Both indices are pool/config positions this connection has
             // carried since routing; a stale one would name another
@@ -3107,8 +3150,8 @@ pub fn Server(comptime IoType: type) type {
             // rather than left to Zig's bounds check to turn into a panic.
             assert(conn.stream.cluster_index < server.config.clusters.len);
             const cluster = server.config.clusters[conn.stream.cluster_index];
-            if (conn.log.endpoint_index != conn_module.LogState.endpoint_none) {
-                assert(conn.log.endpoint_index < cluster.endpoints.len);
+            if (conn.stream.log.endpoint_index != stream_module.LogState.endpoint_none) {
+                assert(conn.stream.log.endpoint_index < cluster.endpoints.len);
             }
             var values: LoggedHeaderValues = undefined;
             const logged = server.loggedHeaderPair(conn, &values);
@@ -3117,24 +3160,24 @@ pub fn Server(comptime IoType: type) type {
                     .l4 => .l4,
                     .http => .http,
                 },
-                .outcome = conn.log.outcome,
-                .started_wall_ns = conn.log.started_wall_ns,
+                .outcome = conn.stream.log.outcome,
+                .started_wall_ns = conn.stream.log.started_wall_ns,
                 // Saturating: the wall clock can step backwards under NTP,
                 // and a duration that wrapped to eighteen quintillion
                 // microseconds would be read as a stall that never happened.
-                .duration_ns = now_wall_ns -| conn.log.started_wall_ns,
+                .duration_ns = now_wall_ns -| conn.stream.log.started_wall_ns,
                 .client = conn.client_address,
-                .upstream = if (conn.log.endpoint_index == conn_module.LogState.endpoint_none)
+                .upstream = if (conn.stream.log.endpoint_index == stream_module.LogState.endpoint_none)
                     null
                 else
-                    cluster.endpoints[conn.log.endpoint_index],
+                    cluster.endpoints[conn.stream.log.endpoint_index],
                 .cluster = cluster.name,
-                .bytes_in = conn.log.bytes_in,
-                .bytes_out = conn.log.bytes_out,
-                .method = conn.log.methodSlice(),
-                .host = conn.log.hostSlice(),
-                .path = conn.log.pathSlice(),
-                .status = conn.log.status,
+                .bytes_in = conn.stream.log.bytes_in,
+                .bytes_out = conn.stream.log.bytes_out,
+                .method = conn.stream.log.methodSlice(),
+                .host = conn.stream.log.hostSlice(),
+                .path = conn.stream.log.pathSlice(),
+                .status = conn.stream.log.status,
                 .upstream_reused = conn.stream.l7.upstream_was_reused,
                 .upstream_replayed = conn.stream.l7.replay_used,
                 .request_headers = logged.request,
@@ -3369,7 +3412,7 @@ pub fn Server(comptime IoType: type) type {
         /// counted for its whole life without pinning a shared slot.
         pub fn chargeEndpoint(server: *Self, conn: *ConnType, cluster_index: u16, endpoint_index: u16) void {
             assert(conn.protocol == .l4 or conn.state == .l7_exchanging);
-            assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
+            assert(conn.charged_endpoint == stream_module.LogState.endpoint_none);
             const key = server.upstreams.keys.key(cluster_index, endpoint_index);
             server.l4_inflight[key] += 1;
             // Every charge is held by a live conn slot, so one endpoint's
@@ -3386,11 +3429,11 @@ pub fn Server(comptime IoType: type) type {
         /// through. Idempotent by the sentinel: a connection shed before
         /// its dial, or torn down twice, has nothing charged.
         fn releaseL4(server: *Self, conn: *ConnType) void {
-            if (conn.charged_endpoint == conn_module.LogState.endpoint_none) return;
+            if (conn.charged_endpoint == stream_module.LogState.endpoint_none) return;
             const key = server.upstreams.keys.key(conn.charged_cluster, conn.charged_endpoint);
             assert(server.l4_inflight[key] >= 1);
             server.l4_inflight[key] -= 1;
-            conn.charged_endpoint = conn_module.LogState.endpoint_none;
+            conn.charged_endpoint = stream_module.LogState.endpoint_none;
         }
 
         pub fn releaseUpstream(

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1018,8 +1018,8 @@ pub fn Server(comptime IoType: type) type {
         pub fn claimStaticSend(server: *Self, conn: *ConnType) void {
             // One write at a time per connection (`armClientWrite`), so a
             // conn already holding one would mean two are in flight.
-            assert(!conn.static_send);
-            conn.static_send = true;
+            assert(!conn.stream.static_send);
+            conn.stream.static_send = true;
             server.static_sends_inflight += 1;
             assert(server.static_sends_inflight <= server.conns.capacity());
         }
@@ -1029,10 +1029,10 @@ pub fn Server(comptime IoType: type) type {
         /// what they were writing — and so the connection's own release
         /// can be the backstop for the ones that end it abruptly.
         pub fn releaseStaticSend(server: *Self, conn: *ConnType) void {
-            if (!conn.static_send) {
+            if (!conn.stream.static_send) {
                 return;
             }
-            conn.static_send = false;
+            conn.stream.static_send = false;
             assert(server.static_sends_inflight >= 1);
             server.static_sends_inflight -= 1;
         }
@@ -1754,12 +1754,12 @@ pub fn Server(comptime IoType: type) type {
             switch (protocol) {
                 .l4 => {
                     // A recv must always have a buffer posted (§6).
-                    assert(conn.relay_buffer != null);
+                    assert(conn.stream.relay_buffer != null);
                     server.armConnect(conn, conn.cluster_index);
                 },
                 .http => {
                     // An idle L7 connection holds no relay buffer (§5).
-                    assert(conn.relay_buffer == null);
+                    assert(conn.stream.relay_buffer == null);
                     Proxy.start(server, conn);
                 },
             }
@@ -1774,6 +1774,15 @@ pub fn Server(comptime IoType: type) type {
                 shed.closeWithRst(IoType, server.io, client_socket);
                 return null;
             };
+            // The pair is taken together, not at the admission tail, and
+            // that is what makes the 1:1 claim structural rather than a
+            // property of one code path: every route that gives a conn
+            // slot back gives its stream back with it, including the §8
+            // rungs that abort before `finishAdmission` ever runs. Taken
+            // apart, those rungs would release a slot whose stream
+            // pointer was never set — and `releaseConn`'s own #234
+            // backstop reads through it.
+            conn.stream = server.admitStream(conn);
             server.updateConnPressure();
             return conn;
         }
@@ -1840,9 +1849,7 @@ pub fn Server(comptime IoType: type) type {
             server.counters.increment("admitted");
             conn.prepare(
                 server,
-                server.admitStream(conn),
                 client_socket,
-                buffer,
                 engine,
                 entryState(listener.protocol),
                 listener.cluster_index,
@@ -1865,6 +1872,19 @@ pub fn Server(comptime IoType: type) type {
             conn.upgrades = listener.upgrades;
             conn.max_body_bytes = listener.max_body_bytes;
             conn.forwarded = listener.forwarded;
+            // The L4 relay buffer is claimed after the conn slot, so it
+            // arrives after the stream that will carry it — installed
+            // here rather than threaded through `Stream.prepare`, which
+            // ran at acquisition, before this buffer existed.
+            //
+            // Deliberately *unlike* `engine`, which is a `Conn.prepare`
+            // parameter precisely so a reset cannot orphan it. The
+            // asymmetry is safe because the two are claimed on opposite
+            // sides of that reset: an engine is in hand before `prepare`
+            // runs and would be overwritten by it, where this arrives
+            // after and has nothing left to overwrite it. Null on the L7
+            // path, which acquires one only when a body relay starts (§5).
+            conn.stream.relay_buffer = buffer;
             // The #140 captures live in a side table addressed by pool
             // slot, so a slot's bytes outlive the connection that wrote
             // them. Clearing on acquire is what keeps them from being
@@ -2011,13 +2031,13 @@ pub fn Server(comptime IoType: type) type {
             // returns a buffer on the L7 path reaches here, so the fork
             // lives once rather than at each of them.
             if (conn.tls != null) {
-                assert(conn.head_buffer_id == ConnType.head_buffer_none);
+                assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
                 return;
             }
-            assert(conn.head_buffer_id != ConnType.head_buffer_none);
+            assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
             assert(server.head_buffers_in_use >= 1);
-            server.io.bufferGroupReturn(conn.head_buffer_id);
-            conn.head_buffer_id = ConnType.head_buffer_none;
+            server.io.bufferGroupReturn(conn.stream.head_buffer_id);
+            conn.stream.head_buffer_id = StreamType.head_buffer_none;
             server.head_buffers_in_use -= 1;
             server.updateHeadPressure();
         }
@@ -2236,20 +2256,8 @@ pub fn Server(comptime IoType: type) type {
             const stream = server.streams.acquire() orelse unreachable;
             stream.prepare(conn);
             assert(stream.conn == conn);
+            assert(stream.relay_buffer == null);
             return stream;
-        }
-
-        /// The release half, called from `continueTeardown` ahead of the
-        /// conn slot's own: §5's rule gains a level here — a conn slot
-        /// releases when its armed set is empty *and* every stream it
-        /// owns has released — and at one stream per connection that
-        /// ordering is the whole of it.
-        fn releaseStream(server: *Self, conn: *ConnType) void {
-            assert(conn.state == .tearing_down);
-            assert(conn.armedCount() == 0);
-            assert(conn.stream.armedCount() == 0);
-            assert(conn.stream.conn == conn);
-            server.streams.release(conn.stream);
         }
 
         /// The same pair for conn slots, with `admitConn` as its acquire
@@ -2262,7 +2270,26 @@ pub fn Server(comptime IoType: type) type {
             // outlived its connection would freeze the `Date` for the
             // life of the process.
             server.releaseStaticSend(conn);
+            // §5's release rule, one level deeper (#274): the stream goes
+            // back before the connection that owns it, never after — a
+            // pool that outlived its owner is how a release order becomes
+            // a leak.
+            //
+            // The stream's own set is asserted; the connection's is not,
+            // and the asymmetry is real rather than an omission. An §8
+            // admission rung returns the slot before `Conn.prepare` has
+            // run, so `conn.armed` here may still hold the *previous*
+            // occupant's bits — which is why this release site has never
+            // asserted anything about the conn slot's contents.
+            // `continueTeardown` is where a prepared slot is checked, and
+            // it asserts both sets before it closes a single fd. The
+            // stream is safe to read on either path because it is
+            // prepared at acquisition, one line after the slot itself.
+            assert(conn.stream.armedCount() == 0);
+            assert(conn.stream.conn == conn);
+            server.streams.release(conn.stream);
             server.conns.release(conn);
+            assert(server.streams.acquired_count == server.conns.acquired_count);
             server.updateConnPressure();
         }
 
@@ -2278,9 +2305,9 @@ pub fn Server(comptime IoType: type) type {
         fn startProxyHeaderPhase(server: *Self, conn: *ConnType) void {
             assert(!conn.isTearingDown());
             assert(conn.state == .connecting);
-            assert(conn.relay_buffer != null);
+            assert(conn.stream.relay_buffer != null);
             assert(conn.armed.deadline);
-            assert(conn.head_len == 0);
+            assert(conn.stream.head_len == 0);
             conn.state = .l4_reading_proxy_header;
             server.armProxyHeaderRecv(conn);
         }
@@ -2291,14 +2318,14 @@ pub fn Server(comptime IoType: type) type {
         /// outreading the staging the §5 budget assigned this phase.
         fn armProxyHeaderRecv(server: *Self, conn: *ConnType) void {
             assert(conn.state == .l4_reading_proxy_header);
-            assert(conn.relay_buffer != null);
-            assert(conn.head_len < constants.proxy_header_bytes_max);
-            const staging = conn.relay_buffer.?
+            assert(conn.stream.relay_buffer != null);
+            assert(conn.stream.head_len < constants.proxy_header_bytes_max);
+            const staging = conn.stream.relay_buffer.?
                 .client_to_upstream[0..constants.proxy_header_bytes_max];
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
-                staging[conn.head_len..],
+                staging[conn.stream.head_len..],
                 &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -2329,9 +2356,9 @@ pub fn Server(comptime IoType: type) type {
                 return;
             };
             assert(received >= 1);
-            conn.head_len += received;
-            assert(conn.head_len <= constants.proxy_header_bytes_max);
-            const staged = conn.relay_buffer.?.client_to_upstream[0..conn.head_len];
+            conn.stream.head_len += received;
+            assert(conn.stream.head_len <= constants.proxy_header_bytes_max);
+            const staged = conn.stream.relay_buffer.?.client_to_upstream[0..conn.stream.head_len];
             const parsed = proxy_protocol.parse(staged);
             switch (parsed) {
                 .need_more => server.armProxyHeaderRecv(conn),
@@ -2353,16 +2380,16 @@ pub fn Server(comptime IoType: type) type {
         ) void {
             assert(conn.state == .l4_reading_proxy_header);
             assert(header.bytes_len >= 1);
-            assert(header.bytes_len <= conn.head_len);
+            assert(header.bytes_len <= conn.stream.head_len);
             server.counters.increment("l4_proxy_header_accepted");
             // Null keeps the observed peer (LOCAL/UNKNOWN, §6): the
             // fronting proxy's own health checks arrive that way.
             if (header.client) |client| {
                 conn.client_address = client;
             }
-            const leftover_len = conn.head_len - header.bytes_len;
-            const staging = conn.relay_buffer.?.client_to_upstream;
-            const leftover = staging[header.bytes_len..conn.head_len];
+            const leftover_len = conn.stream.head_len - header.bytes_len;
+            const staging = conn.stream.relay_buffer.?.client_to_upstream;
+            const leftover = staging[header.bytes_len..conn.stream.head_len];
             if (conn.tls) |engine| {
                 // On a terminating listener those leftover bytes are the
                 // client's first handshake record, not payload: the PROXY
@@ -2370,8 +2397,8 @@ pub fn Server(comptime IoType: type) type {
                 // everything past it already belongs to TLS. Framing them
                 // as relay debt would send a ClientHello to the origin.
                 assert(leftover_len <= engine.plaintext.len);
-                conn.head_len = 0;
-                conn.head_cursor.reset();
+                conn.stream.head_len = 0;
+                conn.stream.head_cursor.reset();
                 server.startTlsPhaseWith(conn, leftover);
                 return;
             }
@@ -2386,15 +2413,15 @@ pub fn Server(comptime IoType: type) type {
                 // own counting will never see; the header is metadata the
                 // origin never receives, so it stays uncounted.
                 conn.log.bytes_in += leftover_len;
-                const direction = &conn.directions[
-                    @intFromEnum(ConnType.Direction.client_to_upstream)
+                const direction = &conn.stream.directions[
+                    @intFromEnum(StreamType.Direction.client_to_upstream)
                 ];
                 assert(direction.phase == .idle);
                 direction.phase = .receiving;
                 direction.owe(leftover_len);
             }
-            conn.head_len = 0;
-            conn.head_cursor.reset();
+            conn.stream.head_len = 0;
+            conn.stream.head_cursor.reset();
             server.startProtocol(conn, .l4);
         }
 
@@ -2650,7 +2677,7 @@ pub fn Server(comptime IoType: type) type {
             // buffer before the dial (§6); an L7 one takes its per-leg.
             // Admission already settled that, so nothing is acquired here.
             if (conn.protocol == .l4) {
-                assert(conn.relay_buffer != null);
+                assert(conn.stream.relay_buffer != null);
                 server.stageTlsPending(conn);
             }
             server.startProtocol(conn, conn.protocol);
@@ -2676,8 +2703,8 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.tls_pending_len <= engine.plaintext.len);
             // At the buffer's front, which is where `sendSlice` reads a
             // TLS direction's pending window from.
-            const direction = &conn.directions[
-                @intFromEnum(ConnType.Direction.client_to_upstream)
+            const direction = &conn.stream.directions[
+                @intFromEnum(StreamType.Direction.client_to_upstream)
             ];
             assert(direction.phase == .idle);
             direction.phase = .receiving;
@@ -2740,17 +2767,17 @@ pub fn Server(comptime IoType: type) type {
             version: config_module.Config.Cluster.ProxyProtocolSend,
         ) void {
             assert(conn.state == .connecting);
-            assert(conn.relay_buffer != null);
+            assert(conn.stream.relay_buffer != null);
             var header_buffer: [proxy_protocol.send_bytes_max]u8 = undefined;
             const local_address = server.io.localAddress(conn.client_socket);
             const header = switch (version) {
                 .v1 => proxy_protocol.writeV1(&header_buffer, &conn.client_address, &local_address),
                 .v2 => proxy_protocol.writeV2(&header_buffer, &conn.client_address, &local_address),
             };
-            const direction = &conn.directions[
-                @intFromEnum(ConnType.Direction.client_to_upstream)
+            const direction = &conn.stream.directions[
+                @intFromEnum(StreamType.Direction.client_to_upstream)
             ];
-            const staging = conn.relay_buffer.?.client_to_upstream;
+            const staging = conn.stream.relay_buffer.?.client_to_upstream;
             const framed = direction.framed_len;
             // Comptime-guaranteed in proxy_protocol: header + the largest
             // receive leftover fit the buffer half together.
@@ -2952,21 +2979,21 @@ pub fn Server(comptime IoType: type) type {
                 // so clearing the second on the strength of the first
                 // would drop a live pool slot without releasing it. The
                 // pointer compare says exactly which case this is.
-                if (conn.relay_buffer == buffer) {
-                    conn.relay_buffer = null;
+                if (conn.stream.relay_buffer == buffer) {
+                    conn.stream.relay_buffer = null;
                 }
                 server.releaseTunnelBuffer(buffer);
                 conn.tunnel_buffer = null;
             }
             // An idle L7 connection holds no relay buffer (§5); only
             // release one that was actually acquired.
-            if (conn.relay_buffer) |buffer| {
+            if (conn.stream.relay_buffer) |buffer| {
                 server.releaseRelayBuffer(buffer);
-                conn.relay_buffer = null;
+                conn.stream.relay_buffer = null;
             }
             // Same rule for the ring buffer: nothing armed references it
             // (asserted above), so the return cannot race a landing recv.
-            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+            if (conn.stream.head_buffer_id != StreamType.head_buffer_none) {
                 server.returnHeadBuffer(conn);
             }
             // The leased upstream slot rides the same release rule: its
@@ -2990,7 +3017,7 @@ pub fn Server(comptime IoType: type) type {
                 conn.tls_pending_len = 0;
             }
             assert(conn.tls == null);
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.tunnel_buffer == null);
             assert(conn.upstream == null);
             assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
@@ -3036,12 +3063,8 @@ pub fn Server(comptime IoType: type) type {
             // truncated body, a drain straggler — and every L4 connection,
             // whose whole life is the unit being logged.
             server.logExchange(conn);
-            // Before the conn slot, never after: the stream is the
-            // connection's, and a pool that outlived its owner is how a
-            // release order becomes a leak (§5).
-            server.releaseStream(conn);
+            // Which returns the stream with it (§5).
             server.releaseConn(conn);
-            assert(server.streams.acquired_count == server.conns.acquired_count);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -43,6 +43,19 @@ pub fn Server(comptime IoType: type) type {
         io: *IoType,
         config: *const config_module.Config,
         conns: Pool(ConnType),
+        /// The §5 stream pool (#274): one exchange per slot, and for now
+        /// exactly one slot per admitted connection.
+        ///
+        /// Sized to `conn_slots` rather than given a limit of its own,
+        /// which is the whole shape of this slice: at one stream per
+        /// connection the pool cannot be exhausted independently, so it
+        /// adds no shed rung and no counter, and the ring budget it
+        /// re-derives comes out where it was. #173 is what makes the two
+        /// counts diverge — a shared pool sized for concurrent *streams*,
+        /// with `SETTINGS_MAX_CONCURRENT_STREAMS` an advertisement over
+        /// it and `REFUSED_STREAM` the rung when it runs dry — and that
+        /// is when it earns an operator-facing limit.
+        streams: Pool(StreamType),
         relay_buffers: Pool(relay.RelayBuffer),
         /// The §5 tunnel pool (#180): relay buffers for upgraded
         /// connections, deliberately *not* the pool above.
@@ -319,6 +332,7 @@ pub fn Server(comptime IoType: type) type {
         const Self = @This();
 
         pub const ConnType = conn_module.Conn(IoType);
+        pub const StreamType = ConnType.StreamType;
         pub const AccessLogType = access_log_module.AccessLog(IoType);
         const Proxy = proxy.Proxy(IoType);
 
@@ -501,6 +515,11 @@ pub fn Server(comptime IoType: type) type {
             server.static_sends_inflight = 0;
             server.initDateSlots();
             try server.conns.init(arena, options.conn_slots);
+            // One stream per connection (#274). Derived rather than
+            // configured, so the pair cannot drift apart in a
+            // hand-written bridge the way two limits could.
+            try server.streams.init(arena, constants.streamSlotsFor(options.conn_slots));
+            assert(server.streams.capacity() == server.conns.capacity());
             try server.relay_buffers.init(arena, options.relay_buffers);
             try wireRelayHalves(arena, server.relay_buffers.slots, options.relay_buffer_bytes);
             try server.initTunnelBuffers(arena, &options);
@@ -1377,6 +1396,12 @@ pub fn Server(comptime IoType: type) type {
             if (!server.access_log.isQuiescent()) return;
             // Same rule for the prober's armed ops (§8).
             if (!server.health.isQuiescent()) return;
+            // Every stream released ahead of the conn that owned it
+            // (#274, `continueTeardown`), and the check above says every
+            // conn is gone — so an outstanding stream here is the split's
+            // own leak, one layer below the one this enumeration was
+            // written for.
+            assert(server.streams.isFullyReleased());
             assert(server.relay_buffers.isFullyReleased());
             // Trivially true until a tunnel can exist, and stated now for
             // exactly that reason: the §9 leak invariant is cheapest to
@@ -1474,6 +1499,10 @@ pub fn Server(comptime IoType: type) type {
             }
             return server.l4Released() and
                 server.conns.isFullyReleased() and
+                // Both pools drain to zero, which is the #274 half of
+                // this invariant: a stream leaked without its connection
+                // is exactly the bug the split makes possible.
+                server.streams.isFullyReleased() and
                 server.relay_buffers.isFullyReleased() and
                 server.tunnel_buffers.isFullyReleased() and
                 server.upstreams.isFullyReleased() and
@@ -1798,6 +1827,7 @@ pub fn Server(comptime IoType: type) type {
             server.counters.increment("admitted");
             conn.prepare(
                 server,
+                server.admitStream(conn),
                 client_socket,
                 buffer,
                 engine,
@@ -2175,6 +2205,37 @@ pub fn Server(comptime IoType: type) type {
             while (index < server.log_headers_per_conn) : (index += 1) {
                 server.logHeaderLen(conn, index).* = 0;
             }
+        }
+
+        /// The stream slot for a connection just admitted (#274).
+        ///
+        /// Not a shed rung, and the `orelse unreachable` is the argument
+        /// rather than an omission: the pool is sized to `conn_slots`,
+        /// every stream is acquired strictly after a conn slot and
+        /// released strictly before one, so occupancy is equal at every
+        /// point and a conn slot in hand *is* a stream slot in hand. The
+        /// assert below states that equality where it is relied on, so
+        /// the day #173 unpins the two counts this reads as a wall that
+        /// moved rather than as a silent overdraw.
+        fn admitStream(server: *Self, conn: *ConnType) *StreamType {
+            assert(!server.draining);
+            assert(server.streams.acquired_count < server.streams.capacity());
+            const stream = server.streams.acquire() orelse unreachable;
+            stream.prepare(conn);
+            assert(stream.conn == conn);
+            return stream;
+        }
+
+        /// The release half, called from `continueTeardown` ahead of the
+        /// conn slot's own: §5's rule gains a level here — a conn slot
+        /// releases when its armed set is empty *and* every stream it
+        /// owns has released — and at one stream per connection that
+        /// ordering is the whole of it.
+        fn releaseStream(server: *Self, conn: *ConnType) void {
+            assert(conn.state == .tearing_down);
+            assert(conn.armedCount() == 0);
+            assert(conn.stream.conn == conn);
+            server.streams.release(conn.stream);
         }
 
         /// The same pair for conn slots, with `admitConn` as its acquire
@@ -2931,7 +2992,12 @@ pub fn Server(comptime IoType: type) type {
             // truncated body, a drain straggler — and every L4 connection,
             // whose whole life is the unit being logged.
             server.logExchange(conn);
+            // Before the conn slot, never after: the stream is the
+            // connection's, and a pool that outlived its owner is how a
+            // release order becomes a leak (§5).
+            server.releaseStream(conn);
             server.releaseConn(conn);
+            assert(server.streams.acquired_count == server.conns.acquired_count);
             server.counters.increment("completed");
             server.maybeStopAfterDrain();
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1755,7 +1755,7 @@ pub fn Server(comptime IoType: type) type {
                 .l4 => {
                     // A recv must always have a buffer posted (§6).
                     assert(conn.stream.relay_buffer != null);
-                    server.armConnect(conn, conn.cluster_index);
+                    server.armConnect(conn, conn.stream.cluster_index);
                 },
                 .http => {
                     // An idle L7 connection holds no relay buffer (§5).
@@ -1852,7 +1852,6 @@ pub fn Server(comptime IoType: type) type {
                 client_socket,
                 engine,
                 entryState(listener.protocol),
-                listener.cluster_index,
                 listener.protocol,
                 // Asked once, here, and kept: at log time the socket may
                 // already be closed (§8).
@@ -1872,6 +1871,10 @@ pub fn Server(comptime IoType: type) type {
             conn.upgrades = listener.upgrades;
             conn.max_body_bytes = listener.max_body_bytes;
             conn.forwarded = listener.forwarded;
+            // The exchange's starting cluster, from the same listener and
+            // for the same reason as the tables above — the L7 path
+            // overwrites it at routing once the head parses (§7).
+            conn.stream.cluster_index = listener.cluster_index;
             // The L4 relay buffer is claimed after the conn slot, so it
             // arrives after the stream that will carry it — installed
             // here rather than threaded through `Stream.prepare`, which
@@ -2870,7 +2873,7 @@ pub fn Server(comptime IoType: type) type {
                 // The teardown raced the dial. A socket that arrived
                 // anyway must still be shut down and closed.
                 if (result) |socket| {
-                    conn.upstream_socket = socket;
+                    conn.stream.upstream_socket = socket;
                     server.io.shutdown(socket, .both);
                 } else |_| {}
                 server.continueTeardown(conn);
@@ -2908,7 +2911,7 @@ pub fn Server(comptime IoType: type) type {
                 server.beginTeardown(conn);
                 return;
             };
-            conn.upstream_socket = socket;
+            conn.stream.upstream_socket = socket;
             server.io.setNodelay(socket) catch |err| {
                 server.witnessKernelPressure(.set_option, err);
             };
@@ -2926,7 +2929,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.isLive());
             conn.state = .tearing_down;
             server.io.shutdown(conn.client_socket, .both);
-            if (conn.upstream_socket) |socket| {
+            if (conn.stream.upstream_socket) |socket| {
                 server.io.shutdown(socket, .both);
             }
             // A dial-timeout verdict (§8) may already have a cancel in
@@ -2964,7 +2967,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.stream.armedCount() == 0);
             // Both fds are shut: nothing here may reference a socket, and
             // the upstream one is the field the caller cleared.
-            assert(conn.upstream_socket == null);
+            assert(conn.stream.upstream_socket == null);
             // The §5 tunnel buffer first, and the order matters: a live
             // tunnel's `relay_buffer` *aliases* its `tunnel_buffer`
             // (#180), so releasing the shared way would hand one pool's
@@ -2999,9 +3002,9 @@ pub fn Server(comptime IoType: type) type {
             // The leased upstream slot rides the same release rule: its
             // socket (if any) was closed by the caller, so the slot is
             // inert (§5). Parking replaces this with reuse later.
-            if (conn.upstream) |leased| {
+            if (conn.stream.upstream) |leased| {
                 server.releaseUpstream(leased);
-                conn.upstream = null;
+                conn.stream.upstream = null;
             }
             // The L4 endpoint charge rides the same rule: the socket that
             // made this connection work against an origin is closed, so
@@ -3019,7 +3022,7 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.tls == null);
             assert(conn.stream.relay_buffer == null);
             assert(conn.tunnel_buffer == null);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
         }
 
@@ -3051,9 +3054,9 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.armedCount() == 0);
             assert(conn.stream.armedCount() == 0);
             server.io.closeNow(conn.client_socket);
-            if (conn.upstream_socket) |socket| {
+            if (conn.stream.upstream_socket) |socket| {
                 server.io.closeNow(socket);
-                conn.upstream_socket = null;
+                conn.stream.upstream_socket = null;
             }
             server.releasePooledResources(conn);
             // The last chance to say anything about this connection (§8).
@@ -3102,8 +3105,8 @@ pub fn Server(comptime IoType: type) type {
             // carried since routing; a stale one would name another
             // operator's backend in the line, so they are checked here
             // rather than left to Zig's bounds check to turn into a panic.
-            assert(conn.cluster_index < server.config.clusters.len);
-            const cluster = server.config.clusters[conn.cluster_index];
+            assert(conn.stream.cluster_index < server.config.clusters.len);
+            const cluster = server.config.clusters[conn.stream.cluster_index];
             if (conn.log.endpoint_index != conn_module.LogState.endpoint_none) {
                 assert(conn.log.endpoint_index < cluster.endpoints.len);
             }
@@ -3132,8 +3135,8 @@ pub fn Server(comptime IoType: type) type {
                 .host = conn.log.hostSlice(),
                 .path = conn.log.pathSlice(),
                 .status = conn.log.status,
-                .upstream_reused = conn.l7.upstream_was_reused,
-                .upstream_replayed = conn.l7.replay_used,
+                .upstream_reused = conn.stream.l7.upstream_was_reused,
+                .upstream_replayed = conn.stream.l7.replay_used,
                 .request_headers = logged.request,
                 .response_headers = logged.response,
             };
@@ -3480,8 +3483,8 @@ pub fn Server(comptime IoType: type) type {
             // turnaround clears `l7`), so the clamp is inert outside an
             // exchange. Its arming side re-bases the armed timer, which is
             // what makes it fire *on* time rather than at the next tick.
-            if (conn.l7.request_deadline_ns != 0) {
-                deadline_ns = @min(deadline_ns, conn.l7.request_deadline_ns);
+            if (conn.stream.l7.request_deadline_ns != 0) {
+                deadline_ns = @min(deadline_ns, conn.stream.l7.request_deadline_ns);
             }
             conn.deadline_ns = deadline_ns;
         }
@@ -3504,7 +3507,7 @@ pub fn Server(comptime IoType: type) type {
         /// widens to the idle budget; `expireDeadline`'s two verdict
         /// branches store their fixed grace window.
         pub fn clearRequestDeadline(conn: *ConnType) void {
-            conn.l7.request_deadline_ns = 0;
+            conn.stream.l7.request_deadline_ns = 0;
         }
 
         fn armDeadline(server: *Self, conn: *ConnType) void {
@@ -3682,7 +3685,7 @@ pub fn Server(comptime IoType: type) type {
             // clamp them straight back to this already-expired cap.
             clearRequestDeadline(conn);
             if (conn.state == .l7_exchanging and
-                conn.l7.pending_verdict == .none and
+                conn.stream.l7.pending_verdict == .none and
                 Proxy.expiryAnswerable(conn))
             {
                 // The verdict grace bounds the escape hatch, not idle
@@ -3694,13 +3697,13 @@ pub fn Server(comptime IoType: type) type {
                 Proxy.beginExpiry(server, conn);
                 return;
             }
-            if (conn.state == .l7_dialing and conn.l7.pending_verdict == .none) {
+            if (conn.state == .l7_dialing and conn.stream.l7.pending_verdict == .none) {
                 // At loop-rest a dialing L7 connection always has its
                 // connect in flight, no data ops, and no response byte.
                 assert(conn.stream.armed.connect);
                 assert(!conn.stream.armed.connect_cancel);
-                assert(!conn.l7.response_started);
-                conn.l7.pending_verdict = .gateway_timeout;
+                assert(!conn.stream.l7.response_started);
+                conn.stream.l7.pending_verdict = .gateway_timeout;
                 // Same fixed grace as the exchange verdict above.
                 server.storeDeadline(conn, server.config.idle_timeout_ms);
                 server.armDeadline(conn);
@@ -3718,8 +3721,8 @@ pub fn Server(comptime IoType: type) type {
             // the state: a connection in `.l7_reading_head` may still be
             // on the idle window, because the budget is installed at the
             // first `Incomplete` and not at the first byte.
-            if (conn.state == .l7_reading_head and conn.l7.head_budget_installed and
-                conn.l7.pending_verdict == .none)
+            if (conn.state == .l7_reading_head and conn.stream.l7.head_budget_installed and
+                conn.stream.l7.pending_verdict == .none)
             {
                 // Gated on the verdict, not merely on the state: the
                 // grace window this branch installs could in principle
@@ -3776,7 +3779,7 @@ pub fn Server(comptime IoType: type) type {
             // connect completion's divert clears it, and that divert
             // leaves .l7_dialing in the same callback.
             if (conn.state == .l7_dialing) {
-                assert(conn.l7.pending_verdict == .gateway_timeout);
+                assert(conn.stream.l7.pending_verdict == .gateway_timeout);
             }
         }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -289,14 +289,26 @@ pub fn Server(comptime IoType: type) type {
         /// zero when it named none. Stored because every index into the
         /// tables above is a multiple of it.
         log_headers_per_conn: u32,
-        /// Highest armed-op count any one connection has reached (§8):
-        /// `Conn.arm` asserts the `conn_ops_max` budget on every arm and,
-        /// under runtime safety only (Debug and ReleaseSafe — the shipped
-        /// build is ReleaseSafe, see docs/IMPLEMENTATION_NOTES.md
-        /// "Shipping ReleaseSafe"), records the peak here, so a test can
-        /// claim a race co-armed exactly the budgeted worst case, not
-        /// merely stayed under it.
+        /// Highest armed-op count any one connection has reached (§8),
+        /// counting both of its slots since #274: `Conn.arm` asserts the
+        /// `conn_ops_max` budget and `Stream.arm` the `stream_ops_max`
+        /// one, and both record this *combined* peak — which is the
+        /// number the CQ is charged per admitted connection, and so the
+        /// one that must not move when ops change slots. Under runtime
+        /// safety only (Debug and ReleaseSafe — the shipped build is
+        /// ReleaseSafe, see docs/IMPLEMENTATION_NOTES.md "Shipping
+        /// ReleaseSafe"), so a test can claim a race co-armed exactly the
+        /// budgeted worst case, not merely stayed under it.
         armed_ops_peak: u8,
+        /// The stream half of that peak (#274), tracked beside it because
+        /// the combined number cannot distinguish the two shapes the
+        /// budget rests on: `stream_ops_max` is two only because a dial
+        /// and the data legs are disjoint, and a seed that ever co-armed
+        /// three stream ops would be a divisor that has to move. The
+        /// assert in `Stream.arm` is what fails first; this is what a
+        /// test reads to claim the peak was *reached*, not merely
+        /// respected.
+        stream_armed_ops_peak: u8,
         /// The raw errno of the most recent kernel-pressure failure, or 0
         /// (§8). Reported as a gauge rather than a counter because it is a
         /// level — "what is failing now" — and because an errno space is
@@ -816,6 +828,7 @@ pub fn Server(comptime IoType: type) type {
             server.render_scratch = undefined;
             server.render_scratch_lent = false;
             server.armed_ops_peak = 0;
+            server.stream_armed_ops_peak = 0;
             server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};
             server.drain_stuck_completion = .{};
@@ -1332,11 +1345,11 @@ pub fn Server(comptime IoType: type) type {
                     .{
                         index,
                         conn.state,
-                        conn.armedCount(),
-                        conn.armed.data_client_to_upstream,
-                        conn.armed.data_upstream_to_client,
-                        conn.armed.connect,
-                        conn.armed.connect_cancel,
+                        conn.armedCount() + conn.stream.armedCount(),
+                        conn.stream.armed.data_client_to_upstream,
+                        conn.stream.armed.data_upstream_to_client,
+                        conn.stream.armed.connect,
+                        conn.stream.armed.connect_cancel,
                         conn.armed.deadline,
                         conn.armed.deadline_cancel,
                         conn.tls != null,
@@ -2234,6 +2247,7 @@ pub fn Server(comptime IoType: type) type {
         fn releaseStream(server: *Self, conn: *ConnType) void {
             assert(conn.state == .tearing_down);
             assert(conn.armedCount() == 0);
+            assert(conn.stream.armedCount() == 0);
             assert(conn.stream.conn == conn);
             server.streams.release(conn.stream);
         }
@@ -2281,11 +2295,11 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.head_len < constants.proxy_header_bytes_max);
             const staging = conn.relay_buffer.?
                 .client_to_upstream[0..constants.proxy_header_bytes_max];
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
                 staging[conn.head_len..],
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onProxyHeaderRecv,
@@ -2297,7 +2311,7 @@ pub fn Server(comptime IoType: type) type {
         /// header reads `need_more` until its last byte lands.
         fn onProxyHeaderRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -2433,11 +2447,11 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.tls != null);
             const destination = conn.tls.?.recvBuffer();
             assert(destination.len >= 1);
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
                 destination,
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onTlsRecv,
@@ -2446,7 +2460,7 @@ pub fn Server(comptime IoType: type) type {
 
         fn onTlsRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -2528,11 +2542,11 @@ pub fn Server(comptime IoType: type) type {
             }
             const staged = engine.outbound();
             if (staged.len >= 1) {
-                conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+                conn.stream.arm(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
                 server.io.send(
                     conn.client_socket,
                     staged,
-                    &conn.op_data_upstream_to_client.completion,
+                    &conn.stream.op_data_upstream_to_client.completion,
                     ConnType,
                     conn,
                     onTlsSent,
@@ -2595,7 +2609,7 @@ pub fn Server(comptime IoType: type) type {
 
         fn onTlsSent(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            conn.stream.delivered(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -2799,12 +2813,12 @@ pub fn Server(comptime IoType: type) type {
                     // Nothing was armed for this dial yet — the arm below
                     // is the first — so teardown here cancels only the
                     // deadline admission left running (§5).
-                    assert(!conn.armed.connect);
+                    assert(!conn.stream.armed.connect);
                     server.beginTeardown(conn);
                     return;
                 },
             };
-            conn.arm(&conn.op_connect, "connect");
+            conn.stream.arm(&conn.stream.op_connect, "connect");
             // An L4 dial holds no slot to record the endpoint on, so the
             // access log takes it here — the only place that knows which
             // origin this connection is being relayed to (§8).
@@ -2815,7 +2829,7 @@ pub fn Server(comptime IoType: type) type {
             }
             server.io.connect(
                 dial.address,
-                &conn.op_connect.completion,
+                &conn.stream.op_connect.completion,
                 ConnType,
                 conn,
                 onConnect,
@@ -2824,7 +2838,7 @@ pub fn Server(comptime IoType: type) type {
 
         fn onConnect(conn: *ConnType, result: Io.ConnectError!IoType.Socket) void {
             const server = conn.server;
-            conn.delivered(&conn.op_connect, "connect");
+            conn.stream.delivered(&conn.stream.op_connect, "connect");
             if (conn.isTearingDown()) {
                 // The teardown raced the dial. A socket that arrived
                 // anyway must still be shut down and closed.
@@ -2890,7 +2904,7 @@ pub fn Server(comptime IoType: type) type {
             }
             // A dial-timeout verdict (§8) may already have a cancel in
             // flight; submitting a second would double-arm the op.
-            if (conn.armed.connect and !conn.armed.connect_cancel) {
+            if (conn.stream.armed.connect and !conn.stream.armed.connect_cancel) {
                 server.armConnectCancel(conn);
             }
             // A dial rebase (§8) may already have this timer's cancel in
@@ -2910,26 +2924,20 @@ pub fn Server(comptime IoType: type) type {
             server.continueTeardown(conn);
         }
 
-        /// Public for the relay: a completion delivered during teardown
-        /// re-enters here (§5). The delivery that empties the armed set
-        /// finishes the whole teardown synchronously: nothing references
-        /// either fd any more, so the closes are plain syscalls — the
-        /// same close-after-full-drain discipline `detachUpstream` and
-        /// the parked reap already use — and the slot releases in the
-        /// same call instead of waiting out two close completions. A
-        /// dial completing against its own teardown still peaks at four
-        /// armed ops: the `conn_ops_max` budget the CQ is sized by (§8).
-        pub fn continueTeardown(server: *Self, conn: *ConnType) void {
+        /// Every pool slot this connection drew from, returned in the one
+        /// order that is safe (§5). Split out of `continueTeardown` for
+        /// the length limit, and it is the right seam: the caller owns
+        /// *when* a release may happen — the armed-set check and the fd
+        /// closes that check licenses — while this owns *what* is
+        /// released and in what order. Its precondition is the caller's
+        /// postcondition, restated rather than assumed.
+        fn releasePooledResources(server: *Self, conn: *ConnType) void {
             assert(conn.state == .tearing_down);
-            if (conn.armedCount() != 0) return;
-            // Nothing armed: no op references either fd, which is what
-            // makes the synchronous closes and the release safe.
             assert(conn.armedCount() == 0);
-            server.io.closeNow(conn.client_socket);
-            if (conn.upstream_socket) |socket| {
-                server.io.closeNow(socket);
-                conn.upstream_socket = null;
-            }
+            assert(conn.stream.armedCount() == 0);
+            // Both fds are shut: nothing here may reference a socket, and
+            // the upstream one is the field the caller cleared.
+            assert(conn.upstream_socket == null);
             // The §5 tunnel buffer first, and the order matters: a live
             // tunnel's `relay_buffer` *aliases* its `tunnel_buffer`
             // (#180), so releasing the shared way would hand one pool's
@@ -2962,15 +2970,15 @@ pub fn Server(comptime IoType: type) type {
                 server.returnHeadBuffer(conn);
             }
             // The leased upstream slot rides the same release rule: its
-            // socket (if any) was closed just above, so the slot is
+            // socket (if any) was closed by the caller, so the slot is
             // inert (§5). Parking replaces this with reuse later.
             if (conn.upstream) |leased| {
                 server.releaseUpstream(leased);
                 conn.upstream = null;
             }
             // The L4 endpoint charge rides the same rule: the socket that
-            // made this connection work against an origin is closed just
-            // above, so the origin is no longer carrying it (§7).
+            // made this connection work against an origin is closed, so
+            // the origin is no longer carrying it (§7).
             server.releaseL4(conn);
             // The TLS engine, last of the per-connection resources and the
             // only one held for the whole life of the connection rather
@@ -2983,8 +2991,44 @@ pub fn Server(comptime IoType: type) type {
             }
             assert(conn.tls == null);
             assert(conn.relay_buffer == null);
+            assert(conn.tunnel_buffer == null);
             assert(conn.upstream == null);
             assert(conn.charged_endpoint == conn_module.LogState.endpoint_none);
+        }
+
+        /// Public for the relay: a completion delivered during teardown
+        /// re-enters here (§5). The delivery that empties *both* armed
+        /// sets finishes the whole teardown synchronously: nothing
+        /// references either fd any more, so the closes are plain
+        /// syscalls — the same close-after-full-drain discipline
+        /// `detachUpstream` and the parked reap already use — and the two
+        /// slots release in the same call instead of waiting out two
+        /// close completions. A dial completing against its own teardown
+        /// still peaks at four armed ops, split two and two across the
+        /// slots since #274: the `conn_ops_max + stream_ops_max` budget
+        /// the CQ is sized by (§8).
+        pub fn continueTeardown(server: *Self, conn: *ConnType) void {
+            assert(conn.state == .tearing_down);
+            // §5's release rule, one level deeper since #274: the conn
+            // slot goes back when *its* armed set is empty **and** every
+            // stream it owns has emptied its own. The exchange's four
+            // completions live on the stream now, so a check that read
+            // only this set would close both fds out from under an armed
+            // recv — which is the shape of bug the rule exists to make
+            // impossible, and which the sim finds on the first idle
+            // timeout when it is got wrong.
+            if (conn.armedCount() != 0 or conn.stream.armedCount() != 0) return;
+            // Nothing armed on either slot: no op references either fd,
+            // which is what makes the synchronous closes and the two
+            // releases safe.
+            assert(conn.armedCount() == 0);
+            assert(conn.stream.armedCount() == 0);
+            server.io.closeNow(conn.client_socket);
+            if (conn.upstream_socket) |socket| {
+                server.io.closeNow(socket);
+                conn.upstream_socket = null;
+            }
+            server.releasePooledResources(conn);
             // The last chance to say anything about this connection (§8).
             // An exchange that reached a verdict already spoke and is
             // skipped by `emitted`; what is left here is everything that
@@ -3630,8 +3674,8 @@ pub fn Server(comptime IoType: type) type {
             if (conn.state == .l7_dialing and conn.l7.pending_verdict == .none) {
                 // At loop-rest a dialing L7 connection always has its
                 // connect in flight, no data ops, and no response byte.
-                assert(conn.armed.connect);
-                assert(!conn.armed.connect_cancel);
+                assert(conn.stream.armed.connect);
+                assert(!conn.stream.armed.connect_cancel);
                 assert(!conn.l7.response_started);
                 conn.l7.pending_verdict = .gateway_timeout;
                 // Same fixed grace as the exchange verdict above.
@@ -3681,12 +3725,12 @@ pub fn Server(comptime IoType: type) type {
         /// the double-arm themselves: a verdict cancel may already be in
         /// flight when teardown starts.
         fn armConnectCancel(server: *Self, conn: *ConnType) void {
-            assert(conn.armed.connect);
-            assert(!conn.armed.connect_cancel);
-            conn.arm(&conn.op_connect_cancel, "connect_cancel");
+            assert(conn.stream.armed.connect);
+            assert(!conn.stream.armed.connect_cancel);
+            conn.stream.arm(&conn.stream.op_connect_cancel, "connect_cancel");
             server.io.connectCancel(
-                &conn.op_connect.completion,
-                &conn.op_connect_cancel.completion,
+                &conn.stream.op_connect.completion,
+                &conn.stream.op_connect_cancel.completion,
                 ConnType,
                 conn,
                 onConnectCancel,
@@ -3694,7 +3738,7 @@ pub fn Server(comptime IoType: type) type {
         }
 
         fn onConnectCancel(conn: *ConnType) void {
-            conn.delivered(&conn.op_connect_cancel, "connect_cancel");
+            conn.stream.delivered(&conn.stream.op_connect_cancel, "connect_cancel");
             if (conn.isTearingDown()) {
                 conn.server.continueTeardown(conn);
                 return;

--- a/src/budget.zig
+++ b/src/budget.zig
@@ -129,7 +129,7 @@ pub fn Budget(comptime IoType: type) type {
                 .upstream_slots = limits.upstream_slots,
                 .upstream_bytes = @sizeOf(UpstreamType),
                 .access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes),
-                .log_header_bytes = ServerType.logHeaderBytes(config, limits.conn_slots),
+                .log_header_bytes = ServerType.logHeaderBytes(config, constants.streamSlotsFor(limits.conn_slots)),
                 .endpoint_table_bytes = ServerType.endpointTableBytes(config),
                 .metrics_bytes = ServerType.metricsBytes(config),
                 .head_buffers = limits.head_buffers,

--- a/src/budget.zig
+++ b/src/budget.zig
@@ -115,6 +115,11 @@ pub fn Budget(comptime IoType: type) type {
             return .{
                 .conn_slots = limits.conn_slots,
                 .conn_bytes = @sizeOf(ServerType.ConnType),
+                // One stream per connection (#274), derived from the
+                // same limit `Server.init` sizes the pool from, so the
+                // printed number and the reserved one cannot disagree.
+                .stream_slots = constants.streamSlotsFor(limits.conn_slots),
+                .stream_bytes = @sizeOf(ServerType.StreamType),
                 .relay_buffers = limits.relay_buffers,
                 // The pool element (free-list header and the two slab
                 // slices) plus both halves it points at, the same shape
@@ -325,7 +330,8 @@ pub fn Budget(comptime IoType: type) type {
             std.debug.print(
                 \\zoxy {s}{s}
                 \\budgets (DESIGN.md §5/§8; closed-form except where marked):
-                \\  memory  total {d} KiB = conn slots {d} x {d} B + relay buffers {d} x {d} B
+                \\  memory  total {d} KiB = conn slots {d} x {d} B + stream slots {d} x {d} B
+                \\          + relay buffers {d} x {d} B
                 \\          + upstream slots {d} x {d} B + head buffers {d} x {d} B (+ ring {d} B)
                 \\          + upstream head buffers {d} x {d} B + head scratch {d} B
                 \\          + access log {d} KiB (+ logged headers {d} B)
@@ -341,6 +347,8 @@ pub fn Budget(comptime IoType: type) type {
                 memory_total / 1024,
                 limits.conn_slots,
                 sizes.conn_bytes,
+                sizes.stream_slots,
+                sizes.stream_bytes,
                 limits.relay_buffers,
                 sizes.relay_buffer_pair_bytes,
                 limits.upstream_slots,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -505,6 +505,31 @@ pub const ring_entries: u16 = 4096;
 /// that reach exactly four (§8, §9).
 pub const conn_ops_max: u32 = 4;
 
+/// Stream slots (`Pool(Stream)`) for a given conn-slot count (#274).
+///
+/// One stream per connection, which is what an HTTP/1.1 exchange model
+/// *is*: a connection carries one request at a time, so a second stream
+/// could never be acquired. Derived here rather than configured because
+/// there is no question for an operator in it yet — the same argument
+/// `health_probe_concurrency` settled (#132) — and because a limit of
+/// its own could drift from `conn_slots` in a hand-written bridge, where
+/// this cannot.
+///
+/// A stream carries no ring ops yet, so `inFlightOps` below is unchanged
+/// and charges nothing per stream slot. The pin is what will hold that
+/// budget still once they move (#274 slice 2): the per-connection charge
+/// splits into a conn share and a stream share, and while the two counts
+/// are equal their sum is the one divisor per admitted connection the CQ
+/// ceiling has always been derived from. #173 is what unpins the counts —
+/// a shared pool sized for concurrent *streams* rather than for
+/// connections — at which point this becomes a limit and the divisor is
+/// re-derived against it.
+pub fn streamSlotsFor(conn_slots: u32) u32 {
+    assert(conn_slots >= 1);
+    assert(conn_slots <= conn_slots_max);
+    return conn_slots;
+}
+
 /// Completions drained per loop tick before control returns to the kernel;
 /// bounds both callback batches and `Io.now_ns` staleness (§4).
 pub const loop_completions_per_tick_max: u32 = 256;
@@ -1488,6 +1513,17 @@ comptime {
 pub const PoolSizes = struct {
     conn_slots: u32,
     conn_bytes: u64,
+    /// The §5 stream pool (#274): one exchange per slot, one slot per
+    /// connection for now, so the count is `streamSlotsFor(conn_slots)`
+    /// and the unit is `@sizeOf` the pool element — the intrusive
+    /// free-list header rides along like every other pool's.
+    ///
+    /// Its own banner term rather than folded into `conn_bytes`, even
+    /// while the two counts are pinned together, because the split is
+    /// exactly what a reader of the banner should be able to see: what
+    /// the connection costs, and what one exchange on it costs.
+    stream_slots: u32,
+    stream_bytes: u64,
     relay_buffers: u32,
     relay_buffer_pair_bytes: u64,
     upstream_slots: u32,
@@ -1603,6 +1639,11 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
     assert(sizes.upstream_slots >= 1);
     assert(sizes.upstream_slots <= upstream_slots_max);
     assert(sizes.conn_bytes > 0);
+    // Pinned to the conn count while an exchange is a connection (#274);
+    // the assert is what will fail loudly the day #173 sizes the pool
+    // for concurrent streams instead and this form needs re-deriving.
+    assert(sizes.stream_slots == streamSlotsFor(sizes.conn_slots));
+    assert(sizes.stream_bytes > 0);
     assert(sizes.relay_buffer_pair_bytes >= 2 * @as(u64, relay_buffer_bytes_min));
     // Once 8 KiB of head, now scalars: the slot's head moved to the §5
     // upstream head pool, whose own bound is asserted below.
@@ -1654,6 +1695,7 @@ pub fn memoryBytesTotal(sizes: *const PoolSizes) u64 {
         assert(sizes.libcrypto_heap_bytes == libcrypto_heap_bytes);
     }
     const total = @as(u64, sizes.conn_slots) * sizes.conn_bytes +
+        @as(u64, sizes.stream_slots) * sizes.stream_bytes +
         @as(u64, sizes.relay_buffers) * sizes.relay_buffer_pair_bytes +
         @as(u64, sizes.upstream_slots) * sizes.upstream_bytes +
         sizes.access_log_bytes + sizes.log_header_bytes +
@@ -1693,6 +1735,9 @@ test "pressure: relay watermarks have a hysteresis gap at every capacity" {
 
 test "budgets: memory total matches the closed form" {
     const conn_bytes: u64 = 10240;
+    // The stream pool's unit (#274). A stand-in like `conn_bytes` above:
+    // this test pins the *sum*, and `@sizeOf` owns the real figure.
+    const stream_bytes: u64 = 16;
     const pair_bytes: u64 = 2 * @as(u64, relay_buffer_bytes_default);
     // Scalars only since the head moved to its own pool (§5).
     const upstream_bytes: u64 = 64;
@@ -1723,6 +1768,7 @@ test "budgets: memory total matches the closed form" {
     // (`Server.metricsBytes` owns that).
     const metrics: u64 = 4096;
     const expected_max = @as(u64, conn_slots_max) * conn_bytes +
+        @as(u64, streamSlotsFor(conn_slots_max)) * stream_bytes +
         @as(u64, relay_buffers_max) * pair_bytes +
         @as(u64, upstream_slots_max) * upstream_bytes +
         accessLogBytes(access_log_buffer_bytes_default) + endpoint_tables +
@@ -1733,6 +1779,8 @@ test "budgets: memory total matches the closed form" {
     try std.testing.expectEqual(expected_max, memoryBytesTotal(&.{
         .conn_slots = conn_slots_max,
         .conn_bytes = conn_bytes,
+        .stream_slots = streamSlotsFor(conn_slots_max),
+        .stream_bytes = stream_bytes,
         .relay_buffers = relay_buffers_max,
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = upstream_slots_max,
@@ -1748,11 +1796,14 @@ test "budgets: memory total matches the closed form" {
     }));
     // The L4-only shape still carries the prober's one response buffer —
     // and the labeled metrics, which exist for every config (§8).
-    const expected_small = 64 * conn_bytes + 8 * pair_bytes + 8 * upstream_bytes +
+    const expected_small = 64 * conn_bytes + streamSlotsFor(64) * stream_bytes +
+        8 * pair_bytes + 8 * upstream_bytes +
         metrics + head_buffer_bytes_default;
     try std.testing.expectEqual(expected_small, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
+        .stream_slots = streamSlotsFor(64),
+        .stream_bytes = stream_bytes,
         .relay_buffers = 8,
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = 8,
@@ -1779,6 +1830,8 @@ test "budgets: memory total matches the closed form" {
     try std.testing.expectEqual(expected_tunnels, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
+        .stream_slots = streamSlotsFor(64),
+        .stream_bytes = stream_bytes,
         .relay_buffers = 8,
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = 8,
@@ -1815,6 +1868,8 @@ test "budgets: memory total matches the closed form" {
     try std.testing.expectEqual(expected_tls, memoryBytesTotal(&.{
         .conn_slots = 64,
         .conn_bytes = conn_bytes,
+        .stream_slots = streamSlotsFor(64),
+        .stream_bytes = stream_bytes,
         .relay_buffers = 8,
         .relay_buffer_pair_bytes = pair_bytes,
         .upstream_slots = 8,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -490,20 +490,51 @@ pub const accept_retry_delay_ms: u32 = 10;
 /// fixes the completion queue at twice this (§4).
 pub const ring_entries: u16 = 4096;
 
-/// Worst-case simultaneously armed ring ops for one connection: four.
-/// Two peaks tie: a teardown racing its own upstream dial holds
-/// {connect, deadline, connect_cancel, deadline_cancel}, and a relay
-/// teardown holds {both data ops, deadline, deadline_cancel}. Closes
-/// never join either set — they are not ring ops at all:
+/// Worst-case simultaneously armed ring ops for one *connection slot*:
+/// two. The deadline and its cancel are all that is left here since #274
+/// moved the exchange onto its own slot — a deadline is the connection's
+/// clock and outlives any one exchange, where the dial and the data legs
+/// do not.
+///
+/// The per-connection worst case is unchanged at four, and that is the
+/// equality the split is checked against rather than a coincidence:
+/// `conn_ops_max + stream_ops_max` is four while a connection owns one
+/// stream, which is what keeps the CQ divisor and every ceiling derived
+/// from it exactly where they were. Both peaks below split the same way,
+/// two and two — a teardown racing its own upstream dial holds
+/// {deadline, deadline_cancel} here and {connect, connect_cancel} there,
+/// and a relay teardown holds {deadline, deadline_cancel} against {both
+/// data ops}.
+///
+/// Closes never join either set — they are not ring ops at all:
 /// `continueTeardown` closes synchronously once every armed op has
 /// drained, nothing referencing the fds by then. Serializing them
 /// behind the drain is what cut this budget from five (a dial
 /// completing against its own cancel used to co-arm the closes with
 /// the deadline and both cancels); making them synchronous then
-/// removed their two completions outright. `Conn.arm` asserts the
-/// budget on every arm, and the drain-vs-dial sim test pins seeds
-/// that reach exactly four (§8, §9).
-pub const conn_ops_max: u32 = 4;
+/// removed their two completions outright. `Conn.arm` asserts this half
+/// on every arm and `Stream.arm` the other, and the drain-vs-dial sim
+/// test pins seeds that reach exactly four combined (§8, §9).
+pub const conn_ops_max: u32 = 2;
+
+/// Worst-case simultaneously armed ring ops for one *stream slot*: two.
+///
+/// The exchange's four completions, of which at most two can be
+/// outstanding at once — the disjointness `Stream.Armed` states: a dial
+/// and its cancel belong to the dialing states, the two data legs to the
+/// relaying and exchanging ones, and nothing arms one kind while the
+/// other is in flight. That claim is what makes the sum above four rather
+/// than six, so it is asserted at the arm site rather than argued here:
+/// a path that ever co-armed three would fail the first seed that reached
+/// it, and the divisor below would need re-deriving.
+pub const stream_ops_max: u32 = 2;
+
+comptime {
+    // The equality #274 rests on, and the reason none of the ceilings
+    // derived from the divisor moved: an admitted connection is charged
+    // exactly what it was charged when all six ops sat on one slot.
+    assert(conn_ops_max + stream_ops_max == 4);
+}
 
 /// Stream slots (`Pool(Stream)`) for a given conn-slot count (#274).
 ///
@@ -1057,7 +1088,13 @@ pub fn inFlightOps(
     assert(listeners <= std.math.maxInt(u16));
     assert(health_probes >= 1);
     assert(health_probes <= health_probe_concurrency_max);
-    return conn_slots * conn_ops_max + upstream_slots +
+    // The stream term is derived rather than passed: the two counts are
+    // pinned while an exchange is a connection (#274), and a parameter
+    // that must always equal `streamSlotsFor(conn_slots)` is a parameter
+    // a caller can pass wrong. `conn_ops_max + stream_ops_max` is the
+    // one divisor per admitted connection this has always charged.
+    return conn_slots * conn_ops_max +
+        streamSlotsFor(conn_slots) * stream_ops_max + upstream_slots +
         2 * (listeners + admin_listeners) +
         admin_conns * admin_conn_ops_max + access_log_ops_max +
         health_probes * health_probe_ops_max + 1 + 1;
@@ -1370,15 +1407,16 @@ comptime {
     // and the admin listener plus its one client op — are carved out (§8).
     // The pair is pinned (`upstream_slots_max = conn_slots_max`), so the
     // shared CQ line has one divisor — an admitted connection costs
-    // `conn_ops_max` conn ops plus the one op of the upstream slot it may
-    // need — rather than one ceiling subtracting from the other.
+    // `conn_ops_max` conn ops plus `stream_ops_max` for the one stream it
+    // owns (#274) plus the one op of the upstream slot it may need —
+    // rather than one ceiling subtracting from the other.
     assert(upstream_slots_max == conn_slots_max);
     assert(conn_slots_max == @divFloor(
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * admin_listeners -
             admin_conns * admin_conn_ops_max - access_log_ops_max -
             health_probe_concurrency_max * health_probe_ops_max - 1 - 1,
-        conn_ops_max + 1,
+        conn_ops_max + stream_ops_max + 1,
     ));
     assert(admin_listeners >= 1);
     assert(admin_conns >= 1);
@@ -1945,7 +1983,13 @@ test "budgets: conn slots sit at the completion-queue ceiling" {
     // that still satisfies it after the parked-upstream reservation, so
     // one more slot would break the budget.
     try std.testing.expect(inFlightOps(conn_slots_max, upstream_slots_max, 0, health_probe_concurrency_max) <= @divExact(completion_queue_entries, 8) * cq_fill_eighths_default);
-    const one_more = (conn_slots_max + 1) * conn_ops_max + upstream_slots_max +
+    // One more connection costs both shares, because the counts are
+    // pinned (#274): a conn slot the pool cannot pair a stream with could
+    // never run an exchange. Spelled as the sum rather than through
+    // `streamSlotsFor`, whose own assert bounds its argument by the very
+    // ceiling this line is trying to step past.
+    const one_more = (conn_slots_max + 1) * (conn_ops_max + stream_ops_max) +
+        upstream_slots_max +
         2 * admin_listeners +
         admin_conns * admin_conn_ops_max + access_log_ops_max +
         health_probe_concurrency_max * health_probe_ops_max + 1 + 1;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -198,11 +198,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.tls != null);
             const destination = conn.tls.?.recvBuffer();
             assert(destination.len >= 1);
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
                 destination,
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onTlsHeadRecv,
@@ -211,7 +211,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onTlsHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -451,10 +451,10 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             assert(conn.head_buffer_id == ConnType.head_buffer_none);
             assert(conn.head_len == 0);
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recvGroup(
                 conn.client_socket,
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onHeadGroupRecv,
@@ -468,11 +468,11 @@ pub fn Proxy(comptime IoType: type) type {
             // Resolved before the arm, so the source's own bound is checked
             // before any state changes.
             const into = headRecvBuffer(server, conn);
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
                 into,
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onHeadRecv,
@@ -481,7 +481,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onHeadGroupRecv(conn: *ConnType, result: Io.RecvGroupError!Io.GroupRecv) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 // The teardown raced the client's first byte (§5): the
                 // kernel may already have bound a ring buffer for the
@@ -539,7 +539,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -1373,10 +1373,10 @@ pub fn Proxy(comptime IoType: type) type {
                 // §8 504.
                 assert(conn.armed.deadline or conn.armed.deadline_cancel);
             }
-            conn.arm(&conn.op_connect, "connect");
+            conn.stream.arm(&conn.stream.op_connect, "connect");
             server.io.connect(
                 pick.address,
-                &conn.op_connect.completion,
+                &conn.stream.op_connect.completion,
                 ConnType,
                 conn,
                 onUpstreamConnect,
@@ -1385,7 +1385,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onUpstreamConnect(conn: *ConnType, result: Io.ConnectError!IoType.Socket) void {
             const server = conn.server;
-            conn.delivered(&conn.op_connect, "connect");
+            conn.stream.delivered(&conn.stream.op_connect, "connect");
             if (conn.isTearingDown()) {
                 // The teardown raced the dial (§5): a socket that arrived
                 // anyway must still be shut down and closed.
@@ -1503,8 +1503,8 @@ pub fn Proxy(comptime IoType: type) type {
         fn beginRetry(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_dialing);
             assert(conn.upstream_socket == null); // A failed dial produced none.
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             const failed = conn.upstream.?;
             assert(conn.l7.tried_count < conn.l7.tried.len);
             conn.l7.tried[conn.l7.tried_count] = failed.endpoint_index;
@@ -1737,11 +1737,11 @@ pub fn Proxy(comptime IoType: type) type {
             const l7 = &conn.l7;
             assert(l7.request_head_sent < l7.rendered_request_len);
             l7.request_op_on_client = false; // A send on the upstream socket.
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
                 upstreamHeadBytes(conn.upstream.?)[l7.request_head_sent..l7.rendered_request_len],
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onRequestHeadSent,
@@ -1750,7 +1750,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onRequestHeadSent(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -1833,11 +1833,11 @@ pub fn Proxy(comptime IoType: type) type {
             const direction = &conn.directions[0];
             const base = conn.l7.request_head_len;
             conn.l7.request_op_on_client = false; // A send on the upstream socket.
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
                 conn.upstream_socket.?,
                 direction.pending(headBytes(server, conn)[base..]),
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onRequestExcessSent,
@@ -1846,7 +1846,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onRequestExcessSent(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -2093,11 +2093,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.l7.response_leg == .awaiting_head);
             const upstream = conn.upstream.?;
             assert(upstream.head_len < upstreamHeadBytes(upstream).len);
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            conn.stream.arm(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.recv(
                 conn.upstream_socket.?,
                 upstreamHeadBytes(upstream)[upstream.head_len..],
-                &conn.op_data_upstream_to_client.completion,
+                &conn.stream.op_data_upstream_to_client.completion,
                 ConnType,
                 conn,
                 onResponseHeadRecv,
@@ -2106,7 +2106,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onResponseHeadRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            conn.stream.delivered(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -2566,8 +2566,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.upgrade_requested);
             assert(conn.upstream_socket != null);
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(conn.l7.request_head_len <= conn.head_len);
             const pipelined = conn.head_len - conn.l7.request_head_len;
             // `tunnel_buffer` stays set: it is what marks which pool this
@@ -2935,11 +2935,11 @@ pub fn Proxy(comptime IoType: type) type {
             else
                 conn.client_write.pending;
             assert(bytes.len >= 1);
-            conn.arm(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            conn.stream.arm(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.send(
                 conn.client_socket,
                 bytes,
-                &conn.op_data_upstream_to_client.completion,
+                &conn.stream.op_data_upstream_to_client.completion,
                 ConnType,
                 conn,
                 onClientWritten,
@@ -3066,7 +3066,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onClientWritten(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_upstream_to_client, "data_upstream_to_client");
+            conn.stream.delivered(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -3377,8 +3377,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// data ops settled with the exchange), so the close is
         /// synchronous, like the parked-reap path.
         fn detachUpstream(server: *ServerType, conn: *ConnType) void {
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             if (conn.upstream) |leased| {
                 server.io.closeNow(conn.upstream_socket.?);
                 server.releaseUpstream(leased);
@@ -3399,10 +3399,10 @@ pub fn Proxy(comptime IoType: type) type {
             // The lazy deadline timer stays armed across the turnaround (§4),
             // and a dial rebase (§8) cancel may still be draining if the
             // exchange outran it — both re-establish the next idle deadline.
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
-            assert(!conn.armed.connect);
-            assert(!conn.armed.connect_cancel);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.connect);
+            assert(!conn.stream.armed.connect_cancel);
             assert(conn.armed.deadline or conn.armed.deadline_cancel);
             // The channel's cursor lives on the conn, not in `l7`, so the
             // reset below does not wipe it: assert it drained instead of
@@ -3476,7 +3476,7 @@ pub fn Proxy(comptime IoType: type) type {
             if (conn.l7.response_started) {
                 return false;
             }
-            if (conn.armed.data_client_to_upstream and conn.l7.request_op_on_client) {
+            if (conn.stream.armed.data_client_to_upstream and conn.l7.request_op_on_client) {
                 return false;
             }
             return true;
@@ -3527,7 +3527,7 @@ pub fn Proxy(comptime IoType: type) type {
             // never be.
             assert(!conn.l7.response_started);
             if (!conn.l7.head_budget_installed) return false;
-            return conn.armed.data_client_to_upstream;
+            return conn.stream.armed.data_client_to_upstream;
         }
 
         /// Begin the #247 head-read verdict: force the armed head recv and
@@ -3563,8 +3563,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.pending_verdict == .none);
             assert(expiryAnswerable(conn));
-            assert(conn.armed.data_client_to_upstream or
-                conn.armed.data_upstream_to_client);
+            assert(conn.stream.armed.data_client_to_upstream or
+                conn.stream.armed.data_upstream_to_client);
             conn.l7.pending_verdict = .gateway_timeout;
             server.io.shutdown(conn.upstream_socket.?, .both);
         }
@@ -3585,8 +3585,8 @@ pub fn Proxy(comptime IoType: type) type {
                 (conn.state == .l7_reading_head and
                     conn.l7.pending_verdict == .request_timeout));
             assert(conn.l7.pending_verdict != .none);
-            if (conn.armed.data_client_to_upstream or
-                conn.armed.data_upstream_to_client)
+            if (conn.stream.armed.data_client_to_upstream or
+                conn.stream.armed.data_upstream_to_client)
             {
                 return; // The sibling's forced completion re-enters here.
             }
@@ -3668,8 +3668,8 @@ pub fn Proxy(comptime IoType: type) type {
             // (#232), and this is what would trip if that ever stopped
             // being true.
             assert(conn.l7.interims_seen == 0);
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
             assert(conn.relay_buffer != null); // Retained across the replay.
             const stale = conn.upstream.?;
@@ -3756,8 +3756,8 @@ pub fn Proxy(comptime IoType: type) type {
                 settlePendingVerdict(server, conn);
                 return;
             }
-            if (conn.l7.response_started or conn.armed.data_client_to_upstream or
-                conn.armed.data_upstream_to_client)
+            if (conn.l7.response_started or conn.stream.armed.data_client_to_upstream or
+                conn.stream.armed.data_upstream_to_client)
             {
                 server.beginTeardown(conn);
                 return;
@@ -3832,8 +3832,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// data ops are free at every caller, so nothing is armed on the
         /// upstream socket and the close is synchronous, like `detach`.
         fn releaseForStaticResponse(server: *ServerType, conn: *ConnType) void {
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             // The head buffer too: the answer is static memory and the
             // lingering drain discards into the shared sink, so nothing
             // past this point reads or writes head bytes — and a reject
@@ -3899,8 +3899,8 @@ pub fn Proxy(comptime IoType: type) type {
         ) void {
             assert(conn.state == .l7_reading_head or conn.state == .l7_dialing or
                 conn.state == .l7_exchanging);
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
             // The head-shed rung can never keep, structurally: nothing was
             // read (the ring was empty, so no buffer was ever bound), the
@@ -3975,8 +3975,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// the whole meaning of a budget that ran out here.
         fn respondMaxForwardsExhausted(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
             const keep = commitStaticVerdict(server, conn, 200, "l7_max_forwards_exhausted", true);
@@ -4090,8 +4090,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             // `respond`'s own contract: both data ops free, so the send
             // and any lingering drain have their completions.
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
             // A terminal verdict runs before routing acquires anything,
             // which is what keeps it clear of every rung past the head
@@ -4200,8 +4200,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             // The same contract `respond` states: both data ops free, so
             // the send and any lingering drain have their completions.
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
             // Routing has acquired nothing yet: a redirect never touches
             // the relay or upstream pools, which is what keeps it out of
@@ -4337,8 +4337,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
-            assert(!conn.armed.data_client_to_upstream);
-            assert(!conn.armed.data_upstream_to_client);
+            assert(!conn.stream.armed.data_client_to_upstream);
+            assert(!conn.stream.armed.data_upstream_to_client);
             // The same OR `resetForNextRequest` needs, for the same reason,
             // and it is not this request's doing: a *previous* request on
             // this connection may have dialed, re-based its deadline (§8),
@@ -4375,11 +4375,11 @@ pub fn Proxy(comptime IoType: type) type {
             // nobody reads may alias, and a reject storm drains through
             // 4 KiB total instead of 8 KiB per draining connection (§5).
             assert(conn.head_buffer_id == ConnType.head_buffer_none);
-            conn.arm(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,
                 server.drainSink(),
-                &conn.op_data_client_to_upstream.completion,
+                &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
                 onDrainRecv,
@@ -4388,7 +4388,7 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn onDrainRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(&conn.op_data_client_to_upstream, "data_client_to_upstream");
+            conn.stream.delivered(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -39,6 +39,7 @@ const Balancer = @import("../balancer.zig").Balancer;
 const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const conn_module = @import("../net/Conn.zig");
+const stream_module = @import("../net/Stream.zig");
 const pump = @import("../net/pump.zig");
 const relay = @import("../net/relay.zig");
 const Io = @import("../io/io.zig");
@@ -145,6 +146,7 @@ pub const RenderScratch = struct {
 pub fn Proxy(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
+    const StreamType = ConnType.StreamType;
     const UpstreamType = @import("../net/upstream.zig").UpstreamPool(IoType).Upstream;
     const Framing = ConnType.Framing;
 
@@ -154,8 +156,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// head from the client.
         pub fn start(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            assert(conn.head_len == 0);
-            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            assert(conn.stream.head_len == 0);
+            assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
             if (conn.tls != null) {
                 // Plaintext the handshake's last flight carried in with it
                 // is already in the head buffer, at its front — a client
@@ -269,7 +271,7 @@ pub fn Proxy(comptime IoType: type) type {
                 answerHeadOverflow(server, conn);
                 return;
             }
-            if (conn.head_len == 0) {
+            if (conn.stream.head_len == 0) {
                 // A record carrying no application data — a KeyUpdate, an
                 // alert, a fragment. Nothing parsed; read again.
                 armTlsHeadRecv(server, conn);
@@ -292,7 +294,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.tls != null);
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
-            if (parser.parseRequestHead(headBytes(server, conn)[0..conn.head_len], true, storage, null)) |_| {
+            if (parser.parseRequestHead(headBytes(server, conn)[0..conn.stream.head_len], true, storage, null)) |_| {
                 // The head completed inside the buffer, so what overran it
                 // was payload.
                 respond(server, conn, 413, "l7_body_too_large");
@@ -342,11 +344,11 @@ pub fn Proxy(comptime IoType: type) type {
                 // RFC 8446 §6.1: anything after a close_notify is ignored.
                 if (self.closed) return;
                 const buffer = headBytes(self.server, self.conn);
-                const room = buffer.len - self.conn.head_len;
+                const room = buffer.len - self.conn.stream.head_len;
                 const take: u32 = @intCast(@min(room, bytes.len));
                 if (take < bytes.len) self.overflowed = true;
                 if (take == 0) return;
-                @memcpy(buffer[self.conn.head_len..][0..take], bytes[0..take]);
+                @memcpy(buffer[self.conn.stream.head_len..][0..take], bytes[0..take]);
                 fillHead(self.conn, take, buffer.len);
                 self.appended += take;
             }
@@ -403,8 +405,8 @@ pub fn Proxy(comptime IoType: type) type {
             // `limits.head_buffer_bytes` to bound what it accepts must get
             // that number back rather than the floor.
             if (conn.tls) |engine| return engine.plaintext[0..engine.head_bytes];
-            assert(conn.head_buffer_id != ConnType.head_buffer_none);
-            return server.io.bufferGroupSlice(conn.head_buffer_id);
+            assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
+            return server.io.bufferGroupSlice(conn.stream.head_buffer_id);
         }
 
         /// The upstream head bytes this exchange holds (§5): acquired at
@@ -422,8 +424,8 @@ pub fn Proxy(comptime IoType: type) type {
             const bytes = headBytes(server, conn);
             // Parsing turns a full buffer into an oversize verdict before
             // we ever get here, so there is always room to read into.
-            assert(conn.head_len < bytes.len);
-            return bytes[conn.head_len..];
+            assert(conn.stream.head_len < bytes.len);
+            return bytes[conn.stream.head_len..];
         }
 
         /// Account for bytes that became head bytes. Named because a
@@ -439,8 +441,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// config's now, not this file's to name.
         fn fillHead(conn: *ConnType, appended: u32, capacity: usize) void {
             assert(appended >= 1);
-            assert(conn.head_len + appended <= capacity);
-            conn.head_len += appended;
+            assert(conn.stream.head_len + appended <= capacity);
+            conn.stream.head_len += appended;
         }
 
         /// The idle arm (§5): a recv that carries no buffer. Fresh
@@ -449,8 +451,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// speaks.
         fn armHeadGroupRecv(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            assert(conn.head_buffer_id == ConnType.head_buffer_none);
-            assert(conn.head_len == 0);
+            assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
+            assert(conn.stream.head_len == 0);
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recvGroup(
                 conn.client_socket,
@@ -499,7 +501,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_reading_head);
-            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
             const bound = result catch |err| switch (err) {
                 error.NoBuffers => {
                     // The client spoke and the ring is empty: §8's newest
@@ -522,7 +524,7 @@ pub fn Proxy(comptime IoType: type) type {
                 },
             };
             assert(bound.len >= 1);
-            conn.head_buffer_id = bound.buffer_id;
+            conn.stream.head_buffer_id = bound.buffer_id;
             server.noteHeadBufferBound();
             // A request begins with its first byte, and only with a byte:
             // started here rather than before the unwrap above, because
@@ -571,22 +573,22 @@ pub fn Proxy(comptime IoType: type) type {
             assert(received >= 1);
             // The request already began at the group delivery that bound
             // the buffer; this is more of the same head.
-            assert(conn.head_buffer_id != ConnType.head_buffer_none);
-            assert(conn.head_len >= 1);
+            assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
+            assert(conn.stream.head_len >= 1);
             conn.log.bytes_in += received;
             fillHead(conn, received, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
         }
 
         /// Parse the accumulated head (§7), resuming the terminator search
-        /// where the last read left off via `conn.head_cursor`. Incomplete
+        /// where the last read left off via `conn.stream.head_cursor`. Incomplete
         /// and room left → read more; oversize or malformed → the matching
         /// static reject; a valid head → routing.
         fn parseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
             const bytes = headBytes(server, conn);
-            const head = bytes[0..conn.head_len];
-            const head_is_full = conn.head_len == bytes.len;
+            const head = bytes[0..conn.stream.head_len];
+            const head_is_full = conn.stream.head_len == bytes.len;
 
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
@@ -596,7 +598,7 @@ pub fn Proxy(comptime IoType: type) type {
                 head,
                 head_is_full,
                 storage,
-                &conn.head_cursor,
+                &conn.stream.head_cursor,
             ) catch |err| switch (err) {
                 error.Incomplete => {
                     // A full buffer never yields Incomplete — the parser
@@ -934,7 +936,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// relay buffer and upstream slot (§8 rungs, 503) and dials.
         fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
             assert(conn.state == .l7_reading_head);
-            assert(request.head_len <= conn.head_len);
+            assert(request.head_len <= conn.stream.head_len);
             recordRequestFacts(server, conn, request);
             // Counted where a request becomes real (#237): a head that
             // parsed and will be answered. A malformed one never reaches
@@ -1041,7 +1043,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 404, "l7_no_route");
             };
 
-            conn.relay_buffer = server.acquireRelayBuffer() orelse {
+            conn.stream.relay_buffer = server.acquireRelayBuffer() orelse {
                 return respond(server, conn, 503, "l7_shed_relay_buffers");
             };
             beginUpstream(server, conn, request, &keys.views, render_scratch);
@@ -1220,7 +1222,7 @@ pub fn Proxy(comptime IoType: type) type {
             scratch: *RenderScratch,
         ) void {
             assert(conn.state == .l7_reading_head);
-            assert(conn.relay_buffer != null);
+            assert(conn.stream.relay_buffer != null);
             // The §3 reuse win: a parked connection to the picked endpoint
             // beats a fresh dial. A close that slipped through while it
             // was parked surfaces as a failure on first use — absorbed by
@@ -1520,7 +1522,7 @@ pub fn Proxy(comptime IoType: type) type {
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
             const request = parser.parseRequestHead(
-                headBytes(server, conn)[0..conn.head_len],
+                headBytes(server, conn)[0..conn.stream.head_len],
                 false,
                 storage,
                 null,
@@ -1550,7 +1552,7 @@ pub fn Proxy(comptime IoType: type) type {
             // bytes are the single source of truth), so a failure here is
             // an invariant violation, not an input condition.
             const request = parser.parseRequestHead(
-                headBytes(server, conn)[0..conn.head_len],
+                headBytes(server, conn)[0..conn.stream.head_len],
                 false,
                 storage,
                 null,
@@ -1780,7 +1782,7 @@ pub fn Proxy(comptime IoType: type) type {
             // (§7). Once the response recv is armed that op is gone, and an
             // op is never canceled (§5) — so a malformed body found later
             // can only tear down. Checking here keeps the 400 reachable.
-            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.head_len];
+            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len];
             const feed = feedFraming(&conn.l7.request_framing, excess);
             if (feed.malformed) {
                 respond(server, conn, 400, "l7_bad_request");
@@ -1813,11 +1815,11 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_head);
             assert(!feed.malformed);
-            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.head_len];
+            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len];
             if (feed.consumed < excess.len) {
                 conn.l7.client_pipelined = true;
             }
-            const direction = &conn.directions[0];
+            const direction = &conn.stream.directions[0];
             direction.owe(feed.consumed);
             conn.l7.request_leg = .sending_body_excess;
             if (direction.owed() >= 1) {
@@ -1830,7 +1832,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn armRequestExcessSend(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
             assert(conn.l7.request_leg == .sending_body_excess);
-            const direction = &conn.directions[0];
+            const direction = &conn.stream.directions[0];
             const base = conn.l7.request_head_len;
             conn.l7.request_op_on_client = false; // A send on the upstream socket.
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
@@ -1863,7 +1865,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(sent >= 1);
-            const direction = &conn.directions[0];
+            const direction = &conn.stream.directions[0];
             direction.credit(sent);
             if (direction.owed() >= 1) {
                 armRequestExcessSend(server, conn);
@@ -1919,7 +1921,7 @@ pub fn Proxy(comptime IoType: type) type {
             /// does everywhere else the client speaks.
             pub fn recvBuffer(conn: *ConnType) []u8 {
                 if (conn.tls) |engine| return engine.recvBuffer();
-                return conn.relay_buffer.?.client_to_upstream;
+                return conn.stream.relay_buffer.?.client_to_upstream;
             }
 
             /// Decrypt so framing — chunked decoding, content-length
@@ -1945,12 +1947,12 @@ pub fn Proxy(comptime IoType: type) type {
 
             /// The framed window lives wherever the transform put it.
             pub fn sendSlice(conn: *ConnType) []const u8 {
-                const state = &conn.directions[
-                    @intFromEnum(ConnType.Direction.client_to_upstream)
+                const state = &conn.stream.directions[
+                    @intFromEnum(StreamType.Direction.client_to_upstream)
                 ];
                 if (state.owed() == 0) return &.{};
                 if (conn.tls) |engine| return state.pending(engine.body_plaintext);
-                return state.pending(conn.relay_buffer.?.client_to_upstream);
+                return state.pending(conn.stream.relay_buffer.?.client_to_upstream);
             }
 
             pub fn beforeRecv(conn: *ConnType) void {
@@ -2568,8 +2570,8 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.upstream_socket != null);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(conn.l7.request_head_len <= conn.head_len);
-            const pipelined = conn.head_len - conn.l7.request_head_len;
+            assert(conn.l7.request_head_len <= conn.stream.head_len);
+            const pipelined = conn.stream.head_len - conn.l7.request_head_len;
             // `tunnel_buffer` stays set: it is what marks which pool this
             // buffer belongs to. `relay_buffer` only *aliases* it, so the
             // relay reads one field like every other connection while the
@@ -2583,7 +2585,7 @@ pub fn Proxy(comptime IoType: type) type {
                 assert(pipelined <= buffer.client_to_upstream.len);
                 @memcpy(
                     buffer.client_to_upstream[0..pipelined],
-                    headBytes(server, conn)[conn.l7.request_head_len..conn.head_len],
+                    headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len],
                 );
             }
             const leased = conn.upstream.?;
@@ -2595,14 +2597,14 @@ pub fn Proxy(comptime IoType: type) type {
             // rungs where either may never have been acquired: this runs
             // only after a rendered head went out, which needed the head
             // buffer, and every routed exchange holds a relay buffer.
-            assert(conn.relay_buffer != null);
-            assert(conn.head_buffer_id != ConnType.head_buffer_none);
-            server.releaseRelayBuffer(conn.relay_buffer.?);
+            assert(conn.stream.relay_buffer != null);
+            assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
+            server.releaseRelayBuffer(conn.stream.relay_buffer.?);
             server.returnHeadBuffer(conn);
-            conn.head_len = 0;
-            conn.head_cursor.reset();
-            conn.relay_buffer = buffer;
-            conn.directions = .{ .{}, .{} };
+            conn.stream.head_len = 0;
+            conn.stream.head_cursor.reset();
+            conn.stream.relay_buffer = buffer;
+            conn.stream.directions = .{ .{}, .{} };
             // Charged while this is still an exchange, so the charge and
             // the slot it replaces never both count the same work: the
             // release above gave the lease back, and this takes its place
@@ -2610,7 +2612,7 @@ pub fn Proxy(comptime IoType: type) type {
             server.chargeEndpoint(conn, cluster_index, endpoint_index);
             conn.state = .relaying;
             if (pipelined >= 1) {
-                const direction = &conn.directions[0];
+                const direction = &conn.stream.directions[0];
                 direction.phase = .receiving;
                 direction.owe(pipelined);
             }
@@ -2917,23 +2919,23 @@ pub fn Proxy(comptime IoType: type) type {
             server: *ServerType,
             conn: *ConnType,
             bytes: []const u8,
-            then: conn_module.ClientWrite.Then,
+            then: stream_module.ClientWrite.Then,
         ) void {
             assert(bytes.len >= 1);
             assert(conn.state == .l7_exchanging or conn.state == .l7_responding);
             // One write at a time: the channel is the only writer of this op,
             // and a previous write either drained or ended in teardown.
-            assert(conn.client_write.pending.len == 0);
-            conn.client_write = .{ .pending = bytes, .then = then };
+            assert(conn.stream.client_write.pending.len == 0);
+            conn.stream.client_write = .{ .pending = bytes, .then = then };
             resumeClientWrite(server, conn);
         }
 
         fn resumeClientWrite(server: *ServerType, conn: *ConnType) void {
-            assert(conn.client_write.pending.len >= 1);
+            assert(conn.stream.client_write.pending.len >= 1);
             const bytes = if (conn.tls != null)
                 (stageClientCiphertext(server, conn) orelse return)
             else
-                conn.client_write.pending;
+                conn.stream.client_write.pending;
             assert(bytes.len >= 1);
             conn.stream.arm(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.send(
@@ -2953,7 +2955,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// length limit with them inline.
         fn assertWriteContinuation(
             conn: *const ConnType,
-            then: conn_module.ClientWrite.Then,
+            then: stream_module.ClientWrite.Then,
         ) void {
             switch (then) {
                 // An interim is out and the origin still owes an answer:
@@ -2995,7 +2997,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .redirect_next_request, .redirect_lingering_close => {
                     assert(conn.state == .l7_responding);
                     if (conn.tls == null) {
-                        assert(conn.head_buffer_id != ConnType.head_buffer_none);
+                        assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
                     }
                 },
             }
@@ -3011,7 +3013,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// access log reports what the client's application received
         /// rather than what the record layer wrapped it in.
         fn creditClientWrite(conn: *ConnType, sent: u32) bool {
-            const write = &conn.client_write;
+            const write = &conn.stream.client_write;
             if (conn.tls) |engine| {
                 engine.outboundSent(sent);
                 if (engine.outbound().len >= 1) return true; // Short send.
@@ -3040,7 +3042,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// compile time (§5).
         fn stageClientCiphertext(server: *ServerType, conn: *ConnType) ?[]const u8 {
             const engine = conn.tls.?;
-            const write = &conn.client_write;
+            const write = &conn.stream.client_write;
             const staged = engine.outbound();
             if (staged.len >= 1) {
                 // A short send: the remainder of a chunk already encrypted.
@@ -3072,7 +3074,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_exchanging or conn.state == .l7_responding);
-            const write = &conn.client_write;
+            const write = &conn.stream.client_write;
             const sent = result catch |err| {
                 // The client is gone; there is no one left to answer.
                 server.witnessKernelPressure(.send, err);
@@ -3193,7 +3195,7 @@ pub fn Proxy(comptime IoType: type) type {
                     return false;
                 }
                 engine.sendApp(
-                    conn.relay_buffer.?.upstream_to_client[0..consumed],
+                    conn.stream.relay_buffer.?.upstream_to_client[0..consumed],
                 ) catch {
                     conn.server.counters.increment("tls_relay_failed");
                     return false;
@@ -3203,19 +3205,19 @@ pub fn Proxy(comptime IoType: type) type {
 
             pub fn sendSlice(conn: *ConnType) []const u8 {
                 if (conn.tls) |engine| return engine.outbound();
-                const state = &conn.directions[
-                    @intFromEnum(ConnType.Direction.upstream_to_client)
+                const state = &conn.stream.directions[
+                    @intFromEnum(StreamType.Direction.upstream_to_client)
                 ];
                 if (state.owed() == 0) return &.{};
-                return state.pending(conn.relay_buffer.?.upstream_to_client);
+                return state.pending(conn.stream.relay_buffer.?.upstream_to_client);
             }
 
             /// Ciphertext outnumbers the plaintext the debt counts, so the
             /// debt settles all at once when the outbox drains — the
             /// pump's contract for a transforming send.
             pub fn creditSend(conn: *ConnType, sent: u32) void {
-                const state = &conn.directions[
-                    @intFromEnum(ConnType.Direction.upstream_to_client)
+                const state = &conn.stream.directions[
+                    @intFromEnum(StreamType.Direction.upstream_to_client)
                 ];
                 if (conn.tls) |engine| {
                     engine.outboundSent(sent);
@@ -3362,7 +3364,7 @@ pub fn Proxy(comptime IoType: type) type {
             // (§5): the response leg is settled, so the client-write
             // channel no longer references them — asserted, because the
             // excess write sends straight from this buffer.
-            assert(conn.client_write.pending.len == 0);
+            assert(conn.stream.client_write.pending.len == 0);
             server.releaseUpstreamHeadBuffer(upstream);
             server.upstreams.park(upstream);
             upstream.deadline_ns = server.io.nowNs() +
@@ -3407,9 +3409,9 @@ pub fn Proxy(comptime IoType: type) type {
             // The channel's cursor lives on the conn, not in `l7`, so the
             // reset below does not wipe it: assert it drained instead of
             // trusting the control flow that got us here.
-            assert(conn.client_write.pending.len == 0);
-            server.releaseRelayBuffer(conn.relay_buffer.?);
-            conn.relay_buffer = null;
+            assert(conn.stream.client_write.pending.len == 0);
+            server.releaseRelayBuffer(conn.stream.relay_buffer.?);
+            conn.stream.relay_buffer = null;
             beginNextRequest(server, conn);
         }
 
@@ -3424,9 +3426,9 @@ pub fn Proxy(comptime IoType: type) type {
         /// exchange to have settled, the other never had one), and only they
         /// can state why they hold.
         fn beginNextRequest(server: *ServerType, conn: *ConnType) void {
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
-            assert(conn.client_write.pending.len == 0);
+            assert(conn.stream.client_write.pending.len == 0);
             // The exchange that just ended has spoken for itself, so its
             // accounting resets with the rest of the per-request state
             // (§8). The captures are left in place: their lengths are what
@@ -3437,18 +3439,18 @@ pub fn Proxy(comptime IoType: type) type {
             // (§5). Conditional because the static-response path already
             // returned it (`releaseForStaticResponse`); the completed-
             // exchange path still holds it here.
-            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+            if (conn.stream.head_buffer_id != StreamType.head_buffer_none) {
                 server.returnHeadBuffer(conn);
             }
-            conn.head_len = 0;
-            conn.head_cursor.reset();
+            conn.stream.head_len = 0;
+            conn.stream.head_cursor.reset();
             conn.l7 = .{};
             conn.log.reset();
             // The #140 captures live in the server's side table, not on
             // `log`, so they need clearing beside it — or the next
             // request's line would report this one's headers.
             server.resetLogHeaders(conn);
-            conn.directions = .{ .{}, .{} };
+            conn.stream.directions = .{ .{}, .{} };
             conn.state = .l7_reading_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
             // Through `start` rather than straight to the group arm: a
@@ -3671,7 +3673,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
             assert(!conn.l7.response_started);
-            assert(conn.relay_buffer != null); // Retained across the replay.
+            assert(conn.stream.relay_buffer != null); // Retained across the replay.
             const stale = conn.upstream.?;
             assert(stale.head_len == 0);
             server.io.closeNow(conn.upstream_socket.?);
@@ -3688,7 +3690,7 @@ pub fn Proxy(comptime IoType: type) type {
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
             const request = parser.parseRequestHead(
-                headBytes(server, conn)[0..conn.head_len],
+                headBytes(server, conn)[0..conn.stream.head_len],
                 false,
                 storage,
                 null,
@@ -3718,7 +3720,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // upstream_was_reused stays default-false: the replay try
                 // is a fresh dial, and a second early failure answers 502.
             };
-            conn.directions = .{ .{}, .{} };
+            conn.stream.directions = .{ .{}, .{} };
             // A fresh pick and a fresh dial — never another checkout (§7):
             // the endpoint's whole idle list may be stale the same way.
             //
@@ -3814,10 +3816,10 @@ pub fn Proxy(comptime IoType: type) type {
             // `fillHead` never appends zero bytes and every reject from
             // this state follows a fill, so an unparsed head cannot tie
             // with `request_head_len`'s zero.
-            assert(conn.head_len >= 1);
-            assert(conn.l7.request_head_len <= conn.head_len);
+            assert(conn.stream.head_len >= 1);
+            assert(conn.l7.request_head_len <= conn.stream.head_len);
             if (!framingDoneOf(&conn.l7.request_framing)) return false;
-            return conn.head_len == conn.l7.request_head_len;
+            return conn.stream.head_len == conn.l7.request_head_len;
         }
 
         /// Everything a static response no longer needs, returned before
@@ -3843,12 +3845,12 @@ pub fn Proxy(comptime IoType: type) type {
             // `head_len` deliberately survives the return: it is a count,
             // not buffer content, and the §7 resync rule still reads it to
             // decide keep-or-close; `beginNextRequest` zeroes it.
-            if (conn.head_buffer_id != ConnType.head_buffer_none) {
+            if (conn.stream.head_buffer_id != StreamType.head_buffer_none) {
                 server.returnHeadBuffer(conn);
             }
-            if (conn.relay_buffer) |buffer| {
+            if (conn.stream.relay_buffer) |buffer| {
                 server.releaseRelayBuffer(buffer);
-                conn.relay_buffer = null;
+                conn.stream.relay_buffer = null;
             }
             // The tunnel this request asked for and did not get (#180).
             // A live tunnel never reaches here — it answers no static
@@ -3863,7 +3865,7 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.upstream = null;
                 conn.upstream_socket = null;
             }
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
         }
@@ -3881,7 +3883,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// not each re-test it.
         fn releaseTunnelClaim(server: *ServerType, conn: *ConnType) void {
             const buffer = conn.tunnel_buffer orelse return;
-            assert(conn.relay_buffer != buffer); // Not yet swapped in: no live tunnel here.
+            assert(conn.stream.relay_buffer != buffer); // Not yet swapped in: no live tunnel here.
             server.releaseTunnelBuffer(buffer);
             conn.tunnel_buffer = null;
         }
@@ -3977,7 +3979,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
             const keep = commitStaticVerdict(server, conn, 200, "l7_max_forwards_exhausted", true);
             const persistence: shed.Persistence = if (keep) .keep else .close;
@@ -3989,7 +3991,7 @@ pub fn Proxy(comptime IoType: type) type {
             // — and a HEAD never reaches here anyway: this is the OPTIONS
             // path alone.
             assert(conn.l7.request_method == .options);
-            const then: conn_module.ClientWrite.Then =
+            const then: stream_module.ClientWrite.Then =
                 if (keep) .next_request else .lingering_close;
             armClientWrite(server, conn, answer.bytes, then);
         }
@@ -4040,7 +4042,7 @@ pub fn Proxy(comptime IoType: type) type {
             // that true for the next one to ask.
             server.stampStaticDate(answer.date);
             server.claimStaticSend(conn);
-            const then: conn_module.ClientWrite.Then =
+            const then: stream_module.ClientWrite.Then =
                 if (keep) .next_request else .lingering_close;
             armClientWrite(server, conn, answer.bytes, then);
         }
@@ -4073,7 +4075,7 @@ pub fn Proxy(comptime IoType: type) type {
             // in the head, so the HEAD prefix carries it too.
             server.stampStaticDate(if (keep) page.keep_date else page.close_date);
             server.claimStaticSend(conn);
-            const then: conn_module.ClientWrite.Then =
+            const then: stream_module.ClientWrite.Then =
                 if (keep) .next_request else .lingering_close;
             armClientWrite(server, conn, bytes, then);
         }
@@ -4096,7 +4098,7 @@ pub fn Proxy(comptime IoType: type) type {
             // A terminal verdict runs before routing acquires anything,
             // which is what keeps it clear of every rung past the head
             // ring (the redirect's precondition, same phase).
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
             // The page is immutable arena memory, never the connection's
             // head buffer — so this answer releases before the send like
@@ -4206,7 +4208,7 @@ pub fn Proxy(comptime IoType: type) type {
             // Routing has acquired nothing yet: a redirect never touches
             // the relay or upstream pools, which is what keeps it out of
             // every shed rung past the head ring.
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
             const location = composeLocation(server, redirect, request_host, forward) catch |err|
                 switch (err) {
@@ -4330,11 +4332,11 @@ pub fn Proxy(comptime IoType: type) type {
         /// this is `resetForNextRequest` minus the exchange it never had.
         fn resumeAfterStaticResponse(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_responding);
-            assert(conn.client_write.pending.len == 0);
+            assert(conn.stream.client_write.pending.len == 0);
             // `respond` frees all three before the send, so a kept
             // connection carries nothing into its next request (§5).
-            assert(conn.head_buffer_id == ConnType.head_buffer_none);
-            assert(conn.relay_buffer == null);
+            assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
+            assert(conn.stream.relay_buffer == null);
             assert(conn.upstream == null);
             assert(conn.upstream_socket == null);
             assert(!conn.stream.armed.data_client_to_upstream);
@@ -4374,7 +4376,7 @@ pub fn Proxy(comptime IoType: type) type {
             // server's one shared sink — recv targets whose contents
             // nobody reads may alias, and a reject storm drains through
             // 4 KiB total instead of 8 KiB per draining connection (§5).
-            assert(conn.head_buffer_id == ConnType.head_buffer_none);
+            assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.recv(
                 conn.client_socket,

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -258,7 +258,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // nobody made, which teardown then writes out as an
                 // aborted exchange with no method and no bytes.
                 server.beginLogRequest(conn);
-                conn.log.bytes_in += head.appended;
+                conn.stream.log.bytes_in += head.appended;
             }
             if (conn.tls.?.peerClosed()) {
                 // An in-band EOF mid-head: the client said it will send no
@@ -534,7 +534,7 @@ pub fn Proxy(comptime IoType: type) type {
             // the parse: a slowloris that dribbles for the whole head-read
             // deadline must report the time it spent doing it (§8).
             server.beginLogRequest(conn);
-            conn.log.bytes_in += bound.len;
+            conn.stream.log.bytes_in += bound.len;
             fillHead(conn, bound.len, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
         }
@@ -575,7 +575,7 @@ pub fn Proxy(comptime IoType: type) type {
             // the buffer; this is more of the same head.
             assert(conn.stream.head_buffer_id != StreamType.head_buffer_none);
             assert(conn.stream.head_len >= 1);
-            conn.log.bytes_in += received;
+            conn.stream.log.bytes_in += received;
             fillHead(conn, received, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
         }
@@ -882,7 +882,7 @@ pub fn Proxy(comptime IoType: type) type {
             // Copied out now because the head buffer is not the log's to
             // read later: the response head renders over it (§7 buffer
             // rotation), and by the exchange's settle these bytes are gone.
-            conn.log.captureMethod(request.method_token);
+            conn.stream.log.captureMethod(request.method_token);
             // The #140 named headers, on the same terms and for the same
             // reason — and here rather than deeper, so every line that
             // reports a parsed request carries them, rejects included.
@@ -922,10 +922,10 @@ pub fn Proxy(comptime IoType: type) type {
         fn captureTarget(conn: *ConnType, host: ?[]const u8, path: []const u8) void {
             assert(conn.state == .l7_reading_head);
             assert(path.len >= 1);
-            conn.log.capturePath(path);
+            conn.stream.log.capturePath(path);
             if (host) |canonical| {
                 assert(canonical.len >= 1);
-                conn.log.captureHost(canonical);
+                conn.stream.log.captureHost(canonical);
             }
         }
 
@@ -1247,7 +1247,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // pick: a request shed for want of a slot contacted no
                 // origin, and a line claiming one would send an operator
                 // looking at a backend that never saw the request (§8).
-                conn.log.endpoint_index = pick.endpoint_index;
+                conn.stream.log.endpoint_index = pick.endpoint_index;
                 conn.stream.upstream = parked;
                 conn.stream.upstream_socket = parked.socket;
                 parked.head_len = 0;
@@ -1330,7 +1330,7 @@ pub fn Proxy(comptime IoType: type) type {
             // The slot is held, so this try really is going to this
             // endpoint — whether or not the dial ends up succeeding. A
             // replay overwrites it, naming the endpoint that served (§7).
-            conn.log.endpoint_index = pick.endpoint_index;
+            conn.stream.log.endpoint_index = pick.endpoint_index;
             conn.state = .l7_dialing;
             // The head-read/idle timer is already armed; re-base it to the
             // tighter per-try connect budget so a hung origin fires the §8
@@ -2003,7 +2003,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // Body bytes this request owns, counted where framing said
                 // which they were: a pipelined tail belongs to the *next*
                 // request, so it must not land on this one's line (§8).
-                conn.log.bytes_in += fr.consumed;
+                conn.stream.log.bytes_in += fr.consumed;
                 if (fr.consumed < received) {
                     // Bytes past the body are a pipelined next request; the
                     // connection will close after this exchange (§7 note).
@@ -2374,10 +2374,10 @@ pub fn Proxy(comptime IoType: type) type {
             }
             // An exchange rendering a response holds an upstream, so the
             // endpoint was recorded when its slot was (§8).
-            assert(conn.log.endpoint_index != conn_module.LogState.endpoint_none);
+            assert(conn.stream.log.endpoint_index != stream_module.LogState.endpoint_none);
             const served = server.balancer.endpointIdentity(
                 conn.stream.cluster_index,
-                conn.log.endpoint_index,
+                conn.stream.log.endpoint_index,
             );
             const carried = conn.stream.l7.sticky_cookie orelse return .assigned;
             if (carried == served) {
@@ -2444,7 +2444,7 @@ pub fn Proxy(comptime IoType: type) type {
             // stamp announces is byte-identical to the tag the next
             // request's parse will match.
             Balancer.formatEndpointTag(
-                server.balancer.endpointIdentity(conn.stream.cluster_index, conn.log.endpoint_index),
+                server.balancer.endpointIdentity(conn.stream.cluster_index, conn.stream.log.endpoint_index),
                 scratch[len..][0..Balancer.endpoint_tag_len],
             );
             len += Balancer.endpoint_tag_len;
@@ -2620,7 +2620,7 @@ pub fn Proxy(comptime IoType: type) type {
             // Recorded here, where the client provably has the handshake
             // (§8): the one line this connection writes at close is the
             // tunnel's, and `101` is what identifies it as one.
-            conn.log.status = 101;
+            conn.stream.log.status = 101;
             // The tunnel's own clock replaces the three that would each
             // cut a healthy session (§8). Stored, not re-based: a rebase
             // exists to pull a deadline *earlier* than the armed timer,
@@ -2899,7 +2899,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.stream.l7.response_leg = .sending_head;
             conn.stream.l7.response_started = true;
             creditSticky(server, verdict);
-            conn.log.status = response.status;
+            conn.stream.log.status = response.status;
             server.captureResponseLogHeaders(conn, response.headers);
             armClientWrite(server, conn, headBytes(server, conn)[0..head_write_len], .response_excess);
         }
@@ -3019,13 +3019,13 @@ pub fn Proxy(comptime IoType: type) type {
                 if (engine.outbound().len >= 1) return true; // Short send.
                 assert(write.staged >= 1);
                 assert(write.staged <= write.pending.len);
-                conn.log.bytes_out += write.staged;
+                conn.stream.log.bytes_out += write.staged;
                 write.pending = write.pending[write.staged..];
                 write.staged = 0;
                 return write.pending.len > 0;
             }
             assert(sent <= write.pending.len);
-            conn.log.bytes_out += sent;
+            conn.stream.log.bytes_out += sent;
             write.pending = write.pending[sent..];
             return write.pending.len > 0;
         }
@@ -3253,7 +3253,7 @@ pub fn Proxy(comptime IoType: type) type {
             /// channel; between them every byte this proxy sends the
             /// client is counted exactly once (§8).
             pub fn afterSend(conn: *ConnType, sent: u32) void {
-                conn.log.bytes_out += sent;
+                conn.stream.log.bytes_out += sent;
             }
 
             pub fn framingDone(conn: *ConnType) bool {
@@ -3331,8 +3331,8 @@ pub fn Proxy(comptime IoType: type) type {
             // This is also the only place `ok` is earned — nothing between
             // the response head being queued and this point may claim it,
             // which is what keeps one `ok` line per `l7_responses`.
-            assert(conn.log.outcome == .aborted);
-            conn.log.outcome = .ok;
+            assert(conn.stream.log.outcome == .aborted);
+            conn.stream.log.outcome = .ok;
             server.logExchange(conn);
 
             const request_complete = conn.stream.l7.request_leg == .done;
@@ -3433,7 +3433,7 @@ pub fn Proxy(comptime IoType: type) type {
             // accounting resets with the rest of the per-request state
             // (§8). The captures are left in place: their lengths are what
             // gate every read, and this zeroes those.
-            assert(conn.log.emitted or conn.log.started_wall_ns == 0);
+            assert(conn.stream.log.emitted or conn.stream.log.started_wall_ns == 0);
             // The request's head buffer goes back to the ring before the
             // idle wait begins — an idle connection holds no head bytes
             // (§5). Conditional because the static-response path already
@@ -3445,7 +3445,7 @@ pub fn Proxy(comptime IoType: type) type {
             conn.stream.head_len = 0;
             conn.stream.head_cursor.reset();
             conn.stream.l7 = .{};
-            conn.log.reset();
+            conn.stream.log.reset();
             // The #140 captures live in the server's side table, not on
             // `log`, so they need clearing beside it — or the next
             // request's line would report this one's headers.
@@ -3951,8 +3951,8 @@ pub fn Proxy(comptime IoType: type) type {
             // What the line will say, recorded here where the verdict is
             // made; it is written once the response is on the wire, so
             // the byte count includes the answer itself (§8).
-            conn.log.status = status;
-            conn.log.outcome = comptime outcomeOfCounter(counter);
+            conn.stream.log.status = status;
+            conn.stream.log.outcome = comptime outcomeOfCounter(counter);
             // §8's "then keep or close per pressure". Closing is not free:
             // it costs the client a fresh handshake and this proxy a fresh
             // accept, conn slot and admission — which is how a shed storm
@@ -4110,8 +4110,8 @@ pub fn Proxy(comptime IoType: type) type {
             ServerType.clearRequestDeadline(conn);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment("l7_responded");
-            conn.log.status = page.status;
-            conn.log.outcome = .responded;
+            conn.stream.log.status = page.status;
+            conn.stream.log.outcome = .responded;
             // The same four brakes every static answer honors (§7, §8):
             // the client's own ask, the drain, relay pressure and the
             // #237 cap.
@@ -4253,8 +4253,8 @@ pub fn Proxy(comptime IoType: type) type {
             ServerType.clearRequestDeadline(conn);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.counters.increment("l7_redirected");
-            conn.log.status = redirect.status;
-            conn.log.outcome = .redirected;
+            conn.stream.log.status = redirect.status;
+            conn.stream.log.outcome = .redirected;
             conn.state = .l7_responding;
             if (keep) {
                 armClientWrite(server, conn, rendered, .redirect_next_request);

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -148,7 +148,7 @@ pub fn Proxy(comptime IoType: type) type {
     const ConnType = conn_module.Conn(IoType);
     const StreamType = ConnType.StreamType;
     const UpstreamType = @import("../net/upstream.zig").UpstreamPool(IoType).Upstream;
-    const Framing = ConnType.Framing;
+    const Framing = StreamType.Framing;
 
     return struct {
         /// Entry from admission: the slot is prepared in `.l7_reading_head`
@@ -226,8 +226,8 @@ pub fn Proxy(comptime IoType: type) type {
             // left HTTPS slowlorises the whole idle window; answering in
             // one arm and resetting in the other would be that defect
             // again, wearing the fix's clothes.
-            if (conn.l7.pending_verdict != .none) {
-                assert(conn.l7.pending_verdict == .request_timeout);
+            if (conn.stream.l7.pending_verdict != .none) {
+                assert(conn.stream.l7.pending_verdict == .request_timeout);
                 settlePendingVerdict(server, conn);
                 return;
             }
@@ -554,8 +554,8 @@ pub fn Proxy(comptime IoType: type) type {
             // error handling below so a forced EOF never reaches the
             // kernel-pressure witness, the same order `settlePendingVerdict`
             // relies on for the upstream verdicts.
-            if (conn.l7.pending_verdict != .none) {
-                assert(conn.l7.pending_verdict == .request_timeout);
+            if (conn.stream.l7.pending_verdict != .none) {
+                assert(conn.stream.l7.pending_verdict == .request_timeout);
                 settlePendingVerdict(server, conn);
                 return;
             }
@@ -647,8 +647,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// bias exists for.
         fn installHeadBudget(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            if (conn.l7.head_budget_installed) return;
-            conn.l7.head_budget_installed = true;
+            if (conn.stream.l7.head_budget_installed) return;
+            conn.stream.l7.head_budget_installed = true;
             const budget_ms = @min(server.config.head_timeout_ms, server.idleTimeoutMs());
             assert(budget_ms >= 1);
             server.narrowDeadline(conn, budget_ms);
@@ -874,11 +874,11 @@ pub fn Proxy(comptime IoType: type) type {
             // Once per request: `resetForNextRequest` and
             // `resumeAfterStaticResponse` both clear `l7` on the turnaround,
             // so a second recording would mean a head was routed twice.
-            assert(conn.l7.request_head_len == 0);
-            conn.l7.request_method = request.method;
-            conn.l7.request_framing = framingFromParsed(request.framing);
-            conn.l7.request_head_len = request.head_len;
-            conn.l7.client_keep_alive = request.keep_alive;
+            assert(conn.stream.l7.request_head_len == 0);
+            conn.stream.l7.request_method = request.method;
+            conn.stream.l7.request_framing = framingFromParsed(request.framing);
+            conn.stream.l7.request_head_len = request.head_len;
+            conn.stream.l7.client_keep_alive = request.keep_alive;
             // Copied out now because the head buffer is not the log's to
             // read later: the response head renders over it (§7 buffer
             // rotation), and by the exchange's settle these bytes are gone.
@@ -899,12 +899,12 @@ pub fn Proxy(comptime IoType: type) type {
         /// exchange clamps under a timer already due on time.
         fn armRequestDeadline(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            assert(conn.l7.request_deadline_ns == 0);
+            assert(conn.stream.l7.request_deadline_ns == 0);
             if (server.config.request_timeout_ms == 0) return;
             const now_ns = server.io.nowNs();
-            conn.l7.request_deadline_ns = now_ns +
+            conn.stream.l7.request_deadline_ns = now_ns +
                 @as(u64, server.config.request_timeout_ms) * std.time.ns_per_ms;
-            assert(conn.l7.request_deadline_ns > now_ns);
+            assert(conn.stream.l7.request_deadline_ns > now_ns);
             server.storeDeadline(conn, server.idleTimeoutMs());
             server.rebaseDeadline(conn);
         }
@@ -1039,7 +1039,7 @@ pub fn Proxy(comptime IoType: type) type {
                     .respond => |page| return respondWithPage(server, conn, page),
                 }
             }
-            conn.cluster_index = router.route(conn.routes, keys.host, keys.views.match) orelse {
+            conn.stream.cluster_index = router.route(conn.routes, keys.host, keys.views.match) orelse {
                 return respond(server, conn, 404, "l7_no_route");
             };
 
@@ -1060,9 +1060,9 @@ pub fn Proxy(comptime IoType: type) type {
             conn: *const ConnType,
             request: *const parser.RequestHead,
         ) Balancer.RequestKey {
-            assert(conn.cluster_index < server.config.clusters.len);
+            assert(conn.stream.cluster_index < server.config.clusters.len);
             assert(request.head_len >= 1);
-            const cluster = &server.config.clusters[conn.cluster_index];
+            const cluster = &server.config.clusters[conn.stream.cluster_index];
             if (cluster.pick != .hash) {
                 return .none;
             }
@@ -1093,7 +1093,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn streamOverLimit(conn: *const ConnType) bool {
             assert(conn.state == .l7_exchanging);
             if (conn.max_body_bytes == 0) return false; // Opted out.
-            return switch (conn.l7.request_framing) {
+            return switch (conn.stream.l7.request_framing) {
                 .chunked => |scanner| scanner.body_bytes > conn.max_body_bytes,
                 .none, .content_length, .until_close => false,
             };
@@ -1134,7 +1134,7 @@ pub fn Proxy(comptime IoType: type) type {
         fn admitUpgrade(server: *ServerType, conn: *ConnType, token: []const u8) bool {
             assert(conn.state == .l7_reading_head);
             assert(conn.tunnel_buffer == null);
-            assert(!conn.l7.upgrade_requested);
+            assert(!conn.stream.l7.upgrade_requested);
             if (!conn.upgrades.websocket or !std.ascii.eqlIgnoreCase(token, "websocket")) {
                 respond(server, conn, 501, "l7_not_implemented");
                 return false;
@@ -1152,7 +1152,7 @@ pub fn Proxy(comptime IoType: type) type {
                 respond(server, conn, 503, "l7_shed_tunnels");
                 return false;
             };
-            conn.l7.upgrade_requested = true;
+            conn.stream.l7.upgrade_requested = true;
             return true;
         }
 
@@ -1172,12 +1172,12 @@ pub fn Proxy(comptime IoType: type) type {
             request_key: Balancer.RequestKey,
         ) ?Balancer.Pick {
             const outcome = server.balancer.pick(
-                conn.cluster_index,
+                conn.stream.cluster_index,
                 &server.endpointLoad(),
                 server.health.healthy,
                 &conn.client_address,
                 request_key,
-                conn.l7.tried[0..conn.l7.tried_count],
+                conn.stream.l7.tried[0..conn.stream.l7.tried_count],
             );
             switch (outcome) {
                 .dial => |chosen| return chosen,
@@ -1188,7 +1188,7 @@ pub fn Proxy(comptime IoType: type) type {
                     // "they are full", and the shed rungs must not absorb
                     // it. A first try cannot land here — the routable set
                     // is non-empty until something has been tried.
-                    assert(conn.l7.tried_count >= 1);
+                    assert(conn.stream.l7.tried_count >= 1);
                     server.counters.increment("upstream_retries_exhausted");
                     respond(server, conn, 502, "l7_bad_gateway");
                     return null;
@@ -1198,7 +1198,7 @@ pub fn Proxy(comptime IoType: type) type {
                     // this fires precisely because no endpoint could be
                     // picked — all of them were full, so an endpoint
                     // label would be an invention.
-                    server.labeled.incrementCluster(.l7_shed_inflight, conn.cluster_index);
+                    server.labeled.incrementCluster(.l7_shed_inflight, conn.stream.cluster_index);
                     respond(server, conn, 503, "l7_shed_endpoint_inflight");
                     return null;
                 },
@@ -1236,20 +1236,20 @@ pub fn Proxy(comptime IoType: type) type {
             // The head bytes are gone by the response render (§7 buffer
             // rotation), so the render's half of #178 — "did the request
             // already name the endpoint it got?" — is recorded now.
-            conn.l7.sticky_cookie = switch (request_key) {
+            conn.stream.l7.sticky_cookie = switch (request_key) {
                 .endpoint => |identity| identity,
                 else => null,
             };
             const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
-            if (server.upstreams.checkout(conn.cluster_index, pick.endpoint_index)) |parked| {
+            if (server.upstreams.checkout(conn.stream.cluster_index, pick.endpoint_index)) |parked| {
                 server.counters.increment("upstream_reused");
                 // Recorded once the slot is actually held, never at the
                 // pick: a request shed for want of a slot contacted no
                 // origin, and a line claiming one would send an operator
                 // looking at a backend that never saw the request (§8).
                 conn.log.endpoint_index = pick.endpoint_index;
-                conn.upstream = parked;
-                conn.upstream_socket = parked.socket;
+                conn.stream.upstream = parked;
+                conn.stream.upstream_socket = parked.socket;
                 parked.head_len = 0;
                 // A parked slot released its head buffer before parking;
                 // the exchange re-acquires here, still in
@@ -1257,7 +1257,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // socket is closed with the slot — the shed costs a
                 // parked origin connection, not a client one).
                 if (!acquireUpstreamHeadOrShed(server, conn)) return;
-                conn.l7.upstream_was_reused = true;
+                conn.stream.l7.upstream_was_reused = true;
                 conn.state = .l7_dialing;
                 // No await happened: this runs in the same callback as the
                 // parse whose result is still live, so the reuse path —
@@ -1281,7 +1281,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// `respond` has already released the slot the caller just
         /// obtained, so the caller only returns.
         fn acquireUpstreamHeadOrShed(server: *ServerType, conn: *ConnType) bool {
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             assert(upstream.head_buffer == null);
             upstream.head_buffer = server.acquireUpstreamHeadBuffer() orelse {
                 respond(server, conn, 503, "l7_shed_upstream_head_buffers");
@@ -1321,9 +1321,9 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_reading_head or conn.state == .l7_dialing or
                 conn.state == .l7_exchanging);
             if (conn.state == .l7_dialing) assert(budget == .carried);
-            assert(conn.upstream == null);
-            assert(conn.upstream_socket == null);
-            conn.upstream = server.acquireUpstream(conn.cluster_index, pick.endpoint_index) orelse {
+            assert(conn.stream.upstream == null);
+            assert(conn.stream.upstream_socket == null);
+            conn.stream.upstream = server.acquireUpstream(conn.stream.cluster_index, pick.endpoint_index) orelse {
                 return respond(server, conn, 503, "l7_shed_upstream_slots");
             };
             if (!acquireUpstreamHeadOrShed(server, conn)) return;
@@ -1392,24 +1392,24 @@ pub fn Proxy(comptime IoType: type) type {
                 // The teardown raced the dial (§5): a socket that arrived
                 // anyway must still be shut down and closed.
                 if (result) |socket| {
-                    conn.upstream_socket = socket;
+                    conn.stream.upstream_socket = socket;
                     server.io.shutdown(socket, .both);
                 } else |_| {}
                 server.continueTeardown(conn);
                 return;
             }
             assert(conn.state == .l7_dialing);
-            if (conn.l7.pending_verdict != .none) {
+            if (conn.stream.l7.pending_verdict != .none) {
                 // The §8 dial-timeout verdict: the deadline canceled this
                 // connect. Whatever the result — the expected Canceled, a
                 // genuine failure, or a success that raced the cancel —
                 // the dial is condemned; a socket that arrived anyway is
                 // attached so respond's upstream disposal closes it.
-                assert(conn.l7.pending_verdict == .gateway_timeout);
-                conn.l7.pending_verdict = .none;
+                assert(conn.stream.l7.pending_verdict == .gateway_timeout);
+                conn.stream.l7.pending_verdict = .none;
                 if (result) |socket| {
-                    conn.upstream.?.socket = socket;
-                    conn.upstream_socket = socket;
+                    conn.stream.upstream.?.socket = socket;
+                    conn.stream.upstream_socket = socket;
                 } else |_| {}
                 witnessNoResponse(server, conn);
                 respond(server, conn, 504, "l7_gateway_timeout");
@@ -1421,10 +1421,10 @@ pub fn Proxy(comptime IoType: type) type {
                 // await, but the leased slot did — it still names the
                 // endpoint this dial was for, and `respond`'s disposal
                 // releases it only after this line.
-                assert(conn.upstream != null);
+                assert(conn.stream.upstream != null);
                 server.labeled.incrementEndpoint(.connect_failed, server.upstreams.keys.key(
-                    conn.upstream.?.cluster_index,
-                    conn.upstream.?.endpoint_index,
+                    conn.stream.upstream.?.cluster_index,
+                    conn.stream.upstream.?.endpoint_index,
                 ));
                 // Same split as the L4 dial: the origin's verdict arrives
                 // typed, our own resource exhaustion does not (§8).
@@ -1437,8 +1437,8 @@ pub fn Proxy(comptime IoType: type) type {
                 // outage.
                 if (err != error.Unexpected) {
                     server.health.witnessPassiveFailure(
-                        conn.upstream.?.cluster_index,
-                        conn.upstream.?.endpoint_index,
+                        conn.stream.upstream.?.cluster_index,
+                        conn.stream.upstream.?.endpoint_index,
                     );
                 }
                 if (retryEligible(server, conn, err)) {
@@ -1448,8 +1448,8 @@ pub fn Proxy(comptime IoType: type) type {
                 respond(server, conn, 502, "l7_bad_gateway");
                 return;
             };
-            conn.upstream.?.socket = socket;
-            conn.upstream_socket = socket;
+            conn.stream.upstream.?.socket = socket;
+            conn.stream.upstream_socket = socket;
             server.io.setNodelay(socket) catch |err| {
                 server.witnessKernelPressure(.set_option, err);
             };
@@ -1478,7 +1478,7 @@ pub fn Proxy(comptime IoType: type) type {
             err: Io.ConnectError,
         ) bool {
             assert(conn.state == .l7_dialing);
-            assert(conn.upstream != null);
+            assert(conn.stream.upstream != null);
             // Exhaustive rather than an `else`, so a fifth connect error
             // is a compile error here — a decision to make once, not a
             // default to inherit silently.
@@ -1486,10 +1486,10 @@ pub fn Proxy(comptime IoType: type) type {
                 error.Refused, error.Unreachable => {},
                 error.Canceled, error.Unexpected => return false,
             }
-            const budget = server.config.clusters[conn.cluster_index].retries;
+            const budget = server.config.clusters[conn.stream.cluster_index].retries;
             assert(budget <= constants.cluster_retries_max);
-            assert(conn.l7.retries_used <= budget);
-            return conn.l7.retries_used < budget;
+            assert(conn.stream.l7.retries_used <= budget);
+            return conn.stream.l7.retries_used < budget;
         }
 
         /// Spend one retry: record the endpoint that refused, give its
@@ -1504,13 +1504,13 @@ pub fn Proxy(comptime IoType: type) type {
         /// reason: only the bytes survive an await, and they are unchanged.
         fn beginRetry(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_dialing);
-            assert(conn.upstream_socket == null); // A failed dial produced none.
+            assert(conn.stream.upstream_socket == null); // A failed dial produced none.
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            const failed = conn.upstream.?;
-            assert(conn.l7.tried_count < conn.l7.tried.len);
-            conn.l7.tried[conn.l7.tried_count] = failed.endpoint_index;
-            conn.l7.tried_count += 1;
+            const failed = conn.stream.upstream.?;
+            assert(conn.stream.l7.tried_count < conn.stream.l7.tried.len);
+            conn.stream.l7.tried[conn.stream.l7.tried_count] = failed.endpoint_index;
+            conn.stream.l7.tried_count += 1;
             // Released before the re-pick, not after: the endpoint's
             // in-flight total is what `p2c` and the §8 cap read, and
             // leaving a dead dial counted there would make the retry
@@ -1518,7 +1518,7 @@ pub fn Proxy(comptime IoType: type) type {
             // doing. The slot is re-acquired in the same callback, so the
             // pool cannot have been emptied in between.
             server.releaseUpstream(failed);
-            conn.upstream = null;
+            conn.stream.upstream = null;
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
             const request = parser.parseRequestHead(
@@ -1534,8 +1534,8 @@ pub fn Proxy(comptime IoType: type) type {
             // and that has not changed.
             const request_key = requestKeyFor(server, conn, &request);
             const pick = pickEndpointOrShed(server, conn, request_key) orelse return;
-            assert(pick.endpoint_index != conn.l7.tried[conn.l7.tried_count - 1]);
-            conn.l7.retries_used += 1;
+            assert(pick.endpoint_index != conn.stream.l7.tried[conn.stream.l7.tried_count - 1]);
+            conn.stream.l7.retries_used += 1;
             server.counters.increment("upstream_retried");
             dialUpstream(server, conn, pick, .carried);
         }
@@ -1557,7 +1557,7 @@ pub fn Proxy(comptime IoType: type) type {
                 storage,
                 null,
             ) catch unreachable;
-            assert(request.head_len == conn.l7.request_head_len);
+            assert(request.head_len == conn.stream.l7.request_head_len);
             // Only this path pays for canonicalization twice, and it has
             // to: routeRequest's use of the shared scratch ended with its
             // frame at the dial — which is also why reusing the same
@@ -1593,10 +1593,10 @@ pub fn Proxy(comptime IoType: type) type {
             scratch: *RenderScratch,
         ) void {
             assert(conn.state == .l7_dialing);
-            assert(request.head_len == conn.l7.request_head_len);
+            assert(request.head_len == conn.stream.l7.request_head_len);
             assert(views.forward.path.len >= 1);
             assert(views.match.len >= 1);
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             // Acquired back when the slot was obtained (`acquireUpstreamHeadOrShed`),
             // while the state still allowed a kept shed; by render time it
             // is a held invariant, not a question.
@@ -1635,7 +1635,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // The participating `Upgrade` travels only when this
                 // listener agreed to carry it (#180); the gate already
                 // refused every other spelling.
-                conn.l7.upgrade_requested,
+                conn.stream.l7.upgrade_requested,
                 &scratch.head,
                 upstreamHeadBytes(upstream),
             ) catch {
@@ -1644,10 +1644,10 @@ pub fn Proxy(comptime IoType: type) type {
                 return respond(server, conn, 431, "l7_headers_too_large");
             };
             assert(rendered.len >= 1);
-            conn.l7.rendered_request_len = @intCast(rendered.len);
-            conn.l7.request_head_sent = 0;
+            conn.stream.l7.rendered_request_len = @intCast(rendered.len);
+            conn.stream.l7.request_head_sent = 0;
             conn.state = .l7_exchanging;
-            conn.l7.request_leg = .sending_head;
+            conn.stream.l7.request_leg = .sending_head;
             server.storeDeadline(conn, server.idleTimeoutMs());
             armRequestHeadSend(server, conn);
         }
@@ -1735,14 +1735,14 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn armRequestHeadSend(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_head);
-            const l7 = &conn.l7;
+            assert(conn.stream.l7.request_leg == .sending_head);
+            const l7 = &conn.stream.l7;
             assert(l7.request_head_sent < l7.rendered_request_len);
             l7.request_op_on_client = false; // A send on the upstream socket.
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
-                conn.upstream_socket.?,
-                upstreamHeadBytes(conn.upstream.?)[l7.request_head_sent..l7.rendered_request_len],
+                conn.stream.upstream_socket.?,
+                upstreamHeadBytes(conn.stream.upstream.?)[l7.request_head_sent..l7.rendered_request_len],
                 &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
                 conn,
@@ -1758,8 +1758,8 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_head);
-            if (conn.l7.pending_verdict != .none) {
+            assert(conn.stream.l7.request_leg == .sending_head);
+            if (conn.stream.l7.pending_verdict != .none) {
                 settlePendingVerdict(server, conn);
                 return;
             }
@@ -1769,9 +1769,9 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(sent >= 1);
-            conn.l7.request_head_sent += sent;
-            assert(conn.l7.request_head_sent <= conn.l7.rendered_request_len);
-            if (conn.l7.request_head_sent < conn.l7.rendered_request_len) {
+            conn.stream.l7.request_head_sent += sent;
+            assert(conn.stream.l7.request_head_sent <= conn.stream.l7.rendered_request_len);
+            if (conn.stream.l7.request_head_sent < conn.stream.l7.rendered_request_len) {
                 armRequestHeadSend(server, conn);
                 return;
             }
@@ -1782,8 +1782,8 @@ pub fn Proxy(comptime IoType: type) type {
             // (§7). Once the response recv is armed that op is gone, and an
             // op is never canceled (§5) — so a malformed body found later
             // can only tear down. Checking here keeps the 400 reachable.
-            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len];
-            const feed = feedFraming(&conn.l7.request_framing, excess);
+            const excess = headBytes(server, conn)[conn.stream.l7.request_head_len..conn.stream.head_len];
+            const feed = feedFraming(&conn.stream.l7.request_framing, excess);
             if (feed.malformed) {
                 respond(server, conn, 400, "l7_bad_request");
                 return;
@@ -1813,15 +1813,15 @@ pub fn Proxy(comptime IoType: type) type {
         /// framing was already advanced and validated by the caller.
         fn forwardRequestExcess(server: *ServerType, conn: *ConnType, feed: FeedResult) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_head);
+            assert(conn.stream.l7.request_leg == .sending_head);
             assert(!feed.malformed);
-            const excess = headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len];
+            const excess = headBytes(server, conn)[conn.stream.l7.request_head_len..conn.stream.head_len];
             if (feed.consumed < excess.len) {
-                conn.l7.client_pipelined = true;
+                conn.stream.l7.client_pipelined = true;
             }
             const direction = &conn.stream.directions[0];
             direction.owe(feed.consumed);
-            conn.l7.request_leg = .sending_body_excess;
+            conn.stream.l7.request_leg = .sending_body_excess;
             if (direction.owed() >= 1) {
                 armRequestExcessSend(server, conn);
             } else {
@@ -1831,13 +1831,13 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn armRequestExcessSend(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_body_excess);
+            assert(conn.stream.l7.request_leg == .sending_body_excess);
             const direction = &conn.stream.directions[0];
-            const base = conn.l7.request_head_len;
-            conn.l7.request_op_on_client = false; // A send on the upstream socket.
+            const base = conn.stream.l7.request_head_len;
+            conn.stream.l7.request_op_on_client = false; // A send on the upstream socket.
             conn.stream.arm(&conn.stream.op_data_client_to_upstream, "data_client_to_upstream");
             server.io.send(
-                conn.upstream_socket.?,
+                conn.stream.upstream_socket.?,
                 direction.pending(headBytes(server, conn)[base..]),
                 &conn.stream.op_data_client_to_upstream.completion,
                 ConnType,
@@ -1854,8 +1854,8 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_body_excess);
-            if (conn.l7.pending_verdict != .none) {
+            assert(conn.stream.l7.request_leg == .sending_body_excess);
+            if (conn.stream.l7.pending_verdict != .none) {
                 settlePendingVerdict(server, conn);
                 return;
             }
@@ -1880,10 +1880,10 @@ pub fn Proxy(comptime IoType: type) type {
         /// carried the whole body).
         fn requestHeadVacated(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.request_leg == .sending_body_excess);
-            conn.l7.request_head_vacated = true;
-            if (conn.l7.response_render_pending) {
-                conn.l7.response_render_pending = false;
+            assert(conn.stream.l7.request_leg == .sending_body_excess);
+            conn.stream.l7.request_head_vacated = true;
+            if (conn.stream.l7.response_render_pending) {
+                conn.stream.l7.response_render_pending = false;
                 beginResponseForward(server, conn);
                 // A deferred render that fails (oversize/malformed origin
                 // head) answers 502 (.l7_responding) or tears down — either
@@ -1891,13 +1891,13 @@ pub fn Proxy(comptime IoType: type) type {
                 // keep pumping into a connection that is already closing (§7).
                 if (conn.state != .l7_exchanging) return;
             }
-            if (framingDoneOf(&conn.l7.request_framing)) {
-                conn.l7.request_leg = .done;
+            if (framingDoneOf(&conn.stream.l7.request_framing)) {
+                conn.stream.l7.request_leg = .done;
             } else {
-                conn.l7.request_leg = .pumping_body;
+                conn.stream.l7.request_leg = .pumping_body;
                 // Relay chunks will flow and be overwritten: from here the
                 // try is no longer reconstructible — no replay (§7).
-                conn.l7.request_body_pumped = true;
+                conn.stream.l7.request_body_pumped = true;
                 armRequestBodyRecv(server, conn);
             }
         }
@@ -1957,18 +1957,18 @@ pub fn Proxy(comptime IoType: type) type {
 
             pub fn beforeRecv(conn: *ConnType) void {
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.request_leg == .pumping_body);
+                assert(conn.stream.l7.request_leg == .pumping_body);
                 // A client-side recv is never armed under a pending verdict:
                 // expiry is unanswerable then, and a verdict arms nothing.
-                assert(conn.l7.pending_verdict == .none);
+                assert(conn.stream.l7.pending_verdict == .none);
                 // A recv on the CLIENT socket: an expiry cannot force it, so
                 // the deadline verdict is unanswerable while this op is armed.
-                conn.l7.request_op_on_client = true;
+                conn.stream.l7.request_op_on_client = true;
             }
 
             pub fn beforeSend(conn: *ConnType) void {
                 assert(conn.state == .l7_exchanging);
-                conn.l7.request_op_on_client = false; // A send on the upstream socket.
+                conn.stream.l7.request_op_on_client = false; // A send on the upstream socket.
             }
 
             /// Completion-time re-checks (post-await): a client-side body
@@ -1976,12 +1976,12 @@ pub fn Proxy(comptime IoType: type) type {
             /// unanswerable then — so none can have arrived during the await.
             pub fn onRecvEntry(conn: *ConnType) void {
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.request_leg == .pumping_body);
-                assert(conn.l7.pending_verdict == .none);
+                assert(conn.stream.l7.request_leg == .pumping_body);
+                assert(conn.stream.l7.pending_verdict == .none);
             }
 
             pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
-                const fr = feedFraming(&conn.l7.request_framing, chunk);
+                const fr = feedFraming(&conn.stream.l7.request_framing, chunk);
                 if (fr.malformed) return fr;
                 // A chunked body announces no size, so the cap can only be
                 // read off what has actually arrived (#236). Checked after
@@ -2007,12 +2007,12 @@ pub fn Proxy(comptime IoType: type) type {
                 if (fr.consumed < received) {
                     // Bytes past the body are a pipelined next request; the
                     // connection will close after this exchange (§7 note).
-                    conn.l7.client_pipelined = true;
+                    conn.stream.l7.client_pipelined = true;
                 }
             }
 
             pub fn framingDone(conn: *ConnType) bool {
-                return framingDoneOf(&conn.l7.request_framing);
+                return framingDoneOf(&conn.stream.l7.request_framing);
             }
 
             pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
@@ -2029,21 +2029,21 @@ pub fn Proxy(comptime IoType: type) type {
 
             pub fn onDrained(server: *ServerType, conn: *ConnType) void {
                 _ = server;
-                conn.l7.request_leg = .done;
+                conn.stream.l7.request_leg = .done;
                 // The delivered recv was the flag's referent; keep the
                 // flag self-descriptive now that no request op is armed.
-                conn.l7.request_op_on_client = false;
+                conn.stream.l7.request_op_on_client = false;
             }
 
             pub fn onComplete(server: *ServerType, conn: *ConnType) void {
                 _ = server;
-                conn.l7.request_leg = .done;
+                conn.stream.l7.request_leg = .done;
             }
 
             pub fn onSendEntry(server: *ServerType, conn: *ConnType) bool {
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.request_leg == .pumping_body);
-                if (conn.l7.pending_verdict != .none) {
+                assert(conn.stream.l7.request_leg == .pumping_body);
+                if (conn.stream.l7.pending_verdict != .none) {
                     settlePendingVerdict(server, conn);
                     return true;
                 }
@@ -2084,20 +2084,20 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn startResponseLeg(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .idle);
-            assert(conn.upstream.?.head_len == 0);
-            conn.l7.response_leg = .awaiting_head;
+            assert(conn.stream.l7.response_leg == .idle);
+            assert(conn.stream.upstream.?.head_len == 0);
+            conn.stream.l7.response_leg = .awaiting_head;
             armResponseHeadRecv(server, conn);
         }
 
         fn armResponseHeadRecv(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            const upstream = conn.upstream.?;
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            const upstream = conn.stream.upstream.?;
             assert(upstream.head_len < upstreamHeadBytes(upstream).len);
             conn.stream.arm(&conn.stream.op_data_upstream_to_client, "data_upstream_to_client");
             server.io.recv(
-                conn.upstream_socket.?,
+                conn.stream.upstream_socket.?,
                 upstreamHeadBytes(upstream)[upstream.head_len..],
                 &conn.stream.op_data_upstream_to_client.completion,
                 ConnType,
@@ -2114,8 +2114,8 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             }
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            if (conn.l7.pending_verdict != .none) {
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            if (conn.stream.l7.pending_verdict != .none) {
                 settlePendingVerdict(server, conn);
                 return;
             }
@@ -2125,7 +2125,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(received >= 1);
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             upstream.head_len += received;
             assert(upstream.head_len <= upstreamHeadBytes(upstream).len);
             parseResponseAndDispatch(server, conn);
@@ -2137,7 +2137,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// framing strictness applies to it all the same).
         fn parseResponseAndDispatch(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             const head = upstreamHeadBytes(upstream)[0..upstream.head_len];
             const head_is_full = upstream.head_len == upstreamHeadBytes(upstream).len;
 
@@ -2147,7 +2147,7 @@ pub fn Proxy(comptime IoType: type) type {
                 head,
                 head_is_full,
                 storage,
-                conn.l7.request_method,
+                conn.stream.l7.request_method,
             ) catch |err| switch (err) {
                 error.Incomplete => {
                     assert(!head_is_full);
@@ -2162,15 +2162,15 @@ pub fn Proxy(comptime IoType: type) type {
             // The render reuses conn.head, so it must wait until the
             // request head has vacated that buffer (§7 buffer rotation);
             // record the head boundary so the deferred render agrees.
-            conn.l7.response_head_len_marker = response.head_len;
-            if (conn.l7.request_head_vacated) {
+            conn.stream.l7.response_head_len_marker = response.head_len;
+            if (conn.stream.l7.request_head_vacated) {
                 // conn.head is already free, so render straight from the
                 // parse we just did — no second parse of the same bytes.
                 // This is the common path: the request head vacates long
                 // before the origin answers.
                 renderResponse(server, conn, &response);
             } else {
-                conn.l7.response_render_pending = true;
+                conn.stream.l7.response_render_pending = true;
             }
         }
 
@@ -2181,18 +2181,18 @@ pub fn Proxy(comptime IoType: type) type {
         /// from the first parse via `renderResponse` and never gets here.
         fn beginResponseForward(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            assert(conn.l7.request_head_vacated);
-            const upstream = conn.upstream.?;
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            assert(conn.stream.l7.request_head_vacated);
+            const upstream = conn.stream.upstream.?;
             const storage = server.borrowHeaderScratch();
             defer server.returnHeaderScratch();
             const response = parser.parseResponseHead(
                 upstreamHeadBytes(upstream)[0..upstream.head_len],
                 false,
                 storage,
-                conn.l7.request_method,
+                conn.stream.l7.request_method,
             ) catch unreachable;
-            assert(response.head_len == conn.l7.response_head_len_marker);
+            assert(response.head_len == conn.stream.l7.response_head_len_marker);
             renderResponse(server, conn, &response);
         }
 
@@ -2280,7 +2280,7 @@ pub fn Proxy(comptime IoType: type) type {
         ) StaticPersistence {
             const would_keep = may_keep and
                 staticResponseResyncable(conn) and
-                conn.l7.client_keep_alive and
+                conn.stream.l7.client_keep_alive and
                 !server.draining and
                 !server.keepAliveSuppressed();
             if (!would_keep) return .{ .keep = false, .capped = false };
@@ -2329,9 +2329,9 @@ pub fn Proxy(comptime IoType: type) type {
             response: *const parser.ResponseHead,
         ) bool {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            return conn.l7.client_keep_alive and
-                !conn.l7.client_pipelined and !server.draining and
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            return conn.stream.l7.client_keep_alive and
+                !conn.stream.l7.client_pipelined and !server.draining and
                 !server.keepAliveSuppressed() and response.framing != .until_close;
         }
 
@@ -2366,8 +2366,8 @@ pub fn Proxy(comptime IoType: type) type {
 
         fn stickyVerdict(server: *const ServerType, conn: *const ConnType) StickyVerdict {
             assert(conn.state == .l7_exchanging);
-            assert(conn.cluster_index < server.config.clusters.len);
-            const cluster = &server.config.clusters[conn.cluster_index];
+            assert(conn.stream.cluster_index < server.config.clusters.len);
+            const cluster = &server.config.clusters[conn.stream.cluster_index];
             switch (cluster.hash_key) {
                 .source_ip, .header => return .none,
                 .cookie => {},
@@ -2376,10 +2376,10 @@ pub fn Proxy(comptime IoType: type) type {
             // endpoint was recorded when its slot was (§8).
             assert(conn.log.endpoint_index != conn_module.LogState.endpoint_none);
             const served = server.balancer.endpointIdentity(
-                conn.cluster_index,
+                conn.stream.cluster_index,
                 conn.log.endpoint_index,
             );
-            const carried = conn.l7.sticky_cookie orelse return .assigned;
+            const carried = conn.stream.l7.sticky_cookie orelse return .assigned;
             if (carried == served) {
                 return .followed;
             }
@@ -2427,7 +2427,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .none, .followed => return edits,
                 .assigned, .repicked => {},
             }
-            const name = switch (server.config.clusters[conn.cluster_index].hash_key) {
+            const name = switch (server.config.clusters[conn.stream.cluster_index].hash_key) {
                 .cookie => |name| name,
                 // The verdict said cookie cluster; the config cannot
                 // have changed under it (§5 parse-once).
@@ -2444,7 +2444,7 @@ pub fn Proxy(comptime IoType: type) type {
             // stamp announces is byte-identical to the tag the next
             // request's parse will match.
             Balancer.formatEndpointTag(
-                server.balancer.endpointIdentity(conn.cluster_index, conn.log.endpoint_index),
+                server.balancer.endpointIdentity(conn.stream.cluster_index, conn.log.endpoint_index),
                 scratch[len..][0..Balancer.endpoint_tag_len],
             );
             len += Balancer.endpoint_tag_len;
@@ -2505,10 +2505,10 @@ pub fn Proxy(comptime IoType: type) type {
             response: *const parser.ResponseHead,
         ) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.upgrade_requested);
+            assert(conn.stream.l7.upgrade_requested);
             assert(response.status == 101);
             assert(conn.tunnel_buffer != null);
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             // No edits and no sticky stamp: #175 and #178 both describe a
             // response an origin *served*, and this one only announces
             // that serving has stopped being HTTP. A `Set-Cookie` naming
@@ -2535,8 +2535,8 @@ pub fn Proxy(comptime IoType: type) type {
             }
             @memcpy(headBytes(server, conn)[rendered.len..][0..trailing.len], trailing);
             const head_write_len: u32 = @intCast(rendered.len + trailing.len);
-            conn.l7.response_leg = .sending_head;
-            conn.l7.response_started = true;
+            conn.stream.l7.response_leg = .sending_head;
+            conn.stream.l7.response_started = true;
             // The status is recorded at `beginTunnel`, not here: a `101`
             // in the log means a tunnel the client actually got, so a
             // handshake whose write never landed reports the teardown it
@@ -2566,12 +2566,12 @@ pub fn Proxy(comptime IoType: type) type {
         /// something this proxy dropped.
         fn beginTunnel(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.upgrade_requested);
-            assert(conn.upstream_socket != null);
+            assert(conn.stream.l7.upgrade_requested);
+            assert(conn.stream.upstream_socket != null);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(conn.l7.request_head_len <= conn.stream.head_len);
-            const pipelined = conn.stream.head_len - conn.l7.request_head_len;
+            assert(conn.stream.l7.request_head_len <= conn.stream.head_len);
+            const pipelined = conn.stream.head_len - conn.stream.l7.request_head_len;
             // `tunnel_buffer` stays set: it is what marks which pool this
             // buffer belongs to. `relay_buffer` only *aliases* it, so the
             // relay reads one field like every other connection while the
@@ -2585,14 +2585,14 @@ pub fn Proxy(comptime IoType: type) type {
                 assert(pipelined <= buffer.client_to_upstream.len);
                 @memcpy(
                     buffer.client_to_upstream[0..pipelined],
-                    headBytes(server, conn)[conn.l7.request_head_len..conn.stream.head_len],
+                    headBytes(server, conn)[conn.stream.l7.request_head_len..conn.stream.head_len],
                 );
             }
-            const leased = conn.upstream.?;
+            const leased = conn.stream.upstream.?;
             const cluster_index = leased.cluster_index;
             const endpoint_index = leased.endpoint_index;
             server.releaseUpstream(leased);
-            conn.upstream = null;
+            conn.stream.upstream = null;
             // Both held for certain here, unlike at the static-response
             // rungs where either may never have been acquired: this runs
             // only after a rendered head went out, which needed the head
@@ -2666,11 +2666,11 @@ pub fn Proxy(comptime IoType: type) type {
             response: *const parser.ResponseHead,
         ) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
+            assert(conn.stream.l7.response_leg == .awaiting_head);
             assert(response.status >= 100);
             assert(response.status < 200);
             assert(response.status != 101); // The caller diverts both 101 cases.
-            if (conn.l7.interims_seen >= constants.interim_responses_max) {
+            if (conn.stream.l7.interims_seen >= constants.interim_responses_max) {
                 // An origin that keeps promising and never answers is an
                 // unbounded loop on the one thread (§3), which no legal
                 // response justifies. Counted apart from a malformed head
@@ -2680,8 +2680,8 @@ pub fn Proxy(comptime IoType: type) type {
                 upstreamFailed(server, conn);
                 return;
             }
-            conn.l7.interims_seen += 1;
-            const upstream = conn.upstream.?;
+            conn.stream.l7.interims_seen += 1;
+            const upstream = conn.stream.upstream.?;
             const scratch = server.borrowRenderScratch();
             defer server.returnRenderScratch();
             const rendered = render.renderResponseHead(
@@ -2711,7 +2711,7 @@ pub fn Proxy(comptime IoType: type) type {
                 );
             }
             upstream.head_len = rest;
-            conn.l7.response_head_len_marker = 0;
+            conn.stream.l7.response_head_len_marker = 0;
             server.counters.increment("l7_interim_forwarded");
             armClientWrite(server, conn, headBytes(server, conn)[0..rendered.len], .interim_sent);
         }
@@ -2721,10 +2721,10 @@ pub fn Proxy(comptime IoType: type) type {
         /// sent `100` and its `200` in one write — or the socket owes it.
         fn resumeAfterInterim(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            assert(!conn.l7.response_started);
-            assert(conn.l7.interims_seen >= 1);
-            const upstream = conn.upstream.?;
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            assert(!conn.stream.l7.response_started);
+            assert(conn.stream.l7.interims_seen >= 1);
+            const upstream = conn.stream.upstream.?;
             if (upstream.head_len >= 1) {
                 parseResponseAndDispatch(server, conn);
                 return;
@@ -2752,7 +2752,7 @@ pub fn Proxy(comptime IoType: type) type {
         ) bool {
             assert(conn.state == .l7_exchanging);
             assert(response.status >= 100);
-            if (conn.l7.upgrade_requested and response.status == 101) {
+            if (conn.stream.l7.upgrade_requested and response.status == 101) {
                 renderUpgradeAccepted(server, conn, response);
                 return false;
             }
@@ -2760,8 +2760,8 @@ pub fn Proxy(comptime IoType: type) type {
                 // The origin declined an upgrade it was offered, which is
                 // legal and ordinary — hand the claim back before the
                 // exchange carries on as any other (#180).
-                if (conn.l7.upgrade_requested) {
-                    conn.l7.upgrade_requested = false;
+                if (conn.stream.l7.upgrade_requested) {
+                    conn.stream.l7.upgrade_requested = false;
                     releaseTunnelClaim(server, conn);
                 }
                 return true;
@@ -2792,11 +2792,11 @@ pub fn Proxy(comptime IoType: type) type {
             const head = headBytes(server, conn);
             assert(rendered_len <= head.len);
             if (rendered_len + excess.len > head.len) {
-                conn.l7.response_excess_len = @intCast(excess.len);
+                conn.stream.l7.response_excess_len = @intCast(excess.len);
                 return rendered_len;
             }
             @memcpy(head[rendered_len..][0..excess.len], excess);
-            conn.l7.response_excess_len = 0; // It rides the head write.
+            conn.stream.l7.response_excess_len = 0; // It rides the head write.
             return rendered_len + @as(u32, @intCast(excess.len));
         }
 
@@ -2806,9 +2806,9 @@ pub fn Proxy(comptime IoType: type) type {
             response: *const parser.ResponseHead,
         ) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_leg == .awaiting_head);
-            assert(conn.l7.request_head_vacated);
-            const upstream = conn.upstream.?;
+            assert(conn.stream.l7.response_leg == .awaiting_head);
+            assert(conn.stream.l7.request_head_vacated);
+            const upstream = conn.stream.upstream.?;
             // Not every status reaching here is *the* response: a tunnel,
             // an interim and an uninvited switch all divert first.
             if (!dispatchByStatus(server, conn, response)) return;
@@ -2823,8 +2823,8 @@ pub fn Proxy(comptime IoType: type) type {
                 conn,
                 downstreamKeepAlive(server, conn, response),
             );
-            conn.l7.downstream_close_announced = !keep_downstream;
-            conn.l7.upstream_reusable = response.keep_alive;
+            conn.stream.l7.downstream_close_announced = !keep_downstream;
+            conn.stream.l7.upstream_reusable = response.keep_alive;
             const verdict = stickyVerdict(server, conn);
             const scratch = server.borrowRenderScratch();
             defer server.returnRenderScratch();
@@ -2851,12 +2851,12 @@ pub fn Proxy(comptime IoType: type) type {
                 return;
             };
             assert(rendered.len >= 1);
-            conn.l7.response_framing = framingFromParsed(response.framing);
+            conn.stream.l7.response_framing = framingFromParsed(response.framing);
 
             // Feed the framing tracker over the body excess that arrived
             // coalesced with the head.
             const excess = upstreamHeadBytes(upstream)[response.head_len..upstream.head_len];
-            const feed = feedFraming(&conn.l7.response_framing, excess);
+            const feed = feedFraming(&conn.stream.l7.response_framing, excess);
             if (feed.malformed) {
                 upstreamFailed(server, conn);
                 return;
@@ -2894,10 +2894,10 @@ pub fn Proxy(comptime IoType: type) type {
             head_write_len: u32,
         ) void {
             assert(conn.state == .l7_exchanging);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             assert(head_write_len >= 1);
-            conn.l7.response_leg = .sending_head;
-            conn.l7.response_started = true;
+            conn.stream.l7.response_leg = .sending_head;
+            conn.stream.l7.response_started = true;
             creditSticky(server, verdict);
             conn.log.status = response.status;
             server.captureResponseLogHeaders(conn, response.headers);
@@ -2963,17 +2963,17 @@ pub fn Proxy(comptime IoType: type) type {
                 // as the response, and no verdict can be pending (#232).
                 .interim_sent => {
                     assert(conn.state == .l7_exchanging);
-                    assert(conn.l7.pending_verdict == .none);
-                    assert(!conn.l7.response_started);
-                    assert(conn.l7.response_leg == .awaiting_head);
+                    assert(conn.stream.l7.pending_verdict == .none);
+                    assert(!conn.stream.l7.response_started);
+                    assert(conn.stream.l7.response_leg == .awaiting_head);
                 },
                 // The handshake is out and nothing has been relayed yet:
                 // still the exchange, still no verdict, and the tunnel
                 // buffer claimed at the gate is still in hand (#180).
                 .tunnel_start => {
                     assert(conn.state == .l7_exchanging);
-                    assert(conn.l7.pending_verdict == .none);
-                    assert(conn.l7.upgrade_requested);
+                    assert(conn.stream.l7.pending_verdict == .none);
+                    assert(conn.stream.l7.upgrade_requested);
                     assert(conn.tunnel_buffer != null);
                 },
                 .response_excess, .response_body => {
@@ -2981,7 +2981,7 @@ pub fn Proxy(comptime IoType: type) type {
                     // pending once response bytes are flowing (negative
                     // space).
                     assert(conn.state == .l7_exchanging);
-                    assert(conn.l7.pending_verdict == .none);
+                    assert(conn.stream.l7.pending_verdict == .none);
                 },
                 // The two static-response endings share one state:
                 // `respond` is the only writer of either, and always sets
@@ -3101,7 +3101,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .interim_sent => resumeAfterInterim(server, conn),
                 .response_excess => sendResponseExcess(server, conn),
                 .response_body => {
-                    assert(conn.l7.response_leg == .sending_body_excess);
+                    assert(conn.stream.l7.response_leg == .sending_body_excess);
                     afterResponseExcess(server, conn);
                 },
                 // A static answer is fully delivered. Log it here rather
@@ -3138,23 +3138,23 @@ pub fn Proxy(comptime IoType: type) type {
         /// coalesced with it but did not fit beside it follows straight from
         /// `upstream.head`; otherwise the body pump takes over.
         fn sendResponseExcess(server: *ServerType, conn: *ConnType) void {
-            assert(conn.l7.response_leg == .sending_head);
-            const excess_len = conn.l7.response_excess_len;
+            assert(conn.stream.l7.response_leg == .sending_head);
+            const excess_len = conn.stream.l7.response_excess_len;
             if (excess_len == 0) {
                 afterResponseExcess(server, conn);
                 return;
             }
-            conn.l7.response_leg = .sending_body_excess;
+            conn.stream.l7.response_leg = .sending_body_excess;
             server.counters.increment("l7_response_excess_sent");
-            const base = conn.l7.response_head_len_marker;
+            const base = conn.stream.l7.response_head_len_marker;
             // These are bytes the origin actually delivered past its head —
             // the bound `DirectionState.pending` used to check for this write
             // before the channel owned the cursor.
-            assert(base + excess_len <= conn.upstream.?.head_len);
+            assert(base + excess_len <= conn.stream.upstream.?.head_len);
             armClientWrite(
                 server,
                 conn,
-                upstreamHeadBytes(conn.upstream.?)[base..][0..excess_len],
+                upstreamHeadBytes(conn.stream.upstream.?)[base..][0..excess_len],
                 .response_body,
             );
         }
@@ -3163,8 +3163,8 @@ pub fn Proxy(comptime IoType: type) type {
         /// body ended there, else pump the remaining body from the origin.
         fn afterResponseExcess(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            conn.l7.response_leg = .pumping_body;
-            if (framingDoneOf(&conn.l7.response_framing)) {
+            conn.stream.l7.response_leg = .pumping_body;
+            if (framingDoneOf(&conn.stream.l7.response_framing)) {
                 finishExchange(server, conn);
             } else {
                 armResponseBodyRecv(server, conn);
@@ -3231,8 +3231,8 @@ pub fn Proxy(comptime IoType: type) type {
 
             pub fn beforeRecv(conn: *ConnType) void {
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.response_leg == .pumping_body);
-                assert(conn.l7.pending_verdict == .none); // response_started.
+                assert(conn.stream.l7.response_leg == .pumping_body);
+                assert(conn.stream.l7.pending_verdict == .none); // response_started.
             }
 
             /// Completion-time re-checks (post-await): once a response byte
@@ -3240,12 +3240,12 @@ pub fn Proxy(comptime IoType: type) type {
             /// invariant must still hold after the await.
             pub fn onRecvEntry(conn: *ConnType) void {
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.response_leg == .pumping_body);
-                assert(conn.l7.pending_verdict == .none); // response_started.
+                assert(conn.stream.l7.response_leg == .pumping_body);
+                assert(conn.stream.l7.pending_verdict == .none); // response_started.
             }
 
             pub fn feed(conn: *ConnType, chunk: []const u8) pump.FeedResult {
-                return feedFraming(&conn.l7.response_framing, chunk);
+                return feedFraming(&conn.stream.l7.response_framing, chunk);
             }
 
             /// Response body bytes that reached the client. The head and
@@ -3257,12 +3257,12 @@ pub fn Proxy(comptime IoType: type) type {
             }
 
             pub fn framingDone(conn: *ConnType) bool {
-                return framingDoneOf(&conn.l7.response_framing);
+                return framingDoneOf(&conn.stream.l7.response_framing);
             }
 
             pub fn onRecvError(server: *ServerType, conn: *ConnType, err: Io.RecvError) void {
                 if (err == error.EndOfStream) {
-                    if (conn.l7.response_framing == .until_close) {
+                    if (conn.stream.l7.response_framing == .until_close) {
                         // The origin's EOF is this framing's terminator.
                         finishExchange(server, conn);
                         return;
@@ -3290,8 +3290,8 @@ pub fn Proxy(comptime IoType: type) type {
             pub fn onSendEntry(server: *ServerType, conn: *ConnType) bool {
                 _ = server;
                 assert(conn.state == .l7_exchanging);
-                assert(conn.l7.response_leg == .pumping_body);
-                assert(conn.l7.pending_verdict == .none); // response_started.
+                assert(conn.stream.l7.response_leg == .pumping_body);
+                assert(conn.stream.l7.pending_verdict == .none); // response_started.
                 return false;
             }
         };
@@ -3307,24 +3307,24 @@ pub fn Proxy(comptime IoType: type) type {
         /// two byte streams are no longer alignable.
         fn finishExchange(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.response_started);
-            conn.l7.response_leg = .done;
+            assert(conn.stream.l7.response_started);
+            conn.stream.l7.response_leg = .done;
             server.counters.increment("l7_responses");
             // The labeled twin (#179): the slot is still attached here —
             // park and detach run below — and it names the endpoint that
             // actually served, which is what "requests per backend" means.
-            assert(conn.upstream != null);
+            assert(conn.stream.upstream != null);
             server.labeled.incrementEndpoint(.responses, server.upstreams.keys.key(
-                conn.upstream.?.cluster_index,
-                conn.upstream.?.endpoint_index,
+                conn.stream.upstream.?.cluster_index,
+                conn.stream.upstream.?.endpoint_index,
             ));
             // #230: a served response ends whatever passive streak was
             // building. Any response — the status is deliberately not
             // read, because an origin answering 500 is a software bug
             // and this counts endpoints, not deployments.
             server.health.witnessPassiveSuccess(
-                conn.upstream.?.cluster_index,
-                conn.upstream.?.endpoint_index,
+                conn.stream.upstream.?.cluster_index,
+                conn.stream.upstream.?.endpoint_index,
             );
             // The whole response reached the client: the line goes out
             // now, before the turnaround below clears what it reports.
@@ -3335,11 +3335,11 @@ pub fn Proxy(comptime IoType: type) type {
             conn.log.outcome = .ok;
             server.logExchange(conn);
 
-            const request_complete = conn.l7.request_leg == .done;
-            if (conn.l7.upstream_reusable and request_complete and !server.draining) {
+            const request_complete = conn.stream.l7.request_leg == .done;
+            if (conn.stream.l7.upstream_reusable and request_complete and !server.draining) {
                 parkUpstream(server, conn);
             }
-            const keep_downstream = !conn.l7.downstream_close_announced and
+            const keep_downstream = !conn.stream.l7.downstream_close_announced and
                 request_complete and !server.draining;
             if (keep_downstream) {
                 detachUpstream(server, conn);
@@ -3358,7 +3358,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// so idle parked sockets free their slots before the 503 wall.
         fn parkUpstream(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            const upstream = conn.upstream.?;
+            const upstream = conn.stream.upstream.?;
             assert(!upstream.parked);
             // The exchange's head bytes go back before the slot parks
             // (§5): the response leg is settled, so the client-write
@@ -3370,8 +3370,8 @@ pub fn Proxy(comptime IoType: type) type {
             upstream.deadline_ns = server.io.nowNs() +
                 @as(u64, server.parkedTimeoutMs()) * std.time.ns_per_ms;
             server.ensureUpstreamSweep();
-            conn.upstream = null;
-            conn.upstream_socket = null;
+            conn.stream.upstream = null;
+            conn.stream.upstream_socket = null;
         }
 
         /// Close and release an upstream that did not park while the conn
@@ -3381,13 +3381,13 @@ pub fn Proxy(comptime IoType: type) type {
         fn detachUpstream(server: *ServerType, conn: *ConnType) void {
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            if (conn.upstream) |leased| {
-                server.io.closeNow(conn.upstream_socket.?);
+            if (conn.stream.upstream) |leased| {
+                server.io.closeNow(conn.stream.upstream_socket.?);
                 server.releaseUpstream(leased);
-                conn.upstream = null;
-                conn.upstream_socket = null;
+                conn.stream.upstream = null;
+                conn.stream.upstream_socket = null;
             }
-            assert(conn.upstream_socket == null);
+            assert(conn.stream.upstream_socket == null);
         }
 
         /// Keep-alive turnaround (§5): the relay buffer goes back to its
@@ -3396,7 +3396,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// a fresh idle deadline.
         fn resetForNextRequest(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             // The exchange is fully settled: no data or dial ops in flight.
             // The lazy deadline timer stays armed across the turnaround (§4),
             // and a dial rebase (§8) cancel may still be draining if the
@@ -3427,7 +3427,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// can state why they hold.
         fn beginNextRequest(server: *ServerType, conn: *ConnType) void {
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             assert(conn.stream.client_write.pending.len == 0);
             // The exchange that just ended has spoken for itself, so its
             // accounting resets with the rest of the per-request state
@@ -3444,7 +3444,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             conn.stream.head_len = 0;
             conn.stream.head_cursor.reset();
-            conn.l7 = .{};
+            conn.stream.l7 = .{};
             conn.log.reset();
             // The #140 captures live in the server's side table, not on
             // `log`, so they need clearing beside it — or the next
@@ -3475,10 +3475,10 @@ pub fn Proxy(comptime IoType: type) type {
         /// it belonged to could not complete regardless.
         pub fn expiryAnswerable(conn: *const ConnType) bool {
             assert(conn.state == .l7_exchanging);
-            if (conn.l7.response_started) {
+            if (conn.stream.l7.response_started) {
                 return false;
             }
-            if (conn.stream.armed.data_client_to_upstream and conn.l7.request_op_on_client) {
+            if (conn.stream.armed.data_client_to_upstream and conn.stream.l7.request_op_on_client) {
                 return false;
             }
             return true;
@@ -3493,18 +3493,18 @@ pub fn Proxy(comptime IoType: type) type {
         /// known: a deadline can only be answered against a try, and a
         /// try is a pick.
         fn witnessNoResponse(server: *ServerType, conn: *const ConnType) void {
-            assert(conn.upstream != null);
+            assert(conn.stream.upstream != null);
             server.labeled.incrementEndpoint(.no_response, server.upstreams.keys.key(
-                conn.upstream.?.cluster_index,
-                conn.upstream.?.endpoint_index,
+                conn.stream.upstream.?.cluster_index,
+                conn.stream.upstream.?.endpoint_index,
             ));
             // #230's second signal. This is the wedged-application case a
             // `tcp` probe is blind to — the kernel completed a handshake
             // the application never got to — so it is the one passive
             // ejection exists for more than any other.
             server.health.witnessPassiveFailure(
-                conn.upstream.?.cluster_index,
-                conn.upstream.?.endpoint_index,
+                conn.stream.upstream.?.cluster_index,
+                conn.stream.upstream.?.endpoint_index,
             );
         }
 
@@ -3527,8 +3527,8 @@ pub fn Proxy(comptime IoType: type) type {
             // set only inside `.l7_exchanging` and cleared on every entry
             // to this state, so a conditional here would read as live and
             // never be.
-            assert(!conn.l7.response_started);
-            if (!conn.l7.head_budget_installed) return false;
+            assert(!conn.stream.l7.response_started);
+            if (!conn.stream.l7.head_budget_installed) return false;
             return conn.stream.armed.data_client_to_upstream;
         }
 
@@ -3548,9 +3548,9 @@ pub fn Proxy(comptime IoType: type) type {
         /// cannot carry another request, so the `408` announces close.
         pub fn beginHeadExpiry(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_reading_head);
-            assert(conn.l7.pending_verdict == .none);
+            assert(conn.stream.l7.pending_verdict == .none);
             assert(headExpiryAnswerable(conn));
-            conn.l7.pending_verdict = .request_timeout;
+            conn.stream.l7.pending_verdict = .request_timeout;
             server.io.shutdown(conn.client_socket, .read);
         }
 
@@ -3563,12 +3563,12 @@ pub fn Proxy(comptime IoType: type) type {
         /// never inline here.
         pub fn beginExpiry(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.pending_verdict == .none);
+            assert(conn.stream.l7.pending_verdict == .none);
             assert(expiryAnswerable(conn));
             assert(conn.stream.armed.data_client_to_upstream or
                 conn.stream.armed.data_upstream_to_client);
-            conn.l7.pending_verdict = .gateway_timeout;
-            server.io.shutdown(conn.upstream_socket.?, .both);
+            conn.stream.l7.pending_verdict = .gateway_timeout;
+            server.io.shutdown(conn.stream.upstream_socket.?, .both);
         }
 
         /// A completion landed with a verdict pending: once the last data
@@ -3585,15 +3585,15 @@ pub fn Proxy(comptime IoType: type) type {
             // would be two copies of that rule to keep in step.
             assert(conn.state == .l7_exchanging or
                 (conn.state == .l7_reading_head and
-                    conn.l7.pending_verdict == .request_timeout));
-            assert(conn.l7.pending_verdict != .none);
+                    conn.stream.l7.pending_verdict == .request_timeout));
+            assert(conn.stream.l7.pending_verdict != .none);
             if (conn.stream.armed.data_client_to_upstream or
                 conn.stream.armed.data_upstream_to_client)
             {
                 return; // The sibling's forced completion re-enters here.
             }
-            const verdict = conn.l7.pending_verdict;
-            conn.l7.pending_verdict = .none;
+            const verdict = conn.stream.l7.pending_verdict;
+            conn.stream.l7.pending_verdict = .none;
             switch (verdict) {
                 .none => unreachable,
                 .gateway_timeout => {
@@ -3620,16 +3620,16 @@ pub fn Proxy(comptime IoType: type) type {
         /// the request leg already done.
         fn replayEligible(conn: *const ConnType) bool {
             assert(conn.state == .l7_exchanging);
-            if (!conn.l7.upstream_was_reused) {
+            if (!conn.stream.l7.upstream_was_reused) {
                 return false;
             }
-            if (conn.l7.replay_used) {
+            if (conn.stream.l7.replay_used) {
                 return false;
             }
-            if (conn.l7.response_started) {
+            if (conn.stream.l7.response_started) {
                 return false;
             }
-            if (conn.upstream.?.head_len != 0) {
+            if (conn.stream.upstream.?.head_len != 0) {
                 return false; // A response byte arrived: the origin spoke.
             }
             // And an interim means it spoke *and the client heard it*
@@ -3641,14 +3641,14 @@ pub fn Proxy(comptime IoType: type) type {
             // settles "may have begun processing" against — to a second
             // origin, after this proxy has already told the client to go
             // ahead.
-            if (conn.l7.interims_seen != 0) {
+            if (conn.stream.l7.interims_seen != 0) {
                 return false;
             }
-            if (conn.l7.request_body_pumped) {
+            if (conn.stream.l7.request_body_pumped) {
                 return false; // Relay chunks flowed; not reconstructible.
             }
-            assert(conn.l7.request_leg != .idle);
-            assert(conn.l7.request_leg != .pumping_body); // Implied by the flag.
+            assert(conn.stream.l7.request_leg != .idle);
+            assert(conn.stream.l7.request_leg != .pumping_body); // Implied by the flag.
             return true;
         }
 
@@ -3657,29 +3657,29 @@ pub fn Proxy(comptime IoType: type) type {
         /// already cleared; the caller (settle) proved both data ops free.
         fn beginReplay(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.pending_verdict == .none);
-            assert(conn.l7.replay_used); // Spent before the try began.
+            assert(conn.stream.l7.pending_verdict == .none);
+            assert(conn.stream.l7.replay_used); // Spent before the try began.
             // A replay always precedes any #181 retry, never follows one:
             // it needs a *reused* checkout, and a retry only ever dials
             // fresh. So the rebuild below defaulting the tried set to
             // empty is the truth, not a reset.
-            assert(conn.l7.tried_count == 0);
+            assert(conn.stream.l7.tried_count == 0);
             // No interim was relayed, so the rebuild below defaulting
             // `interims_seen` to zero is the truth rather than a reset —
             // `replayEligible` refuses a replay once one has gone out
             // (#232), and this is what would trip if that ever stopped
             // being true.
-            assert(conn.l7.interims_seen == 0);
+            assert(conn.stream.l7.interims_seen == 0);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             assert(conn.stream.relay_buffer != null); // Retained across the replay.
-            const stale = conn.upstream.?;
+            const stale = conn.stream.upstream.?;
             assert(stale.head_len == 0);
-            server.io.closeNow(conn.upstream_socket.?);
+            server.io.closeNow(conn.stream.upstream_socket.?);
             server.releaseUpstream(stale);
-            conn.upstream = null;
-            conn.upstream_socket = null;
+            conn.stream.upstream = null;
+            conn.stream.upstream_socket = null;
             server.counters.increment("upstream_replayed");
             // Rebuild the per-try state from the §7 source of truth — the
             // client's bytes, intact in conn.head (the eligible legs sent
@@ -3695,19 +3695,19 @@ pub fn Proxy(comptime IoType: type) type {
                 storage,
                 null,
             ) catch unreachable;
-            assert(request.head_len == conn.l7.request_head_len);
-            conn.l7 = .{
-                .request_method = conn.l7.request_method,
+            assert(request.head_len == conn.stream.l7.request_head_len);
+            conn.stream.l7 = .{
+                .request_method = conn.stream.l7.request_method,
                 .request_framing = framingFromParsed(request.framing),
-                .request_head_len = conn.l7.request_head_len,
-                .client_keep_alive = conn.l7.client_keep_alive,
+                .request_head_len = conn.stream.l7.request_head_len,
+                .client_keep_alive = conn.stream.l7.client_keep_alive,
                 .replay_used = true,
                 // The §8 cap rides across too: a replay is the *same*
                 // client-visible request taking its one free retry, not a
                 // new exchange, so it must not win itself a fresh budget.
                 // Dropping it here would silently uncap the rest of the
                 // exchange, since `storeDeadline` stops clamping at zero.
-                .request_deadline_ns = conn.l7.request_deadline_ns,
+                .request_deadline_ns = conn.stream.l7.request_deadline_ns,
                 // The #180 claim rides across, and must: the tunnel
                 // buffer is held on the connection, so a rebuild that
                 // dropped this flag would re-render the head *without*
@@ -3716,7 +3716,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // never asked for, and the claim would sit unspent until
                 // the connection closed. Found by the simulator, on a
                 // seed where a stale checkout replayed a handshake.
-                .upgrade_requested = conn.l7.upgrade_requested,
+                .upgrade_requested = conn.stream.l7.upgrade_requested,
                 // upstream_was_reused stays default-false: the replay try
                 // is a fresh dial, and a second early failure answers 502.
             };
@@ -3730,7 +3730,7 @@ pub fn Proxy(comptime IoType: type) type {
             // the same request key (#178), re-derived from the re-parse
             // exactly like the framing: same bytes, same key.
             const request_key = requestKeyFor(server, conn, &request);
-            conn.l7.sticky_cookie = switch (request_key) {
+            conn.stream.l7.sticky_cookie = switch (request_key) {
                 .endpoint => |identity| identity,
                 else => null,
             };
@@ -3747,18 +3747,18 @@ pub fn Proxy(comptime IoType: type) type {
         /// completion the answer would need.
         fn upstreamFailed(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .l7_exchanging);
-            assert(conn.l7.pending_verdict == .none); // Handlers divert first.
+            assert(conn.stream.l7.pending_verdict == .none); // Handlers divert first.
             if (replayEligible(conn)) {
-                conn.l7.pending_verdict = .replay;
-                conn.l7.replay_used = true; // Spent now: a loop is impossible.
+                conn.stream.l7.pending_verdict = .replay;
+                conn.stream.l7.replay_used = true; // Spent now: a loop is impossible.
                 // Force the sibling op, if armed (the response recv during
                 // an excess send); settle acts immediately when both are
                 // already free (the head-send failure case).
-                server.io.shutdown(conn.upstream_socket.?, .both);
+                server.io.shutdown(conn.stream.upstream_socket.?, .both);
                 settlePendingVerdict(server, conn);
                 return;
             }
-            if (conn.l7.response_started or conn.stream.armed.data_client_to_upstream or
+            if (conn.stream.l7.response_started or conn.stream.armed.data_client_to_upstream or
                 conn.stream.armed.data_upstream_to_client)
             {
                 server.beginTeardown(conn);
@@ -3771,11 +3771,11 @@ pub fn Proxy(comptime IoType: type) type {
             // conclusion by deadline where this one reaches it by
             // transport error, and an endpoint is no healthier for
             // failing fast.
-            assert(!conn.l7.response_started);
-            assert(conn.upstream != null);
+            assert(!conn.stream.l7.response_started);
+            assert(conn.stream.upstream != null);
             server.health.witnessPassiveFailure(
-                conn.upstream.?.cluster_index,
-                conn.upstream.?.endpoint_index,
+                conn.stream.upstream.?.cluster_index,
+                conn.stream.upstream.?.endpoint_index,
             );
             respond(server, conn, 502, "l7_bad_gateway");
         }
@@ -3817,9 +3817,9 @@ pub fn Proxy(comptime IoType: type) type {
             // this state follows a fill, so an unparsed head cannot tie
             // with `request_head_len`'s zero.
             assert(conn.stream.head_len >= 1);
-            assert(conn.l7.request_head_len <= conn.stream.head_len);
-            if (!framingDoneOf(&conn.l7.request_framing)) return false;
-            return conn.stream.head_len == conn.l7.request_head_len;
+            assert(conn.stream.l7.request_head_len <= conn.stream.head_len);
+            if (!framingDoneOf(&conn.stream.l7.request_framing)) return false;
+            return conn.stream.head_len == conn.stream.l7.request_head_len;
         }
 
         /// Everything a static response no longer needs, returned before
@@ -3857,24 +3857,24 @@ pub fn Proxy(comptime IoType: type) type {
             // response — so this is always an unspent claim.
             assert(conn.state != .relaying);
             releaseTunnelClaim(server, conn);
-            if (conn.upstream) |leased| {
-                if (conn.upstream_socket) |socket| {
+            if (conn.stream.upstream) |leased| {
+                if (conn.stream.upstream_socket) |socket| {
                     server.io.closeNow(socket);
                 }
                 server.releaseUpstream(leased);
-                conn.upstream = null;
-                conn.upstream_socket = null;
+                conn.stream.upstream = null;
+                conn.stream.upstream_socket = null;
             }
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
-            assert(conn.upstream_socket == null);
+            assert(conn.stream.upstream == null);
+            assert(conn.stream.upstream_socket == null);
         }
 
         /// Undo an unspent tunnel claim (#180): the gate takes a buffer
         /// before the handshake is forwarded, and every ending other than
         /// the origin's `101` has to give it back.
         ///
-        /// One chokepoint because the claim outlives `conn.l7`. The
+        /// One chokepoint because the claim outlives `conn.stream.l7`. The
         /// per-exchange state resets at every keep-alive turnaround, but
         /// this lives on the connection, so a path that forgot would pin a
         /// pool slot no session is using for as long as the client stays —
@@ -3903,7 +3903,7 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.state == .l7_exchanging);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             // The head-shed rung can never keep, structurally: nothing was
             // read (the ring was empty, so no buffer was ever bound), the
             // request's bytes wait unread in the socket, and a kept
@@ -3936,7 +3936,7 @@ pub fn Proxy(comptime IoType: type) type {
             comptime counter: []const u8,
             may_keep: bool,
         ) bool {
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             releaseForStaticResponse(server, conn);
             // Retiring the *cap* is only half of it — `conn.deadline_ns`
             // is still standing wherever the cap clamped it, and the
@@ -3980,7 +3980,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             const keep = commitStaticVerdict(server, conn, 200, "l7_max_forwards_exhausted", true);
             const persistence: shed.Persistence = if (keep) .keep else .close;
             const answer = server.static_responses.getOptions(persistence);
@@ -3990,7 +3990,7 @@ pub fn Proxy(comptime IoType: type) type {
             // The answer is bodiless, so a HEAD would take the same bytes
             // — and a HEAD never reaches here anyway: this is the OPTIONS
             // path alone.
-            assert(conn.l7.request_method == .options);
+            assert(conn.stream.l7.request_method == .options);
             const then: stream_module.ClientWrite.Then =
                 if (keep) .next_request else .lingering_close;
             armClientWrite(server, conn, answer.bytes, then);
@@ -4025,11 +4025,11 @@ pub fn Proxy(comptime IoType: type) type {
             keep: bool,
         ) void {
             assert(conn.state == .l7_responding);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             // Keeping implies the head parsed (§7 resync), which is what
             // makes the HEAD decision below sound wherever it matters.
             if (keep) {
-                assert(conn.l7.request_head_len >= 1);
+                assert(conn.stream.l7.request_head_len >= 1);
             }
             if (configuredPage(server, status)) |page| {
                 return armPageWrite(server, conn, page, keep);
@@ -4063,7 +4063,7 @@ pub fn Proxy(comptime IoType: type) type {
             assert(conn.state == .l7_responding);
             assert(page.keep_head_len <= page.keep.len);
             assert(page.close_head_len <= page.close.len);
-            const head_only = conn.l7.request_method == .head;
+            const head_only = conn.stream.l7.request_method == .head;
             const bytes = if (keep)
                 (if (head_only) page.keep[0..page.keep_head_len] else page.keep)
             else
@@ -4094,12 +4094,12 @@ pub fn Proxy(comptime IoType: type) type {
             // and any lingering drain have their completions.
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             // A terminal verdict runs before routing acquires anything,
             // which is what keeps it clear of every rung past the head
             // ring (the redirect's precondition, same phase).
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             // The page is immutable arena memory, never the connection's
             // head buffer — so this answer releases before the send like
             // every other static one, rather than holding through it the
@@ -4204,12 +4204,12 @@ pub fn Proxy(comptime IoType: type) type {
             // the send and any lingering drain have their completions.
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
-            assert(!conn.l7.response_started);
+            assert(!conn.stream.l7.response_started);
             // Routing has acquired nothing yet: a redirect never touches
             // the relay or upstream pools, which is what keeps it out of
             // every shed rung past the head ring.
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
+            assert(conn.stream.upstream == null);
             const location = composeLocation(server, redirect, request_host, forward) catch |err|
                 switch (err) {
                     // The request's own target made the Location too long
@@ -4337,8 +4337,8 @@ pub fn Proxy(comptime IoType: type) type {
             // connection carries nothing into its next request (§5).
             assert(conn.stream.head_buffer_id == StreamType.head_buffer_none);
             assert(conn.stream.relay_buffer == null);
-            assert(conn.upstream == null);
-            assert(conn.upstream_socket == null);
+            assert(conn.stream.upstream == null);
+            assert(conn.stream.upstream_socket == null);
             assert(!conn.stream.armed.data_client_to_upstream);
             assert(!conn.stream.armed.data_upstream_to_client);
             // The same OR `resetForNextRequest` needs, for the same reason,

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -21,150 +21,6 @@ const upstream_module = @import("upstream.zig");
 
 const assert = std.debug.assert;
 
-/// Strict recv → send → recv per direction (§6): exactly one data op in
-/// flight per direction, phase says which; per-connection memory stays
-/// constant regardless of stream size. Nothing here depends on the Io
-/// backend, so it lives at file scope rather than being re-instantiated
-/// per `Conn(IoType)` — which is also what makes it unit-testable.
-///
-/// The two counts are one debt, kept in the units *framing* works in:
-/// `framed_len` is what framing assigned to this message out of the last
-/// recv, and `credited_len` is how much of that the target has accepted —
-/// a short send resumes from there. Today every send writes those same
-/// bytes, so the debt is settled in the units it was incurred and
-/// `pending` can slice one buffer with both cursors.
-///
-/// A *transforming* direction breaks that symmetry, and §4's TLS
-/// termination is the one coming: the wire would carry ciphertext, which is
-/// neither the same bytes nor the same count, so it has to keep its own
-/// wire cursor and credit this debt only once a whole framed chunk is out.
-/// Naming the debt apart from the wire is what keeps that a change to
-/// `credit` and `pending` rather than a change at every call site — and
-/// until then, that the two are the same bytes is what `pending` asserts.
-pub const DirectionState = struct {
-    phase: Phase = .idle,
-    /// Bytes framing assigned to this message from the last recv.
-    framed_len: u32 = 0,
-    /// How many of those the target has accepted.
-    credited_len: u32 = 0,
-
-    pub const Phase = enum(u8) { idle, receiving, sending, finished };
-
-    /// Framing chose `len` bytes of what the last recv delivered: a fresh
-    /// debt, nothing credited yet. Zero is legal — framing may end a
-    /// message without forwarding a byte.
-    ///
-    /// The previous debt must be settled first. That is the strict
-    /// recv → send → recv discipline (§6) stated as a precondition rather
-    /// than left to the call sites: overwriting an unsettled debt is
-    /// precisely how a direction would forget bytes it still owed the
-    /// target, and losing them silently is the failure mode this vocabulary
-    /// exists to make loud.
-    pub fn owe(state: *DirectionState, len: u32) void {
-        assert(state.owed() == 0);
-        state.framed_len = len;
-        state.credited_len = 0;
-    }
-
-    /// Grow the debt from the *front* (#142 send): `len` new bytes now
-    /// sit ahead of everything framed, nothing credited yet. Legal only
-    /// before the first credit — prepending to a partially-sent window
-    /// would resend bytes already gone — which in practice means at the
-    /// pre-relay staging sites, where the caller has just moved the
-    /// framed bytes over and written the new ones in front.
-    pub fn stageFront(state: *DirectionState, len: u32) void {
-        assert(len >= 1);
-        assert(state.credited_len == 0);
-        state.framed_len += len;
-        assert(state.owed() == state.framed_len);
-    }
-
-    /// The target accepted `len` more of the debt.
-    pub fn credit(state: *DirectionState, len: u32) void {
-        assert(len >= 1);
-        state.credited_len += len;
-        assert(state.credited_len <= state.framed_len);
-    }
-
-    /// What the target has not accepted yet.
-    pub fn owed(state: *const DirectionState) u32 {
-        assert(state.credited_len <= state.framed_len);
-        return state.framed_len - state.credited_len;
-    }
-
-    /// The window of `buffer` still owed: what a send arms, and what a
-    /// short send resumes from. `buffer` starts where this direction's
-    /// framed bytes start — the relay buffer on a body leg, past the head
-    /// on an excess leg (§7).
-    pub fn pending(state: *const DirectionState, buffer: []const u8) []const u8 {
-        assert(state.owed() >= 1);
-        assert(state.framed_len <= buffer.len);
-        return buffer[state.credited_len..state.framed_len];
-    }
-};
-
-/// One client-directed write in flight (§7, §8): the plaintext still to
-/// deliver, and where control goes once it is all out.
-///
-/// Three writes on the L7 path go to the client outside the body pump — the
-/// rendered response head, the body excess that arrived coalesced with it,
-/// and a static error response — and they differ only in which bytes they
-/// carry and what happens next. One channel for all three means one cursor,
-/// one short-write resume, one teardown interlock, and (§4) one place for a
-/// transforming client side to turn plaintext into wire bytes. The body pump
-/// is the fourth client-directed writer and carries that same seam of its
-/// own (`pump.zig`).
-pub const ClientWrite = struct {
-    /// Shrunk from the front as bytes leave, so a resume is the same code
-    /// whether they live in static memory (§8), the head buffer, or an
-    /// upstream head. Empty means no write is in flight.
-    pending: []const u8 = &.{},
-    then: Then = .lingering_close,
-    /// How much of `pending`'s front the engine has already encrypted
-    /// into its outbox (§4), zero on a plaintext connection. The cursor
-    /// above counts plaintext, because that is what the writers framed and
-    /// what the access log means by `bytes_out`; the wire carries more.
-    /// So `pending` advances only when the chunk that produced the
-    /// ciphertext has fully gone out — never per byte the socket took.
-    staged: u32 = 0,
-
-    /// What the channel does when `pending` empties.
-    pub const Then = enum(u8) {
-        /// The rendered response head is out: forward any coalesced body
-        /// excess, else move on to the body pump.
-        response_excess,
-        /// The coalesced excess is out: the body pump, or the exchange ends.
-        response_body,
-        /// A static response is out: the lingering close (§7, §8).
-        lingering_close,
-        /// An interim `1xx` reached the client and the exchange is
-        /// *not* over (#232): go back to reading the origin's next
-        /// response head, which may already be buffered behind it.
-        interim_sent,
-        /// The origin's `101` is out and the client has it, so the HTTP
-        /// conversation on this connection is over (#180): hand the
-        /// connection to the relay. Deliberately *after* the head reaches
-        /// the client rather than at the parse — a tunnel that started
-        /// relaying before its handshake landed would interleave frame
-        /// bytes with the head that announces them.
-        tunnel_start,
-        /// A static response is out and the client's byte stream is still
-        /// synchronized: serve the next request on this connection (§7,
-        /// §8). The keep half of the ladder's "then keep or close per
-        /// pressure" — see `proxy.staticResponseResyncable` for what
-        /// earns it.
-        next_request,
-        /// A #176 redirect is out. The two arms mirror the static pair
-        /// above with one extra obligation: the redirect rendered into
-        /// the connection's head buffer and *held* it through the send
-        /// — a static answer returns it before arming — so the buffer
-        /// goes back to the ring here, before the continuation whose
-        /// asserts require it gone.
-        redirect_next_request,
-        redirect_lingering_close,
-    };
-};
-
 /// What an access-log line needs that is not still on the connection when
 /// the line is written (DESIGN.md §8). The head buffer is the reason this
 /// exists: it holds the request head only until the response head renders
@@ -291,11 +147,6 @@ pub fn Conn(comptime IoType: type) type {
         /// its presence one field means an unset upstream can never be
         /// read as a live fd handle.
         upstream_socket: ?IoType.Socket,
-        /// Held for the L4 connection's life; on the L7 path it is null
-        /// until a body relay starts and again once the connection goes
-        /// idle on keep-alive — an idle L7 connection costs a slot and
-        /// head buffer only (§5).
-        relay_buffer: ?*relay.RelayBuffer,
         /// The §5 tunnel buffer this connection has claimed (#180), held
         /// from the moment its upgrade request is admitted until the
         /// tunnel closes — or until the exchange fails before `101`, in
@@ -309,13 +160,6 @@ pub fn Conn(comptime IoType: type) type {
         /// upgrade being admitted and the origin answering; at `101` the
         /// shared one goes back and this one takes its place.
         tunnel_buffer: ?*relay.RelayBuffer,
-        /// Whether this connection's pending client write is reading the
-        /// server's shared static response memory (#234) — the claim that
-        /// holds the `Date` stamp off those bytes while a send may be
-        /// reading them. False for every other write, including the #176
-        /// redirect, which renders into this connection's own head buffer
-        /// and so shares nothing.
-        static_send: bool,
         /// Absolute deadline; state transitions only store a new value —
         /// the armed timer op is never touched (§4).
         deadline_ns: u64,
@@ -324,37 +168,6 @@ pub fn Conn(comptime IoType: type) type {
         /// an always-active connection is still reaped (§6).
         birth_ns: u64,
         armed: Armed,
-        directions: [2]DirectionState,
-        /// The §5 head-ring buffer this connection holds, or
-        /// `head_buffer_none`. Bound by the seam at the delivery that
-        /// starts a request (`recvGroup`) and returned at the keep-alive
-        /// turnaround, before a static response goes out, or at teardown —
-        /// so an idle connection holds no head bytes at all, and an L4
-        /// connection never binds one. The bytes live in the ring's slab
-        /// (`bufferGroupSlice`); everything the old inline array promised
-        /// still holds of them: request/response head accumulates across
-        /// recv retries, parsing is detect-and-retry — carried forward by
-        /// `head_cursor` rather than restarted at byte 0 (§7) — the
-        /// buffer's content stays the single source of truth while held,
-        /// and nothing zeroes it — bytes past `head_len` are never read.
-        head_buffer_id: u16,
-        /// Bytes of the held head buffer filled so far; the head's end is
-        /// found by parsing, the body (or a pipelined next head) follows
-        /// it. A count, not content: it survives the buffer's return at a
-        /// static response, because the §7 resync rule still reads it to
-        /// decide keep-or-close; `beginNextRequest` zeroes it. The
-        /// `l4_reading_proxy_header` phase (#142) counts the same way
-        /// over its own staging — the relay buffer's client→upstream
-        /// half — and zeroes it at hand-over, so the relay starts clean
-        /// and the L7 meaning is never mixed with the L4 one.
-        head_len: u32,
-        /// Carries a partial head parse across recv retries, so a head that
-        /// arrives in pieces is parsed once rather than re-parsed from byte 0
-        /// on every arrival (§7). Zeroed wherever `head_len` is, because the
-        /// two describe the same head; see `http.parser.HeadCursor` for why
-        /// the quadratic version was a denial of service and not merely
-        /// wasteful.
-        head_cursor: parser.HeadCursor = .{},
         /// This connection's TLS session (§4), or null on a plaintext
         /// listener — which is every connection on a deployment without a
         /// `tls` block, and what makes the whole feature cost nothing
@@ -387,9 +200,6 @@ pub fn Conn(comptime IoType: type) type {
         /// tickets were still going out — the same send error, two
         /// different things to count.
         tls_session_up: bool,
-        /// The client-directed write in flight, if any (§7, §8) — see
-        /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
-        client_write: ClientWrite,
         /// The cluster to dial. Seeded from the listener at admission; on
         /// the L7 path `routeRequest` overwrites it with the request
         /// path's cluster once the head parses (§7).
@@ -465,16 +275,6 @@ pub fn Conn(comptime IoType: type) type {
         /// parameterized by the connection it points back at — see its
         /// own docstring for why that is a parameter and not an import.
         pub const StreamType = stream_module.Stream(IoType, Self);
-
-        /// "This connection holds no head-ring buffer." Out of range by
-        /// construction: a group never publishes more than
-        /// `buffer_group_entries_max` ids, and the comptime check below
-        /// keeps the sentinel above every real one.
-        pub const head_buffer_none: u16 = std.math.maxInt(u16);
-
-        comptime {
-            assert(constants.buffer_group_entries_max <= head_buffer_none);
-        }
 
         pub const State = enum(u8) {
             // L4 relay states.
@@ -733,11 +533,6 @@ pub fn Conn(comptime IoType: type) type {
             };
         };
 
-        pub const Direction = enum(u1) {
-            client_to_upstream,
-            upstream_to_client,
-        };
-
         /// One bit per embedded op; release requires all clear (§5) —
         /// and, since #274, requires the same of every stream this
         /// connection owns. Closes carry no bit: they are synchronous
@@ -766,14 +561,7 @@ pub fn Conn(comptime IoType: type) type {
         pub fn prepare(
             conn: *Self,
             server: *ServerType,
-            /// This connection's stream slot (#274), acquired by the
-            /// caller. A parameter for the same reason `engine` is one:
-            /// a slot is recycled, and a caller that acquired a stream
-            /// and then let this reset the field would leak one per
-            /// connection.
-            stream: *StreamType,
             client_socket: IoType.Socket,
-            buffer: ?*relay.RelayBuffer,
             engine: ?*TlsEngine,
             state: State,
             cluster_index: u16,
@@ -782,24 +570,17 @@ pub fn Conn(comptime IoType: type) type {
         ) void {
             assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;
-            conn.stream = stream;
+            // Deliberately not set here: the slot's stream was acquired
+            // with the slot itself (`admitConn`) and is already paired.
+            // A reset that installed one would be a reset that could
+            // orphan the one already held.
             conn.state = state;
             conn.client_socket = client_socket;
             conn.upstream_socket = null;
-            conn.relay_buffer = buffer;
             conn.tunnel_buffer = null;
-            // The claim is the server's counter to release, and
-            // `releaseConn` has already done so by the time a slot is
-            // handed out again — this only states the invariant the reset
-            // inherits.
-            conn.static_send = false;
             conn.deadline_ns = 0;
             conn.birth_ns = server.io.nowNs();
             conn.armed = .{};
-            conn.directions = .{ .{}, .{} };
-            conn.head_buffer_id = head_buffer_none;
-            conn.head_len = 0;
-            conn.head_cursor.reset();
             // A parameter, not a field the caller installs afterwards: a
             // slot is recycled across listeners, so a caller that acquired
             // an engine and then let this reset it would leak one per
@@ -807,7 +588,6 @@ pub fn Conn(comptime IoType: type) type {
             conn.tls = engine;
             conn.tls_pending_len = 0;
             conn.tls_session_up = false;
-            conn.client_write = .{};
             conn.cluster_index = cluster_index;
             // Placeholders until the admission tail installs the
             // listener's real tables (§7); L4 never reads them.
@@ -846,8 +626,6 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.stream.conn == conn);
             assert(conn.armedCount() == 0);
             assert(conn.stream.armedCount() == 0);
-            assert(conn.head_len == 0);
-            assert(conn.client_write.pending.len == 0);
             assert(conn.upstream == null);
             assert(conn.l7.request_leg == .idle);
             assert(!conn.log.emitted);
@@ -895,45 +673,4 @@ pub fn Conn(comptime IoType: type) type {
             return @popCount(@as(u2, @bitCast(conn.armed)));
         }
     };
-}
-
-test "direction: a framed chunk is owed until credited, then settled" {
-    var state: DirectionState = .{};
-    const buffer = "0123456789";
-
-    state.owe(6);
-    try std.testing.expectEqual(@as(u32, 6), state.owed());
-    try std.testing.expectEqualStrings("012345", state.pending(buffer));
-
-    // A short send: what is left is the tail, resumed from the credit.
-    state.credit(2);
-    try std.testing.expectEqual(@as(u32, 4), state.owed());
-    try std.testing.expectEqualStrings("2345", state.pending(buffer));
-
-    state.credit(4);
-    try std.testing.expectEqual(@as(u32, 0), state.owed());
-}
-
-test "direction: a settled debt is the precondition for the next one" {
-    var state: DirectionState = .{};
-    state.owe(4);
-    state.credit(4);
-    try std.testing.expectEqual(@as(u32, 0), state.owed());
-
-    // Only now may the next chunk be owed, and it starts from zero rather
-    // than from where the last one ended — every framed chunk is its own
-    // debt over the same buffer. `owe` asserts that settlement, so the
-    // recv → send → recv discipline (§6) cannot be skipped quietly.
-    state.owe(3);
-    try std.testing.expectEqual(@as(u32, 3), state.owed());
-    try std.testing.expectEqualStrings("abc", state.pending("abcdef"));
-}
-
-test "direction: framing may end a message owing nothing" {
-    var state: DirectionState = .{};
-    state.owe(0);
-    // Nothing to forward, so nothing arms a send — `pending` asserts a
-    // non-empty debt precisely because a zero one must not reach a send
-    // (the seam's `bytes.len >= 1` contract, §4).
-    try std.testing.expectEqual(@as(u32, 0), state.owed());
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -17,7 +17,6 @@ const filter = @import("../http/filter.zig");
 const relay = @import("relay.zig");
 const stream_module = @import("Stream.zig");
 const TlsEngine = @import("../tls/Engine.zig");
-const upstream_module = @import("upstream.zig");
 
 const assert = std.debug.assert;
 
@@ -125,7 +124,6 @@ pub const LogState = struct {
 
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
-    const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
 
     return struct {
         pool_next: u32,
@@ -143,10 +141,6 @@ pub fn Conn(comptime IoType: type) type {
         stream: *StreamType,
         state: State,
         client_socket: IoType.Socket,
-        /// Null until the upstream dial completes; making the socket and
-        /// its presence one field means an unset upstream can never be
-        /// read as a live fd handle.
-        upstream_socket: ?IoType.Socket,
         /// The §5 tunnel buffer this connection has claimed (#180), held
         /// from the moment its upgrade request is admitted until the
         /// tunnel closes — or until the exchange fails before `101`, in
@@ -200,10 +194,6 @@ pub fn Conn(comptime IoType: type) type {
         /// tickets were still going out — the same send error, two
         /// different things to count.
         tls_session_up: bool,
-        /// The cluster to dial. Seeded from the listener at admission; on
-        /// the L7 path `routeRequest` overwrites it with the request
-        /// path's cluster once the head parses (§7).
-        cluster_index: u16,
         /// The listener's §7 route table, never empty — an l4 listener
         /// resolves to the one catch-all route it can never consult, since
         /// it has no path to match. Set once at admission and constant for
@@ -231,10 +221,6 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's §7 client-address forwarding mode, same lifetime
         /// as `routes`; null leaves `X-Forwarded-For` untouched.
         forwarded: ?config_module.Config.Listener.Forwarded,
-        /// The leased upstream slot during an L7 exchange; released at
-        /// teardown alongside the conn slot (§5). Null outside exchanges
-        /// and on the whole L4 path.
-        upstream: ?*UpstreamType,
         /// The endpoint this L4 connection is charged against in the
         /// server's per-endpoint in-flight table (§7), or `endpoint_none`
         /// when it is charged against none — every L7 connection, and
@@ -244,12 +230,13 @@ pub fn Conn(comptime IoType: type) type {
         /// bookkeeping, and clearing it is what makes the release
         /// exactly-once.
         charged_endpoint: u16,
-        /// The cluster half of that key. `cluster_index` cannot serve:
-        /// the L7 path overwrites it per request at routing, so a key
-        /// built from it at teardown need not be the key charged.
+        /// The cluster half of that key. The exchange's `cluster_index`
+        /// cannot serve — it is readable at release time, on the stream
+        /// this connection still holds, but it is the wrong value: the
+        /// L7 path overwrites it per request at routing (and again per
+        /// retry and replay), so a key built from it at teardown need not
+        /// be the key that was charged.
         charged_cluster: u16,
-        /// L7 exchange bookkeeping (§7); reset per exchange.
-        l7: L7State,
         /// What this connection speaks (§6, §7). Read only by the access
         /// log, at teardown, to decide which kind of line a connection
         /// owes — an unanswered HTTP request, or the L4 connection itself.
@@ -340,199 +327,6 @@ pub fn Conn(comptime IoType: type) type {
             };
         }
 
-        /// How a message body is delimited and how much of it remains —
-        /// the §7 framing verdicts turned into countdown state the pumps
-        /// consume chunk by chunk.
-        pub const Framing = union(enum) {
-            none,
-            /// Body bytes still to relay.
-            content_length: u64,
-            /// The scanner owns the end-of-message detection.
-            chunked: parser.ChunkedScanner,
-            /// Responses only: the body runs to the origin's EOF.
-            until_close,
-        };
-
-        /// Per-leg progress of an L7 exchange (§7). The request leg sends
-        /// the rendered head, then pumps the framed body client → origin;
-        /// the response leg starts as soon as the request head is on the
-        /// wire (early responses are legal, §7) and mirrors it back.
-        pub const L7State = struct {
-            request_leg: Leg = .idle,
-            response_leg: Leg = .idle,
-            request_method: parser.Method = .get,
-            request_framing: Framing = .none,
-            response_framing: Framing = .none,
-            /// Bytes of `head` consumed by the request head; body excess
-            /// received with it sits at [request_head_len..head_len].
-            request_head_len: u32 = 0,
-            /// Bytes of `upstream.head` consumed by the response head;
-            /// body excess received with it sits at [marker..head_len].
-            response_head_len_marker: u32 = 0,
-            /// Length of the rendered request head being sent into
-            /// upstream.head, and the cursor over it (short sends resume).
-            /// The response head has no pair here: it goes out through the
-            /// client-write channel, which owns its own cursor
-            /// (`ClientWrite`).
-            rendered_request_len: u32 = 0,
-            request_head_sent: u32 = 0,
-            /// Response body bytes that arrived coalesced with the response
-            /// head and did not fit in `conn.head` beside the rendered head:
-            /// they follow it from `upstream.head[response_head_len_marker..]`
-            /// as the channel's next write. Zero when the excess rode along
-            /// with the head, or when there was none.
-            response_excess_len: u32 = 0,
-            /// Absolute cap on this exchange, set at routing from
-            /// `request_timeout_ms` (§8); `storeDeadline` clamps every
-            /// deadline to it, so unlike the idle timeout no activity can
-            /// push it out. `0` when the timeout is disabled. It lives in
-            /// `l7` rather than beside `birth_ns` precisely so the
-            /// per-request lifetime is structural: every keep-alive
-            /// turnaround clears `l7` wholesale, so the cap cannot outlive
-            /// the exchange that set it even if a rung forgets to retire
-            /// it. Rungs that answer early *do* retire it explicitly, via
-            /// `Server.clearRequestDeadline`. The §7 replay is the one
-            /// place `l7` is rebuilt mid-exchange, so it carries this field
-            /// across by hand — a replay is the same request retrying, not
-            /// a new one earning a fresh budget.
-            request_deadline_ns: u64 = 0,
-            /// Whether this request's #235 head budget is already
-            /// installed. Set on the first parse that comes back
-            /// `Incomplete` — the moment a client is provably mid-sentence
-            /// — and read so the *next* fragment does not install it
-            /// again: a budget a dribbling client could push out by
-            /// dribbling would bound nothing at all.
-            ///
-            /// In `l7` rather than on the connection because the budget is
-            /// one head's, and the wholesale clear at every keep-alive
-            /// turnaround is what makes the next request earn its own.
-            ///
-            /// Unlike `request_deadline_ns` above, the §7 replay does *not*
-            /// carry this across its rebuild, and does not need to: a
-            /// replay runs from `.l7_exchanging` and moves to
-            /// `.l7_dialing`, so it never re-enters the `.l7_reading_head`
-            /// state `installHeadBudget` asserts on. There is no second
-            /// head to budget, so a flag reset to false is inert rather
-            /// than a budget silently reissued.
-            head_budget_installed: bool = false,
-            /// The endpoint identity this request's stickiness cookie
-            /// named (#178), or null when the cluster is not
-            /// cookie-keyed or the request carried nothing usable.
-            /// Recorded at routing — the head bytes are gone by the
-            /// response render (§7 buffer rotation), and the render is
-            /// exactly who asks: it compares this against the endpoint
-            /// that actually served, and stamps a Set-Cookie on any
-            /// mismatch. The replay rebuild re-derives it from its
-            /// re-parse, like the framing.
-            sticky_cookie: ?u64 = null,
-            /// True once the request head has been forwarded off conn.head
-            /// (head sent and any coalesced body excess drained), so the
-            /// response head may render into conn.head (§7 buffer rotation).
-            request_head_vacated: bool = false,
-            /// The origin's head parsed while conn.head was still occupied;
-            /// render it once `request_head_vacated`.
-            response_render_pending: bool = false,
-            /// True once any response byte reached the client — the §8
-            /// verdict split between answering 502 and plain teardown.
-            response_started: bool = false,
-            /// A verdict decided while data ops were still armed, acted on
-            /// when the last one settles: ops are never canceled (§5), they
-            /// are *forced* — the upstream socket is shut down and each
-            /// armed op completes with an error its handler diverts on.
-            pending_verdict: PendingVerdict = .none,
-            /// The armed request-leg op is a recv on the CLIENT socket
-            /// (the body pump). Such an op cannot be forced without closing
-            /// the client the verdict would answer, so expiry stays a
-            /// teardown then — the stall is the client's own body (§8).
-            request_op_on_client: bool = false,
-            /// The client's persistence ask (RFC 9112 §9), captured at
-            /// routing; the render-time decision may still announce close
-            /// (pressure, drain, §8).
-            client_keep_alive: bool = false,
-            /// What the rendered response told the client. The connection
-            /// honors its own announcement: a keep-alive answer keeps
-            /// serving, an announced close closes (§7).
-            downstream_close_announced: bool = true,
-            /// The origin's persistence verdict from its response head;
-            /// parking requires it (§5).
-            upstream_reusable: bool = false,
-            /// The client sent bytes past the request's framing — a
-            /// pipelined next request. Pipelining is unsupported: the
-            /// exchange completes and the connection closes, dropping the
-            /// early bytes (§7 note; clients recover per RFC).
-            client_pipelined: bool = false,
-            /// This try runs over a checked-out parked connection (§5) —
-            /// the precondition for the §7 stale replay: only a *reused*
-            /// connection's early failure is blamed on staleness.
-            upstream_was_reused: bool = false,
-            /// The request leg entered the body pump: relay-buffer chunks
-            /// flowed and were overwritten, so the try is no longer
-            /// reconstructible from conn.head — replay is off the table.
-            request_body_pumped: bool = false,
-            /// The one free replay is spent (§7): a failure on the replay
-            /// try answers 502 like any other, never a second replay.
-            replay_used: bool = false,
-            /// This request asked for an upgrade the listener allows, and
-            /// a tunnel buffer is held for it (#180). What makes `101`
-            /// terminal rather than interim on the response path, and what
-            /// tells the render to let the participating
-            /// `Connection`/`Upgrade` pair travel.
-            upgrade_requested: bool = false,
-            /// Interim `1xx` responses this exchange has already relayed
-            /// (#232). Per exchange, not per connection: the bound is
-            /// about one origin answering one request, and a keep-alive
-            /// turnaround clears `l7` wholesale, so it cannot leak into
-            /// the next request even if a path forgets to reset it.
-            interims_seen: u8 = 0,
-            /// The endpoints this request dialed and had refused or found
-            /// unreachable (#181), in the order it tried them — the
-            /// exclusion set the next pick runs over. Sized for the first
-            /// try plus every retry the largest configured budget allows,
-            /// so it is a fixed field like everything else on this
-            /// connection and never grows.
-            tried: [constants.cluster_retries_max + 1]u16 = @splat(0),
-            /// How many of `tried` are written. Every entry past it is
-            /// stale from an earlier request on this connection and must
-            /// not be read.
-            tried_count: u16 = 0,
-            /// Retries spent against the cluster's budget. Equal to
-            /// `tried_count` between hops, since a retry records the
-            /// endpoint that failed and spends a retry to leave it in the
-            /// same step — and one *behind* it in the terminal state where
-            /// the endpoint set ran out first, because that last failure
-            /// is recorded and then answered rather than retried.
-            retries_used: u16 = 0,
-
-            pub const Leg = enum(u8) {
-                idle,
-                sending_head,
-                awaiting_head,
-                /// Forwarding body bytes that arrived coalesced with the
-                /// head, sent straight from the head buffer (§7) so a body
-                /// larger than a relay buffer is never copied through one.
-                sending_body_excess,
-                pumping_body,
-                done,
-            };
-
-            /// The deferred verdicts: the §8 request-deadline 504 and the
-            /// §7 stale-replay retry, both settled once the last armed
-            /// data op is forced to completion.
-            pub const PendingVerdict = enum(u8) {
-                none,
-                gateway_timeout,
-                replay,
-                /// The #235 head budget expired on a client mid-sentence,
-                /// and it is owed a `408` (#247). The odd one out: the
-                /// armed op it waits on is a recv on the **client**
-                /// socket, so the force is a read-half shutdown rather
-                /// than the upstream teardown the other two use — the
-                /// connection has to survive writable to carry the
-                /// answer.
-                request_timeout,
-            };
-        };
-
         /// One bit per embedded op; release requires all clear (§5) —
         /// and, since #274, requires the same of every stream this
         /// connection owns. Closes carry no bit: they are synchronous
@@ -564,7 +358,6 @@ pub fn Conn(comptime IoType: type) type {
             client_socket: IoType.Socket,
             engine: ?*TlsEngine,
             state: State,
-            cluster_index: u16,
             protocol: config_module.Config.Listener.Protocol,
             client_address: std.Io.net.IpAddress,
         ) void {
@@ -576,7 +369,6 @@ pub fn Conn(comptime IoType: type) type {
             // orphan the one already held.
             conn.state = state;
             conn.client_socket = client_socket;
-            conn.upstream_socket = null;
             conn.tunnel_buffer = null;
             conn.deadline_ns = 0;
             conn.birth_ns = server.io.nowNs();
@@ -588,7 +380,6 @@ pub fn Conn(comptime IoType: type) type {
             conn.tls = engine;
             conn.tls_pending_len = 0;
             conn.tls_session_up = false;
-            conn.cluster_index = cluster_index;
             // Placeholders until the admission tail installs the
             // listener's real tables (§7); L4 never reads them.
             conn.routes = &.{};
@@ -598,10 +389,8 @@ pub fn Conn(comptime IoType: type) type {
             conn.max_body_bytes = 0;
             conn.requests_served = 0;
             conn.forwarded = null;
-            conn.upstream = null;
             conn.charged_endpoint = LogState.endpoint_none;
             conn.charged_cluster = 0;
-            conn.l7 = .{};
             conn.protocol = protocol;
             conn.client_address = client_address;
             // The field defaults are `reset`'s values; a recycled slot
@@ -626,8 +415,6 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.stream.conn == conn);
             assert(conn.armedCount() == 0);
             assert(conn.stream.armedCount() == 0);
-            assert(conn.upstream == null);
-            assert(conn.l7.request_leg == .idle);
             assert(!conn.log.emitted);
             assert(conn.log.bytes_in == 0);
         }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -455,10 +455,6 @@ pub fn Conn(comptime IoType: type) type {
         /// connection on the L4 one.
         log: LogState,
 
-        op_data_client_to_upstream: Op,
-        op_data_upstream_to_client: Op,
-        op_connect: Op,
-        op_connect_cancel: Op,
         op_deadline: Op,
         op_deadline_cancel: Op,
 
@@ -468,7 +464,7 @@ pub fn Conn(comptime IoType: type) type {
         /// rather than beside `ServerType` above because `Stream` is
         /// parameterized by the connection it points back at — see its
         /// own docstring for why that is a parameter and not an import.
-        pub const StreamType = stream_module.Stream(Self);
+        pub const StreamType = stream_module.Stream(IoType, Self);
 
         /// "This connection holds no head-ring buffer." Out of range by
         /// construction: a group never publishes more than
@@ -742,14 +738,17 @@ pub fn Conn(comptime IoType: type) type {
             upstream_to_client,
         };
 
-        /// One bit per embedded op; release requires all clear (§5).
-        /// Closes carry no bit: they are synchronous syscalls once this
-        /// set is empty, never ring ops (`Server.continueTeardown`).
-        pub const Armed = packed struct(u6) {
-            data_client_to_upstream: bool = false,
-            data_upstream_to_client: bool = false,
-            connect: bool = false,
-            connect_cancel: bool = false,
+        /// One bit per embedded op; release requires all clear (§5) —
+        /// and, since #274, requires the same of every stream this
+        /// connection owns. Closes carry no bit: they are synchronous
+        /// syscalls once both sets are empty, never ring ops
+        /// (`Server.continueTeardown`).
+        ///
+        /// What is left here is the connection's own clock. The dial and
+        /// the two data legs are the *exchange's* and live on `Stream`;
+        /// a deadline outlives any one exchange on the connection, which
+        /// is exactly the line the split draws.
+        pub const Armed = packed struct(u2) {
             deadline: bool = false,
             deadline_cancel: bool = false,
         };
@@ -837,10 +836,6 @@ pub fn Conn(comptime IoType: type) type {
             if (protocol == .l4 and server.access_log.sink != null) {
                 conn.log.started_wall_ns = server.io.nowWallNs();
             }
-            conn.op_data_client_to_upstream = .{};
-            conn.op_data_upstream_to_client = .{};
-            conn.op_connect = .{};
-            conn.op_connect_cancel = .{};
             conn.op_deadline = .{};
             conn.op_deadline_cancel = .{};
             assert(conn.state == state);
@@ -850,6 +845,7 @@ pub fn Conn(comptime IoType: type) type {
             // read through the wrong partner (§5).
             assert(conn.stream.conn == conn);
             assert(conn.armedCount() == 0);
+            assert(conn.stream.armedCount() == 0);
             assert(conn.head_len == 0);
             assert(conn.client_write.pending.len == 0);
             assert(conn.upstream == null);
@@ -873,9 +869,16 @@ pub fn Conn(comptime IoType: type) type {
             // shipped build is ReleaseSafe, so this compare-and-max runs
             // in production now, same cost class as the assert next to
             // it; only the counter's only reader is a test.
+            //
+            // The *combined* count since #274, and that is the point: the
+            // CQ is charged per admitted connection, so what this peaks at
+            // must be what it peaked at before the ops moved. `Stream.arm`
+            // samples the same sum from its own side.
             if (std.debug.runtime_safety) {
-                conn.server.armed_ops_peak =
-                    @max(conn.server.armed_ops_peak, conn.armedCount());
+                conn.server.armed_ops_peak = @max(
+                    conn.server.armed_ops_peak,
+                    conn.armedCount() + conn.stream.armedCount(),
+                );
             }
         }
 
@@ -889,7 +892,7 @@ pub fn Conn(comptime IoType: type) type {
         }
 
         pub fn armedCount(conn: *const Self) u8 {
-            return @popCount(@as(u6, @bitCast(conn.armed)));
+            return @popCount(@as(u2, @bitCast(conn.armed)));
         }
     };
 }

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -8,10 +8,8 @@
 
 const std = @import("std");
 
-const access_log = @import("../access_log.zig");
 const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
-const parser = @import("../http/parser.zig");
 const router = @import("../http/router.zig");
 const filter = @import("../http/filter.zig");
 const relay = @import("relay.zig");
@@ -19,108 +17,6 @@ const stream_module = @import("Stream.zig");
 const TlsEngine = @import("../tls/Engine.zig");
 
 const assert = std.debug.assert;
-
-/// What an access-log line needs that is not still on the connection when
-/// the line is written (DESIGN.md §8). The head buffer is the reason this
-/// exists: it holds the request head only until the response head renders
-/// over it (§7 buffer rotation), so a line emitted at settle time would
-/// find the method, host and path it is supposed to report already gone.
-/// Each is therefore copied out — bounded, truncation marked — while it is
-/// still there.
-///
-/// One instance per connection, covering one *request* on the L7 path
-/// (`reset` runs at every keep-alive turnaround) and the whole connection
-/// on the L4 path, which has no smaller unit. The arrays are deliberately
-/// not cleared by `reset`: the lengths beside them gate every read, so
-/// clearing 500-odd bytes per request would be work for an invariant that
-/// already holds — the same argument `Conn.head` makes.
-pub const LogState = struct {
-    /// Wall-clock nanoseconds at which this request — or, on L4, this
-    /// connection — began. Zero means nothing is in flight, which is what
-    /// keeps an idle keep-alive connection reaped by its deadline from
-    /// emitting a line about a request nobody made; it is also why nothing
-    /// sets it while the log is off, so a disabled log reads no clock.
-    ///
-    /// Wall-clock rather than the monotonic deadline clock because a line
-    /// needs both a date and a duration, and one precise read at each end
-    /// answers both — where `Io.now_ns` is coarse and cached per tick (§4),
-    /// which would report 0 µs for every request served inside one batch.
-    started_wall_ns: u64 = 0,
-    /// Bytes read from the client and written to it, for this request.
-    bytes_in: u64 = 0,
-    bytes_out: u64 = 0,
-    /// The endpoint the balancer picked (§7), or `endpoint_none` before
-    /// one was — every reject that fires ahead of routing.
-    endpoint_index: u16 = endpoint_none,
-    /// The status this request was answered with; 0 until one is decided.
-    status: u16 = 0,
-    outcome: access_log.Outcome = .aborted,
-    /// Set once this request's line has been written, so the teardown
-    /// fallback cannot emit a second one for an exchange that already
-    /// reported its own outcome.
-    emitted: bool = false,
-    method_len: u8 = 0,
-    host_len: u16 = 0,
-    path_len: u16 = 0,
-    method: [constants.access_log_method_bytes_max]u8 = undefined,
-    host: [constants.host_bytes_max]u8 = undefined,
-    path: [constants.access_log_path_bytes_max]u8 = undefined,
-
-    /// No endpoint has been picked. `maxInt` rather than a separate flag:
-    /// the loader rejects a cluster declaring more than `maxInt(u16)`
-    /// endpoints (`EndpointsOverLimit`), so a real index stops at
-    /// `maxInt(u16) - 1` and the sentinel can never collide with one.
-    /// That bound used to be `endpoints_per_cluster_max`; with the policy
-    /// ceiling gone, the index type is what is left holding it up.
-    pub const endpoint_none: u16 = std.math.maxInt(u16);
-
-    comptime {
-        // A relationship, not a restatement: the loader bounds real
-        // indices by `endpoint_index_max`, and this is what makes that
-        // bound the right one. Widening either past the other is a
-        // compile error rather than a sentinel that means two things.
-        assert(constants.endpoint_index_max < endpoint_none);
-    }
-
-    /// Start a fresh request's accounting. Only the scalars: the three
-    /// captures are read through their lengths, which this zeroes.
-    pub fn reset(state: *LogState) void {
-        state.started_wall_ns = 0;
-        state.bytes_in = 0;
-        state.bytes_out = 0;
-        state.endpoint_index = endpoint_none;
-        state.status = 0;
-        state.outcome = .aborted;
-        state.emitted = false;
-        state.method_len = 0;
-        state.host_len = 0;
-        state.path_len = 0;
-    }
-
-    pub fn methodSlice(state: *const LogState) []const u8 {
-        return state.method[0..state.method_len];
-    }
-
-    pub fn hostSlice(state: *const LogState) []const u8 {
-        return state.host[0..state.host_len];
-    }
-
-    pub fn pathSlice(state: *const LogState) []const u8 {
-        return state.path[0..state.path_len];
-    }
-
-    pub fn captureMethod(state: *LogState, token: []const u8) void {
-        state.method_len = @intCast(access_log.captureTruncated(&state.method, token).len);
-    }
-
-    pub fn captureHost(state: *LogState, host: []const u8) void {
-        state.host_len = @intCast(access_log.captureTruncated(&state.host, host).len);
-    }
-
-    pub fn capturePath(state: *LogState, path: []const u8) void {
-        state.path_len = @intCast(access_log.captureTruncated(&state.path, path).len);
-    }
-};
 
 pub fn Conn(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
@@ -224,9 +120,9 @@ pub fn Conn(comptime IoType: type) type {
         /// The endpoint this L4 connection is charged against in the
         /// server's per-endpoint in-flight table (§7), or `endpoint_none`
         /// when it is charged against none — every L7 connection, and
-        /// every L4 one shed before it dialed. Separate from
-        /// `log.endpoint_index`, which the access log still needs after
-        /// the charge is released; this one is the release's own
+        /// every L4 one shed before it dialed. Separate from the
+        /// exchange's `stream.log.endpoint_index`, which the access log
+        /// still needs after the charge is released; this one is the release's own
         /// bookkeeping, and clearing it is what makes the release
         /// exactly-once.
         charged_endpoint: u16,
@@ -248,9 +144,6 @@ pub fn Conn(comptime IoType: type) type {
         /// already be closed, and `getpeername` on a closed fd names
         /// whoever inherited the number.
         client_address: std.Io.net.IpAddress,
-        /// Access-log capture (§8); per request on the L7 path, per
-        /// connection on the L4 one.
-        log: LogState,
 
         op_deadline: Op,
         op_deadline_cancel: Op,
@@ -389,22 +282,10 @@ pub fn Conn(comptime IoType: type) type {
             conn.max_body_bytes = 0;
             conn.requests_served = 0;
             conn.forwarded = null;
-            conn.charged_endpoint = LogState.endpoint_none;
+            conn.charged_endpoint = stream_module.LogState.endpoint_none;
             conn.charged_cluster = 0;
             conn.protocol = protocol;
             conn.client_address = client_address;
-            // The field defaults are `reset`'s values; a recycled slot
-            // needs both the scalars and the (unread) capture arrays, and
-            // this sets them in one write.
-            conn.log = .{};
-            // An L4 connection is its own log unit and starts here; an L7
-            // one starts a request only when its first head byte lands, so
-            // an idle keep-alive connection that is reaped without ever
-            // being asked anything owes no line. Both are gated on the log
-            // being on, so a deployment without one reads no clock here.
-            if (protocol == .l4 and server.access_log.sink != null) {
-                conn.log.started_wall_ns = server.io.nowWallNs();
-            }
             conn.op_deadline = .{};
             conn.op_deadline_cancel = .{};
             assert(conn.state == state);
@@ -415,8 +296,6 @@ pub fn Conn(comptime IoType: type) type {
             assert(conn.stream.conn == conn);
             assert(conn.armedCount() == 0);
             assert(conn.stream.armedCount() == 0);
-            assert(!conn.log.emitted);
-            assert(conn.log.bytes_in == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -15,6 +15,7 @@ const parser = @import("../http/parser.zig");
 const router = @import("../http/router.zig");
 const filter = @import("../http/filter.zig");
 const relay = @import("relay.zig");
+const stream_module = @import("Stream.zig");
 const TlsEngine = @import("../tls/Engine.zig");
 const upstream_module = @import("upstream.zig");
 
@@ -274,6 +275,16 @@ pub fn Conn(comptime IoType: type) type {
         pool_next: u32,
         generation: u32,
         server: *ServerType,
+        /// The §5 stream slot carrying this connection's exchange
+        /// (#274). Exactly one for now, held for the connection's life,
+        /// which is what keeps the ring budget where it was; #173 turns
+        /// this into the set a multiplexed connection owns.
+        ///
+        /// Not optional: a connection without a stream could not run an
+        /// exchange at all, and the 1:1 cap means the acquire past the
+        /// conn slot's own rung can never fail — `admitStream` states
+        /// that argument where it is made.
+        stream: *StreamType,
         state: State,
         client_socket: IoType.Socket,
         /// Null until the upstream dial completes; making the socket and
@@ -452,6 +463,12 @@ pub fn Conn(comptime IoType: type) type {
         op_deadline_cancel: Op,
 
         const Self = @This();
+
+        /// This connection's stream slot type (#274). Declared here
+        /// rather than beside `ServerType` above because `Stream` is
+        /// parameterized by the connection it points back at — see its
+        /// own docstring for why that is a parameter and not an import.
+        pub const StreamType = stream_module.Stream(Self);
 
         /// "This connection holds no head-ring buffer." Out of range by
         /// construction: a group never publishes more than
@@ -750,6 +767,12 @@ pub fn Conn(comptime IoType: type) type {
         pub fn prepare(
             conn: *Self,
             server: *ServerType,
+            /// This connection's stream slot (#274), acquired by the
+            /// caller. A parameter for the same reason `engine` is one:
+            /// a slot is recycled, and a caller that acquired a stream
+            /// and then let this reset the field would leak one per
+            /// connection.
+            stream: *StreamType,
             client_socket: IoType.Socket,
             buffer: ?*relay.RelayBuffer,
             engine: ?*TlsEngine,
@@ -760,6 +783,7 @@ pub fn Conn(comptime IoType: type) type {
         ) void {
             assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;
+            conn.stream = stream;
             conn.state = state;
             conn.client_socket = client_socket;
             conn.upstream_socket = null;
@@ -820,6 +844,11 @@ pub fn Conn(comptime IoType: type) type {
             conn.op_deadline = .{};
             conn.op_deadline_cancel = .{};
             assert(conn.state == state);
+            // The pairing this slice rests on, stated where it is made:
+            // the stream the caller acquired is the one that points back
+            // here, so the two slots are each other's and neither can be
+            // read through the wrong partner (§5).
+            assert(conn.stream.conn == conn);
             assert(conn.armedCount() == 0);
             assert(conn.head_len == 0);
             assert(conn.client_write.pending.len == 0);

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -22,8 +22,154 @@
 const std = @import("std");
 
 const constants = @import("../constants.zig");
+const parser = @import("../http/parser.zig");
+const relay = @import("relay.zig");
 
 const assert = std.debug.assert;
+
+/// Strict recv → send → recv per direction (§6): exactly one data op in
+/// flight per direction, phase says which; per-connection memory stays
+/// constant regardless of stream size. Nothing here depends on the Io
+/// backend, so it lives at file scope rather than being re-instantiated
+/// per `Conn(IoType)` — which is also what makes it unit-testable.
+///
+/// The two counts are one debt, kept in the units *framing* works in:
+/// `framed_len` is what framing assigned to this message out of the last
+/// recv, and `credited_len` is how much of that the target has accepted —
+/// a short send resumes from there. Today every send writes those same
+/// bytes, so the debt is settled in the units it was incurred and
+/// `pending` can slice one buffer with both cursors.
+///
+/// A *transforming* direction breaks that symmetry, and §4's TLS
+/// termination is the one coming: the wire would carry ciphertext, which is
+/// neither the same bytes nor the same count, so it has to keep its own
+/// wire cursor and credit this debt only once a whole framed chunk is out.
+/// Naming the debt apart from the wire is what keeps that a change to
+/// `credit` and `pending` rather than a change at every call site — and
+/// until then, that the two are the same bytes is what `pending` asserts.
+pub const DirectionState = struct {
+    phase: Phase = .idle,
+    /// Bytes framing assigned to this message from the last recv.
+    framed_len: u32 = 0,
+    /// How many of those the target has accepted.
+    credited_len: u32 = 0,
+
+    pub const Phase = enum(u8) { idle, receiving, sending, finished };
+
+    /// Framing chose `len` bytes of what the last recv delivered: a fresh
+    /// debt, nothing credited yet. Zero is legal — framing may end a
+    /// message without forwarding a byte.
+    ///
+    /// The previous debt must be settled first. That is the strict
+    /// recv → send → recv discipline (§6) stated as a precondition rather
+    /// than left to the call sites: overwriting an unsettled debt is
+    /// precisely how a direction would forget bytes it still owed the
+    /// target, and losing them silently is the failure mode this vocabulary
+    /// exists to make loud.
+    pub fn owe(state: *DirectionState, len: u32) void {
+        assert(state.owed() == 0);
+        state.framed_len = len;
+        state.credited_len = 0;
+    }
+
+    /// Grow the debt from the *front* (#142 send): `len` new bytes now
+    /// sit ahead of everything framed, nothing credited yet. Legal only
+    /// before the first credit — prepending to a partially-sent window
+    /// would resend bytes already gone — which in practice means at the
+    /// pre-relay staging sites, where the caller has just moved the
+    /// framed bytes over and written the new ones in front.
+    pub fn stageFront(state: *DirectionState, len: u32) void {
+        assert(len >= 1);
+        assert(state.credited_len == 0);
+        state.framed_len += len;
+        assert(state.owed() == state.framed_len);
+    }
+
+    /// The target accepted `len` more of the debt.
+    pub fn credit(state: *DirectionState, len: u32) void {
+        assert(len >= 1);
+        state.credited_len += len;
+        assert(state.credited_len <= state.framed_len);
+    }
+
+    /// What the target has not accepted yet.
+    pub fn owed(state: *const DirectionState) u32 {
+        assert(state.credited_len <= state.framed_len);
+        return state.framed_len - state.credited_len;
+    }
+
+    /// The window of `buffer` still owed: what a send arms, and what a
+    /// short send resumes from. `buffer` starts where this direction's
+    /// framed bytes start — the relay buffer on a body leg, past the head
+    /// on an excess leg (§7).
+    pub fn pending(state: *const DirectionState, buffer: []const u8) []const u8 {
+        assert(state.owed() >= 1);
+        assert(state.framed_len <= buffer.len);
+        return buffer[state.credited_len..state.framed_len];
+    }
+};
+
+/// One client-directed write in flight (§7, §8): the plaintext still to
+/// deliver, and where control goes once it is all out.
+///
+/// Three writes on the L7 path go to the client outside the body pump — the
+/// rendered response head, the body excess that arrived coalesced with it,
+/// and a static error response — and they differ only in which bytes they
+/// carry and what happens next. One channel for all three means one cursor,
+/// one short-write resume, one teardown interlock, and (§4) one place for a
+/// transforming client side to turn plaintext into wire bytes. The body pump
+/// is the fourth client-directed writer and carries that same seam of its
+/// own (`pump.zig`).
+pub const ClientWrite = struct {
+    /// Shrunk from the front as bytes leave, so a resume is the same code
+    /// whether they live in static memory (§8), the head buffer, or an
+    /// upstream head. Empty means no write is in flight.
+    pending: []const u8 = &.{},
+    then: Then = .lingering_close,
+    /// How much of `pending`'s front the engine has already encrypted
+    /// into its outbox (§4), zero on a plaintext connection. The cursor
+    /// above counts plaintext, because that is what the writers framed and
+    /// what the access log means by `bytes_out`; the wire carries more.
+    /// So `pending` advances only when the chunk that produced the
+    /// ciphertext has fully gone out — never per byte the socket took.
+    staged: u32 = 0,
+
+    /// What the channel does when `pending` empties.
+    pub const Then = enum(u8) {
+        /// The rendered response head is out: forward any coalesced body
+        /// excess, else move on to the body pump.
+        response_excess,
+        /// The coalesced excess is out: the body pump, or the exchange ends.
+        response_body,
+        /// A static response is out: the lingering close (§7, §8).
+        lingering_close,
+        /// An interim `1xx` reached the client and the exchange is
+        /// *not* over (#232): go back to reading the origin's next
+        /// response head, which may already be buffered behind it.
+        interim_sent,
+        /// The origin's `101` is out and the client has it, so the HTTP
+        /// conversation on this connection is over (#180): hand the
+        /// connection to the relay. Deliberately *after* the head reaches
+        /// the client rather than at the parse — a tunnel that started
+        /// relaying before its handshake landed would interleave frame
+        /// bytes with the head that announces them.
+        tunnel_start,
+        /// A static response is out and the client's byte stream is still
+        /// synchronized: serve the next request on this connection (§7,
+        /// §8). The keep half of the ladder's "then keep or close per
+        /// pressure" — see `proxy.staticResponseResyncable` for what
+        /// earns it.
+        next_request,
+        /// A #176 redirect is out. The two arms mirror the static pair
+        /// above with one extra obligation: the redirect rendered into
+        /// the connection's head buffer and *held* it through the send
+        /// — a static answer returns it before arming — so the buffer
+        /// goes back to the ring here, before the continuation whose
+        /// asserts require it gone.
+        redirect_next_request,
+        redirect_lingering_close,
+    };
+};
 
 /// `ConnType` is a parameter rather than an import, and that is load
 /// bearing: `Conn` names this type for its own field, so importing back
@@ -63,8 +209,70 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
         op_data_upstream_to_client: Op,
         op_connect: Op,
         op_connect_cancel: Op,
+        /// Held for the L4 connection's life; on the L7 path it is null
+        /// until a body relay starts and again once the connection goes
+        /// idle on keep-alive — an idle L7 connection costs a slot and
+        /// head buffer only (§5).
+        relay_buffer: ?*relay.RelayBuffer,
+        /// Whether this connection's pending client write is reading the
+        /// server's shared static response memory (#234) — the claim that
+        /// holds the `Date` stamp off those bytes while a send may be
+        /// reading them. False for every other write, including the #176
+        /// redirect, which renders into this connection's own head buffer
+        /// and so shares nothing.
+        static_send: bool,
+        directions: [2]DirectionState,
+        /// The §5 head-ring buffer this connection holds, or
+        /// `head_buffer_none`. Bound by the seam at the delivery that
+        /// starts a request (`recvGroup`) and returned at the keep-alive
+        /// turnaround, before a static response goes out, or at teardown —
+        /// so an idle connection holds no head bytes at all, and an L4
+        /// connection never binds one. The bytes live in the ring's slab
+        /// (`bufferGroupSlice`); everything the old inline array promised
+        /// still holds of them: request/response head accumulates across
+        /// recv retries, parsing is detect-and-retry — carried forward by
+        /// `head_cursor` rather than restarted at byte 0 (§7) — the
+        /// buffer's content stays the single source of truth while held,
+        /// and nothing zeroes it — bytes past `head_len` are never read.
+        head_buffer_id: u16,
+        /// Bytes of the held head buffer filled so far; the head's end is
+        /// found by parsing, the body (or a pipelined next head) follows
+        /// it. A count, not content: it survives the buffer's return at a
+        /// static response, because the §7 resync rule still reads it to
+        /// decide keep-or-close; `beginNextRequest` zeroes it. The
+        /// `l4_reading_proxy_header` phase (#142) counts the same way
+        /// over its own staging — the relay buffer's client→upstream
+        /// half — and zeroes it at hand-over, so the relay starts clean
+        /// and the L7 meaning is never mixed with the L4 one.
+        head_len: u32,
+        /// Carries a partial head parse across recv retries, so a head that
+        /// arrives in pieces is parsed once rather than re-parsed from byte 0
+        /// on every arrival (§7). Zeroed wherever `head_len` is, because the
+        /// two describe the same head; see `http.parser.HeadCursor` for why
+        /// the quadratic version was a denial of service and not merely
+        /// wasteful.
+        head_cursor: parser.HeadCursor = .{},
+        /// The client-directed write in flight, if any (§7, §8) — see
+        /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
+        client_write: ClientWrite,
 
         const Self = @This();
+
+        /// "This exchange holds no head-ring buffer." Out of range by
+        /// construction: a group never publishes more than
+        /// `buffer_group_entries_max` ids, and the comptime check below
+        /// keeps the sentinel above every real one.
+        pub const head_buffer_none: u16 = std.math.maxInt(u16);
+
+        comptime {
+            assert(constants.buffer_group_entries_max <= head_buffer_none);
+        }
+
+        /// Which leg of the exchange, and the index into `directions`.
+        pub const Direction = enum(u1) {
+            client_to_upstream,
+            upstream_to_client,
+        };
 
         /// One bit per embedded op; the stream releases only with all
         /// clear, and its connection only once that has happened (§5).
@@ -92,8 +300,14 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
         };
 
         /// Acquisition-time reset, mirroring `Conn.prepare`. The pool
-        /// pair above stays untouched; everything else a stream will
-        /// carry gets its value here as the fields arrive.
+        /// pair above stays untouched; everything the exchange carries
+        /// gets its value here.
+        ///
+        /// The exchange starts holding no relay buffer. On the L7 path
+        /// one is acquired only when a body relay starts and given back at
+        /// the keep-alive turnaround (§5) — an idle L7 connection costs a
+        /// slot and a head buffer, no more — and on the L4 path the
+        /// admission tail installs the one it claimed.
         pub fn prepare(stream: *Self, conn: *ConnType) void {
             stream.conn = conn;
             stream.armed = .{};
@@ -101,7 +315,21 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
             stream.op_data_upstream_to_client = .{};
             stream.op_connect = .{};
             stream.op_connect_cancel = .{};
+            stream.relay_buffer = null;
+            // The claim is the server's counter to release, and
+            // `releaseConn` has already done so by the time a slot is
+            // handed out again — this only states the invariant the reset
+            // inherits.
+            stream.static_send = false;
+            stream.directions = .{ .{}, .{} };
+            stream.head_buffer_id = head_buffer_none;
+            stream.head_len = 0;
+            stream.head_cursor.reset();
+            stream.client_write = .{};
             assert(stream.armedCount() == 0);
+            assert(stream.relay_buffer == null);
+            assert(stream.head_len == 0);
+            assert(stream.client_write.pending.len == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately
@@ -144,4 +372,45 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
             return @popCount(@as(u4, @bitCast(stream.armed)));
         }
     };
+}
+
+test "direction: a framed chunk is owed until credited, then settled" {
+    var state: DirectionState = .{};
+    const buffer = "0123456789";
+
+    state.owe(6);
+    try std.testing.expectEqual(@as(u32, 6), state.owed());
+    try std.testing.expectEqualStrings("012345", state.pending(buffer));
+
+    // A short send: what is left is the tail, resumed from the credit.
+    state.credit(2);
+    try std.testing.expectEqual(@as(u32, 4), state.owed());
+    try std.testing.expectEqualStrings("2345", state.pending(buffer));
+
+    state.credit(4);
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
+}
+
+test "direction: a settled debt is the precondition for the next one" {
+    var state: DirectionState = .{};
+    state.owe(4);
+    state.credit(4);
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
+
+    // Only now may the next chunk be owed, and it starts from zero rather
+    // than from where the last one ended — every framed chunk is its own
+    // debt over the same buffer. `owe` asserts that settlement, so the
+    // recv → send → recv discipline (§6) cannot be skipped quietly.
+    state.owe(3);
+    try std.testing.expectEqual(@as(u32, 3), state.owed());
+    try std.testing.expectEqualStrings("abc", state.pending("abcdef"));
+}
+
+test "direction: framing may end a message owing nothing" {
+    var state: DirectionState = .{};
+    state.owe(0);
+    // Nothing to forward, so nothing arms a send — `pending` asserts a
+    // non-empty debt precisely because a zero one must not reach a send
+    // (the seam's `bytes.len >= 1` contract, §4).
+    try std.testing.expectEqual(@as(u32, 0), state.owed());
 }

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -24,6 +24,7 @@ const std = @import("std");
 const constants = @import("../constants.zig");
 const parser = @import("../http/parser.zig");
 const relay = @import("relay.zig");
+const upstream_module = @import("upstream.zig");
 
 const assert = std.debug.assert;
 
@@ -180,6 +181,8 @@ pub const ClientWrite = struct {
 /// makes it exponential. Passing the type in leaves exactly one
 /// instantiation of each, and `Conn.StreamType` is the one name for it.
 pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
+    const UpstreamType = upstream_module.UpstreamPool(IoType).Upstream;
+
     return struct {
         /// Pool bookkeeping (`mem/Pool.zig`): owned by the pool, and
         /// deliberately untouched by `prepare` — the same rule
@@ -255,6 +258,20 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
         /// The client-directed write in flight, if any (§7, §8) — see
         /// `ClientWrite`. Idle on the L4 path, which relays through the pump.
         client_write: ClientWrite,
+        /// Null until the upstream dial completes; making the socket and
+        /// its presence one field means an unset upstream can never be
+        /// read as a live fd handle.
+        upstream_socket: ?IoType.Socket,
+        /// The cluster to dial. Seeded from the listener at admission; on
+        /// the L7 path `routeRequest` overwrites it with the request
+        /// path's cluster once the head parses (§7).
+        cluster_index: u16,
+        /// The leased upstream slot during an L7 exchange; released at
+        /// teardown alongside the conn slot (§5). Null outside exchanges
+        /// and on the whole L4 path.
+        upstream: ?*UpstreamType,
+        /// L7 exchange bookkeeping (§7); reset per exchange.
+        l7: L7State,
 
         const Self = @This();
 
@@ -267,6 +284,199 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
         comptime {
             assert(constants.buffer_group_entries_max <= head_buffer_none);
         }
+
+        /// How a message body is delimited and how much of it remains —
+        /// the §7 framing verdicts turned into countdown state the pumps
+        /// consume chunk by chunk.
+        pub const Framing = union(enum) {
+            none,
+            /// Body bytes still to relay.
+            content_length: u64,
+            /// The scanner owns the end-of-message detection.
+            chunked: parser.ChunkedScanner,
+            /// Responses only: the body runs to the origin's EOF.
+            until_close,
+        };
+
+        /// Per-leg progress of an L7 exchange (§7). The request leg sends
+        /// the rendered head, then pumps the framed body client → origin;
+        /// the response leg starts as soon as the request head is on the
+        /// wire (early responses are legal, §7) and mirrors it back.
+        pub const L7State = struct {
+            request_leg: Leg = .idle,
+            response_leg: Leg = .idle,
+            request_method: parser.Method = .get,
+            request_framing: Framing = .none,
+            response_framing: Framing = .none,
+            /// Bytes of `head` consumed by the request head; body excess
+            /// received with it sits at [request_head_len..head_len].
+            request_head_len: u32 = 0,
+            /// Bytes of `upstream.head` consumed by the response head;
+            /// body excess received with it sits at [marker..head_len].
+            response_head_len_marker: u32 = 0,
+            /// Length of the rendered request head being sent into
+            /// upstream.head, and the cursor over it (short sends resume).
+            /// The response head has no pair here: it goes out through the
+            /// client-write channel, which owns its own cursor
+            /// (`ClientWrite`).
+            rendered_request_len: u32 = 0,
+            request_head_sent: u32 = 0,
+            /// Response body bytes that arrived coalesced with the response
+            /// head and did not fit in `conn.head` beside the rendered head:
+            /// they follow it from `upstream.head[response_head_len_marker..]`
+            /// as the channel's next write. Zero when the excess rode along
+            /// with the head, or when there was none.
+            response_excess_len: u32 = 0,
+            /// Absolute cap on this exchange, set at routing from
+            /// `request_timeout_ms` (§8); `storeDeadline` clamps every
+            /// deadline to it, so unlike the idle timeout no activity can
+            /// push it out. `0` when the timeout is disabled. It lives in
+            /// `l7` rather than beside `birth_ns` precisely so the
+            /// per-request lifetime is structural: every keep-alive
+            /// turnaround clears `l7` wholesale, so the cap cannot outlive
+            /// the exchange that set it even if a rung forgets to retire
+            /// it. Rungs that answer early *do* retire it explicitly, via
+            /// `Server.clearRequestDeadline`. The §7 replay is the one
+            /// place `l7` is rebuilt mid-exchange, so it carries this field
+            /// across by hand — a replay is the same request retrying, not
+            /// a new one earning a fresh budget.
+            request_deadline_ns: u64 = 0,
+            /// Whether this request's #235 head budget is already
+            /// installed. Set on the first parse that comes back
+            /// `Incomplete` — the moment a client is provably mid-sentence
+            /// — and read so the *next* fragment does not install it
+            /// again: a budget a dribbling client could push out by
+            /// dribbling would bound nothing at all.
+            ///
+            /// In `l7` rather than on the connection because the budget is
+            /// one head's, and the wholesale clear at every keep-alive
+            /// turnaround is what makes the next request earn its own.
+            ///
+            /// Unlike `request_deadline_ns` above, the §7 replay does *not*
+            /// carry this across its rebuild, and does not need to: a
+            /// replay runs from `.l7_exchanging` and moves to
+            /// `.l7_dialing`, so it never re-enters the `.l7_reading_head`
+            /// state `installHeadBudget` asserts on. There is no second
+            /// head to budget, so a flag reset to false is inert rather
+            /// than a budget silently reissued.
+            head_budget_installed: bool = false,
+            /// The endpoint identity this request's stickiness cookie
+            /// named (#178), or null when the cluster is not
+            /// cookie-keyed or the request carried nothing usable.
+            /// Recorded at routing — the head bytes are gone by the
+            /// response render (§7 buffer rotation), and the render is
+            /// exactly who asks: it compares this against the endpoint
+            /// that actually served, and stamps a Set-Cookie on any
+            /// mismatch. The replay rebuild re-derives it from its
+            /// re-parse, like the framing.
+            sticky_cookie: ?u64 = null,
+            /// True once the request head has been forwarded off conn.head
+            /// (head sent and any coalesced body excess drained), so the
+            /// response head may render into conn.head (§7 buffer rotation).
+            request_head_vacated: bool = false,
+            /// The origin's head parsed while conn.head was still occupied;
+            /// render it once `request_head_vacated`.
+            response_render_pending: bool = false,
+            /// True once any response byte reached the client — the §8
+            /// verdict split between answering 502 and plain teardown.
+            response_started: bool = false,
+            /// A verdict decided while data ops were still armed, acted on
+            /// when the last one settles: ops are never canceled (§5), they
+            /// are *forced* — the upstream socket is shut down and each
+            /// armed op completes with an error its handler diverts on.
+            pending_verdict: PendingVerdict = .none,
+            /// The armed request-leg op is a recv on the CLIENT socket
+            /// (the body pump). Such an op cannot be forced without closing
+            /// the client the verdict would answer, so expiry stays a
+            /// teardown then — the stall is the client's own body (§8).
+            request_op_on_client: bool = false,
+            /// The client's persistence ask (RFC 9112 §9), captured at
+            /// routing; the render-time decision may still announce close
+            /// (pressure, drain, §8).
+            client_keep_alive: bool = false,
+            /// What the rendered response told the client. The connection
+            /// honors its own announcement: a keep-alive answer keeps
+            /// serving, an announced close closes (§7).
+            downstream_close_announced: bool = true,
+            /// The origin's persistence verdict from its response head;
+            /// parking requires it (§5).
+            upstream_reusable: bool = false,
+            /// The client sent bytes past the request's framing — a
+            /// pipelined next request. Pipelining is unsupported: the
+            /// exchange completes and the connection closes, dropping the
+            /// early bytes (§7 note; clients recover per RFC).
+            client_pipelined: bool = false,
+            /// This try runs over a checked-out parked connection (§5) —
+            /// the precondition for the §7 stale replay: only a *reused*
+            /// connection's early failure is blamed on staleness.
+            upstream_was_reused: bool = false,
+            /// The request leg entered the body pump: relay-buffer chunks
+            /// flowed and were overwritten, so the try is no longer
+            /// reconstructible from conn.head — replay is off the table.
+            request_body_pumped: bool = false,
+            /// The one free replay is spent (§7): a failure on the replay
+            /// try answers 502 like any other, never a second replay.
+            replay_used: bool = false,
+            /// This request asked for an upgrade the listener allows, and
+            /// a tunnel buffer is held for it (#180). What makes `101`
+            /// terminal rather than interim on the response path, and what
+            /// tells the render to let the participating
+            /// `Connection`/`Upgrade` pair travel.
+            upgrade_requested: bool = false,
+            /// Interim `1xx` responses this exchange has already relayed
+            /// (#232). Per exchange, not per connection: the bound is
+            /// about one origin answering one request, and a keep-alive
+            /// turnaround clears `l7` wholesale, so it cannot leak into
+            /// the next request even if a path forgets to reset it.
+            interims_seen: u8 = 0,
+            /// The endpoints this request dialed and had refused or found
+            /// unreachable (#181), in the order it tried them — the
+            /// exclusion set the next pick runs over. Sized for the first
+            /// try plus every retry the largest configured budget allows,
+            /// so it is a fixed field like everything else on this
+            /// connection and never grows.
+            tried: [constants.cluster_retries_max + 1]u16 = @splat(0),
+            /// How many of `tried` are written. Every entry past it is
+            /// stale from an earlier request on this connection and must
+            /// not be read.
+            tried_count: u16 = 0,
+            /// Retries spent against the cluster's budget. Equal to
+            /// `tried_count` between hops, since a retry records the
+            /// endpoint that failed and spends a retry to leave it in the
+            /// same step — and one *behind* it in the terminal state where
+            /// the endpoint set ran out first, because that last failure
+            /// is recorded and then answered rather than retried.
+            retries_used: u16 = 0,
+
+            pub const Leg = enum(u8) {
+                idle,
+                sending_head,
+                awaiting_head,
+                /// Forwarding body bytes that arrived coalesced with the
+                /// head, sent straight from the head buffer (§7) so a body
+                /// larger than a relay buffer is never copied through one.
+                sending_body_excess,
+                pumping_body,
+                done,
+            };
+
+            /// The deferred verdicts: the §8 request-deadline 504 and the
+            /// §7 stale-replay retry, both settled once the last armed
+            /// data op is forced to completion.
+            pub const PendingVerdict = enum(u8) {
+                none,
+                gateway_timeout,
+                replay,
+                /// The #235 head budget expired on a client mid-sentence,
+                /// and it is owed a `408` (#247). The odd one out: the
+                /// armed op it waits on is a recv on the **client**
+                /// socket, so the force is a read-half shutdown rather
+                /// than the upstream teardown the other two use — the
+                /// connection has to survive writable to carry the
+                /// answer.
+                request_timeout,
+            };
+        };
 
         /// Which leg of the exchange, and the index into `directions`.
         pub const Direction = enum(u1) {
@@ -326,10 +536,19 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
             stream.head_len = 0;
             stream.head_cursor.reset();
             stream.client_write = .{};
+            stream.upstream_socket = null;
+            stream.upstream = null;
+            stream.l7 = .{};
+            // The listener's, and so not known until the admission tail
+            // resolves one (`finishAdmission`); on the L7 path `routeRequest`
+            // overwrites it per request anyway (§7).
+            stream.cluster_index = 0;
             assert(stream.armedCount() == 0);
             assert(stream.relay_buffer == null);
             assert(stream.head_len == 0);
             assert(stream.client_write.pending.len == 0);
+            assert(stream.upstream == null);
+            assert(stream.l7.request_leg == .idle);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -21,6 +21,8 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
+
 const assert = std.debug.assert;
 
 /// `ConnType` is a parameter rather than an import, and that is load
@@ -31,7 +33,7 @@ const assert = std.debug.assert;
 /// stands in one such cycle with `Server`; a third participant is what
 /// makes it exponential. Passing the type in leaves exactly one
 /// instantiation of each, and `Conn.StreamType` is the one name for it.
-pub fn Stream(comptime ConnType: type) type {
+pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
     return struct {
         /// Pool bookkeeping (`mem/Pool.zig`): owned by the pool, and
         /// deliberately untouched by `prepare` — the same rule
@@ -50,14 +52,96 @@ pub fn Stream(comptime ConnType: type) type {
         /// arrives as `*Stream` and reaches everything else through
         /// exactly this field.
         conn: *ConnType,
+        /// The exchange's armed set (§5). The connection's own deadline
+        /// pair stays on `Conn`: a deadline is the *connection's* clock,
+        /// and it outlives any one exchange on it. Everything here is the
+        /// exchange's — the dial, its cancel, and the two data legs — so
+        /// this is the set that has to empty before the stream slot goes
+        /// back, one level below the rule that governs the conn slot.
+        armed: Armed,
+        op_data_client_to_upstream: Op,
+        op_data_upstream_to_client: Op,
+        op_connect: Op,
+        op_connect_cancel: Op,
 
         const Self = @This();
+
+        /// One bit per embedded op; the stream releases only with all
+        /// clear, and its connection only once that has happened (§5).
+        ///
+        /// The peak is two, not four, and the disjointness is why: a dial
+        /// and its cancel belong to `.connecting`/`.l7_dialing`, the data
+        /// pair to `.relaying`/`.l7_exchanging`, and no state arms one
+        /// kind while the other is outstanding. `constants.stream_ops_max`
+        /// is that claim as a number, and `arm` below is where it fails if
+        /// it is ever wrong.
+        pub const Armed = packed struct(u4) {
+            data_client_to_upstream: bool = false,
+            data_upstream_to_client: bool = false,
+            connect: bool = false,
+            connect_cancel: bool = false,
+        };
+
+        /// The same shape `Conn.Op` has, and deliberately its own type:
+        /// the generation recorded here is the *stream's*, so a straggler
+        /// into a recycled stream trips `delivered` even when the
+        /// connection under it was never recycled at all (§5).
+        pub const Op = struct {
+            completion: IoType.Completion = .{},
+            generation_at_submit: u32 = 0,
+        };
 
         /// Acquisition-time reset, mirroring `Conn.prepare`. The pool
         /// pair above stays untouched; everything else a stream will
         /// carry gets its value here as the fields arrive.
         pub fn prepare(stream: *Self, conn: *ConnType) void {
             stream.conn = conn;
+            stream.armed = .{};
+            stream.op_data_client_to_upstream = .{};
+            stream.op_data_upstream_to_client = .{};
+            stream.op_connect = .{};
+            stream.op_connect_cancel = .{};
+            assert(stream.armedCount() == 0);
+        }
+
+        /// Records the arm in the op and the armed set; call immediately
+        /// before submitting through the seam. The mirror of `Conn.arm`,
+        /// enforcing this half of the §8 ring budget at its own arm site:
+        /// the CQ is sized as `conn_ops_max` per conn slot plus
+        /// `stream_ops_max` per stream slot, so exceeding either here is
+        /// the invariant violation the budget makes unreachable.
+        pub fn arm(stream: *Self, op: *Op, comptime bit: []const u8) void {
+            assert(!@field(stream.armed, bit));
+            op.generation_at_submit = stream.generation;
+            @field(stream.armed, bit) = true;
+            assert(stream.armedCount() <= constants.stream_ops_max);
+            // The combined per-connection peak, tracked at both arm sites
+            // so it reads the same number it always did (§8): what the CQ
+            // is charged for an admitted connection did not change when
+            // the ops moved, and a peak that quietly grew would say the
+            // split took something with it.
+            if (std.debug.runtime_safety) {
+                const server = stream.conn.server;
+                server.armed_ops_peak = @max(
+                    server.armed_ops_peak,
+                    stream.conn.armedCount() + stream.armedCount(),
+                );
+                server.stream_armed_ops_peak =
+                    @max(server.stream_armed_ops_peak, stream.armedCount());
+            }
+        }
+
+        /// Every delivery passes through here first: the generation
+        /// recorded at submit must still match, and the bit must be set —
+        /// a straggler into a recycled stream fails loudly (§5).
+        pub fn delivered(stream: *Self, op: *const Op, comptime bit: []const u8) void {
+            assert(op.generation_at_submit == stream.generation);
+            assert(@field(stream.armed, bit));
+            @field(stream.armed, bit) = false;
+        }
+
+        pub fn armedCount(stream: *const Self) u8 {
+            return @popCount(@as(u4, @bitCast(stream.armed)));
         }
     };
 }

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -1,0 +1,63 @@
+//! The stream slot (DESIGN.md §5): one *exchange*, drawn from a pool of
+//! its own rather than inlined into the connection slot that carries it.
+//!
+//! Today a connection **is** an exchange — one request at a time, its
+//! state inlined into `Conn` — and this slice (#274) draws the seam
+//! without yet moving anything through it. Every admitted connection
+//! acquires exactly one stream and holds it for the connection's life, so
+//! the two pools have equal capacity and equal occupancy and nothing
+//! observable changes. What it buys is §5's release rule and its
+//! generation discipline replicated one layer down, proven under the
+//! existing sweep before #173 puts N streams on a connection and makes
+//! them load-bearing: a straggling completion into a recycled *stream* is
+//! the same bug as one into a recycled slot, and it has to fail the same
+//! way.
+//!
+//! The 1:1 cap is also what holds the ring budget still. `conn_ops_max`
+//! becomes a conn share plus a stream share whose sum at one stream per
+//! connection is exactly what it was, so the CQ ceiling and the printed
+//! fd form do not move — an equality sharp enough that a changed banner
+//! means the split took something with it that it should not have.
+
+const std = @import("std");
+
+const assert = std.debug.assert;
+
+/// `ConnType` is a parameter rather than an import, and that is load
+/// bearing: `Conn` names this type for its own field, so importing back
+/// would make the two generics mutually re-entrant — Zig memoizes an
+/// instantiation only once it completes, so a cycle re-evaluates both
+/// sides until the comptime branch quota gives out. `Conn` already
+/// stands in one such cycle with `Server`; a third participant is what
+/// makes it exponential. Passing the type in leaves exactly one
+/// instantiation of each, and `Conn.StreamType` is the one name for it.
+pub fn Stream(comptime ConnType: type) type {
+    return struct {
+        /// Pool bookkeeping (`mem/Pool.zig`): owned by the pool, and
+        /// deliberately untouched by `prepare` — the same rule
+        /// `Conn.prepare` states about its own pair, and what makes the
+        /// generation a straggler can be caught by survive a reset.
+        pool_next: u32,
+        generation: u32,
+        /// The connection this stream runs on. Installed at acquisition
+        /// and constant for the stream's life: a stream never migrates
+        /// between connections here, and does not under #173 either —
+        /// RFC 9113 identifiers are scoped to one connection.
+        ///
+        /// A back-pointer rather than a lookup because it is what the
+        /// completion handlers will read. The Io seam takes a typed
+        /// userdata pointer, so an op moved onto a stream (slice 2)
+        /// arrives as `*Stream` and reaches everything else through
+        /// exactly this field.
+        conn: *ConnType,
+
+        const Self = @This();
+
+        /// Acquisition-time reset, mirroring `Conn.prepare`. The pool
+        /// pair above stays untouched; everything else a stream will
+        /// carry gets its value here as the fields arrive.
+        pub fn prepare(stream: *Self, conn: *ConnType) void {
+            stream.conn = conn;
+        }
+    };
+}

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -21,6 +21,7 @@
 
 const std = @import("std");
 
+const access_log = @import("../access_log.zig");
 const constants = @import("../constants.zig");
 const parser = @import("../http/parser.zig");
 const relay = @import("relay.zig");
@@ -172,6 +173,108 @@ pub const ClientWrite = struct {
     };
 };
 
+/// What an access-log line needs that is not still on the connection when
+/// the line is written (DESIGN.md §8). The head buffer is the reason this
+/// exists: it holds the request head only until the response head renders
+/// over it (§7 buffer rotation), so a line emitted at settle time would
+/// find the method, host and path it is supposed to report already gone.
+/// Each is therefore copied out — bounded, truncation marked — while it is
+/// still there.
+///
+/// One instance per connection, covering one *request* on the L7 path
+/// (`reset` runs at every keep-alive turnaround) and the whole connection
+/// on the L4 path, which has no smaller unit. The arrays are deliberately
+/// not cleared by `reset`: the lengths beside them gate every read, so
+/// clearing 500-odd bytes per request would be work for an invariant that
+/// already holds — the same argument `Conn.head` makes.
+pub const LogState = struct {
+    /// Wall-clock nanoseconds at which this request — or, on L4, this
+    /// connection — began. Zero means nothing is in flight, which is what
+    /// keeps an idle keep-alive connection reaped by its deadline from
+    /// emitting a line about a request nobody made; it is also why nothing
+    /// sets it while the log is off, so a disabled log reads no clock.
+    ///
+    /// Wall-clock rather than the monotonic deadline clock because a line
+    /// needs both a date and a duration, and one precise read at each end
+    /// answers both — where `Io.now_ns` is coarse and cached per tick (§4),
+    /// which would report 0 µs for every request served inside one batch.
+    started_wall_ns: u64 = 0,
+    /// Bytes read from the client and written to it, for this request.
+    bytes_in: u64 = 0,
+    bytes_out: u64 = 0,
+    /// The endpoint the balancer picked (§7), or `endpoint_none` before
+    /// one was — every reject that fires ahead of routing.
+    endpoint_index: u16 = endpoint_none,
+    /// The status this request was answered with; 0 until one is decided.
+    status: u16 = 0,
+    outcome: access_log.Outcome = .aborted,
+    /// Set once this request's line has been written, so the teardown
+    /// fallback cannot emit a second one for an exchange that already
+    /// reported its own outcome.
+    emitted: bool = false,
+    method_len: u8 = 0,
+    host_len: u16 = 0,
+    path_len: u16 = 0,
+    method: [constants.access_log_method_bytes_max]u8 = undefined,
+    host: [constants.host_bytes_max]u8 = undefined,
+    path: [constants.access_log_path_bytes_max]u8 = undefined,
+
+    /// No endpoint has been picked. `maxInt` rather than a separate flag:
+    /// the loader rejects a cluster declaring more than `maxInt(u16)`
+    /// endpoints (`EndpointsOverLimit`), so a real index stops at
+    /// `maxInt(u16) - 1` and the sentinel can never collide with one.
+    /// That bound used to be `endpoints_per_cluster_max`; with the policy
+    /// ceiling gone, the index type is what is left holding it up.
+    pub const endpoint_none: u16 = std.math.maxInt(u16);
+
+    comptime {
+        // A relationship, not a restatement: the loader bounds real
+        // indices by `endpoint_index_max`, and this is what makes that
+        // bound the right one. Widening either past the other is a
+        // compile error rather than a sentinel that means two things.
+        assert(constants.endpoint_index_max < endpoint_none);
+    }
+
+    /// Start a fresh request's accounting. Only the scalars: the three
+    /// captures are read through their lengths, which this zeroes.
+    pub fn reset(state: *LogState) void {
+        state.started_wall_ns = 0;
+        state.bytes_in = 0;
+        state.bytes_out = 0;
+        state.endpoint_index = endpoint_none;
+        state.status = 0;
+        state.outcome = .aborted;
+        state.emitted = false;
+        state.method_len = 0;
+        state.host_len = 0;
+        state.path_len = 0;
+    }
+
+    pub fn methodSlice(state: *const LogState) []const u8 {
+        return state.method[0..state.method_len];
+    }
+
+    pub fn hostSlice(state: *const LogState) []const u8 {
+        return state.host[0..state.host_len];
+    }
+
+    pub fn pathSlice(state: *const LogState) []const u8 {
+        return state.path[0..state.path_len];
+    }
+
+    pub fn captureMethod(state: *LogState, token: []const u8) void {
+        state.method_len = @intCast(access_log.captureTruncated(&state.method, token).len);
+    }
+
+    pub fn captureHost(state: *LogState, host: []const u8) void {
+        state.host_len = @intCast(access_log.captureTruncated(&state.host, host).len);
+    }
+
+    pub fn capturePath(state: *LogState, path: []const u8) void {
+        state.path_len = @intCast(access_log.captureTruncated(&state.path, path).len);
+    }
+};
+
 /// `ConnType` is a parameter rather than an import, and that is load
 /// bearing: `Conn` names this type for its own field, so importing back
 /// would make the two generics mutually re-entrant — Zig memoizes an
@@ -272,6 +375,19 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
         upstream: ?*UpstreamType,
         /// L7 exchange bookkeeping (§7); reset per exchange.
         l7: L7State,
+
+        /// Access-log capture (§8) — and the seam #274 exists to draw.
+        ///
+        /// One line covers one *request* on the L7 path and one whole
+        /// *connection* on the L4 path, which has no smaller unit. That
+        /// was already true when this lived on the conn slot, but it was
+        /// true by convention: `reset` was called at each keep-alive
+        /// turnaround, and a path that forgot would report the previous
+        /// request's method on the next request's line (#129). Here the
+        /// unit is structural — a line belongs to the exchange that owns
+        /// this slot — and on the L4 path the exchange simply lasts as
+        /// long as the connection does.
+        log: LogState,
 
         const Self = @This();
 
@@ -543,12 +659,22 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
             // resolves one (`finishAdmission`); on the L7 path `routeRequest`
             // overwrites it per request anyway (§7).
             stream.cluster_index = 0;
+            // The field defaults are `reset`'s values; a recycled slot
+            // needs both the scalars and the (unread) capture arrays, and
+            // this sets them in one write. The clock stays at zero: an L4
+            // exchange starts its line in the admission tail, once a
+            // listener says it is one, and an L7 exchange only when its
+            // first head byte lands.
+            stream.log = .{};
             assert(stream.armedCount() == 0);
             assert(stream.relay_buffer == null);
             assert(stream.head_len == 0);
             assert(stream.client_write.pending.len == 0);
             assert(stream.upstream == null);
             assert(stream.l7.request_leg == .idle);
+            assert(!stream.log.emitted);
+            assert(stream.log.bytes_in == 0);
+            assert(stream.log.started_wall_ns == 0);
         }
 
         /// Records the arm in the op and the armed set; call immediately

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -204,13 +204,13 @@ pub fn Pump(
         fn source(conn: *const ConnType) IoType.Socket {
             return switch (direction) {
                 .client_to_upstream => conn.client_socket,
-                .upstream_to_client => conn.upstream_socket.?,
+                .upstream_to_client => conn.stream.upstream_socket.?,
             };
         }
 
         fn target(conn: *const ConnType) IoType.Socket {
             return switch (direction) {
-                .client_to_upstream => conn.upstream_socket.?,
+                .client_to_upstream => conn.stream.upstream_socket.?,
                 .upstream_to_client => conn.client_socket,
             };
         }

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -125,8 +125,11 @@ pub fn Pump(
     return struct {
         const bit = "data_" ++ direction_tag;
 
-        fn op(conn: *ConnType) *ConnType.Op {
-            return &@field(conn, "op_data_" ++ direction_tag);
+        /// The exchange's op, on the stream slot since #274 — the pump
+        /// itself is unchanged by that move, because it reached the op
+        /// through this one accessor and nothing else.
+        fn op(conn: *ConnType) *ConnType.StreamType.Op {
+            return &@field(conn.stream, "op_data_" ++ direction_tag);
         }
 
         fn directionState(conn: *ConnType) *conn_module.DirectionState {
@@ -217,7 +220,7 @@ pub fn Pump(
             // `beforeRecv` hook: every pump reads and writes the relay buffer.
             assert(conn.relay_buffer != null);
             if (@hasDecl(Policy, "beforeRecv")) Policy.beforeRecv(conn);
-            conn.arm(op(conn), bit);
+            conn.stream.arm(op(conn), bit);
             server.io.recv(
                 source(conn),
                 recvBuffer(conn),
@@ -230,7 +233,7 @@ pub fn Pump(
 
         fn onRecv(conn: *ConnType, result: Io.RecvError!u32) void {
             const server = conn.server;
-            conn.delivered(op(conn), bit);
+            conn.stream.delivered(op(conn), bit);
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;
@@ -300,7 +303,7 @@ pub fn Pump(
             // `bytes.len >= 1` (§4), and an empty slice here would mean a
             // caller asked to write with nothing staged.
             assert(wire.len >= 1);
-            conn.arm(op(conn), bit);
+            conn.stream.arm(op(conn), bit);
             server.io.send(
                 target(conn),
                 wire,
@@ -313,7 +316,7 @@ pub fn Pump(
 
         fn onSend(conn: *ConnType, result: Io.SendError!u32) void {
             const server = conn.server;
-            conn.delivered(op(conn), bit);
+            conn.stream.delivered(op(conn), bit);
             if (conn.isTearingDown()) {
                 server.continueTeardown(conn);
                 return;

--- a/src/net/pump.zig
+++ b/src/net/pump.zig
@@ -91,6 +91,7 @@
 const std = @import("std");
 
 const conn_module = @import("Conn.zig");
+const stream_module = @import("Stream.zig");
 const Io = @import("../io/io.zig");
 
 const assert = std.debug.assert;
@@ -115,7 +116,7 @@ pub const FeedResult = struct {
 
 pub fn Pump(
     comptime IoType: type,
-    comptime direction: conn_module.Conn(IoType).Direction,
+    comptime direction: conn_module.Conn(IoType).StreamType.Direction,
     comptime Policy: type,
 ) type {
     const ConnType = conn_module.Conn(IoType);
@@ -132,12 +133,12 @@ pub fn Pump(
             return &@field(conn.stream, "op_data_" ++ direction_tag);
         }
 
-        fn directionState(conn: *ConnType) *conn_module.DirectionState {
-            return &conn.directions[@intFromEnum(direction)];
+        fn directionState(conn: *ConnType) *stream_module.DirectionState {
+            return &conn.stream.directions[@intFromEnum(direction)];
         }
 
         fn buffer(conn: *ConnType) []u8 {
-            return @field(conn.relay_buffer.?, direction_tag);
+            return @field(conn.stream.relay_buffer.?, direction_tag);
         }
 
         // -- the transform seam (§4, §6; see the module header) --
@@ -218,7 +219,7 @@ pub fn Pump(
             // A direction-agnostic precondition the pump enforces itself, so
             // the shared mechanism never relies solely on the optional
             // `beforeRecv` hook: every pump reads and writes the relay buffer.
-            assert(conn.relay_buffer != null);
+            assert(conn.stream.relay_buffer != null);
             if (@hasDecl(Policy, "beforeRecv")) Policy.beforeRecv(conn);
             conn.stream.arm(op(conn), bit);
             server.io.recv(
@@ -296,7 +297,7 @@ pub fn Pump(
         }
 
         pub fn armSend(server: *ServerType, conn: *ConnType) void {
-            assert(conn.relay_buffer != null);
+            assert(conn.stream.relay_buffer != null);
             if (@hasDecl(Policy, "beforeSend")) Policy.beforeSend(conn);
             const wire = sendSlice(conn);
             // Nothing arms an empty send: the seam's contract is

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -38,6 +38,7 @@ const std = @import("std");
 const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
 const conn_module = @import("Conn.zig");
+const stream_module = @import("Stream.zig");
 const pump = @import("pump.zig");
 const router = @import("../http/router.zig");
 const server_module = @import("../Server.zig");
@@ -48,7 +49,7 @@ const assert = std.debug.assert;
 
 const ServerSim = server_module.Server(SimIo);
 const ConnSim = conn_module.Conn(SimIo);
-const Direction = ConnSim.Direction;
+const Direction = ConnSim.StreamType.Direction;
 
 /// `[u16 big-endian length][payload]` — the smallest framing with a real
 /// header, so every frame puts two bytes on the wire that framing never
@@ -118,8 +119,8 @@ const Scratch = struct {
 /// dead code — the transform seam is this file's only job.
 fn Base(comptime direction: Direction) type {
     return struct {
-        fn state(conn: *ConnSim) *conn_module.DirectionState {
-            return &conn.directions[@intFromEnum(direction)];
+        fn state(conn: *ConnSim) *stream_module.DirectionState {
+            return &conn.stream.directions[@intFromEnum(direction)];
         }
 
         fn targetSocket(conn: *const ConnSim) SimIo.Socket {
@@ -170,8 +171,8 @@ fn Base(comptime direction: Direction) type {
             assert(state(conn).phase != .finished);
             state(conn).phase = .finished;
             server.io.shutdown(targetSocket(conn), .write);
-            if (conn.directions[0].phase == .finished and
-                conn.directions[1].phase == .finished)
+            if (conn.stream.directions[0].phase == .finished and
+                conn.stream.directions[1].phase == .finished)
             {
                 server.beginTeardown(conn);
             }
@@ -267,7 +268,7 @@ const ToUpstreamPolicy = struct {
         assert(chunk.len >= 1);
         scratch.inbound_len += @intCast(chunk.len);
         assert(scratch.inbound_len <= scratch.inbound.len);
-        const out = conn.relay_buffer.?.client_to_upstream;
+        const out = conn.stream.relay_buffer.?.client_to_upstream;
         var out_len: u32 = 0;
         // Bounded by the scratch: each turn either consumes a whole frame or
         // breaks out.
@@ -332,7 +333,7 @@ const ToClientPolicy = struct {
         // runs exactly once per framed chunk.
         assert(scratch.outbound_len == scratch.outbound_sent);
         if (consumed > payload_max) return false;
-        const body = conn.relay_buffer.?.upstream_to_client[0..consumed];
+        const body = conn.stream.relay_buffer.?.upstream_to_client[0..consumed];
         std.mem.writeInt(u16, scratch.outbound[0..2], @intCast(consumed), .big);
         @memcpy(scratch.outbound[header_bytes..][0..consumed], body);
         scratch.outbound_len = header_bytes + consumed;
@@ -358,7 +359,7 @@ const ToClientPolicy = struct {
         scratch.outbound_sent += sent;
         assert(scratch.outbound_sent <= scratch.outbound_len);
         if (scratch.outbound_sent < scratch.outbound_len) return;
-        const direction_state = &conn.directions[@intFromEnum(Direction.upstream_to_client)];
+        const direction_state = &conn.stream.directions[@intFromEnum(Direction.upstream_to_client)];
         direction_state.credit(direction_state.owed());
     }
 };
@@ -698,7 +699,9 @@ const Harness = struct {
         // release rule this harness asserts at teardown does.
         const stream = bed.server.streams.acquire().?;
         stream.prepare(conn);
+        conn.stream = stream;
         const buffer = bed.server.relay_buffers.acquire().?;
+        stream.relay_buffer = buffer;
         // The accept gate and the admission tail are not exercised here, so
         // their counters are set by hand: `reconcile` (§9) checks
         // completed <= admitted <= accepted, and this connection did pass
@@ -707,9 +710,7 @@ const Harness = struct {
         bed.server.counters.increment("admitted");
         conn.prepare(
             &bed.server,
-            stream,
             bed.proxy_client_socket,
-            buffer,
             // Plaintext: this bed drives the pump seam directly, which is
             // the layer a transform sits above rather than inside.
             null,

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -125,7 +125,7 @@ fn Base(comptime direction: Direction) type {
 
         fn targetSocket(conn: *const ConnSim) SimIo.Socket {
             return switch (direction) {
-                .client_to_upstream => conn.upstream_socket.?,
+                .client_to_upstream => conn.stream.upstream_socket.?,
                 .upstream_to_client => conn.client_socket,
             };
         }
@@ -715,11 +715,10 @@ const Harness = struct {
             // the layer a transform sits above rather than inside.
             null,
             .connecting,
-            0,
             .l4,
             bed.server.io.peerAddress(bed.proxy_client_socket),
         );
-        conn.upstream_socket = bed.proxy_upstream_socket;
+        conn.stream.upstream_socket = bed.proxy_upstream_socket;
         conn.state = .relaying;
         bed.conn = conn;
         bed.server.storeDeadline(conn, 5_000);

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -693,6 +693,11 @@ const Harness = struct {
         assert(bed.conn == null);
         assert(scratch.isClean());
         const conn = bed.server.conns.acquire().?;
+        // One stream per connection (#274), like the admission tail this
+        // bed stands in for: the pump seam does not read it yet, but the
+        // release rule this harness asserts at teardown does.
+        const stream = bed.server.streams.acquire().?;
+        stream.prepare(conn);
         const buffer = bed.server.relay_buffers.acquire().?;
         // The accept gate and the admission tail are not exercised here, so
         // their counters are set by hand: `reconcile` (§9) checks
@@ -702,6 +707,7 @@ const Harness = struct {
         bed.server.counters.increment("admitted");
         conn.prepare(
             &bed.server,
+            stream,
             bed.proxy_client_socket,
             buffer,
             // Plaintext: this bed drives the pump seam directly, which is
@@ -720,10 +726,15 @@ const Harness = struct {
         PumpToClient.armRecv(&bed.server, conn);
     }
 
-    /// Every scenario ends the same way: the connection is gone, both pools
-    /// are back, and the books balance.
+    /// Every scenario ends the same way: the connection is gone, every
+    /// pool it drew from is back, and the books balance.
     fn expectSettled(bed: *Harness) !void {
         try std.testing.expect(bed.server.conns.isFullyReleased());
+        // Checked beside its siblings rather than left to the hard assert
+        // in `continueTeardown` (#274): this bed acquires the stream by
+        // hand, so it is exactly the caller that could get the pairing
+        // wrong and never reach that teardown at all.
+        try std.testing.expect(bed.server.streams.isFullyReleased());
         try std.testing.expect(bed.server.relay_buffers.isFullyReleased());
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
         try std.testing.expect(bed.server.reconcile());

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -58,7 +58,7 @@ pub fn Relay(comptime IoType: type) type {
             return struct {
                 fn targetSocket(conn: *const ConnType) IoType.Socket {
                     return switch (direction) {
-                        .client_to_upstream => conn.upstream_socket.?,
+                        .client_to_upstream => conn.stream.upstream_socket.?,
                         .upstream_to_client => conn.client_socket,
                     };
                 }
@@ -348,7 +348,7 @@ pub fn Relay(comptime IoType: type) type {
 
         pub fn start(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .relaying);
-            assert(conn.upstream_socket != null);
+            assert(conn.stream.upstream_socket != null);
             const client_to_upstream =
                 &conn.stream.directions[@intFromEnum(Direction.client_to_upstream)];
             if (client_to_upstream.owed() >= 1) {

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 
 const constants = @import("../constants.zig");
 const conn_module = @import("Conn.zig");
+const stream_module = @import("Stream.zig");
 const pump = @import("pump.zig");
 const TlsEngine = @import("../tls/Engine.zig");
 const Io = @import("../io/io.zig");
@@ -45,7 +46,8 @@ pub const RelayBuffer = struct {
 pub fn Relay(comptime IoType: type) type {
     const ServerType = @import("../Server.zig").Server(IoType);
     const ConnType = conn_module.Conn(IoType);
-    const Direction = ConnType.Direction;
+    const StreamType = ConnType.StreamType;
+    const Direction = StreamType.Direction;
 
     return struct {
         /// The L4 relay policy for one direction: no framing, EOF is a
@@ -61,8 +63,8 @@ pub fn Relay(comptime IoType: type) type {
                     };
                 }
 
-                fn state(conn: *ConnType) *conn_module.DirectionState {
-                    return &conn.directions[@intFromEnum(direction)];
+                fn state(conn: *ConnType) *stream_module.DirectionState {
+                    return &conn.stream.directions[@intFromEnum(direction)];
                 }
 
                 pub fn beforeRecv(conn: *ConnType) void {
@@ -203,7 +205,7 @@ pub fn Relay(comptime IoType: type) type {
                     if (direction == .client_to_upstream) {
                         if (conn.tls) |engine| return engine.recvBuffer();
                     }
-                    return @field(conn.relay_buffer.?, @tagName(direction));
+                    return @field(conn.stream.relay_buffer.?, @tagName(direction));
                 }
 
                 /// Decrypt, so framing sees plaintext and never learns a
@@ -245,7 +247,7 @@ pub fn Relay(comptime IoType: type) type {
                     const engine = conn.tls orelse return true;
                     if (!hasOutboundRoom(conn.server, conn)) return false;
                     engine.sendApp(
-                        conn.relay_buffer.?.upstream_to_client[0..consumed],
+                        conn.stream.relay_buffer.?.upstream_to_client[0..consumed],
                     ) catch {
                         conn.server.counters.increment("tls_relay_failed");
                         return false;
@@ -264,7 +266,7 @@ pub fn Relay(comptime IoType: type) type {
                         return direction_state.pending(engine.plaintext);
                     }
                     if (direction_state.owed() == 0) return &.{};
-                    return direction_state.pending(@field(conn.relay_buffer.?, @tagName(direction)));
+                    return direction_state.pending(@field(conn.stream.relay_buffer.?, @tagName(direction)));
                 }
 
                 /// Credit whichever cursor tracks the wire. Only the
@@ -348,7 +350,7 @@ pub fn Relay(comptime IoType: type) type {
             assert(conn.state == .relaying);
             assert(conn.upstream_socket != null);
             const client_to_upstream =
-                &conn.directions[@intFromEnum(Direction.client_to_upstream)];
+                &conn.stream.directions[@intFromEnum(Direction.client_to_upstream)];
             if (client_to_upstream.owed() >= 1) {
                 // Payload that arrived coalesced behind a PROXY header
                 // (#142): the receive phase staged it at the buffer's
@@ -363,15 +365,15 @@ pub fn Relay(comptime IoType: type) type {
                 assert(client_to_upstream.phase == .idle);
                 PumpClientToUpstream.armRecv(server, conn);
             }
-            assert(conn.directions[1].phase == .idle);
+            assert(conn.stream.directions[1].phase == .idle);
             PumpUpstreamToClient.armRecv(server, conn);
         }
 
         /// Both directions drained: the orderly end of an L4 connection.
         fn maybeFinish(server: *ServerType, conn: *ConnType) void {
             assert(conn.state == .relaying);
-            if (conn.directions[0].phase == .finished) {
-                if (conn.directions[1].phase == .finished) {
+            if (conn.stream.directions[0].phase == .finished) {
+                if (conn.stream.directions[1].phase == .finished) {
                     // The one L4 ending that is not a failure: both peers
                     // said goodbye. Every other way this connection can end
                     // — a reset, a deadline, a drain straggler — leaves the

--- a/src/net/relay.zig
+++ b/src/net/relay.zig
@@ -123,13 +123,13 @@ pub fn Relay(comptime IoType: type) type {
                 pub fn afterFeed(conn: *ConnType, received: u32, fr: pump.FeedResult) void {
                     _ = received;
                     if (direction == .client_to_upstream) {
-                        conn.log.bytes_in += fr.consumed;
+                        conn.stream.log.bytes_in += fr.consumed;
                     }
                 }
 
                 pub fn afterSend(conn: *ConnType, sent: u32) void {
                     if (direction == .upstream_to_client) {
-                        conn.log.bytes_out += sent;
+                        conn.stream.log.bytes_out += sent;
                     }
                 }
 
@@ -379,7 +379,7 @@ pub fn Relay(comptime IoType: type) type {
                     // — a reset, a deadline, a drain straggler — leaves the
                     // access log's default `aborted` in place (§8), so the
                     // line distinguishes a completed relay from a cut one.
-                    conn.log.outcome = .closed;
+                    conn.stream.log.outcome = .closed;
                     server.beginTeardown(conn);
                 }
             }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1055,6 +1055,12 @@ test "teardown: a drain racing its own upstream dial peaks at four armed ops" {
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("drained_at_deadline"));
         try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
         try std.testing.expectEqual(@as(u8, 4), bed.server.armed_ops_peak);
+        // And the #274 split of that same four: {connect, connect_cancel}
+        // on the stream, {deadline, deadline_cancel} on the conn. The
+        // combined figure above is what the CQ is charged and is what
+        // must not move; this one is why `stream_ops_max` is two rather
+        // than four, pinned by the seeds that actually reach the race.
+        try std.testing.expectEqual(@as(u8, 2), bed.server.stream_armed_ops_peak);
         try bed.expectDrained();
     }
 }


### PR DESCRIPTION
Closes #274. Slice 4 of the #173 HTTP/2 epic, and the one that de-risks it.

Splits the exchange out of the connection slot — `Conn` + `Stream` — while the
tree still speaks only HTTP/1.1, with the stream pool capped at one stream per
connection. The exchange-model change §13 warns about lands here, under the
*existing* sim sweep, live gate, coverage census and zero-alloc gate, with
HTTP/2 nowhere in the picture.

## The budget equality held

The issue names this as the slice's sharpest test: at one stream per connection
the totals must come out unchanged, and a change in the banner means the split
moved something it should not have.

| | pre-#274 | after |
|---|---|---|
| `fds` | 4094 | **4094** |
| `ring … in-flight ops <=` | 6871 | **6871** |
| conn slot | 2144 B | 536 B |
| stream slot | — | 1640 B |
| `Conn.zig` | 907 lines | 344 |

Both budget lines are byte-identical at every one of the five commits.
`conn_ops_max: 4` became `conn_ops_max: 2` (the deadline pair — the
connection's own clock) plus `stream_ops_max: 2` (the exchange's four ops, of
which at most two co-arm because a dial and the data legs are disjoint). The
comptime assert that derives `conn_slots_max` now reads
`conn_ops_max + stream_ops_max + 1` and still yields 11457.

The disjointness is asserted rather than argued: `Stream.arm` holds the count
to `stream_ops_max` on every arm across the sweep, and the pinned drain-vs-dial
seeds assert a stream peak of exactly 2 beside the combined 4 they already
pinned. `armed_ops_peak` became that combined count, sampled from both arm
sites, because the CQ is charged per admitted connection and that is the number
which must not move.

Total per-connection cost of the split: **+32 bytes** (the stream's pool
header, the two back-pointers, padding).

## Slices

One commit each, each independently green on `zig build ci`:

1. `f21ecf1` — `Pool(Stream)` beside the conn pool, 1:1, no fields moved.
2. `9f47b97` — the four exchange ring ops; the `conn_ops_max` split.
3. `04de591` — `directions`, `client_write`, `static_send`, `relay_buffer`, the head buffer and cursor.
4. `59199a7` — `l7: L7State`, `upstream`, `upstream_socket`, `cluster_index`.
5. `9e252c3` — `log: LogState` and the #140 capture table; the per-request/per-connection seam.

## Two bugs found, both in the lifecycle

Both surfaced against oracles that already work, which is the whole argument
for landing this before #275 rather than alongside it.

- **Teardown gated on the wrong armed set** (slice 2). Moving the ops left
  `continueTeardown` checking `conn.armedCount()` alone, so it closed both fds
  under an armed recv — ten tests aborted on the first idle timeout, tracing
  into `SimIo.socketEntry`. §5's release rule genuinely needed its extra level:
  a conn slot releases when its armed set is empty **and** every stream it owns
  has released.
- **A conn slot released without its stream** (slice 3). The §8 admission rungs
  abort before `finishAdmission` runs, so they returned a slot whose
  `conn.stream` was never set, and `releaseConn`'s #234 backstop dereferenced
  it. Fixed by pairing acquisition and release — the stream is taken in
  `admitConn` and returned in `releaseConn`, so there is exactly one acquire
  site and one release site for the pair, and "a conn slot in hand is a stream
  slot in hand" is structural rather than a property of one path.

Slices 4 and 5 moved more code than either and passed first try. The risk in
this change lives at the acquire/release/drain edges, not in the data.

## Gates

All existing, all unchanged:

- `zig build ci` green — 4096 sim seeds, both pools draining to zero.
- The coverage census unchanged at 76 counters fired / 17 exempt; no counter
  appeared or disappeared.
- The live gate's equalities: 144 http + 2 l4 exchanges, 146 access-log lines,
  counters reconcile — on both the default build and the ReleaseSafe twin.
- The zero-alloc gate and the §5/fd/CQ closed forms.
- `zig fmt --check` clean.

**Not run: `zig build bench`.** The issue asks for Tier-1 bands compared across
runs, which is a merge-tier gate wanting a real nginx origin. This touches the
hot path's object layout, and #162 is the precedent for a pooling change that
measured clean but moved RSS behaviour — worth running before merge.
`bench/micro/conn_touch_scaling.zig` was ported to arm on the stream slot where
the op now lives, and while there it gained real storage for the peak counters:
`arm`'s tracking wrote through an uninitialised `conn.server`, live UB in a
ReleaseSafe binary.

## Follow-ups, deliberately not in scope

- The Io seam's userdata stays `*ConnType`; handlers reach ops through
  `conn.stream`. Who a completion is delivered to is only observable once a
  connection owns more than one stream — that migration belongs to #275.
- `routeRequest` (114 lines), `beginReplay` (82) and `beginTunnel` (79) remain
  over TIGER_STYLE's 70-line hard limit. All pre-date this work and none grew
  under it (every hunk touching them has matching add/remove counts), but
  nearly every line in all three was rewritten across the five slices. A
  splitting pass is separable and worth doing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)