### PR TITLE
style: measure the function-length limit in code lines, and enforce it

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -556,7 +556,7 @@ pub fn build(b: *std.Build) void {
 
     const lint_run = b.addRunArtifact(lint_exe);
     lint_run.addDirectoryArg(b.path("src"));
-    const lint_step = b.step("lint", "fd-boundary lint: raw syscalls only under src/io/");
+    const lint_step = b.step("lint", "Mechanical TIGER_STYLE rules over src/: import boundaries, loop bounds, function length");
     lint_step.dependOn(&lint_run.step);
 
     // The per-change gates. The Tier-1 `bench` step is deliberately

--- a/docs/TIGER_STYLE.md
+++ b/docs/TIGER_STYLE.md
@@ -52,7 +52,14 @@ and the **proxy-specific deltas**. When in doubt, read the original.
   errors — OSDI'14.)
 - **Explicitly-sized integers** (`u32`, `u63`, …). Avoid `usize` except for real
   machine-word/index quantities.
-- **Functions ≤ 70 lines.** Hard limit.
+- **Functions ≤ 70 lines of code.** Hard limit, lint-enforced
+  (`scripts/lint.zig`). Comment and blank lines do not count: this codebase
+  buys its correctness partly with dense explanation, and a limit measured
+  in physical lines taxes exactly that — it would flag `dialUpstream` for
+  the 35-line comment justifying one assertion (#253), and reward deleting
+  it. Measured across the tree, 70 *physical* lines flagged 16 functions of
+  which 13 were more than a third comment; 70 *code* lines flags the three
+  that were genuinely long.
 - **4-space indentation.** `zig fmt` clean; trailing comma on wrapped signatures.
 - **Braces on every `if`** unless it fits on one line (defense against
   `goto fail;`-class bugs).

--- a/scripts/lint.zig
+++ b/scripts/lint.zig
@@ -163,7 +163,8 @@ fn lintFile(
         }
     }
     assert(line_number >= 1);
-    return violation_count + lintUnboundedLoops(contents, path);
+    return violation_count + lintUnboundedLoops(contents, path) +
+        lintFunctionLengths(contents, path);
 }
 
 /// Flag every `while (true)` whose bound is neither asserted nor
@@ -541,4 +542,261 @@ test "pathIsUnder: exact files, directory prefixes, and near misses" {
     try std.testing.expect(!pathIsUnder("io", "io/"));
     // An empty spec confines a needle to nowhere.
     try std.testing.expect(!pathIsUnder("anything.zig", ""));
+}
+
+/// TIGER_STYLE's function-length limit, made mechanical — and measured in
+/// *code* lines, which is the whole point of having it here rather than
+/// leaving it to review.
+///
+/// A physical-line limit taxes the practice this codebase is most
+/// distinctive for. Measured over the tree the day this rule landed, 70
+/// physical lines flagged 16 functions, 13 of them more than a third
+/// comment: `dialUpstream` at 75 physical was 32 lines of code and a
+/// 35-line comment justifying one assertion (#253), a comment a
+/// million-seed soak paid for. A rule that says "shorten this" about that
+/// function is a rule that rewards deleting the explanation. Counting
+/// code alone flagged the three that were genuinely long.
+const function_code_lines_max: u32 = 70;
+
+/// How far a wrapped signature may run before its `{`. Generous: the
+/// widest in the tree is nine lines, and over-running merely means this
+/// pass cannot tell a type constructor from an ordinary function.
+const signature_lines_max: u32 = 16;
+
+fn lintFunctionLengths(contents: []const u8, path: []const u8) u32 {
+    assert(path.len > 0);
+    var violation_count: u32 = 0;
+    var scan: FunctionScan = .{ .contents = contents };
+    // Bounded by the line count: `next` advances past the header it
+    // returned, and a file is already held under `file_bytes_max`.
+    while (scan.next()) |found| {
+        if (found.code_lines <= function_code_lines_max) continue;
+        std.debug.print("{s}:{d}: function is {d} lines of code, limit is {d} " ++
+            "(TIGER_STYLE; comments and blanks do not count)\n", .{
+            path,
+            found.line_number,
+            found.code_lines,
+            function_code_lines_max,
+        });
+        violation_count += 1;
+    }
+    return violation_count;
+}
+
+/// The count without the report — what the tests below assert on, the
+/// same split `nextUnboundedLoop` has.
+fn countOverlongFunctions(contents: []const u8) u32 {
+    return countOverlongFunctionsAt(contents, function_code_lines_max);
+}
+
+/// The same count against an arbitrary limit. The threshold is a
+/// parameter so the tests can state a fixture in five readable lines
+/// instead of seventy: what they are checking is where the boundary
+/// falls and what counts toward it, neither of which is a property of
+/// the number 70.
+fn countOverlongFunctionsAt(contents: []const u8, limit: u32) u32 {
+    var count: u32 = 0;
+    var scan: FunctionScan = .{ .contents = contents };
+    // Bounded by the file's function count: `next` advances past each
+    // header it returns.
+    while (scan.next()) |found| {
+        if (found.code_lines > limit) count += 1;
+    }
+    return count;
+}
+
+/// Walks the function bodies in one file, skipping the comptime type
+/// constructors (`fn Name(...) type`) that are containers rather than
+/// functions — the 70-line rule is about a body a reader must hold in
+/// their head, and `fn Server(comptime IoType: type) type` is a module.
+const FunctionScan = struct {
+    contents: []const u8,
+    line_index: u32 = 0,
+
+    const Found = struct {
+        line_number: u32,
+        code_lines: u32,
+    };
+
+    fn next(scan: *FunctionScan) ?Found {
+        // Bounded: every iteration advances `line_index` by at least one,
+        // and the file has finitely many lines.
+        while (scan.lineAt(scan.line_index)) |line| {
+            const start = scan.line_index;
+            scan.line_index += 1;
+            const indent = headerIndent(line) orelse continue;
+            if (scan.isTypeConstructor(start)) continue;
+            const code_lines = scan.countBody(start, indent) orelse continue;
+            return .{ .line_number = start + 1, .code_lines = code_lines };
+        }
+        return null;
+    }
+
+    /// The zero-based `index`th line, or null past the end.
+    fn lineAt(scan: *const FunctionScan, index: u32) ?[]const u8 {
+        var seen: u32 = 0;
+        var offset: usize = 0;
+        // Bounded by the file length: each step moves past one newline.
+        while (offset <= scan.contents.len) {
+            const end = std.mem.indexOfScalarPos(u8, scan.contents, offset, '\n') orelse
+                scan.contents.len;
+            if (seen == index) return scan.contents[offset..end];
+            if (end == scan.contents.len) return null;
+            seen += 1;
+            offset = end + 1;
+        }
+        return null;
+    }
+
+    /// True when the signature starting at `start` returns `type`.
+    fn isTypeConstructor(scan: *const FunctionScan, start: u32) bool {
+        var offset: u32 = 0;
+        while (offset < signature_lines_max) : (offset += 1) {
+            const line = scan.lineAt(start + offset) orelse return false;
+            const trimmed = std.mem.trimEnd(u8, line, " \t\r");
+            if (!std.mem.endsWith(u8, trimmed, "{")) continue;
+            return std.mem.indexOf(u8, trimmed, ") type {") != null;
+        }
+        return false;
+    }
+
+    /// Lines of code from the header through the closing brace at the
+    /// same indent, or null when no such brace is found — a signature
+    /// this pass could not follow, which it declines to judge rather than
+    /// guessing.
+    fn countBody(scan: *const FunctionScan, start: u32, indent: usize) ?u32 {
+        var code_lines: u32 = 0;
+        var offset: u32 = 0;
+        // Bounded by the file's line count, which `file_bytes_max`
+        // bounds in turn.
+        while (scan.lineAt(start + offset)) |line| : (offset += 1) {
+            if (!isBlankOrComment(line)) code_lines += 1;
+            if (offset >= 1 and isCloseAt(line, indent)) return code_lines;
+        }
+        return null;
+    }
+};
+
+/// The indent of a function header line, or null when the line is not
+/// one. `fn` must open the statement: a `fn` inside a type expression or
+/// a string is not a declaration this rule is about.
+fn headerIndent(line: []const u8) ?usize {
+    const indent = line.len - std.mem.trimStart(u8, line, " ").len;
+    const rest = line[indent..];
+    const body = if (std.mem.startsWith(u8, rest, "pub ")) rest["pub ".len..] else rest;
+    if (!std.mem.startsWith(u8, body, "fn ")) return null;
+    // A name and an open paren, so `fn` in prose cannot match.
+    if (std.mem.indexOfScalar(u8, body, '(') == null) return null;
+    return indent;
+}
+
+/// True for the `}` that closes a declaration opened at `indent`.
+fn isCloseAt(line: []const u8, indent: usize) bool {
+    if (line.len != indent + 1) return false;
+    if (line[indent] != '}') return false;
+    for (line[0..indent]) |byte| {
+        if (byte != ' ') return false;
+    }
+    return true;
+}
+
+fn isBlankOrComment(line: []const u8) bool {
+    const trimmed = std.mem.trim(u8, line, " \t\r");
+    if (trimmed.len == 0) return true;
+    return std.mem.startsWith(u8, trimmed, "//");
+}
+
+test "countOverlongFunctions: the boundary is exact" {
+    // Three code lines: the header, one statement, the brace.
+    const at_limit =
+        \\fn f() void {
+        \\    step();
+        \\}
+        \\
+    ;
+    const over =
+        \\fn f() void {
+        \\    step();
+        \\    step();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countOverlongFunctionsAt(at_limit, 3));
+    try std.testing.expectEqual(@as(u32, 1), countOverlongFunctionsAt(over, 3));
+}
+
+test "countOverlongFunctions: comments and blanks do not count" {
+    // The rule's whole point: explanation is not length. A physical-line
+    // limit would flag this body and reward deleting the reason it works.
+    const padded =
+        \\fn f() void {
+        \\    // Why this is correct, at length.
+        \\    //
+        \\    // Still explaining.
+        \\
+        \\    step();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countOverlongFunctionsAt(padded, 3));
+}
+
+test "countOverlongFunctions: a comptime type constructor is not a function" {
+    // `fn Server(comptime IoType: type) type` is a module, and the limit
+    // is about a body a reader holds in their head.
+    const constructor =
+        \\fn Server(comptime IoType: type) type {
+        \\    step();
+        \\    step();
+        \\    step();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countOverlongFunctionsAt(constructor, 3));
+}
+
+test "countOverlongFunctions: a wrapped signature is still recognized" {
+    // The `) type {` this pass looks for may be several lines below the
+    // `fn`, which is how every generic in the tree is written.
+    const wrapped =
+        \\fn Pool(
+        \\    comptime T: type,
+        \\) type {
+        \\    step();
+        \\    step();
+        \\    step();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 0), countOverlongFunctionsAt(wrapped, 3));
+}
+
+test "countOverlongFunctions: a nested declaration is measured at its own indent" {
+    const nested =
+        \\    fn inner() void {
+        \\        step();
+        \\        step();
+        \\    }
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 1), countOverlongFunctionsAt(nested, 3));
+    try std.testing.expectEqual(@as(u32, 0), countOverlongFunctionsAt(nested, 4));
+}
+
+test "countOverlongFunctions: each overlong function in a file is counted" {
+    const source =
+        \\fn a() void {
+        \\    step();
+        \\    step();
+        \\}
+        \\fn b() void {
+        \\    step();
+        \\}
+        \\fn c() void {
+        \\    step();
+        \\    step();
+        \\}
+        \\
+    ;
+    try std.testing.expectEqual(@as(u32, 2), countOverlongFunctionsAt(source, 3));
 }

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -431,6 +431,19 @@ pub fn Client(comptime IoType: type) type {
             /// plus Connection tokens, as the parser computed them.
             keep_alives: [responses_max]bool,
             violation: ?ClientError,
+
+            /// A walk that has read nothing yet. A decl on the type
+            /// rather than a literal at the one call site: the zero value
+            /// of a `Walk` is a property of the type, and stating it here
+            /// keeps the walk itself about walking.
+            pub const empty: Walk = .{
+                .complete_count = 0,
+                .interim_count = 0,
+                .offset = 0,
+                .statuses = @splat(0),
+                .keep_alives = @splat(false),
+                .violation = null,
+            };
         };
 
         /// Walk the received bytes as a sequence of responses, validating
@@ -439,15 +452,55 @@ pub fn Client(comptime IoType: type) type {
         /// a legal prefix (the adversary cuts mid-anything); bytes that
         /// can never extend to a legal transcript — or one complete
         /// response more than the transcript contains — are a violation.
+        /// The per-status header oracles (#176, #240, #180): the three
+        /// statuses whose *content* is the claim under test, where a
+        /// status check alone would pass a render that dropped or
+        /// corrupted the header carrying it. Null when the head is
+        /// consistent with what its status promises.
+        ///
+        /// Split from `walkResponses` for the length limit, and the seam
+        /// is what each half is: this one judges one head, the caller
+        /// walks a byte stream of them.
+        fn checkStatusHeaders(response: parser.ResponseHead, entry: Spec) ?ClientError {
+            // The #176 oracle: `filter_redirect` is the only script
+            // that earns a 301, its rule composes from the request's
+            // own host and canonical path, and both are fixed — so
+            // every 301 must carry exactly the canonical Location.
+            if (response.status == 301) {
+                if (!headerEquals(response.headers, "Location", canon.redirect_location)) {
+                    return ClientError.RedirectLocationWrong;
+                }
+            }
+            // The #240 oracle: a final-recipient answer's whole
+            // content is what it says about this hop, so a `200` that
+            // reached the client without an exact `Allow` answered
+            // the question with nothing.
+            if (response.status == 200 and entry.answered_here) {
+                if (!headerEquals(response.headers, "Allow", parser.allow_value)) {
+                    return ClientError.AllowMissing;
+                }
+            }
+            // The #180 oracle, and the mirror of the redirect check
+            // above: §7 lets the participating `Upgrade` survive
+            // hop-by-hop stripping precisely so the client is told
+            // *what* it was upgraded to, and the proxy writes its own
+            // `Connection: upgrade` rather than echoing whatever
+            // arrived. A status check alone cannot see either — a
+            // render that dropped or corrupted the pair would still
+            // produce a `101` and pass — so the headers are demanded
+            // by name, byte for byte.
+            if (response.status == 101) {
+                if (!headerEquals(response.headers, "upgrade", "websocket") or
+                    !headerEquals(response.headers, "connection", "upgrade"))
+                {
+                    return ClientError.UpgradePairMissing;
+                }
+            }
+            return null;
+        }
+
         pub fn walkResponses(bytes: []const u8, entry: Spec, connection: Connection) Walk {
-            var walk = Walk{
-                .complete_count = 0,
-                .interim_count = 0,
-                .offset = 0,
-                .statuses = @splat(0),
-                .keep_alives = @splat(false),
-                .violation = null,
-            };
+            var walk: Walk = .empty;
             while (walk.complete_count < responses_max) {
                 assert(walk.offset <= bytes.len);
                 if (walk.offset == bytes.len) return walk;
@@ -501,42 +554,9 @@ pub fn Client(comptime IoType: type) type {
                     walk.violation = violation;
                     return walk;
                 }
-                // The #176 oracle: `filter_redirect` is the only script
-                // that earns a 301, its rule composes from the request's
-                // own host and canonical path, and both are fixed — so
-                // every 301 must carry exactly the canonical Location.
-                if (response.status == 301) {
-                    if (!headerEquals(response.headers, "Location", canon.redirect_location)) {
-                        walk.violation = ClientError.RedirectLocationWrong;
-                        return walk;
-                    }
-                }
-                // The #240 oracle: a final-recipient answer's whole
-                // content is what it says about this hop, so a `200` that
-                // reached the client without an exact `Allow` answered
-                // the question with nothing.
-                if (response.status == 200 and entry.answered_here) {
-                    if (!headerEquals(response.headers, "Allow", parser.allow_value)) {
-                        walk.violation = ClientError.AllowMissing;
-                        return walk;
-                    }
-                }
-                // The #180 oracle, and the mirror of the redirect check
-                // above: §7 lets the participating `Upgrade` survive
-                // hop-by-hop stripping precisely so the client is told
-                // *what* it was upgraded to, and the proxy writes its own
-                // `Connection: upgrade` rather than echoing whatever
-                // arrived. A status check alone cannot see either — a
-                // render that dropped or corrupted the pair would still
-                // produce a `101` and pass — so the headers are demanded
-                // by name, byte for byte.
-                if (response.status == 101) {
-                    if (!headerEquals(response.headers, "upgrade", "websocket") or
-                        !headerEquals(response.headers, "connection", "upgrade"))
-                    {
-                        walk.violation = ClientError.UpgradePairMissing;
-                        return walk;
-                    }
+                if (checkStatusHeaders(response, entry)) |violation| {
+                    walk.violation = violation;
+                    return walk;
                 }
                 const body = bytes[walk.offset + response.head_len ..];
                 const verdict = walkBody(response, body, entry) orelse return walk;

--- a/src/config.zig
+++ b/src/config.zig
@@ -1310,6 +1310,56 @@ fn resolveAdminBind(admin_json: ?AdminJson) ValidationError!?std.Io.net.IpAddres
 /// resolvers have each enforced their own half, because a pool past this
 /// is not merely wasteful — the fd and ring budgets are derived from
 /// `conn_slots` on the strength of it (`fdsRequired`, `inFlightOps`), so
+/// The two pools a *feature* switches on: TLS engines, reserved exactly
+/// when some listener terminates, and #180's tunnels, reserved exactly
+/// when some listener allows an upgrade. Their own group because both are
+/// zero for a deployment that asked for neither — which is what makes
+/// each feature free — and both are bounded by the conn slots above.
+fn resolveFeaturePools(
+    limits_json: *const LimitsJson,
+    conn_slots: u32,
+    tls_listeners_count: u32,
+    upgrade_listeners_count: u32,
+) ValidationError!struct { tls_engines: u32, tunnels: u32 } {
+    const tls_engines = try resolveTlsEngines(
+        limits_json.tls_engines,
+        conn_slots,
+        tls_listeners_count,
+    );
+    const tunnels = try resolveTunnels(
+        limits_json.tunnels,
+        conn_slots,
+        upgrade_listeners_count,
+    );
+    return .{ .tls_engines = tls_engines, .tunnels = tunnels };
+}
+
+/// The two head pools (§5), which exist only for an HTTP listener: the
+/// downstream ring and the upstream pool. Their own group because both
+/// are gated on the same `http_listeners_count` and each is bounded by a
+/// different slot count above.
+fn resolveHeadPools(
+    limits_json: *const LimitsJson,
+    conn_slots: u32,
+    upstream_slots: u32,
+    http_listeners_count: u32,
+) ValidationError!struct { head_buffers: u32, upstream_head_buffers: u32 } {
+    const head_buffers = try resolveHeadBuffers(
+        limits_json.head_buffers,
+        conn_slots,
+        http_listeners_count,
+    );
+    const upstream_head_buffers = try resolveUpstreamHeadBuffers(
+        limits_json.upstream_head_buffers,
+        upstream_slots,
+        http_listeners_count,
+    );
+    return .{
+        .head_buffers = head_buffers,
+        .upstream_head_buffers = upstream_head_buffers,
+    };
+}
+
 /// a breach here is an under-provisioned ring rather than spare memory.
 fn assertPoolsFitConnSlots(
     conn_slots: u32,
@@ -1344,26 +1394,18 @@ fn resolveLimits(
     const conn_slots = slots.conn_slots;
     const relay_buffers = slots.relay_buffers;
     const upstream_slots = slots.upstream_slots;
-    const head_buffers = try resolveHeadBuffers(
-        limits_json.head_buffers,
+    const head_pools = try resolveHeadPools(
+        limits_json,
         conn_slots,
-        http_listeners_count,
-    );
-    const upstream_head_buffers = try resolveUpstreamHeadBuffers(
-        limits_json.upstream_head_buffers,
         upstream_slots,
         http_listeners_count,
     );
     const head_buffer_bytes = try resolveHeadBufferBytes(limits_json.head_buffer_bytes);
     const relay_buffer_bytes = try resolveRelayBufferBytes(limits_json.relay_buffer_bytes);
-    const tls_engines = try resolveTlsEngines(
-        limits_json.tls_engines,
+    const feature_pools = try resolveFeaturePools(
+        limits_json,
         conn_slots,
         tls_listeners_count,
-    );
-    const tunnels = try resolveTunnels(
-        limits_json.tunnels,
-        conn_slots,
         upgrade_listeners_count,
     );
     const cq_fill_eighths = try resolveCqFill(
@@ -1383,17 +1425,23 @@ fn resolveLimits(
         access_log_on,
         log_header_count,
     );
-    assertPoolsFitConnSlots(conn_slots, relay_buffers, head_buffers, tls_engines, tunnels);
+    assertPoolsFitConnSlots(
+        conn_slots,
+        relay_buffers,
+        head_pools.head_buffers,
+        feature_pools.tls_engines,
+        feature_pools.tunnels,
+    );
     return .{
         .conn_slots = conn_slots,
         .relay_buffers = relay_buffers,
         .upstream_slots = upstream_slots,
-        .head_buffers = head_buffers,
-        .upstream_head_buffers = upstream_head_buffers,
+        .head_buffers = head_pools.head_buffers,
+        .upstream_head_buffers = head_pools.upstream_head_buffers,
         .head_buffer_bytes = head_buffer_bytes,
         .relay_buffer_bytes = relay_buffer_bytes,
-        .tls_engines = tls_engines,
-        .tunnels = tunnels,
+        .tls_engines = feature_pools.tls_engines,
+        .tunnels = feature_pools.tunnels,
         .keepalive_requests = limits_json.keepalive_requests orelse
             constants.keepalive_requests_default,
         .cq_fill_eighths = cq_fill_eighths,

--- a/src/http/parser.zig
+++ b/src/http/parser.zig
@@ -1024,6 +1024,68 @@ const HeaderAnalysis = struct {
 /// than a slice: both spans are fields of the one aggregate now, and
 /// handing this a slice of `raw` while it writes `headers` would state an
 /// aliasing relation the caller cannot check.
+/// Fold one header into the running analysis (§7). Split from
+/// `analyzeHeaders` for the length limit, and it is the shape
+/// TIGER_STYLE asks for: the caller's loop is straight-line, and the
+/// branching lives in a leaf that sees one header and nothing else.
+///
+/// `Malformed` here is always the same class of finding — a duplicate or
+/// empty field whose two readings would disagree, which is the
+/// request-smuggling shape §7's strictness exists to refuse.
+fn foldHeader(
+    analysis: *HeaderAnalysis,
+    header: Header,
+    value: []const u8,
+) error{Malformed}!void {
+    switch (header.tag) {
+        .host => {
+            // A second Host changes routing depending on who reads which —
+            // a smuggling shape, like an empty one (RFC 9112 §3.2).
+            if (analysis.host != null) {
+                return error.Malformed;
+            }
+            if (value.len == 0) {
+                return error.Malformed;
+            }
+            analysis.host = value;
+        },
+        .content_length => {
+            // Duplicate Content-Length is rejected outright, identical
+            // values included (§7 "duplicate/garbage Content-Length").
+            if (analysis.content_length != null) {
+                return error.Malformed;
+            }
+            analysis.content_length = try parseDecimal(value);
+        },
+        .transfer_encoding => {
+            // A second Transfer-Encoding header is the list form in
+            // disguise; only the single exact "chunked" is ever legal
+            // here, so any repeat is malformed.
+            if (analysis.te_chunked or analysis.te_other) {
+                return error.Malformed;
+            }
+            if (std.ascii.eqlIgnoreCase(value, "chunked")) {
+                analysis.te_chunked = true;
+            } else {
+                analysis.te_other = true;
+            }
+        },
+        .connection => {
+            // Multiple Connection headers combine as one list (RFC 9110).
+            scanConnectionTokens(value, analysis);
+        },
+        // `x_forwarded_for` and `max_forwards` join the no-analysis
+        // set: their tags exist so the *render* can find them cheaply
+        // (§7), and nothing about framing, routing or persistence
+        // reads either here. `Max-Forwards` in particular is read
+        // only for the two methods RFC 9110 §7.6.2 names, by
+        // `maxForwards` below — parsing it for every request would
+        // let a garbage value on a POST reject a request the spec
+        // says may ignore the field entirely (#240).
+        .other, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for, .max_forwards => {},
+    }
+}
+
 fn analyzeHeaders(
     header_count: usize,
     headers_storage: *HeaderStorage,
@@ -1044,53 +1106,7 @@ fn analyzeHeaders(
         // decision, here and in the render walk, tests the tag instead.
         const header: Header = .init(raw_header.key, raw_header.value);
         headers_storage.headers[index] = header;
-        switch (header.tag) {
-            .host => {
-                // A second Host changes routing depending on who reads which —
-                // a smuggling shape, like an empty one (RFC 9112 §3.2).
-                if (analysis.host != null) {
-                    return error.Malformed;
-                }
-                if (raw_header.value.len == 0) {
-                    return error.Malformed;
-                }
-                analysis.host = raw_header.value;
-            },
-            .content_length => {
-                // Duplicate Content-Length is rejected outright, identical
-                // values included (§7 "duplicate/garbage Content-Length").
-                if (analysis.content_length != null) {
-                    return error.Malformed;
-                }
-                analysis.content_length = try parseDecimal(raw_header.value);
-            },
-            .transfer_encoding => {
-                // A second Transfer-Encoding header is the list form in
-                // disguise; only the single exact "chunked" is ever legal
-                // here, so any repeat is malformed.
-                if (analysis.te_chunked or analysis.te_other) {
-                    return error.Malformed;
-                }
-                if (std.ascii.eqlIgnoreCase(raw_header.value, "chunked")) {
-                    analysis.te_chunked = true;
-                } else {
-                    analysis.te_other = true;
-                }
-            },
-            .connection => {
-                // Multiple Connection headers combine as one list (RFC 9110).
-                scanConnectionTokens(raw_header.value, &analysis);
-            },
-            // `x_forwarded_for` and `max_forwards` join the no-analysis
-            // set: their tags exist so the *render* can find them cheaply
-            // (§7), and nothing about framing, routing or persistence
-            // reads either here. `Max-Forwards` in particular is read
-            // only for the two methods RFC 9110 §7.6.2 names, by
-            // `maxForwards` below — parsing it for every request would
-            // let a garbage value on a POST reject a request the spec
-            // says may ignore the field entirely (#240).
-            .other, .keep_alive, .proxy_connection, .te, .upgrade, .x_forwarded_for, .max_forwards => {},
-        }
+        try foldHeader(&analysis, header, raw_header.value);
     }
     assert(!(analysis.te_chunked and analysis.te_other));
     if (analysis.host) |host| {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -934,9 +934,22 @@ pub fn Proxy(comptime IoType: type) type {
         /// selects a cluster (400 if it will not canonicalize, 404 if no
         /// route matches, §7/§8); a routable request then claims its
         /// relay buffer and upstream slot (§8 rungs, 503) and dials.
-        fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
+        /// §7's `admit` phase: everything answerable about the request
+        /// itself, before a single resource is acquired. True when the
+        /// request survives to be routed; false when it has already been
+        /// answered — the same convention `admitUpgrade` below uses, and
+        /// the reason every rejection here is a tail call.
+        ///
+        /// Split from `routeRequest` on the seam §7's own phase model
+        /// draws: this half needs nothing but the parsed head, where the
+        /// half below borrows scratch, takes a relay buffer and picks an
+        /// endpoint.
+        fn admitRequest(
+            server: *ServerType,
+            conn: *ConnType,
+            request: *const parser.RequestHead,
+        ) bool {
             assert(conn.state == .l7_reading_head);
-            assert(request.head_len <= conn.stream.head_len);
             recordRequestFacts(server, conn, request);
             // Counted where a request becomes real (#237): a head that
             // parsed and will be answered. A malformed one never reaches
@@ -964,7 +977,8 @@ pub fn Proxy(comptime IoType: type) type {
             // this proxy the final recipient of every TRACE chain
             // unconditionally, which is half of RFC 9110 §7.6.2.
             if (request.method == .connect or request.method == .trace) {
-                return respond(server, conn, 501, "l7_not_implemented");
+                respond(server, conn, 501, "l7_not_implemented");
+                return false;
             }
             // RFC 9110 §7.6.2's hop budget, checked before anything is
             // acquired because a budget that ran out means no origin is
@@ -980,16 +994,20 @@ pub fn Proxy(comptime IoType: type) type {
                     // about either; this proxy answers the way it answers
                     // every other field it reads and cannot parse, rather
                     // than guessing which budget was meant.
-                    .malformed => return respond(server, conn, 400, "l7_bad_request"),
+                    .malformed => {
+                        respond(server, conn, 400, "l7_bad_request");
+                        return false;
+                    },
                     .hops => |hops| {
                         if (hops == 0) {
-                            return respondMaxForwardsExhausted(server, conn);
+                            respondMaxForwardsExhausted(server, conn);
+                            return false;
                         }
                     },
                 }
             }
             if (parser.headerValue(request.headers, "upgrade")) |token| {
-                if (!admitUpgrade(server, conn, token)) return;
+                if (!admitUpgrade(server, conn, token)) return false;
             }
             // A declared body over the listener's cap is knowable now, so
             // it is refused now (#236) — the §8 tunnel rung's own
@@ -999,9 +1017,18 @@ pub fn Proxy(comptime IoType: type) type {
             // still unread in the socket and draining it only to reject it
             // is the wrong trade at the size this triggers on.
             if (bodyOverLimit(conn, request)) {
-                return respond(server, conn, 413, "l7_body_over_limit");
+                respond(server, conn, 413, "l7_body_over_limit");
+                return false;
             }
+            return true;
+        }
 
+        /// §7's `route` phase: canonicalize once, filter, route, then take
+        /// the first resource this request has needed.
+        fn routeRequest(server: *ServerType, conn: *ConnType, request: *const parser.RequestHead) void {
+            assert(conn.state == .l7_reading_head);
+            assert(request.head_len <= conn.stream.head_len);
+            if (!admitRequest(server, conn, request)) return;
             // §7: canonicalize the host and path once, then apply filters
             // and routing to that one view before acquiring any resource,
             // so a bad path, a policy reject, or an unrouted host/path is

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -687,6 +687,37 @@ const Http1Bed = struct {
         health_interval_ms: u32 = 40,
     };
 
+    /// The bed's `Config`, assembled apart from the rest of `setUp` for
+    /// the length limit. It is the natural half: everything here is what
+    /// the *loader* would have produced, where the caller's remaining
+    /// half is what the runtime does with it.
+    fn buildConfig(bed: *Http1Bed, options: Options) void {
+        bed.config = .{
+            .listeners = &bed.listeners,
+            .clusters = &bed.clusters,
+            // The #237 cap is read off the *config*, which is where the
+            // loader puts it; `InitOptions` sizes the pools. The bed keeps
+            // the rest of `limits` at its struct defaults, which is what
+            // every test before this one was measuring against.
+            .limits = .{ .keepalive_requests = options.keepalive_requests },
+            .connect_timeout_ms = connect_timeout_ms,
+            .idle_timeout_ms = idle_timeout_ms,
+            // Mirrors the idle window unless a test is about the split
+            // (#235): the bed's timeouts are milliseconds, so a flat
+            // default would sit far above the window it must tighten.
+            .head_timeout_ms = options.head_timeout_ms orelse idle_timeout_ms,
+            .drain_deadline_ms = options.drain_deadline_ms,
+            .max_lifetime_ms = options.max_lifetime_ms,
+            .request_timeout_ms = options.request_timeout_ms,
+            .tunnel_timeout_ms = constants.tunnel_ms_default,
+            .access_log_sink = if (options.access_log) .stdout else null,
+            .health_interval_ms = options.health_interval_ms,
+            .error_pages = options.error_pages,
+            .access_log_request_headers = options.access_log_request_headers,
+            .access_log_response_headers = options.access_log_response_headers,
+        };
+    }
+
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
         bed.arena_state = std.heap.ArenaAllocator.init(gpa);
         errdefer bed.arena_state.deinit();
@@ -729,30 +760,7 @@ const Http1Bed = struct {
             else
                 null,
         }};
-        bed.config = .{
-            .listeners = &bed.listeners,
-            .clusters = &bed.clusters,
-            // The #237 cap is read off the *config*, which is where the
-            // loader puts it; `InitOptions` sizes the pools. The bed keeps
-            // the rest of `limits` at its struct defaults, which is what
-            // every test before this one was measuring against.
-            .limits = .{ .keepalive_requests = options.keepalive_requests },
-            .connect_timeout_ms = connect_timeout_ms,
-            .idle_timeout_ms = idle_timeout_ms,
-            // Mirrors the idle window unless a test is about the split
-            // (#235): the bed's timeouts are milliseconds, so a flat
-            // default would sit far above the window it must tighten.
-            .head_timeout_ms = options.head_timeout_ms orelse idle_timeout_ms,
-            .drain_deadline_ms = options.drain_deadline_ms,
-            .max_lifetime_ms = options.max_lifetime_ms,
-            .request_timeout_ms = options.request_timeout_ms,
-            .tunnel_timeout_ms = constants.tunnel_ms_default,
-            .access_log_sink = if (options.access_log) .stdout else null,
-            .health_interval_ms = options.health_interval_ms,
-            .error_pages = options.error_pages,
-            .access_log_request_headers = options.access_log_request_headers,
-            .access_log_response_headers = options.access_log_response_headers,
-        };
+        bed.buildConfig(options);
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
             .relay_buffers = options.relay_buffers,

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -351,6 +351,32 @@ pub const TestBed = struct {
         }
     }
 
+    /// The bed's TLS credentials, loaded apart from `setUp` for the
+    /// length limit — and it is the half worth naming, since the
+    /// deterministic-nonce option below is a §9 property (a seeded run
+    /// replays a byte-exact handshake) and never a production setting.
+    fn loadCredentials(
+        bed: *TestBed,
+        arena: std.mem.Allocator,
+        options: SetUpOptions,
+        server_options: ServerSim.InitOptions,
+    ) !void {
+        bed.tls_credentials = .{null};
+        if (options.tls) {
+            assert(server_options.tls_engines >= 1);
+            bed.tls_credentials[0] = try Credentials.load(
+                arena,
+                fixture_cert_pem,
+                fixture_key_pem,
+                // Deterministic signatures, so a seeded run replays a
+                // byte-exact handshake — the §9 property the whole
+                // simulation rests on. Never set in production.
+                .{ .deterministic_nonce = true },
+            );
+            bed.server.setTlsCredentials(&bed.tls_credentials);
+        }
+    }
+
     pub fn setUp(bed: *TestBed, gpa: std.mem.Allocator, options: SetUpOptions) !void {
         bed.arena_state = std.heap.ArenaAllocator.init(gpa);
         errdefer bed.arena_state.deinit();
@@ -410,20 +436,7 @@ pub const TestBed = struct {
         else
             0;
         try bed.server.init(arena, &bed.sim_io, &bed.config, server_options);
-        bed.tls_credentials = .{null};
-        if (options.tls) {
-            assert(server_options.tls_engines >= 1);
-            bed.tls_credentials[0] = try Credentials.load(
-                arena,
-                fixture_cert_pem,
-                fixture_key_pem,
-                // Deterministic signatures, so a seeded run replays a
-                // byte-exact handshake — the §9 property the whole
-                // simulation rests on. Never set in production.
-                .{ .deterministic_nonce = true },
-            );
-            bed.server.setTlsCredentials(&bed.tls_credentials);
-        }
+        try bed.loadCredentials(arena, options, server_options);
         try bed.server.start();
 
         bed.scenario = .{


### PR DESCRIPTION
TIGER_STYLE has called 70 lines a hard limit since the beginning, and nothing
enforced it — `scripts/lint.zig` covered import boundaries and loop bounds
only. Sixteen functions had drifted past it. Making it mechanical meant first
asking what it should measure, and the answer turned out not to be the number.

## The metric, not the number

Measured across all 1317 functions in `src/`:

| limit | over by physical lines | over by **code** lines |
|---|---|---|
| 70 | 16 | **3** |
| 80 | 8 | 1 |
| 100 | 3 | 0 |

The functions a physical-line limit flags are 42–63% comment:

```
114 phys /  60 code   routeRequest
104 phys /  61 code   renderRequestHead
 82 phys /  44 code   beginReplay
 75 phys /  32 code   dialUpstream      ← 42% code
```

`dialUpstream` is 75 physical lines and **32 lines of code**, flagged entirely
for the 35-line comment justifying one assertion — the #253 finding that a
million-seed soak paid for. A rule that says "shorten this" about that function
is a rule that rewards deleting the reason it is correct, which is the opposite
of what this codebase spends its comments on.

Raising the number to 100 does not fix that. It retires the rule instead: three
functions in the whole tree.

So the limit stays 70 and counts non-blank, non-comment lines.

## What that flags

Four functions, split in `6a0e1e8` on seams they already had:

- `walkResponses` 88 → 60. `checkStatusHeaders` holds the three per-status
  oracles (#176, #240, #180) whose *content* is the claim under test — a status
  check alone would pass a render that dropped the header carrying it — and
  `Walk.empty` moves the zero value onto the type.
- The two test-bed `setUp`s, 85 and 73. `buildConfig` is what the loader would
  have produced; `loadCredentials` holds the deterministic-nonce credentials a
  seeded run replays a byte-exact handshake from (§9).
- `resolveLimits` 71 → 50. `resolveFeaturePools` (the two pools a feature
  switches on, zero for a deployment that asked for neither) and
  `resolveHeadPools` (the two gated on an HTTP listener).

Two more are split on rules other than length, and are worth doing at any limit:

- `analyzeHeaders` → `foldHeader`, which is what TIGER_STYLE's control-flow
  section asks for directly: push `for`s down, keep the caller's loop
  straight-line, put the branching in a leaf that sees one header.
- `routeRequest` → `admitRequest`, matching the phase model DESIGN.md §7
  already names — `admit` needs nothing but the parsed head, where `route`
  borrows scratch, takes a relay buffer and picks an endpoint.

Nothing else is touched. `Server.zig`, `render.zig`, `constants.zig` and
`SimIo.zig` are untouched by this branch.

## The rule

`scripts/lint.zig` grows it, beside the loop-bound rule it already mechanizes
and for the same stated reason. It skips comptime type constructors —
`fn Server(comptime IoType: type) type` is a module, not a body a reader holds
in their head — and reports the count, so a violation says how far over it is.

The threshold is a parameter to the countable core, so the six tests state
their fixtures in five readable lines rather than seventy: the exact boundary,
the comment-padding case the metric exists for, the constructor exemption, a
wrapped signature, nested declarations, and multiple functions per file.
Mutating either the limit or the comparison fails them.

The lint still runs over `src/` only — extending it would apply the
import-boundary rules to `sim/` and `smoke/`, which legitimately differ — but
the whole tree is clean by the new metric today.

## Gates

`zig build ci` green — 4096 sim seeds, census unchanged at 76 counters fired /
17 exempt, both smoke runs clean (144 http + 2 l4 exchanges, 146 access-log
lines, counters reconcile), `zig fmt --check` clean. Each commit was verified
to stand on its own: `6a0e1e8`'s tests pass before the lint exists.

## Note on how this landed

The first version of this branch split **17** functions, because I applied the
old metric before questioning it. Thirteen of those were never over the limit
by code lines — including a 32-line function and a 38-line one — and would have
been gratuitous churn across `proxy.zig`, `Server.zig` and `config.zig`
immediately before #275 rewrites them. That branch was discarded and this one
rebuilt from `main`; the durable output here is the metric and its enforcement,
not the refactoring, which turned out to be four functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)