### PR TITLE
cli: `--check` prices a config without taking a port (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ processes behind `SO_REUSEPORT`, never threads sharing memory.
 The binary takes exactly one argument, the path to a JSON config:
 
 ```sh
-zoxy config.json
+zoxy config.json           # start the proxy
+zoxy --check config.json   # validate and price it, without binding a port
 ```
 
 A minimal config — one L4 listener forwarding to one origin:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -733,6 +733,20 @@ Rules:
   `conn_slots_max`/`upstream_slots_max` are therefore stated at *zero*
   configured listeners, and each listener a config declares spends from
   the same budget.
+- **`--check` runs that gauntlet without taking a port** (#301). Refusing
+  at startup rather than warning is the right trade, and it is also what
+  makes the pre-flight worth having: a config can be valid JSON, valid
+  semantically, and still not start *on this box* — and config is
+  parse-once immutable (§1), so the blast radius of finding that out the
+  hard way is an outage rather than a failed reload. `--check` loads the
+  config, opens every file it names, prices the pools and measures the fd
+  demand against the observed `RLIMIT_NOFILE`, prints the banner to
+  stdout and exits: `0` if it would start here, `1` if the config is
+  wrong, `2` if the config is right and this machine cannot fit it. It is
+  the same code path and not a second validator — a pre-flight that
+  agreed with the binary only by construction would be worse than none —
+  and the live gate (§9) runs it over the config it then serves, which is
+  the only place that agreement can be observed.
 - **The CQ fill is a headroom knob, not a pool shrink.**
   `limits.cq_fill_eighths` sets how many eighths of the completion queue
   the worst-case in-flight ops may fill: ⅞ (the default, the fill the c10k

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,10 @@ in [DESIGN.md](DESIGN.md), which the bare `§` references point at.
 The binary takes exactly one argument, the path to a JSON config:
 
 ```sh
-zoxy config.json     # start the proxy
-zoxy --help          # usage summary (-h)
-zoxy --version       # print the version (-V)
+zoxy config.json           # start the proxy
+zoxy --check config.json   # validate and price it, bind nothing (-c)
+zoxy --help                # usage summary (-h)
+zoxy --version             # print the version (-V)
 ```
 
 A release prints its bare version, `zoxy 0.0.9`. A build made from source
@@ -36,11 +37,66 @@ process prints `zoxy: invalid config '<path>': <reason>` and exits `1`. That
 is what makes the replacement procedure below safe to run against a live
 port.
 
+A config that is *valid* and still will not start here — its fd budget is
+above this machine's `RLIMIT_NOFILE` hard limit — is refused the same way,
+after the startup banner, so the numbers that refused it are on the screen
+with the reason.
+
+### Checking a config without running it
+
+`--check` is that same refusal, asked for on purpose. It loads the config,
+opens every file the config names, prices the pools and measures the fd
+demand against this machine's `RLIMIT_NOFILE` — everything a start does up
+to the banner — and then exits without binding a port:
+
+```console
+$ zoxy --check config.json
+zoxy 0.0.9
+budgets (DESIGN.md §5/§8; closed-form except where marked):
+  memory  total 47127 KiB = conn slots 1386 x 440 B + stream slots 1386 x 1448 B
+          …
+  fds     4094 required (asserted against RLIMIT_NOFILE)
+  ring    4096 entries, completion queue 8192, in-flight ops <= 6871
+  config  1 listener(s), 1 cluster(s), 0 error page(s), access log stdout
+  rlimit  RLIMIT_NOFILE 524288 soft, 524288 hard (a start raises the soft limit to the fd budget)
+  check   config.json: valid, and this box can start it
+```
+
+The output is not a bare `OK` because the interesting question is usually
+not whether the config parses. Config shape is yours to size, and a shape
+that does not fit is *refused* rather than warned about — so `--check`
+answers "will this start" and "what will it cost" with one command, and a
+CI job, a config-management dry run and a pre-deploy hook can all run it.
+
+The whole report goes to **stdout**, unlike the startup banner: a check
+run's output is its result rather than diagnostics printed beside a
+process that carries on serving. Reasons for a refusal still go to stderr,
+where every other startup refusal already writes them.
+
+| exit | meaning |
+|---|---|
+| `0` | the config loads and this machine can start it |
+| `1` | the config is wrong — unreadable, unparseable, semantically refused, or naming a file that will not load |
+| `2` | the config is right and *this machine* cannot fit it: the fd budget is above the `RLIMIT_NOFILE` hard limit |
+
+The split between `1` and `2` is what a CI job branches on. A build agent
+with a stock `RLIMIT_NOFILE` may legitimately accept `2` on a config sized
+for production; it must never accept `1`.
+
+Two things to know before wiring it into a pipeline. It does the **full**
+load, so every body, error page and certificate the config names is opened
+— which means it needs the same file permissions the proxy would, and a
+config naming production certificates cannot be checked on an agent that
+does not hold them. And an `access_log` `file` sink is created if it is
+absent, exactly as a start creates it; the alternative would be a check
+that passes on a log directory the start then cannot write.
+
 ### Signals
 
-The banner goes to stderr, and so does the `SIGUSR1` counter dump: stdout
-belongs to the access log, whose `stdout` sink must stay one uncontaminated
-JSON line per event.
+The *startup* banner goes to stderr, and so does the `SIGUSR1` counter
+dump: stdout belongs to the access log, whose `stdout` sink must stay one
+uncontaminated JSON line per event. `--check` is the exception and not a
+contradiction — it never serves, so nothing is writing that access log.
 
 | signal | effect |
 |---|---|
@@ -87,9 +143,14 @@ order:
 <!-- figure: reuseport-handoff -->
 
 ```sh
+zoxy --check new-config.json || exit 1   # refuse to proceed on a bad config
 zoxy new-config.json &   # the replacement binds the same port and starts serving
 kill -TERM "$old_pid"    # the old process drains its work, then exits 0
 ```
+
+The first line is optional and worth having: starting the replacement is
+already safe, but a `--check` that fails costs nothing and keeps a
+half-written config from ever reaching a `&`.
 
 Starting the replacement *first* is what makes this safe: a config zoxy
 refuses never reaches a listener, so the new process exits `1` with its

--- a/scripts/lint.zig
+++ b/scripts/lint.zig
@@ -99,6 +99,11 @@ const loop_bound_lookahead_lines: u32 = 6;
 const main_allowed_members = [_][]const u8{
     "getrlimit",
     "setrlimit",
+    // The two types `getrlimit` answers in, so a reported limit can be
+    // held and rendered without the value leaving the allowlist.
+    "rlimit",
+    "rlim_t",
+    "RLIM",
     "sigaction",
     "Sigaction",
     "sigemptyset",

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -53,6 +53,41 @@ const zoxy_log_path = work_directory ++ "/zoxy.log";
 const robots_path = work_directory ++ "/robots.txt";
 const robots_body = "User-agent: *\nDisallow: /private\n";
 
+/// The #301 pre-flight's own files. `--check` writes its whole result to
+/// stdout, so the gate captures stdout and stderr apart: the split is the
+/// decision that issue made, and a gate that merged the two streams could
+/// not see it.
+const check_stdout_path = work_directory ++ "/check.out";
+const check_log_path = work_directory ++ "/check.log";
+const invalid_config_path = work_directory ++ "/invalid.json";
+
+/// A config the *loader* refuses rather than the schema — a bind that is
+/// well-shaped JSON and not an address (`ListenerBindInvalid`). Chosen
+/// deliberately: the semantic checks are the ones only the real loader
+/// makes, so refusing this is what says `--check` runs the loader instead
+/// of a second, agreeable validator.
+const invalid_config_text =
+    \\{"listeners":[{"bind":"not-an-address","cluster":"a"}],
+    \\"clusters":{"a":{"endpoints":["127.0.0.1:1"]}}}
+;
+
+/// What `--check` must exit with. Spelled here rather than imported from
+/// `main.zig`'s `CheckExit`, on the rule the rest of this file follows:
+/// the gate reads what the binary *did*, so a drift has to fail loudly
+/// rather than agree with itself.
+const check_exit_ok: u8 = 0;
+const check_exit_invalid_config: u8 = 1;
+
+/// The two lines that must reach stdout for the budget to have been
+/// reported at all — the banner's own header, and the verdict line only a
+/// check run writes.
+const check_banner_needle = "budgets (DESIGN.md";
+const check_verdict_needle = "  check   ";
+
+/// The most of a check run's stdout the gate will read. A banner is about
+/// 1 KiB; anything near this cap is itself the finding.
+const check_output_bytes_max: usize = 16 * 1024;
+
 /// The §4 fixture the terminating listener serves. Handed in by the build
 /// rather than embedded here (`@embedFile` cannot escape a module root),
 /// and written to the work directory so the proxy reads it off disk the
@@ -333,6 +368,7 @@ var watchdog_child_pid = std.atomic.Value(i32).init(0);
 /// statement about everything before it having finished.
 const Stage = enum {
     starting,
+    pre_flight,
     awaiting_listener,
     load,
     counter_scrape,
@@ -348,6 +384,7 @@ const Stage = enum {
     fn label(stage: Stage) []const u8 {
         return switch (stage) {
             .starting => "starting the proxy",
+            .pre_flight => "the --check pre-flight (#301)",
             .awaiting_listener => "waiting for the listener",
             .load => "the http and l4 load",
             .counter_scrape => "the counter scrapes",
@@ -428,6 +465,10 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
 
     const ports = try reservePorts(io);
     try writeConfig(arena, io, &ports, origin.port);
+    // Before the spawn, because that ordering is the claim: the config
+    // `--check` just passed is the one this run then serves.
+    enterStage(.pre_flight);
+    const check_ok = try checkPassed(arena, io, flags.zoxy_path);
     var child = try spawnZoxy(io, flags.zoxy_path);
     var running = true;
     defer if (running) child.kill(io);
@@ -461,7 +502,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
     const passed = log_ok and counters.passed and sticky_ok and bodies_ok and
-        tls_ok and memory_ok and drain_ok;
+        tls_ok and memory_ok and drain_ok and check_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -484,7 +525,7 @@ fn report(
     var memory_buffer: [64]u8 = undefined;
     std.debug.print(
         "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, counters reconcile, " ++
-            "{d} probes in {d}ms, {s}, clean drain\n",
+            "{d} probes in {d}ms, {s}, --check agrees, clean drain\n",
         .{
             lines.http,
             lines.l4,
@@ -1746,6 +1787,99 @@ fn prepareWorkDirectory(io: Io) !void {
     // decision.
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = tls_cert_path, .data = tls_cert_pem });
     try Io.Dir.cwd().writeFile(io, .{ .sub_path = tls_key_path, .data = tls_key_pem });
+    // The #301 pre-flight's negative case, written beside the real one so
+    // both reach the same binary through the same argument.
+    try Io.Dir.cwd().writeFile(io, .{
+        .sub_path = invalid_config_path,
+        .data = invalid_config_text,
+    });
+}
+
+/// One `--check` run's verdict: the code it exited with, and whether the
+/// budget reached **stdout**. The placement is the decision #301 made —
+/// a check run's whole output is its result, unlike the startup banner,
+/// which is diagnostics beside a process that goes on to serve — so the
+/// gate pins it rather than trusting it.
+const CheckRun = struct {
+    exit_code: u8,
+    budget_on_stdout: bool,
+};
+
+/// The #301 pre-flight, over the very config this run is about to serve
+/// and over one no loader will take.
+///
+/// That first pairing is the whole claim `--check` makes: it says a
+/// config would start here, and the only place that can be *checked* is
+/// where the real binary then starts on the same file. The second pins
+/// the other half — that the mode refuses what the loader refuses, with
+/// the exit code a CI job branches on rather than a bare non-zero.
+fn checkPassed(arena: std.mem.Allocator, io: Io, zoxy_path: []const u8) !bool {
+    assert(zoxy_path.len >= 1);
+    const accepted = try runZoxyCheck(arena, io, zoxy_path, config_path);
+    const refused = try runZoxyCheck(arena, io, zoxy_path, invalid_config_path);
+    var passed = true;
+    if (accepted.exit_code != check_exit_ok) {
+        std.debug.print(
+            "FAIL: --check refused the config this run then served (exit {d})\n",
+            .{accepted.exit_code},
+        );
+        passed = false;
+    }
+    if (!accepted.budget_on_stdout) {
+        std.debug.print("FAIL: --check wrote no budget to stdout\n", .{});
+        passed = false;
+    }
+    if (refused.exit_code != check_exit_invalid_config) {
+        std.debug.print(
+            "FAIL: --check did not refuse a config the loader refuses (exit {d})\n",
+            .{refused.exit_code},
+        );
+        passed = false;
+    }
+    // Nothing was loaded, so there is nothing to price: a budget printed
+    // beside a refusal would be a number for a config that does not
+    // exist.
+    if (refused.budget_on_stdout) {
+        std.debug.print("FAIL: --check priced a config it refused\n", .{});
+        passed = false;
+    }
+    return passed;
+}
+
+/// One `zoxy --check <config>`, with the two streams captured apart.
+fn runZoxyCheck(
+    arena: std.mem.Allocator,
+    io: Io,
+    zoxy_path: []const u8,
+    config: []const u8,
+) !CheckRun {
+    assert(zoxy_path.len >= 1);
+    assert(config.len >= 1);
+    const out_file = try Io.Dir.cwd().createFile(io, check_stdout_path, .{});
+    defer out_file.close(io);
+    const log_file = try Io.Dir.cwd().createFile(io, check_log_path, .{});
+    defer log_file.close(io);
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ zoxy_path, "--check", config },
+        .stdout = .{ .file = out_file },
+        .stderr = .{ .file = log_file },
+    });
+    const term = try child.wait(io);
+    const text = try Io.Dir.cwd().readFileAlloc(
+        io,
+        check_stdout_path,
+        arena,
+        .limited(check_output_bytes_max),
+    );
+    assert(text.len <= check_output_bytes_max);
+    return .{
+        // A check that died of a signal has no code to report, and the
+        // sentinel is outside every code `CheckExit` defines, so it can
+        // only ever read as a failure.
+        .exit_code = if (term == .exited) term.exited else 255,
+        .budget_on_stdout = std.mem.indexOf(u8, text, check_banner_needle) != null and
+            std.mem.indexOf(u8, text, check_verdict_needle) != null,
+    };
 }
 
 /// zoxy's own output goes to a file rather than this process's stderr:

--- a/src/budget.zig
+++ b/src/budget.zig
@@ -203,14 +203,45 @@ pub fn Budget(comptime IoType: type) type {
             return total;
         }
 
-        /// The §5 banner, to **stderr**: the banner is diagnostics, and
-        /// stdout belongs to the data an operator may point there — the
-        /// access log's `stdout` sink must stay one uncontaminated JSON
-        /// line per event. Stderr is where the counter dump already
-        /// goes, and via the same `std.debug.print` plain-write path, so
-        /// the two interleave whole-lines even when both land in one
-        /// redirected file (a positional writer here would be silently
-        /// overwritten by the dump's shared-offset writes).
+        /// Where a banner goes.
+        ///
+        /// Two sinks rather than two renderings: `--check` (#301) prints
+        /// the same budget to stdout, and a second copy of these format
+        /// strings would be a second thing to keep in step with the
+        /// closed form. The union is what lets one body serve both.
+        pub const Sink = union(enum) {
+            /// **stderr**, through `std.debug.print`: the banner is
+            /// diagnostics, and stdout belongs to the data an operator
+            /// may point there — the access log's `stdout` sink must
+            /// stay one uncontaminated JSON line per event. Stderr is
+            /// where the counter dump already goes, and via the same
+            /// plain-write path, so the two interleave whole-lines even
+            /// when both land in one redirected file (a positional
+            /// writer here would be silently overwritten by the dump's
+            /// shared-offset writes).
+            diagnostics,
+            /// A writer the caller owns and flushes. This is the arm a
+            /// check run takes, where the banner is not diagnostics
+            /// printed beside a result — it *is* the result.
+            writer: *std.Io.Writer,
+        };
+
+        /// One chunk of banner to whichever sink. The `.diagnostics` arm
+        /// cannot fail (`std.debug.print` ignores its own write errors),
+        /// so every error this returns belongs to the caller's writer.
+        fn emit(
+            sink: Sink,
+            comptime format: []const u8,
+            args: anytype,
+        ) std.Io.Writer.Error!void {
+            switch (sink) {
+                .diagnostics => std.debug.print(format, args),
+                .writer => |writer| try writer.print(format, args),
+            }
+        }
+
+        /// The §5 banner, to stderr — `Sink.diagnostics` carries why
+        /// that and not stdout.
         pub fn print(
             config: *const config_module.Config,
             demands: Demands,
@@ -219,6 +250,39 @@ pub fn Budget(comptime IoType: type) type {
             config_arena_bytes: u64,
             build: Build,
         ) void {
+            // `unreachable` rather than `catch {}`: `emit`'s
+            // `.diagnostics` arm never calls `try`, so this error does
+            // not exist — and stating that is what makes a future
+            // fallible diagnostics path fail loudly instead of writing
+            // half a banner and saying nothing.
+            emitBanner(.diagnostics, config, demands, config_arena_bytes, build) catch unreachable;
+        }
+
+        /// The same banner to a writer the caller owns and flushes —
+        /// `--check`'s stdout (#301). One body, so a check run and the
+        /// start it predicts can never price one config two ways.
+        pub fn printTo(
+            writer: *std.Io.Writer,
+            config: *const config_module.Config,
+            demands: Demands,
+            config_arena_bytes: u64,
+            build: Build,
+        ) std.Io.Writer.Error!void {
+            return emitBanner(.{ .writer = writer }, config, demands, config_arena_bytes, build);
+        }
+
+        /// The banner itself, once, for whichever sink asked. Both
+        /// public entry points land here, which is the property that
+        /// matters: the startup banner and the `--check` report are the
+        /// same closed form evaluated once, not two renderings that
+        /// happen to agree today.
+        fn emitBanner(
+            sink: Sink,
+            config: *const config_module.Config,
+            demands: Demands,
+            config_arena_bytes: u64,
+            build: Build,
+        ) std.Io.Writer.Error!void {
             assert(config.listeners.len >= 1);
             assert(demands.fds > 0);
             // Every budget reflects the *effective* config (§5, §8): the
@@ -235,11 +299,11 @@ pub fn Budget(comptime IoType: type) type {
             const access_log_bytes = constants.accessLogBytes(limits.access_log_buffer_bytes);
             const sizes = poolSizesFor(config);
             const memory_total = totalBytesFor(&sizes, config_arena_bytes);
-            printMemoryBanner(config, &sizes, memory_total, access_log_bytes, config_arena_bytes, build);
+            try emitMemoryBanner(sink, config, &sizes, memory_total, access_log_bytes, config_arena_bytes, build);
             // A stack temporary in a function that runs once at startup,
             // not a reservation (§5).
             var fact_buffer: [failure_detection_fact_bytes]u8 = undefined;
-            std.debug.print(
+            try emit(sink,
                 \\  fds     {d} required (asserted against RLIMIT_NOFILE)
                 \\  ring    {d} entries, completion queue {d}, in-flight ops <= {d}
                 \\  config  {d} listener(s), {d} cluster(s), {d} error page(s), access log {s}{s}
@@ -256,7 +320,7 @@ pub fn Budget(comptime IoType: type) type {
                 // measured number already covers them; this count is
                 // what says why it grew.
                 config.error_pages.len,
-                if (config.access_log_sink) |sink| @tagName(sink) else "off",
+                if (config.access_log_sink) |log_sink| @tagName(log_sink) else "off",
                 failureDetectionFact(config, &fact_buffer),
             });
         }
@@ -310,24 +374,25 @@ pub fn Budget(comptime IoType: type) type {
         }
 
         /// The banner's version and memory lines — the §5 closed form
-        /// itemized. Split from `print` for the length limit; the two
-        /// prints are sequential same-thread writes to stderr, so
-        /// nothing interleaves.
-        fn printMemoryBanner(
+        /// itemized. Split from `emitBanner` for the length limit; the
+        /// two emissions are sequential same-thread writes to one sink,
+        /// so nothing interleaves.
+        fn emitMemoryBanner(
+            sink: Sink,
             config: *const config_module.Config,
             sizes: *const constants.PoolSizes,
             memory_total: u64,
             access_log_bytes: u64,
             config_arena_bytes: u64,
             build: Build,
-        ) void {
+        ) std.Io.Writer.Error!void {
             assert(memory_total > 0);
             assert(config.listeners.len >= 1);
             const limits = config.limits;
             // The version leads, because this banner is what a bug
             // report pastes and `--version` is what it does not think to
             // run.
-            std.debug.print(
+            try emit(sink,
                 \\zoxy {s}{s}
                 \\budgets (DESIGN.md §5/§8; closed-form except where marked):
                 \\  memory  total {d} KiB = conn slots {d} x {d} B + stream slots {d} x {d} B

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -988,6 +988,19 @@ pub fn openLogSink(path: []const u8) !posix.fd_t {
     }, 0o644);
 }
 
+/// Give back an `openLogSink` fd the caller will not write through.
+///
+/// A serving process never does — it holds its sink for the process's
+/// life — so this exists for `--check` (#301), the one mode that opens
+/// the sink solely to learn whether it opens. Asking it about the
+/// inherited stdout is asserted misuse: that fd was not this seam's to
+/// hand out and is not its to close.
+pub fn closeLogSink(fd: posix.fd_t) void {
+    assert(fd != log_sink_stdout);
+    assert(fd >= 0);
+    closeFd(fd);
+}
+
 /// Reopen the `file` sink at its configured path (§8 rotation): open the
 /// new fd *first* — on failure the old one stays and the caller keeps
 /// writing where lines were already landing — then close the old and

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,13 @@
 //! until a drain completes. `--help` and `--version` are answered before any
 //! of that and exit immediately.
 //!
+//! `--check` (#301) is that same sequence stopped one step short: it loads
+//! the config, opens every file the config names, prices the pools and
+//! measures the demand against this box's `RLIMIT_NOFILE` — then reports
+//! and exits without binding a port. Deliberately the same code and not a
+//! second validator: a pre-flight that agreed with the real binary only by
+//! construction would be worse than not having one.
+//!
 //! This file is the *application* — the CLI, the filesystem, and the two
 //! process-level syscalls. Everything an embedder would need identically
 //! is the library's (§13): the budget's closed form and banner live in
@@ -71,26 +78,39 @@ fn buildIdSuffix(comptime version: []const u8, comptime id: []const u8) []const 
 /// the loop lives for the whole process (§3).
 var global_io: XevIo = undefined;
 
-pub fn main(init: std.process.Init) !void {
+pub fn main(init: std.process.Init) !u8 {
     const arena = init.arena.allocator();
 
     const args = try init.minimal.args.toSlice(arena);
-    const config_path = switch (classifyArgs(args)) {
-        .run => |path| path,
+    assert(args.len >= 1); // argv always carries the program name at [0].
+    switch (classifyArgs(args)) {
+        .run => |path| {
+            try serve(init, arena, path);
+            return 0;
+        },
+        // The one mode with more than one non-zero answer, so it returns
+        // its own code rather than an error (#301).
+        .check => |path| return checkConfig(init, arena, path),
         .help => {
             try printHelp(init.io);
-            return;
+            return 0;
         },
         .version => {
             try printVersion(init.io);
-            return;
+            return 0;
         },
         .usage => |reason| {
             printUsageError(reason);
             return error.InvalidArguments;
         },
-    };
+    }
+}
 
+/// Start the proxy and hand the process to the loop until a drain
+/// completes — the module doc's sequence, and the only mode that takes a
+/// port.
+fn serve(init: std.process.Init, arena: std.mem.Allocator, config_path: []const u8) !void {
+    assert(config_path.len >= 1);
     // Measured across the read, not assumed from the file size: the
     // parse allocates its own structures beside the text it parses, and
     // both live in the arena for the process's life (§5).
@@ -98,23 +118,30 @@ pub fn main(init: std.process.Init) !void {
     const config = try readConfig(init.io, arena, config_path);
     const config_arena_bytes = init.arena.queryCapacity() - arena_before;
 
-    const cq_entries = try resolveBudgets(&config, config_arena_bytes);
-    const log_sink_fd = try openLogSinkFd(&config);
-    // Certificates before the loop, on `openLogSinkFd`'s reasoning: the
-    // config named a file, so open it while a failure can still name it
-    // and stop the process, rather than surfacing as a broken connection
-    // under traffic (§4).
-    const tls_credentials = try loadTlsCredentials(init.io, arena, &config);
+    const demands = BudgetXev.demandsFor(&config);
+    // The closed form and the banner are the library's (`budget.zig`,
+    // §13): they have to price exactly what `Server.init` reserves, and
+    // a second derivation here would be a copy that could drift.
+    //
+    // Printed *before* the box is asked for anything, so a start the fd
+    // budget refuses still leaves behind the numbers that refused it —
+    // `--check` prints whatever its verdict for the same reason (#301),
+    // and the two modes agreeing on that is the point.
+    BudgetXev.print(&config, demands, config_arena_bytes, .{
+        .version = build_options.version,
+        .id_suffix = build_id_suffix,
+    });
+    const resources = try openStartupResources(init.io, arena, &config, demands);
 
     // The ring is the config's to size (§5), count and unit both;
     // Server.init asserts its own accounting against the same numbers.
     try global_io.init(
         arena,
-        cq_entries,
+        demands.cq_entries,
         @intCast(config.listeners.len),
         config.limits.head_buffers,
         config.limits.head_buffer_bytes,
-        log_sink_fd,
+        resources.log_sink_fd,
         // The path rides beside its fd so SIGHUP can reopen it (§8).
         if (config.access_log_sink) |sink| switch (sink) {
             .stdout => null,
@@ -123,8 +150,8 @@ pub fn main(init: std.process.Init) !void {
     );
     var server: ServerXev = undefined;
     try server.init(arena, &global_io, &config, config.limits);
-    if (tls_credentials.len > 0) {
-        server.setTlsCredentials(tls_credentials);
+    if (resources.tls_credentials.len > 0) {
+        server.setTlsCredentials(resources.tls_credentials);
     }
     try server.start();
     installSignalHandlers();
@@ -136,27 +163,226 @@ pub fn main(init: std.process.Init) !void {
     server.dumpMetrics();
 }
 
-/// The §5/§8 startup budget gauntlet. The closed form and the banner are
-/// the library's (`budget.zig`, §13) — they have to price exactly what
-/// `Server.init` reserves, and a second derivation here would be a copy
-/// that could drift. What stays is what only an application may do: raise
-/// `RLIMIT_NOFILE` to the demand. Returns the CQ depth the ring must be
-/// created with.
-fn resolveBudgets(
+/// Everything a start takes from the box before the loop exists.
+const StartupResources = struct {
+    /// The fd `XevIo` writes access-log bytes to (§8).
+    log_sink_fd: @TypeOf(XevIo.log_sink_stdout),
+    /// One slot per listener, null where the listener is plaintext —
+    /// empty when nothing terminates TLS.
+    tls_credentials: []const ?zoxy.tls.Credentials,
+};
+
+/// The §5/§8 startup gauntlet: raise `RLIMIT_NOFILE` to the demand, open
+/// the access log's sink, load every listener's certificate. What only an
+/// application may do, in the order it must do it.
+///
+/// One function rather than two hand-synced sequences, because the order
+/// is itself a *verdict*: a config that fails two of these earns the
+/// answer of whichever a start reaches first, and `--check` (#301)
+/// reports that answer as an exit code an operator branches on — `1` says
+/// change the file, `2` says run it elsewhere. `serve` and
+/// `checkStartFits` both call this, so the two cannot drift and no
+/// comment has to guard that they don't.
+fn openStartupResources(
+    io: std.Io,
+    arena: std.mem.Allocator,
     config: *const zoxy.config.Config,
-    config_arena_bytes: u64,
-) !u32 {
+    demands: BudgetXev.Demands,
+) !StartupResources {
     assert(config.listeners.len >= 1);
-    const demands = BudgetXev.demandsFor(config);
+    assert(demands.fds > 0);
+    // `demandsFor` bounds this from above but never from below, and a
+    // zero is a closed form that broke upstream: `serve` creates the
+    // ring at this depth, and a ring that deep completes nothing.
+    assert(demands.cq_entries > 0);
+    // fds are pre-budgeted rather than shed (§8), so this is both the
+    // first thing the box can refuse and the first thing asked of it.
     try ensureFdBudget(demands.fds);
-    BudgetXev.print(config, demands, config_arena_bytes, .{
+    const log_sink_fd = try openLogSinkFd(config);
+    // Certificates before the loop, on `openLogSinkFd`'s reasoning: the
+    // config named a file, so open it while a failure can still name it
+    // and stop the process, rather than surfacing as a broken connection
+    // under traffic (§4).
+    const tls_credentials = try loadTlsCredentials(io, arena, config);
+    assert(tls_credentials.len == 0 or tls_credentials.len == config.listeners.len);
+    return .{ .log_sink_fd = log_sink_fd, .tls_credentials = tls_credentials };
+}
+
+/// What `--check` exits with (#301). Three answers rather than two,
+/// because the difference is what a CI job acts on: a build agent with a
+/// small `RLIMIT_NOFILE` may legitimately accept `does_not_fit` on a
+/// config sized for production, and must never accept `invalid_config`.
+const CheckExit = enum(u8) {
+    /// The config loads and this box can start it.
+    ok = 0,
+    /// The config is wrong: unreadable, unparseable, semantically
+    /// refused, or naming a file that will not load. A path the process
+    /// cannot open counts as the config's own, deliberately — the
+    /// operator has to change something either way, and a CI job that
+    /// does not hold the deployment's certificates should check a config
+    /// that does not name them rather than learn to ignore a code that
+    /// also covers a real mistake.
+    invalid_config = 1,
+    /// The config is right and this machine is what refused it: the fd
+    /// budget is above `RLIMIT_NOFILE`'s hard limit, the startup arena
+    /// could not be had, or libcrypto would not take the fixed heap
+    /// (§5). The same file would start elsewhere.
+    does_not_fit = 2,
+};
+
+/// Which of the two failing verdicts a load error is. The question this
+/// answers is not whose fault the failure is but what the operator does
+/// next: change the config, or run it somewhere else.
+fn checkExitFor(err: anyerror) CheckExit {
+    return switch (err) {
+        error.OutOfMemory,
+        error.FdBudgetUnsatisfiable,
+        error.LibcryptoHeapUnavailable,
+        => .does_not_fit,
+        else => .invalid_config,
+    };
+}
+
+/// `--check` (#301): everything `serve` does up to the banner, and
+/// nothing that takes a port.
+///
+/// zoxy needs this more than its peers do, because two of its virtues
+/// make a bad config expensive. Config shape is the operator's to size
+/// (§5) and a shape that does not fit is *refused*, not warned about; and
+/// config is parse-once immutable (§1), so the blast radius of a bad one
+/// is not a failed reload but an outage. This is the pre-flight that pays
+/// for both, and the reason it is a mode rather than a tool is that a
+/// second validator could disagree with the binary.
+fn checkConfig(init: std.process.Init, arena: std.mem.Allocator, config_path: []const u8) !u8 {
+    assert(config_path.len >= 1);
+    const arena_before = init.arena.queryCapacity();
+    // The one failure with no budget to report: nothing was loaded, so
+    // there is no config to price and this arm answers without a banner.
+    const config = readConfig(init.io, arena, config_path) catch |err|
+        return @intFromEnum(checkExitFor(err));
+    const config_arena_bytes = init.arena.queryCapacity() - arena_before;
+    const demands = BudgetXev.demandsFor(&config);
+    assert(demands.fds > 0);
+
+    // Read before the gauntlet below: `ensureFdBudget` raises the soft
+    // limit toward the demand, so asking afterwards would report what
+    // this check just did rather than what it found.
+    const nofile = try std.posix.getrlimit(.NOFILE);
+    const verdict = checkStartFits(init.io, arena, &config, demands);
+    try writeCheckReport(init.io, &.{
+        .config = &config,
+        .demands = demands,
+        .config_arena_bytes = config_arena_bytes,
+        .config_path = config_path,
+        .nofile = nofile,
+        .verdict = verdict,
+    });
+    return @intFromEnum(verdict);
+}
+
+/// Ask the box for exactly what a start asks it for, and give it back.
+///
+/// The gauntlet is `openStartupResources`, unchanged and unbranched — a
+/// check that ran its own sequence could reach a different verdict than
+/// the start it predicts, which is the way #301 warns a pre-flight can be
+/// worse than none. Every arm names its own reason on stderr on the way
+/// out (§5's rule that a path which cannot open stops the process), so
+/// what comes back here is only the verdict.
+fn checkStartFits(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    config: *const zoxy.config.Config,
+    demands: BudgetXev.Demands,
+) CheckExit {
+    assert(config.listeners.len >= 1);
+    assert(demands.fds > 0);
+    const resources = openStartupResources(io, arena, config, demands) catch |err|
+        return checkExitFor(err);
+    // Given straight back, because a check holds nothing. The `file`
+    // sink was still *created* if it was absent, exactly as a start
+    // creates it: the alternative is a check that passes on a log
+    // directory the start then cannot write.
+    if (resources.log_sink_fd != XevIo.log_sink_stdout) {
+        XevIo.closeLogSink(resources.log_sink_fd);
+    }
+    return .ok;
+}
+
+/// What a check run prints: the priced config, the verdict it earned, and
+/// the two facts only a check has — the file it was asked about, and the
+/// `RLIMIT_NOFILE` it found on the way in.
+const CheckReport = struct {
+    config: *const zoxy.config.Config,
+    demands: BudgetXev.Demands,
+    config_arena_bytes: u64,
+    config_path: []const u8,
+    nofile: std.posix.rlimit,
+    verdict: CheckExit,
+};
+
+/// A check run's whole output, to **stdout** — unlike the startup banner,
+/// which is diagnostics printed beside a process that then goes on to
+/// serve. Here there is nothing beside: the budget *is* the result, so an
+/// operator redirecting it into a file or a CI artifact must get it
+/// rather than an empty one. The reasons for a failure still go to
+/// stderr, where every other startup refusal already writes them.
+///
+/// Printed whatever the verdict, and that is the point of #301: a budget
+/// that does not fit is exactly the one whose numbers an operator needs
+/// in front of them.
+fn writeCheckReport(io: std.Io, report: *const CheckReport) !void {
+    assert(report.config_path.len >= 1);
+    assert(report.nofile.max >= report.nofile.cur);
+    // The writer drains to stdout whenever this staging buffer fills, so
+    // its size is a batching choice, not a cap on the banner's length.
+    var buffer: [1024]u8 = undefined;
+    var file_writer: std.Io.File.Writer = .init(.stdout(), io, &buffer);
+    const writer = &file_writer.interface;
+    try BudgetXev.printTo(writer, report.config, report.demands, report.config_arena_bytes, .{
         .version = build_options.version,
         .id_suffix = build_id_suffix,
     });
-    // What the ring is created with, so a zero would be a loop that can
-    // complete nothing — the closed form broke upstream of here.
-    assert(demands.cq_entries > 0);
-    return demands.cq_entries;
+    var soft_buffer: [rlimit_text_bytes]u8 = undefined;
+    var hard_buffer: [rlimit_text_bytes]u8 = undefined;
+    try writer.print(
+        \\  rlimit  RLIMIT_NOFILE {s} soft, {s} hard (a start raises the soft limit to the fd budget)
+        \\  check   {s}: {s}
+        \\
+    , .{
+        rlimitText(report.nofile.cur, &soft_buffer),
+        rlimitText(report.nofile.max, &hard_buffer),
+        report.config_path,
+        checkVerdictText(report.verdict),
+    });
+    try writer.flush();
+}
+
+/// The verdict as the line an operator reads. The switch is exhaustive
+/// over `CheckExit`, so a fourth verdict is a compile error rather than a
+/// check that reports nothing — no runtime guard adds anything.
+fn checkVerdictText(verdict: CheckExit) []const u8 {
+    return switch (verdict) {
+        .ok => "valid, and this box can start it",
+        .invalid_config => "refused; the reason is on stderr",
+        .does_not_fit => "valid, but this box cannot start it; the reason is on stderr",
+    };
+}
+
+/// The widest a limit renders: `RLIM_INFINITY` is the largest `rlim_t`,
+/// and every other value is shorter.
+const rlimit_text_bytes = std.fmt.count("{d}", .{std.math.maxInt(std.posix.rlim_t)});
+
+/// One `RLIMIT_NOFILE` bound as an operator reads it. `RLIM_INFINITY`
+/// renders as 18446744073709551615, which reads as a bug rather than as
+/// "no limit", so it gets the word instead.
+fn rlimitText(value: std.posix.rlim_t, buffer: []u8) []const u8 {
+    assert(buffer.len == rlimit_text_bytes);
+    if (value == std.posix.RLIM.INFINITY) return "unlimited";
+    // The assert above covers every `rlim_t`, which is what makes the
+    // buffer wide enough for whatever this value is.
+    const rendered = std.fmt.bufPrint(buffer, "{d}", .{value}) catch unreachable;
+    assert(rendered.len <= rlimit_text_bytes);
+    return rendered;
 }
 
 /// The §8 access-log sink as the fd `XevIo` will write: the inherited
@@ -349,11 +575,12 @@ fn readBodyFile(
     };
 }
 
-/// What the command line asked for: run against a config, or one of the
-/// two informational modes, or a usage mistake (with the reason so the
-/// message can be specific).
+/// What the command line asked for: run against a config, check one
+/// without running it (#301), or one of the two informational modes, or a
+/// usage mistake (with the reason so the message can be specific).
 const Cli = union(enum) {
     run: []const u8,
+    check: []const u8,
     help,
     version,
     usage: UsageError,
@@ -362,9 +589,11 @@ const Cli = union(enum) {
 const UsageError = enum { missing_config, extra_arguments, unknown_option };
 
 /// Classify argv without touching the world, so it is unit-testable. zoxy
-/// takes exactly one positional argument — the config path; a `--help` or
-/// `--version` anywhere on the line wins so it still works appended to a
-/// half-typed command.
+/// takes exactly one positional argument — the config path — and every
+/// flag it has is a *mode* rather than an option carrying a value, so any
+/// of them may appear anywhere on the line. `--help` and `--version` win
+/// over `--check` for the reason they win over a config path: they still
+/// work appended to a half-typed command.
 fn classifyArgs(args: []const []const u8) Cli {
     assert(args.len >= 1); // argv always carries the program name at [0].
     for (args[1..]) |arg| {
@@ -373,13 +602,24 @@ fn classifyArgs(args: []const []const u8) Cli {
     for (args[1..]) |arg| {
         if (flagMatches(arg, "-V", "--version")) return .version;
     }
-    if (args.len < 2) return .{ .usage = .missing_config };
-    if (args.len > 2) return .{ .usage = .extra_arguments };
-    const only = args[1];
-    // A lone unrecognized -flag is a typo, not a file named "-x".
-    if (only.len > 0 and only[0] == '-') return .{ .usage = .unknown_option };
-    assert(only.len == 0 or only[0] != '-');
-    return .{ .run = only };
+    var check = false;
+    var config_path: []const u8 = "";
+    var positionals: u32 = 0;
+    for (args[1..]) |arg| {
+        if (flagMatches(arg, "-c", "--check")) {
+            check = true;
+            continue;
+        }
+        // A lone unrecognized -flag is a typo, not a file named "-x".
+        if (arg.len > 0 and arg[0] == '-') return .{ .usage = .unknown_option };
+        positionals += 1;
+        assert(positionals < args.len);
+        if (positionals == 1) config_path = arg;
+    }
+    if (positionals == 0) return .{ .usage = .missing_config };
+    if (positionals > 1) return .{ .usage = .extra_arguments };
+    assert(config_path.len == 0 or config_path[0] != '-');
+    return if (check) .{ .check = config_path } else .{ .run = config_path };
 }
 
 fn flagMatches(arg: []const u8, short: []const u8, long: []const u8) bool {
@@ -392,14 +632,23 @@ const help_text =
     \\zoxy {s} — a zero-allocation L4/L7 edge proxy.
     \\
     \\Usage:
-    \\  zoxy <config.json>   Start the proxy with the given JSON config.
-    \\  zoxy --help, -h      Show this message and exit.
-    \\  zoxy --version, -V   Print the version and exit.
+    \\  zoxy <config.json>          Start the proxy with the given JSON config.
+    \\  zoxy --check <config.json>  Validate and price the config, then exit
+    \\                              without binding anything (-c).
+    \\  zoxy --help, -h             Show this message and exit.
+    \\  zoxy --version, -V          Print the version and exit.
     \\
     \\zoxy reads the whole config once at startup, sizes every pool and the
     \\io_uring ring from it, then serves without allocating again. The config
     \\format is documented by the JSON Schema shipped with each release and by
     \\docs/DESIGN.md.
+    \\
+    \\--check runs that whole load — every body, error page and certificate
+    \\the config names is opened, so it needs the same file permissions the
+    \\proxy would — and prints the budget banner to stdout. It exits 0 when
+    \\the config would start on this machine, 1 when the config is wrong, and
+    \\2 when the config is right and this machine cannot fit it (an fd budget
+    \\above the RLIMIT_NOFILE hard limit).
     \\
     \\Signals:
     \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0.
@@ -439,16 +688,29 @@ fn printUsageError(reason: UsageError) void {
         .unknown_option => "unknown option; run `zoxy --help` for usage",
     };
     std.debug.print(
-        "zoxy: {s}\nusage: zoxy <config.json>  (or --help, --version)\n",
+        "zoxy: {s}\nusage: zoxy <config.json>  (or --check, --help, --version)\n",
         .{detail},
     );
 }
 
 /// fds are pre-budgeted, not shed (§8): raise the soft limit up to the
 /// hard limit, and refuse to start if even that cannot cover the budget.
-fn ensureFdBudget(fds_required: u32) !void {
+///
+/// One error for every way this can fail, the kernel's included, because
+/// they all mean the same thing to whoever reads it — this box will not
+/// give this config the descriptors it needs — and because `--check`
+/// classifies on the error (#301): a distinct value here is what keeps
+/// "run it elsewhere" from ever being reported as "change the file". The
+/// specific reason is printed instead of returned, here where the numbers
+/// that produced it are still in hand.
+fn ensureFdBudget(fds_required: u32) error{FdBudgetUnsatisfiable}!void {
+    assert(fds_required > 0);
     const required: u64 = fds_required;
-    var limits = try std.posix.getrlimit(.NOFILE);
+    var limits = std.posix.getrlimit(.NOFILE) catch |err| {
+        std.debug.print("zoxy: cannot read RLIMIT_NOFILE: {t}\n", .{err});
+        return error.FdBudgetUnsatisfiable;
+    };
+    assert(limits.max >= limits.cur);
     if (limits.cur >= required) return;
     if (limits.max < required) {
         std.debug.print(
@@ -458,7 +720,13 @@ fn ensureFdBudget(fds_required: u32) !void {
         return error.FdBudgetUnsatisfiable;
     }
     limits.cur = required;
-    try std.posix.setrlimit(.NOFILE, limits);
+    std.posix.setrlimit(.NOFILE, limits) catch |err| {
+        std.debug.print(
+            "zoxy: cannot raise RLIMIT_NOFILE to the fd budget {d}: {t}\n",
+            .{ required, err },
+        );
+        return error.FdBudgetUnsatisfiable;
+    };
 }
 
 fn installSignalHandlers() void {
@@ -579,6 +847,74 @@ test "classifyArgs: help wins over version, and both win appended to a config" {
     try testing.expect(classifyArgs(&.{ "zoxy", "--version", "--help" }) == .help);
     try testing.expect(classifyArgs(&.{ "zoxy", "config.json", "--help" }) == .help);
     try testing.expect(classifyArgs(&.{ "zoxy", "config.json", "--version" }) == .version);
+}
+
+test "classifyArgs: --check names the config it must not run" {
+    // Either side of the path: `--check` carries no value of its own, so
+    // its position on the line is not information.
+    const leading = classifyArgs(&.{ "zoxy", "--check", "config.json" });
+    try testing.expect(leading == .check);
+    try testing.expectEqualStrings("config.json", leading.check);
+    const trailing = classifyArgs(&.{ "zoxy", "config.json", "-c" });
+    try testing.expect(trailing == .check);
+    try testing.expectEqualStrings("config.json", trailing.check);
+    // Still exactly one positional, and still the informational modes
+    // first — a `--check` with nothing to check is the same mistake a
+    // bare `zoxy` is.
+    try testing.expectEqual(
+        Cli{ .usage = .missing_config },
+        classifyArgs(&.{ "zoxy", "--check" }),
+    );
+    try testing.expectEqual(
+        Cli{ .usage = .extra_arguments },
+        classifyArgs(&.{ "zoxy", "--check", "a.json", "b.json" }),
+    );
+    try testing.expect(classifyArgs(&.{ "zoxy", "--check", "a.json", "--help" }) == .help);
+    // And a config path is still a config path when nobody asked to
+    // check it.
+    try testing.expect(classifyArgs(&.{ "zoxy", "config.json" }) == .run);
+}
+
+test "checkExitFor: the box's refusals are told from the config's" {
+    // What the operator does next is the whole distinction (#301): these
+    // three say "run it elsewhere"…
+    try testing.expectEqual(CheckExit.does_not_fit, checkExitFor(error.OutOfMemory));
+    try testing.expectEqual(
+        CheckExit.does_not_fit,
+        checkExitFor(error.LibcryptoHeapUnavailable),
+    );
+    // The one value `ensureFdBudget` collapses every kernel answer into,
+    // and the reason it has a distinct value at all.
+    try testing.expectEqual(
+        CheckExit.does_not_fit,
+        checkExitFor(error.FdBudgetUnsatisfiable),
+    );
+    // …and everything else says "change the file", including a path in
+    // it that would not open, which is the arm most worth pinning: a CI
+    // job must not learn to ignore the code a real mistake also earns.
+    try testing.expectEqual(CheckExit.invalid_config, checkExitFor(error.FileNotFound));
+    try testing.expectEqual(CheckExit.invalid_config, checkExitFor(error.AccessDenied));
+    try testing.expectEqual(CheckExit.invalid_config, checkExitFor(error.MissingField));
+    // The codes themselves are the CI contract, so they are asserted
+    // rather than left to the declaration order.
+    try testing.expectEqual(@as(u8, 0), @intFromEnum(CheckExit.ok));
+    try testing.expectEqual(@as(u8, 1), @intFromEnum(CheckExit.invalid_config));
+    try testing.expectEqual(@as(u8, 2), @intFromEnum(CheckExit.does_not_fit));
+}
+
+test "rlimitText: an infinite limit reads as one" {
+    var buffer: [rlimit_text_bytes]u8 = undefined;
+    try testing.expectEqualStrings("1024", rlimitText(1024, &buffer));
+    try testing.expectEqualStrings("0", rlimitText(0, &buffer));
+    // The case the helper exists for: 2^64-1 in a banner reads as a bug.
+    try testing.expectEqualStrings(
+        "unlimited",
+        rlimitText(std.posix.RLIM.INFINITY, &buffer),
+    );
+    // The buffer is wide enough for the widest value that is not
+    // INFINITY, which is what the `catch unreachable` inside rests on.
+    const widest = std.math.maxInt(std.posix.rlim_t) - 1;
+    try testing.expectEqual(rlimit_text_bytes, rlimitText(widest, &buffer).len);
 }
 
 test "classifyArgs: usage mistakes carry their reason" {


### PR DESCRIPTION
Closes #301.

Every peer has a dry run, and zoxy needs one more than they do. Config
shape is the operator's to size (§5) and a shape that does not fit is
*refused* rather than warned about; config is parse-once immutable (§1),
so the blast radius of a bad one is an outage, not a failed reload. The
only way to learn either was to run the real binary, which binds ports.

`zoxy --check <config.json>` runs the start up to the banner and nothing
after: load the config, open every file it names, price the pools, and
measure the fd demand against this box's `RLIMIT_NOFILE`.

```console
$ zoxy --check config/example.json
zoxy 0.7.0
budgets (DESIGN.md §5/§8; closed-form except where marked):
  memory  total 47127 KiB = conn slots 1386 x 440 B + stream slots 1386 x 1448 B
          …
  fds     4094 required (asserted against RLIMIT_NOFILE)
  ring    4096 entries, completion queue 8192, in-flight ops <= 6871
  config  1 listener(s), 1 cluster(s), 0 error page(s), access log stdout
  rlimit  RLIMIT_NOFILE 524288 soft, 524288 hard (a start raises the soft limit to the fd budget)
  check   config/example.json: valid, and this box can start it
```

## Decisions the issue left open

- **Spelling** — `--check`/`-c`, matching `haproxy -c`. It carries no
  operand, so it composes with the existing "a flag anywhere on the line
  wins" rule rather than introducing option-with-value parsing.
- **Exit codes** — three: `0` would start here, `1` the config is wrong,
  `2` the config is right and *this box* cannot fit it. The split is what
  a CI job branches on. A path the config names counts as the config's,
  deliberately: an agent that lacks the deployment's certificates should
  check a config that does not name them rather than learn to ignore a
  code that also covers a real mistake.
- **Filesystem** — the full load, per the issue. An `access_log` `file`
  sink is created when absent, exactly as a start creates it; the fd is
  closed immediately through a new `XevIo.closeLogSink`, so the syscall
  stays behind the §4 seam.
- **stdout** — the whole report goes there; refusal reasons stay on
  stderr. `budget.zig` grows a `Sink` so the startup banner and the check
  report are one evaluation of the closed form rather than two renderings
  that agree today.
- **Banner on failure** — printed for every verdict that got far enough
  to price a config, which is the point: a budget that does not fit is
  exactly the one whose numbers an operator needs.

## One shape decision worth review

The gauntlet moves into a single `openStartupResources`, called by both
`serve` and the check. That is not tidying. The order is itself a
verdict — a config failing two of these earns the answer of whichever a
start reaches first, and the two answers say opposite things about what
the operator does next. The first draft of this PR had the check run its
own sequence and got that wrong: a config that both exceeded
`RLIMIT_NOFILE` and named an unreadable certificate reported "change the
file" when the real blocker was the machine. One body means the two modes
cannot drift and no comment has to guard that they don't.

`ensureFdBudget` narrows to `error{FdBudgetUnsatisfiable}` so the
classification stays unambiguous once every failure flows through one
`catch`; the specific reason is printed where the numbers are still in
hand.

## Behaviour change to the serving path

The banner now prints before the box is asked for anything, so a start
the fd budget refuses leaves behind the numbers that refused it — it
previously printed nothing at all:

```
zoxy 0.7.0
budgets (DESIGN.md §5/§8; closed-form except where marked):
  fds     34381 required (asserted against RLIMIT_NOFILE)
zoxy: RLIMIT_NOFILE hard limit 4096 is below the fd budget 34381 (§8)
```

`bench/run.zig` already assumed the banner is the first thing zoxy
prints; this makes that unconditional rather than true-when-the-fd-check-
passes. Stated in `docs/README.md` rather than slipped in.

## Gate

The live gate runs `--check` over the very config it then serves — the
only place the agreement can be observed — and over one the *loader*
refuses (`ListenerBindInvalid`, a semantic check no schema makes),
pinning the exit code, the stdout/stderr split, and that a refused config
is never priced. Green runs now say `--check agrees`.

`zig build ci` and `zig fmt --check` pass. All four verdict paths were
also exercised by hand, including exit `2` on a c10k config under a stock
4096 `RLIMIT_NOFILE` and exit `1` on an unreadable certificate.

## Not in scope

Config reload and hot restart (out per §1). The `zig build schema` ↔
`--check` differential gate this makes possible is #305's, not this
slice's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)