### PR TITLE
metrics: SIGUSR1 stops dumping counters (#310)

### DIFF
--- a/bench/run.zig
+++ b/bench/run.zig
@@ -317,7 +317,7 @@ fn forwardStderr(io: Io, child: *const std.process.Child) void {
 /// all excess shed with a correct status (5xx and accept-RSTs — the
 /// latter are the conn-slot wall, so zrk's connect errors are exempt
 /// from the health gate), bounded latency for what was admitted, and a
-/// clean drain. SIGUSR1 lands the counter dump in the run log first.
+/// clean drain. The drain's exit tally lands the counters in the run log.
 fn runOverload(
     arena: std.mem.Allocator,
     io: Io,
@@ -352,9 +352,11 @@ fn runOverload(
     printReport("zoxy overload", &report, .keep_alive);
     std.debug.print("zoxy overload RSS: {d} KiB -> {d} KiB\n", .{ rss_before_kb, rss_after_kb });
 
-    // The counter dump (sheds, pressure engagements) lands in the run
-    // log for the human band review before the drain.
-    try std.posix.kill(child.id.?, .USR1);
+    // The counters this row is read against — sheds and pressure
+    // engagements — are cumulative, so the drain's own exit tally carries
+    // them (`drainChild` forwards it to the run log). This used to send
+    // SIGUSR1 first to get them *before* the drain; that signal stopped
+    // printing anything in #310, and nothing was lost with it.
     const drained_cleanly = try drainChild(io, &child, &running, "zoxy overload");
     return overloadPassed(rss_before_kb, rss_after_kb, &report, drained_cleanly);
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -668,7 +668,7 @@ are still there.
 The labeled metrics (§8, #179) add one more reservation on the same
 promise: the per-endpoint counter tables with their prebuilt label
 strings, and the two render staging buffers — the admin scrape response
-and the SIGUSR1 dump. The buffers stopped being comptime constants when
+and the exit tally. The buffers stopped being comptime constants when
 the exposition gained labels: the rendered text's length depends on
 endpoint count, cluster-name length and address literals, none known
 before config load. The term stays closed-form — `Server.metricsBytes`
@@ -1969,8 +1969,14 @@ origin, not one this proxy can pick for them.
   asserts counters reconcile (admitted = completed + shed + in-flight)
   under every seed. Counters live in `counters.zig` (§10); exposure is
   the admin/metrics listener's Prometheus rendering (`admin.zig`, one
-  reserved scrape slot off the shared pools) plus a SIGUSR1 dump through
-  the seam's `signal` primitive (§4).
+  reserved scrape slot off the shared pools), and nothing else while the
+  process serves. A SIGUSR1 dump to stderr was the second reader until
+  #310 removed it, for two reasons worth keeping written down: the
+  exposition is a *snapshot*, so a second dump on one stream repeats
+  every series and leaves a file no scraper can ingest — and it grew with
+  clusters x endpoints (#179), reaching 1.6 MB, which a blocking write on
+  a slow stderr pipe turned into a parked loop. The drain's exit tally
+  survives both objections: once per process, after `run` has returned.
 - **The exposition says which backend, not only how many** (#179,
   settled 2026-08-02). Beside the process totals, labeled families:
   per-endpoint counters for dial failures, responses served and health

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,20 +93,32 @@ that passes on a log directory the start then cannot write.
 
 ### Signals
 
-The *startup* banner goes to stderr, and so does the `SIGUSR1` counter
-dump: stdout belongs to the access log, whose `stdout` sink must stay one
-uncontaminated JSON line per event. `--check` is the exception and not a
-contradiction — it never serves, so nothing is writing that access log.
+The startup banner goes to stderr, and so does the exit tally: stdout
+belongs to the access log, whose `stdout` sink must stay one uncontaminated
+JSON line per event. `--check` is the exception and not a contradiction —
+it never serves, so nothing is writing that access log.
 
 | signal | effect |
 |---|---|
 | `SIGTERM`, `SIGINT` | drain in-flight connections, then exit 0 |
-| `SIGUSR1` | dump counters to stderr |
 | `SIGHUP` | reopen the access log's `file` sink — rotation, and nothing else |
+| `SIGUSR1` | ignored |
 
 A completed drain prints the counters one last time on its way out, so a
 process that exited cleanly leaves its final tally behind without anyone
-having to have scraped it.
+having to have scraped it. A drain that gets *stuck* prints them too,
+beside the diagnostic naming which plane never finished — those two are
+the only paths that put counters on stderr, and both run once, at the end
+of a process. The reason it is not more than that is the format:
+Prometheus exposition is a snapshot, so two of them written to one stream
+repeat every series and parse as neither. Live counters come from
+[`/metrics`](#metrics), which frames each rendering as its own response.
+
+> [!NOTE]
+> `SIGUSR1` used to dump counters here and no longer does. It is
+> explicitly *ignored* rather than left unhandled, because its default
+> disposition is to terminate — an operator's muscle memory must not
+> become an outage.
 
 ### A minimal config
 
@@ -1134,8 +1146,9 @@ every lifecycle counter, and live pool-occupancy gauges:
 ```
 
 One scrape is served at a time from a slot reserved outside the data-path
-pools, so a scrape and a request can never shed one another. `SIGUSR1` dumps
-the same rendering to stderr, which needs no listener at all.
+pools, so a scrape and a request can never shed one another. This listener
+is how live counters are read: there is no signal that prints them, because
+a second snapshot on one stream invalidates the first.
 
 The gauges matter as much as the counters: a `shed_*` counter only moves once
 a wall is *hit*, while `zoxy_conn_slots_in_use` against

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -133,7 +133,7 @@ pub fn Server(comptime IoType: type) type {
         /// also moves the matching bare counter, and `reconcile` holds
         /// the partitions equal.
         labeled: counters_module.Labeled,
-        /// Staging for the SIGUSR1/post-drain metrics dump (§8): the
+        /// Staging for the §8 exit tally: the
         /// full exposition — counters then labeled — no longer fits a
         /// fixed stack buffer once its length is the config's, so it is
         /// arena memory priced in the banner (`metricsBytes`).
@@ -1369,17 +1369,43 @@ pub fn Server(comptime IoType: type) type {
         fn onSignal(server: *Self, signal: Io.Signal) void {
             switch (signal) {
                 .terminate => server.beginDrain(),
-                .dump_counters => server.dumpMetrics(),
                 .reopen_log => server.access_log.requestReopen(),
             }
         }
 
-        /// The SIGUSR1 / post-drain §8 dump: the exact exposition the
-        /// scrape serves — counters then the labeled breakdown — through
-        /// the same two renderers, so the dump and the endpoint can never
-        /// disagree on the wire format. Staged in the arena buffer sized
-        /// for both at init; one print, so the two halves cannot
-        /// interleave with other stderr writers.
+        /// The §8 exit tally: the exact exposition the scrape serves —
+        /// counters then the labeled breakdown — through the same two
+        /// renderers, so the dump and the endpoint can never disagree on
+        /// the wire format. Staged in the arena buffer sized for both at
+        /// init; one print, so the two halves cannot interleave with
+        /// other stderr writers.
+        ///
+        /// Blocking, and that is now a property of *where it runs* rather
+        /// than a hazard (#310). SIGUSR1 used to call it from a live loop,
+        /// which is what #310 was — a dump that reached 1.6 MB on a stderr
+        /// pipe parked the whole proxy in one `writev`. The signal no
+        /// longer carries this; `/metrics` does, framed as a response and
+        /// non-blocking.
+        ///
+        /// The two callers left are both past the point a stall can cost
+        /// anything, for two *different* reasons:
+        ///
+        ///   - `main` prints the final tally after `run` has returned, so
+        ///     there is no loop to park and no op that could complete.
+        ///   - `reportStuckDrain` runs immediately before an unconditional
+        ///     `abort`: the process is already committed to a hard exit,
+        ///     so there is no serving left to delay. And a stall there is
+        ///     bounded rather than open-ended — the alarm watchdog
+        ///     (`armDrainWatchdog`) is not an op the loop delivers, so it
+        ///     fires through a blocked `writev` and ends the process.
+        ///     Deliberately *not* the argument that the loop has stopped
+        ///     delivering: `onDrainStuck` is itself a timer completion the
+        ///     loop delivered, which is the whole reason the alarm exists
+        ///     beside it (#226).
+        ///
+        /// Called *once* per process either way, which is what keeps the
+        /// output honest: Prometheus exposition is a snapshot, so two of
+        /// them concatenated repeat every series and parse as neither.
         pub fn dumpMetrics(server: *const Self) void {
             assert(server.dump_buffer.len >= counters_module.Counters.render_bytes_max);
             const snapshot = server.gauges();
@@ -3336,7 +3362,7 @@ pub fn Server(comptime IoType: type) type {
         }
 
         /// The live occupancy of all three pools, read straight off them
-        /// for a scrape or a SIGUSR1 dump (§8). The only producer of
+        /// for a scrape or the exit tally (§8). The only producer of
         /// `Counters.Gauges` — nothing mirrors these levels, so nothing
         /// can disagree with the pool it reports.
         ///

--- a/src/config.zig
+++ b/src/config.zig
@@ -139,7 +139,7 @@ pub const Config = struct {
     /// and that is the point — a multi-endpoint cluster with no failure
     /// detection is legitimate behind a mesh, or when the endpoints are
     /// themselves VIPs, so warning every startup would teach operators
-    /// to ignore the stream the banner and the `SIGUSR1` dump share.
+    /// to ignore the stream the banner and the exit tally share.
     ///
     /// Clusters with fewer than two endpoints a request could actually
     /// be sent to are excluded deliberately: there is nowhere to eject

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1592,7 +1592,7 @@ pub const PoolSizes = struct {
     endpoint_table_bytes: u64,
     /// The #179 labeled metrics (§8): the per-endpoint/per-cluster
     /// counter tables and their prebuilt label strings, plus the two
-    /// render staging buffers — the admin response and the SIGUSR1 dump
+    /// render staging buffers — the admin response and the exit tally
     /// — whose length became the config's when the exposition gained
     /// labels. Its own term on the issue's own argument: the cost of
     /// labelling your metrics should be visible next to everything else

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -680,7 +680,7 @@ pub const Counters = struct {
 
     /// Render every counter and gauge as Prometheus exposition text into a
     /// caller-owned buffer (zero-alloc, §5) — the single renderer shared by
-    /// the SIGUSR1 `dump` and the admin endpoint. The buffer must be
+    /// the exit tally and the admin endpoint. The buffer must be
     /// at least `render_bytes_max`; that bound is exact, so a correctly
     /// sized caller can never truncate. Returns the filled prefix.
     ///

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1555,9 +1555,6 @@ fn onNotifierWake(
     if (mask & signalBit(.terminate) != 0) {
         callback(io.signal_userdata, .terminate);
     }
-    if (mask & signalBit(.dump_counters) != 0) {
-        callback(io.signal_userdata, .dump_counters);
-    }
     if (mask & signalBit(.reopen_log) != 0) {
         callback(io.signal_userdata, .reopen_log);
     }

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -73,7 +73,6 @@ pub const XevIo = @import("XevIo.zig");
 /// simulator can inject drain as just another scheduled event (§4).
 pub const Signal = enum(u8) {
     terminate,
-    dump_counters,
     /// SIGHUP: reopen the access log's file sink (§8 rotation). This is
     /// the *only* meaning SIGHUP carries — zoxy does not reload config
     /// (§1 non-goal: the §5 pools are startup-fixed, so a config change

--- a/src/main.zig
+++ b/src/main.zig
@@ -651,10 +651,13 @@ const help_text =
     \\above the RLIMIT_NOFILE hard limit).
     \\
     \\Signals:
-    \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0.
-    \\  SIGUSR1           Dump counters to stderr.
+    \\  SIGTERM, SIGINT   Drain in-flight connections, then exit 0. The
+    \\                    counters are printed once on the way out.
     \\  SIGHUP            Reopen the access log's file sink (rotation).
     \\                    No other meaning: config changes are a restart.
+    \\  SIGUSR1           Ignored. It printed the counters until they moved
+    \\                    to the admin listener's /metrics, which frames each
+    \\                    rendering as its own response.
     \\
 ;
 
@@ -737,9 +740,8 @@ fn installSignalHandlers() void {
     };
     std.posix.sigaction(.TERM, &action, null);
     std.posix.sigaction(.INT, &action, null);
-    std.posix.sigaction(.USR1, &action, null);
     std.posix.sigaction(.HUP, &action, null);
-    // §8's drain watchdog (#226). Unlike the four above, this one never
+    // §8's drain watchdog (#226). Unlike the three above, this one never
     // reaches the loop: every other bound in the proxy is an op the loop
     // delivers, which makes them all blind to a backend that has stopped
     // delivering — including `onDrainStuck`, the backstop for exactly
@@ -769,6 +771,14 @@ fn installSignalHandlers() void {
         .flags = 0,
     };
     std.posix.sigaction(.PIPE, &ignore, null);
+    // SIGUSR1 carried the counter dump until #310 removed it, and its
+    // default disposition is *terminate*. Dropping the handler without
+    // this line would turn an operator's muscle memory — the signal that
+    // used to print counters — into an outage. Ignored rather than
+    // handled, because there is nothing left for it to mean: the
+    // exposition it used to write is what `/metrics` serves, framed and
+    // scrapeable, and the drain still prints the final tally.
+    std.posix.sigaction(.USR1, &ignore, null);
 }
 
 /// Async-signal-safe by delegation: the seam's handler is one `write` and
@@ -788,7 +798,6 @@ fn onAlarm(signal_number: std.posix.SIG) callconv(.c) void {
 fn onRawSignal(signal_number: std.posix.SIG) callconv(.c) void {
     const signal: zoxy.Io.Signal = switch (signal_number) {
         .TERM, .INT => .terminate,
-        .USR1 => .dump_counters,
         .HUP => .reopen_log,
         else => return,
     };


### PR DESCRIPTION
Closes #310.

`dumpMetrics` rendered the whole Prometheus exposition and wrote it with
`std.debug.print` — one blocking `writev` — from the signal callback,
which runs on the event loop.

| config | dump size |
|---|---|
| 8 clusters × 64 endpoints | 215,367 B |
| 16 clusters × 256 endpoints | 1,673,267 B |

With stderr on a pipe whose reader stalled:

```
state:   S (sleeping)
wchan:   anon_pipe_write
syscall: 20            ← writev
probe:   NO RESPONSE after 2004.0 ms (TimeoutError)

# drain the pipe:
probe:   served in 2.7 ms
```

Alive, healthy, serving nothing. `zoxy config.json 2>&1 | logger` plus one
`SIGUSR1` was the whole reproduction.

## Why this deletes the feature instead of hardening it

I built the asynchronous fix first — a `dumpWrite` seam op in both
backends, the dump as a drain plane — and while doing so found the output
is **unconsumable**.

Prometheus exposition is a *snapshot*. Two dumps written to one stream
repeat every series with repeated `# TYPE` lines. Sending two `SIGUSR1`s
and letting the process drain leaves a file with three copies of every
metric and no delimiter between them:

```
zoxy_endpoint_healthy{cluster="origin",endpoint="127.0.0.1:9001"} 1
# TYPE zoxy_accepted counter          ← dump 2 starts here, no separator
```
```
      3 zoxy_upstream_slots_parked
      3 zoxy_upstream_slots_leased
      3 zoxy_upstream_slots_capacity
```

No scraper can ingest that. The format's contract is broken by the second
call, so this was never a collection mechanism — it only looked like one.
Nor is it a peer convention: HAProxy has `show stat` on the admin socket,
Envoy the admin endpoint, nginx nothing.

The async route would also have cost a **fifth drain plane**: a `SIGUSR1`
landing just before the `SIGTERM` leaves an armed write across the drain,
so `maybeStopAfterDrain`, `onDrainStuck`, `reportStuckDrain` and the sim
harness's strand attribution would each grow an arm — on top of the new op
in `io.zig`, `XevIo`, `SimIo` and the contract test. That is a lot of
machinery to make an unreadable output non-blocking.

## `SIGUSR1` is ignored, not unhandled

Its default disposition is **terminate**. Dropping the handler without
saying so would turn an operator's muscle memory — the signal that used to
print counters — into an outage. It gets the same explicit `SIG_IGN` that
`SIGPIPE` already has, and `--help` and the signals table say so.

## What survives

- `/metrics` frames each rendering as its own response: non-blocking,
  scrapeable, unchanged.
- The drain still prints one exit tally — once, after `run` returns, which
  is both valid exposition and unable to park anything.
- The stuck-drain report keeps its blocking write, on a narrower argument
  than the one I first wrote: **not** that the loop has stopped delivering
  (`onDrainStuck` is itself a completion the loop delivered — the reason
  the alarm watchdog exists beside it, #226), but that the process is
  already committed to an unconditional `abort`, and the alarm is not an op
  and so fires through a blocked write.

## The trade, stated rather than discovered

`admin` is optional and off by default, so a deployment that does not run
it now has **no live counter access** — only the tally at exit. That is in
the docs. If it bites, a bounded human-readable summary on the signal is
the obvious follow-up, and a separate decision from this one.

## Also fixed

`bench/run.zig`'s overload row sent `SIGUSR1` to land the counter dump in
the run log, which this turned into a silent no-op. Removed: the sheds and
pressure engagements it wanted are cumulative, so the drain's tally already
carries them.

## Verification

```
alive after SIGUSR1: yes      (default action would have killed it)
wchan:  io_cqring_wait
served in 2.8 ms
served in 4.3 ms              (stderr pipe still stalled)
exit tally: 1 × zoxy_accepted (one snapshot — valid exposition)
```

`zig build ci` and `zig fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)