### PR TITLE
docs: the TLS block ships after the freeze, so #297 must be additive (#305)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -784,6 +784,17 @@ Rules:
   cannot supply — they are resolved addresses, and an address is not an
   identity. Decided here, implemented with the features that need it: a
   key with no feature behind it is not a freeze, it is a promise.
+
+  All three of those features ship *after* 1.0.0, which turns this record
+  from a convenience into the contract they are held to. Two of them add
+  keys and are additive by nature. The certificate set is not: today's
+  `tls` is one `{cert, key}` pair, and a freeze means a config that was
+  valid at 1.0.0 stays valid. So `cert`/`key` survive as the one-pair
+  spelling of `certificates`, the way `endpoints` already accepts a bare
+  literal beside its object form and `pick` accepts a bare policy beside
+  its object — sugar for the common case, one general form underneath.
+  Breaking it instead would be the freeze meaning nothing the first time
+  it was tested.
 - **An address is a string, and `unix:` extends its grammar** (#303,
   #305). `bind` and `endpoints` stay single scalars rather than becoming
   tagged objects or gaining a second key — they are the two most-written


### PR DESCRIPTION
#296, #297 and #304 all moved to **v1.1.0**, which lands every one of them
on the far side of the 1.0.0 config freeze. That turns §5's recorded `tls`
decision from a convenience into the contract those three are held to, and
it adds one clause that was not needed while they sat in v1.0.0.

## Two of the three are additive; one is not

| issue | what it does to the config | after a freeze |
|---|---|---|
| #296 upstream TLS | adds a `tls` key to a **cluster** | a new key — fine |
| #304 mTLS | adds `client_ca` inside a **listener's** `tls` | a new key — fine |
| #297 SNI credentials | changes `tls` from one `{cert, key}` pair to a **set** | replaces an existing key |

A freeze means a config valid at 1.0.0 stays valid. Replacing `cert`/`key`
with `certificates` would break every such config the first time the
freeze was tested, so the shape recorded in §5 gains one clause:
**`cert`/`key` survive as the one-pair spelling of `certificates`.**

```json
"tls": { "cert": "…", "key": "…" }

"tls": { "certificates": [ {"cert": "…", "key": "…"}, … ] }
```

## Why this costs almost nothing

The dual spelling is already this codebase's idiom rather than a
concession invented for TLS: `endpoints` accepts a bare
`"127.0.0.1:9000"` beside its `{address, weight}` object, and `pick`
accepts a bare `"p2c"` beside its `{policy, key}` object. Sugar for the
common case, one general form underneath.

And the fork is free to express: the `oneOf` emitter added in #305 Part 1
turns "exactly one of these fields" into schema rather than a loader rule,
so this costs a `schema_one_of` declaration.

## Why now rather than in #297

It was free to break while that issue sat in v1.0.0, and it is not any
more. Writing it down at the moment the milestone moved is the difference
between a constraint #297 is built to and one it discovers — which is the
same argument #305 Part 1 made for recording the `tls` and `unix:` shapes
instead of implementing them early.

Docs only. `zig build ci` and `zig fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)