### PR TITLE
deps: repin libxev for the kqueue submit livelock (#314)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,14 +34,45 @@
     .dependencies = .{
         // Audited fork: zoxy-io/libxev branch zoxy-buffer-group = upstream
         // 9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf (the audited snapshot)
-        // plus four commits, each its own stacked PR:
+        // plus five commits, each its own stacked PR:
         //   c369817 expose io_uring setup flags through Options
         //   6bd950d expose the CQ depth (IORING_SETUP_CQSIZE) — the c10k
         //           lever
         //   b3d6b55 keep the raw errno on the Completion (zoxy-io/libxev#2)
         //   24da6d0 recv_group — provided-buffer receives (zoxy-io/libxev#3)
+        //   fe5a07b leave readiness to the wait in submit (kqueue)
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
+        //
+        // Re-audit for fe5a07b, signed off 2026-08-27. **kqueue only**, and
+        // the one commit in this stack that fixes upstream rather than
+        // extending it: `Loop.submit` was completing readiness reported to
+        // its own kevent, whose eventlist aliases its changelist. Safe with
+        // one call, wrong with two — a submission queue longer than
+        // `events.len` is drained in batches, and a completion batch 1
+        // registered comes back ready in batch 2's reply, already performed
+        // and already linked into `completions`. The second push splices a
+        // linked node and the two intrusive lists cross; `queue.push`'s
+        // assert catches it in ReleaseSafe, and ReleaseFast spins on the
+        // cycle forever — a core pinned, both listeners dead, SIGTERM never
+        // delivered because the loop never returns to the kernel (#314).
+        //
+        // The diff is one `continue` and its reasoning: readiness belongs to
+        // the wait, which already owns it (the wait has always ignored
+        // EV_ERROR, the mirror of this split). Every filter here is
+        // level-triggered, so nothing is lost by leaving it — except
+        // EVFILT_MACHPORT, which arms with MACH_RCV_MSG and so *delivers* on
+        // report rather than signalling; that one is still consumed, and the
+        // draft that skipped it hung the async tests. No API, error set, or
+        // io_uring path is touched.
+        //
+        // Upstream has this as mitchellh/libxev#122 (2024) and #169 (2025),
+        // both open, both load-level repros with no mechanism named; #227 and
+        // #234 are the IOCP and epoll members of the family. mitchellh/libxev#224
+        // clears the same assert with `c.next = null` before the push, which
+        // truncates whichever list the node was linked in and silently orphans
+        // the rest — the reason this carries its own fix rather than that one.
+        // Send upstream; the pin moves only after re-audit either way.
         //
         // Re-audit for 24da6d0 (§4, §5's head-buffer ring), signed off
         // 2026-08-02 against zoxy-io/libxev#3 (standing open like the rest
@@ -69,8 +100,8 @@
         // arms discard which errno failed, which is what left a c10k run
         // reporting 227,628 indistinguishable failures.
         .libxev = .{
-            .url = "git+https://github.com/zoxy-io/libxev#24da6d01bdc426cbbee045d7bfaf18843d0e6d2e",
-            .hash = "libxev-0.0.0-86vtczxOFAB_0IplaVvIkI3iUUo61wUtF10OMILaoVRG",
+            .url = "git+https://github.com/zoxy-io/libxev#fe5a07b4c2920e254e0c4504e5814999696b63b6",
+            .hash = "libxev-0.0.0-86vtc_ZhFAAfG-sAVZbbuZfYYc7wdbZbUsDli3Sn0Afw",
         },
         // Load generator, §9 Tier 0/1 only — never linked into the proxy
         // (no `src/` file imports it), so a bump moves what the benchmark


### PR DESCRIPTION
Fixes #314.

`Loop.submit` drains the submission queue in batches of `events.len` and
hands the kernel that same array as both changelist and eventlist, so it has
somewhere to report a per-change `EV_ERROR`. It was also completing the
*readiness* the reply carries: `perform`, then push onto `completions`.

That is safe with one kevent call and wrong with two. A submission queue
longer than one batch costs two, and every completion the first batch
registered is a candidate to come back as ready in the second batch's reply —
already performed, already linked into `completions`. The second push splices
a node that is not free, the two intrusive lists cross, and `ReleaseFast`
spins on the resulting cycle forever: a core pinned, both listeners dead, and
`SIGTERM` never delivered because the loop never returns to the kernel, so the
drain this proxy owns never runs.

Below one batch there is only ever one kevent call here, so nothing can be
reported to it twice. That is why #314 is a cliff and not a slope.

## The fix

[zoxy-io/libxev@fe5a07b](https://github.com/zoxy-io/libxev/commit/fe5a07b4c2920e254e0c4504e5814999696b63b6)
leaves readiness to the wait, which already owns it — the wait has ignored
`EV_ERROR` since it was written, and this is the mirror of that split. Every
filter the backend registers is level-triggered (`EV_ADD | EV_ENABLE`, never
`EV_CLEAR` or `EV_ONESHOT`), so nothing is lost by leaving it there.

`EVFILT_MACHPORT` is the exception and is still consumed: it arms with
`MACH_RCV_MSG`, so the kevent reporting it has already dequeued the message
into the completion's buffer. The first draft skipped it and hung
`xev.Async`'s tests.

The pin's re-audit note records the scope: kqueue only, one `continue` and its
reasoning, no API, error set, or io_uring path touched.

## Why our own fix and not upstream's

Upstream has this as mitchellh/libxev#122 (2024, `wrk` at 512 connections) and
mitchellh/libxev#169 (2025, same assert under a proxy benchmark) — both open,
both load-level repros with no mechanism named. mitchellh/libxev#227 and #234
are the IOCP and epoll members of the same family.

mitchellh/libxev#224 clears the same assert with `c.next = null` before the
push. But that assert only fires when the node is linked **and** is not the
tail, so in every case it catches, clearing the link truncates the list the
node was linked in and orphans everything behind it — completions that are
then never submitted and never completed. For a proxy that trades a crash for
silent loss: an orphaned submission is a connection that hangs and a slot that
never comes back.

## Verification

From a clean unpack of the new pin, closed-loop zrk against the §9 nginx
fixture, fresh process per row, both builds:

| conns | ReleaseSafe | ReleaseFast | before |
|---|---|---|---|
| 128 | 90739 req/s | 92552 req/s | clean |
| 256 | 91344 req/s | 92939 req/s | **wedged 4/5, panicked 3/3** |
| 384 | 90763 req/s | 91429 req/s | untestable |
| 512 | 88716 req/s | 87623 req/s | untestable |
| 1024 | 85556 req/s | 85191 req/s | untestable |

Every row: zero timeouts, zero idle CPU after the load stops, drains on
`SIGTERM`. Throughput at 128 is unchanged, so the added branch costs nothing
measurable, and the ceiling now degrades gracefully to 1024 connections
instead of falling off a cliff at 256.

`zig build ci` green: 4096 sim seeds, both smoke legs, clean drain. libxev's
own suite passes, including a new regression test that drives `n = 256 + 44`
pipe writes through a single `submit` — one batch boundary, and a pipe is
writable the instant it is registered. It aborts on `queue.push`'s
`assert(v.next == null)` without the fix.

## Not included

No gate yet. The cheapest one is a smoke leg at ≥256 connections asserting the
process still answers and still drains — it needs the macOS job (kqueue only)
and the ReleaseSafe twin #283 already builds (it only *traps* there). Happy to
add it here or leave it for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
