### PR TITLE
l7: a route may match a header, so a pinned canary has an expression (#302)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1096,6 +1096,44 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   one matches only the any-host routes; config hosts must themselves be
   canonical (rejected at load otherwise), so a request host compares
   byte-for-byte against them.
+- **The header is the table's third dimension** (#302), between the two
+  above: **host, then header, then prefix**. A route gains an optional
+  `header` — `{ "name": "X-Canary", "present": true }` or an `equals` —
+  and the three keys are a **conjunction**: every one a route states must
+  hold. Cluster selection stays the route table's alone (a `cluster`
+  filter action would be the second engine §7 refuses), so a pinned
+  canary is a narrower *route* rather than a competing mechanism. What
+  weights (#174) already cover is the probabilistic case; this is the
+  pinned one, which is not probabilistic and cannot be expressed by a
+  share.
+
+  The ordering is a decision, and worth recording as one because **no
+  peer proxy makes it**. Envoy and HAProxy match routes in *config
+  order*, first match wins; Traefik sorts by rule length or an explicit
+  priority. Where a specificity ranking exists at all it is within one
+  dimension — Envoy's domain search order, nginx's `location`
+  precedence — never across two. This table faces the question only
+  because it sorts at load, which is what makes an answer independent of
+  the sequence an operator wrote the rules in — for every pair the tiers
+  can separate. Two routes sharing a host and a prefix while naming
+  different headers are distinct rules (not duplicates) of equal
+  specificity, and a request carrying both matches both; there the
+  earlier route wins, which is config order doing for one case what
+  every peer does for all of them. The comparator says so explicitly
+  rather than inheriting it from `std.mem.sort` being stable. Host outermost is Envoy's
+  own nesting, where a `virtual_host` is chosen by domain and header
+  matching happens on the routes inside it, and it reads right for the
+  case: a canary is a variant of a service, not a different service.
+
+  Two kinds of predicate, not the three `filters` carry: `equals` is one
+  `mem.eql` on a zero-copy head slice and `present` is one lookup, where
+  `contains` is a scan whose cost grows with what a client sent, on a
+  table every request walks. The predicate type and its evaluator live in
+  `router.zig` so the two matchers cannot disagree about whether a
+  request carries a header — the same argument that made `prefixMatches`
+  public for filters to share. A header is a routing key *and* is
+  forwarded: the origin sees it and can log which side of a cut served
+  the request, unlike the canonical `Host`, which is a key only.
 - **`TRACE` is refused, and `Max-Forwards` is spent** (#240). RFC 9110
   §7.6.2 is one of the few places the spec names intermediaries
   directly: a hop in an `OPTIONS` or `TRACE` chain MUST check the

--- a/docs/README.md
+++ b/docs/README.md
@@ -514,6 +514,63 @@ origin receives, so the router and the backend cannot disagree about which
 resource was named. Structure-changing escapes (`%2F`, `%00`, truncated
 escapes) are rejected with `400`; no matching route is a `404`.
 
+#### Pinning a canary with a header
+
+Percentage canaries are [endpoint weights](#weights): put the new version's
+endpoints in the same cluster at low weight and every pick policy honours
+it. What weights cannot express is the **pinned** case — a specific client,
+a test account, an internal gateway's header — because it is not
+probabilistic. A route can match a header for exactly that:
+
+```json
+"routes": [
+    { "header": { "name": "X-Canary", "present": true },
+      "prefix": "/", "cluster": "next" },
+    { "prefix": "/", "cluster": "stable" }
+]
+```
+
+Either `{ "present": true }` for any value, or `{ "equals": "..." }` for
+one. Names match case-insensitively (RFC 9110); values do not. There is no
+substring or regex matching — a route's predicate is a bounded comparison,
+on a table every request walks.
+
+**Host, then header, then prefix.** Every key a route states must hold —
+the three are a conjunction, not a ranking — and where several routes
+match, the most specific wins in that order: a host-scoped route beats an
+any-host one, and within a host group a route naming a header beats one
+that does not.
+
+```json
+"routes": [
+    { "host": "api.example.com", "header": { "name": "X-Canary", "present": true },
+      "prefix": "/", "cluster": "api-canary" },
+    { "host": "api.example.com", "prefix": "/",  "cluster": "api" },
+    { "header": { "name": "X-Canary", "present": true },
+      "prefix": "/", "cluster": "canary" },
+    { "prefix": "/", "cluster": "web" }
+]
+```
+
+Those four can be written in any sequence and answer identically: the table
+is sorted once at startup, so config order cannot change which of two
+*differently* specific routes wins.
+
+Config order does decide one case, and it is the case the tiers cannot
+separate: two routes sharing a host and a prefix but naming **different**
+headers are distinct rules of equal specificity, and a request carrying
+both matches both. The one written first wins — the same thing every other
+proxy does for every route, here narrowed to the only place zoxy has left
+for it.
+
+> [!NOTE]
+> Two things worth knowing before you lean on this. A request that gains or
+> loses the header **moves to a different cluster**, so a `hash` pick still
+> holds within each cluster but not across the change — "sticky" and
+> "canary" together is exactly where that surprises people. And the header
+> is a routing key *and* is forwarded, so the origin sees it and can log
+> which side of the cut served the request.
+
 `CONNECT` and `TRACE` are answered `501` and never reach a backend.
 `CONNECT` asks the proxy to open an arbitrary destination, which is
 forward-proxy behaviour; `TRACE` echoes a request back, which is the

--- a/src/config.zig
+++ b/src/config.zig
@@ -730,6 +730,7 @@ pub const ValidationError = error{
     ListenerProxyProtocolModeUnknown,
     ListenerTlsWithSniRoutes,
     RouteSniIsAddress,
+    RouteHeaderMatchKind,
     LimitRelayBufferUnderSniRouting,
     ListenerTlsCertPathEmpty,
     ListenerTlsKeyPathEmpty,
@@ -2427,13 +2428,55 @@ pub const RouteJson = struct {
     /// Optional §7 host scope; absent means the route matches any host.
     host: ?[]const u8 = null,
     prefix: []const u8,
+    /// Optional #302 header scope; absent means the route matches any
+    /// request. Conjoined with the other two, not ranked against them.
+    header: ?RouteHeaderJson = null,
     cluster: []const u8,
 
-    pub const schema_doc = "One longest-prefix route entry.";
+    pub const schema_doc =
+        "One route entry. Every key it states must hold — host, header and " ++
+        "prefix are a conjunction — and the table is matched most-specific " ++
+        "first: host, then header, then prefix.";
     pub const schema_fields = .{
         .host = .{ .desc = "Canonical host scope; absent matches any host." },
         .prefix = .{ .desc = "Canonical origin-form path prefix; must start with a slash." },
+        .header = .{
+            .desc = "Header the request must carry for this route to match; " ++
+                "absent matches any request. A route naming one is the " ++
+                "narrower rule and is tried before the same route without.",
+        },
         .cluster = .{ .desc = "Name of the cluster matching requests route to." },
+    };
+};
+
+/// A route's header predicate (#302): a pinned canary is a specific
+/// client, a test account or an internal gateway's header, which endpoint
+/// weights cannot express because it is not probabilistic.
+///
+/// Two kinds, and deliberately not the three `filters` have. `equals` is
+/// one `mem.eql` on a zero-copy head slice and `present` is one lookup;
+/// `contains` is a scan whose cost grows with the header a client sent,
+/// on a table every request walks. §7 draws the line where a route
+/// dimension would become the second match engine it refuses, and a
+/// substring test is the near side of it.
+pub const RouteHeaderJson = struct {
+    name: []const u8,
+    /// Exactly one of these selects the predicate kind.
+    present: ?bool = null,
+    equals: ?[]const u8 = null,
+
+    pub const schema_doc =
+        "One header predicate on a route. Exactly one of `present`/`equals` " ++
+        "selects the kind. No substring or regex matching: a route's " ++
+        "predicate is a bounded comparison, on a table every request walks.";
+    pub const schema_one_of = [_][]const u8{ "present", "equals" };
+    pub const schema_fields = .{
+        .name = .{ .desc = "Header field name (matched case-insensitively)." },
+        .present = .{
+            .desc = "Matches when the header is present at all (present: false is rejected).",
+            .const_true = true,
+        },
+        .equals = .{ .desc = "Matches when the header's value equals this string exactly." },
     };
 };
 
@@ -3143,7 +3186,7 @@ pub const dto_types = .{
     ForwardedJson,      ProxyProtocolJson,   ClusterProxyProtocolJson, EndpointJson,
     ResponseFilterJson, ResponseMatchJson,   RedirectJson,             BodyJson,
     TlsJson,            PassiveEjectionJson, HttpListenerJson,         L4ListenerJson,
-    L4RouteJson,
+    L4RouteJson,        RouteHeaderJson,
 };
 
 comptime {
@@ -3976,6 +4019,41 @@ fn hostBitsSet(comptime T: type, bits: T, prefix_len: u8) bool {
     return (bits & host_mask) != 0;
 }
 
+/// A route's header predicate (#302), resolved into the same
+/// `HeaderMatch` the filter table uses — one type, one evaluator, so two
+/// matchers cannot disagree about whether a request carries a header.
+///
+/// Held to the same name and value rules as a filter's match, which
+/// includes what those rules deliberately do *not* reject: a
+/// proxy-managed name like `Content-Length` is matchable here as it is
+/// there. Only an *edit* target is reserved (§7), because rewriting one
+/// smuggles a framing change past the render — reading one to pick a
+/// backend changes nothing, and routing runs before any edit anyway.
+fn resolveRouteHeader(header_json: RouteHeaderJson) ParseError!router.HeaderMatch {
+    try validateHeaderName(header_json.name);
+    const set: u8 = @as(u8, @intFromBool(header_json.present != null)) +
+        @intFromBool(header_json.equals != null);
+    assert(set <= 2); // The route header has two kind fields.
+    if (set != 1) {
+        return error.RouteHeaderMatchKind;
+    }
+    if (header_json.present) |present| {
+        if (!present) {
+            return error.RouteHeaderMatchKind; // "present: false" is not a predicate.
+        }
+        return .{ .name = header_json.name, .kind = .present, .value = "" };
+    }
+    const value = header_json.equals.?;
+    // An `equals: ""` predicate is meaningful — a header present with an
+    // empty value — so the empty value is legal, as it is for a filter.
+    try validateHeaderValue(value);
+    // `headerMatches` asserts this of every predicate it is handed; the
+    // name came through `validateHeaderName`, so stating it here is what
+    // ties the producer to that precondition.
+    assert(header_json.name.len >= 1);
+    return .{ .name = header_json.name, .kind = .equals, .value = value };
+}
+
 fn resolveHeaderMatches(
     arena: std.mem.Allocator,
     headers_json: []const HeaderMatchJson,
@@ -4259,11 +4337,20 @@ fn resolveRoutes(
     for (routes_json, 0..) |route_json, index| {
         try validateRoutePrefix(route_json.prefix, head_buffer_bytes);
         const host = if (route_json.host) |raw| try validateRouteHost(raw) else null;
+        const header = if (route_json.header) |raw|
+            try resolveRouteHeader(raw)
+        else
+            null;
         for (routes_json[0..index]) |previous| {
             // Earlier routes already passed validateRouteHost, so their raw
             // host equals its canonical form — a byte compare is sound.
             if (optionalHostEql(previous.host, host) and
-                std.mem.eql(u8, previous.prefix, route_json.prefix))
+                std.mem.eql(u8, previous.prefix, route_json.prefix) and
+                // The header is part of what makes a route distinct
+                // (#302): two rules sharing a host and prefix but naming
+                // different headers are different rules, and only the
+                // pair that agrees on all three is the same rule twice.
+                routeHeaderEql(previous.header, route_json.header))
             {
                 return error.RouteDuplicate;
             }
@@ -4271,25 +4358,87 @@ fn resolveRoutes(
         routes[index] = .{
             .host = host,
             .prefix = route_json.prefix,
+            .header = header,
             .cluster_index = try clusterIndexOf(clusters, route_json.cluster),
         };
     }
-    // Host-specific first, then longest-prefix-first (§7): the router's
-    // linear scan then finds the most specific match first — any route
-    // scoped to the request's host before any any-host route, and within a
-    // group the longest prefix. Ties are rejected as duplicates above.
-    std.mem.sort(router.Route, routes, {}, routeMoreSpecific);
-    assert(routes.len >= 1);
-    return routes;
+    // Host, then header, then prefix (§7, #302): the router's linear scan
+    // then finds the most specific match first.
+    //
+    // Sorted through an index permutation rather than in place, so the
+    // comparator can fall back to config order *explicitly*. Since #302
+    // that fallback is reachable: two routes may share a host and a
+    // prefix and still be distinct rules, because they name different
+    // headers — legal, not duplicates, and equally specific by every
+    // tier this comparator has. Something must decide between them for a
+    // request that carries both, and config order is the only thing left
+    // that an operator can see and control. Leaning on `std.mem.sort`
+    // being stable would get the same answer today while making it a
+    // property of the standard library rather than of this table.
+    const order = try arena.alloc(u16, routes.len);
+    for (order, 0..) |*slot, index| slot.* = @intCast(index);
+    std.mem.sort(u16, order, routes, routeOrderMoreSpecific);
+    const sorted = try arena.alloc(router.Route, routes.len);
+    for (order, sorted) |from, *slot| {
+        assert(from < routes.len);
+        slot.* = routes[from];
+    }
+    assert(sorted.len >= 1);
+    return sorted;
 }
 
+/// The comparator over indices, so an exact tie can fall back to the
+/// order the operator wrote — see `resolveRoutes` for why that fallback
+/// is reachable and why it is not left to sort stability.
+fn routeOrderMoreSpecific(routes: []const router.Route, left: u16, right: u16) bool {
+    assert(left < routes.len);
+    assert(right < routes.len);
+    if (routeMoreSpecific({}, routes[left], routes[right])) return true;
+    if (routeMoreSpecific({}, routes[right], routes[left])) return false;
+    // Equally specific: earlier in the config wins, which is what every
+    // peer proxy does for *every* route and what this table now does for
+    // the one case its tiers cannot separate.
+    return left < right;
+}
+
+/// Host, then header, then prefix (#302) — the order `router.route`'s
+/// doc argues for, applied once here so a request-time match is a scan
+/// over an already-sorted table.
 fn routeMoreSpecific(_: void, left: router.Route, right: router.Route) bool {
     const left_scoped = left.host != null;
     const right_scoped = right.host != null;
     if (left_scoped != right_scoped) {
         return left_scoped; // A host-scoped route sorts before an any-host one.
     }
+    const left_keyed = left.header != null;
+    const right_keyed = right.header != null;
+    if (left_keyed != right_keyed) {
+        // Within one host group, a route naming a header is the narrower
+        // rule: it answers a subset of what the same route without one
+        // would. A canary pinned by header must therefore be reachable
+        // past the rule it is a variant of.
+        return left_keyed;
+    }
     return left.prefix.len > right.prefix.len;
+}
+
+/// Whether two route header predicates are the same rule. Compared on
+/// the raw DTOs rather than the resolved matches because this runs inside
+/// the resolve loop, before the later route has one — and the name
+/// compare is case-insensitive for the reason the matcher's is: RFC 9110
+/// says `X-Canary` and `x-canary` are one header.
+fn routeHeaderEql(left: ?RouteHeaderJson, right: ?RouteHeaderJson) bool {
+    const left_header = left orelse return right == null;
+    const right_header = right orelse return false;
+    if (!std.ascii.eqlIgnoreCase(left_header.name, right_header.name)) {
+        return false;
+    }
+    if ((left_header.present != null) != (right_header.present != null)) {
+        return false;
+    }
+    const left_equals = left_header.equals orelse return right_header.equals == null;
+    const right_equals = right_header.equals orelse return false;
+    return std.mem.eql(u8, left_equals, right_equals);
 }
 
 fn optionalHostEql(left: ?[]const u8, right: ?[]const u8) bool {
@@ -5204,6 +5353,171 @@ test "config: a listener's body key is what names its protocol" {
     }
 }
 
+test "config: a header route sorts between its host and its prefix" {
+    // #302's central question, answered: host, then header, then prefix.
+    // The table is written in the least helpful order on purpose — config
+    // order must not be able to change an answer.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","http":{"routes":[
+        \\   {"prefix":"/","cluster":"web"},
+        \\   {"header":{"name":"X-Canary","present":true},"prefix":"/","cluster":"canary"},
+        \\   {"host":"api.example.com","prefix":"/","cluster":"api"},
+        \\   {"host":"api.example.com","header":{"name":"X-Canary","present":true},
+        \\    "prefix":"/","cluster":"api-canary"}]}}],
+        \\ "clusters":{"web":{"endpoints":["127.0.0.1:2"]},
+        \\   "canary":{"endpoints":["127.0.0.1:3"]},
+        \\   "api":{"endpoints":["127.0.0.1:4"]},
+        \\   "api-canary":{"endpoints":["127.0.0.1:5"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const routes = parsed.listeners[0].routes;
+    try std.testing.expectEqual(@as(usize, 4), routes.len);
+    // Host group first, and within it the header rule ahead of the bare
+    // one; then the any-host group repeating the same shape.
+    try std.testing.expect(routes[0].host != null and routes[0].header != null);
+    try std.testing.expect(routes[1].host != null and routes[1].header == null);
+    try std.testing.expect(routes[2].host == null and routes[2].header != null);
+    try std.testing.expect(routes[3].host == null and routes[3].header == null);
+}
+
+test "config: two header rules of equal specificity keep config order" {
+    // The one tie #302 leaves. Same host, same prefix, different headers:
+    // distinct rules, equally specific by every tier, and a request
+    // carrying both matches both. The earlier one wins — stated here
+    // because it is a promise the docs make, and because relying on
+    // `std.mem.sort` being stable would make it std's promise instead.
+    const tail = "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}," ++
+        "\"b\":{\"endpoints\":[\"127.0.0.1:3\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"routes\":[";
+    const canary = "{\"header\":{\"name\":\"X-Canary\",\"present\":true}," ++
+        "\"prefix\":\"/\",\"cluster\":\"a\"}";
+    const beta = "{\"header\":{\"name\":\"X-Beta\",\"present\":true}," ++
+        "\"prefix\":\"/\",\"cluster\":\"b\"}";
+    const catch_all = "{\"prefix\":\"/\",\"cluster\":\"a\"}";
+
+    // Written canary-first: the canary rule is tried first.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ canary ++ "," ++ beta ++ "," ++ catch_all ++ "]}}]," ++ tail,
+        );
+        const routes = parsed.listeners[0].routes;
+        try std.testing.expectEqualStrings("X-Canary", routes[0].header.?.name);
+        try std.testing.expectEqualStrings("X-Beta", routes[1].header.?.name);
+        try std.testing.expect(routes[2].header == null);
+    }
+    // Written beta-first: the other way round, and nothing else moves.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ beta ++ "," ++ canary ++ "," ++ catch_all ++ "]}}]," ++ tail,
+        );
+        const routes = parsed.listeners[0].routes;
+        try std.testing.expectEqualStrings("X-Beta", routes[0].header.?.name);
+        try std.testing.expectEqualStrings("X-Canary", routes[1].header.?.name);
+        try std.testing.expect(routes[2].header == null);
+    }
+    // And the catch-all sorts last from either spelling — the tiers still
+    // decide everything they can separate, whatever the order.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ catch_all ++ "," ++ beta ++ "," ++ canary ++ "]}}]," ++ tail,
+        );
+        const routes = parsed.listeners[0].routes;
+        try std.testing.expect(routes[0].header != null);
+        try std.testing.expect(routes[1].header != null);
+        try std.testing.expect(routes[2].header == null);
+    }
+}
+
+test "config: a route header is a bounded predicate, held to the filter's rules" {
+    const tail = "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"routes\":[";
+
+    // Exactly one kind, and `present: false` is not a predicate.
+    try expectParseError(
+        error.RouteHeaderMatchKind,
+        head ++ "{\"header\":{\"name\":\"X-C\"},\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail,
+    );
+    try expectParseError(
+        error.RouteHeaderMatchKind,
+        head ++ "{\"header\":{\"name\":\"X-C\",\"present\":true,\"equals\":\"v\"}," ++
+            "\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail,
+    );
+    try expectParseError(
+        error.RouteHeaderMatchKind,
+        head ++ "{\"header\":{\"name\":\"X-C\",\"present\":false}," ++
+            "\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail,
+    );
+    // `contains` is not a route predicate at all — the DTO has no such
+    // field, so the strict parser refuses it rather than a rule doing so.
+    try expectParseError(
+        error.UnknownField,
+        head ++ "{\"header\":{\"name\":\"X-C\",\"contains\":\"v\"}," ++
+            "\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail,
+    );
+    // A name is a token, on the filter table's rule.
+    try expectParseError(
+        error.FilterHeaderNameInvalid,
+        head ++ "{\"header\":{\"name\":\"X Canary\",\"present\":true}," ++
+            "\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail,
+    );
+    // But a proxy-managed name is *matchable*, exactly as it is in a
+    // filter's match: only an edit target is reserved, because rewriting
+    // one smuggles a framing change past the render. Reading one to pick
+    // a backend changes nothing — pinned here so the two tables cannot
+    // drift on what a header name may be.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        _ = try expectParseOk(&arena_state, head ++
+            "{\"header\":{\"name\":\"Content-Length\",\"present\":true}," ++
+            "\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail);
+    }
+}
+
+test "config: the header is part of what makes a route distinct" {
+    const tail = "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"routes\":[";
+
+    // Same host and prefix, different headers: two rules, not a duplicate
+    // — which is the whole point of the dimension.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++
+            "{\"header\":{\"name\":\"X-C\",\"equals\":\"v1\"},\"prefix\":\"/\",\"cluster\":\"a\"}," ++
+            "{\"header\":{\"name\":\"X-C\",\"equals\":\"v2\"},\"prefix\":\"/\",\"cluster\":\"a\"}," ++
+            "{\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail);
+        try std.testing.expectEqual(@as(usize, 3), parsed.listeners[0].routes.len);
+    }
+    // Agreeing on all three is the same rule written twice.
+    try expectParseError(error.RouteDuplicate, head ++
+        "{\"header\":{\"name\":\"X-C\",\"equals\":\"v1\"},\"prefix\":\"/\",\"cluster\":\"a\"}," ++
+        "{\"header\":{\"name\":\"x-c\",\"equals\":\"v1\"},\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail);
+    // And a header rule does not collide with the bare rule it varies.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++
+            "{\"header\":{\"name\":\"X-C\",\"present\":true},\"prefix\":\"/\",\"cluster\":\"a\"}," ++
+            "{\"prefix\":\"/\",\"cluster\":\"a\"}]}}]," ++ tail);
+        try std.testing.expectEqual(@as(usize, 2), parsed.listeners[0].routes.len);
+    }
+}
+
 test "config: l4 sni routes resolve, named before any-name" {
     var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
@@ -5393,11 +5707,11 @@ test "config: explicit routes resolve, sorted longest-prefix-first" {
     // The cluster the router will hand back for the longest match.
     try std.testing.expectEqual(
         @as(?u16, routes[0].cluster_index),
-        router.route(routes, null, "/api/v2/x"),
+        router.route(routes, null, "/api/v2/x", &.{}),
     );
     try std.testing.expectEqual(
         @as(?u16, routes[2].cluster_index),
-        router.route(routes, null, "/elsewhere"),
+        router.route(routes, null, "/elsewhere", &.{}),
     );
 }
 
@@ -5468,11 +5782,11 @@ test "config: host routes resolve, host-specific sorted before any-host" {
     // The router hands host-specificity precedence over prefix length.
     try std.testing.expectEqual(
         @as(?u16, routes[1].cluster_index),
-        router.route(routes, "api.example.com", "/other"),
+        router.route(routes, "api.example.com", "/other", &.{}),
     );
     try std.testing.expectEqual(
         @as(?u16, routes[2].cluster_index),
-        router.route(routes, "other.example.com", "/v2"),
+        router.route(routes, "other.example.com", "/v2", &.{}),
     );
 }
 

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -18,16 +18,11 @@ const shed = @import("../shed.zig");
 
 const assert = std.debug.assert;
 
-/// A single header predicate: the named header must be present, or equal,
-/// or contain the given value (case-insensitive name, per RFC 9110).
-pub const HeaderMatch = struct {
-    name: []const u8,
-    kind: Kind,
-    /// Unused for `.present`; the compared value otherwise.
-    value: []const u8,
-
-    pub const Kind = enum(u8) { present, equals, contains };
-};
+/// One header predicate. Lives in `router.zig` since #302 gave the route
+/// table its own header dimension: two matchers judging one header have
+/// to judge it identically, so the predicate belongs in the module they
+/// both import — the same argument that put `prefixMatches` there.
+pub const HeaderMatch = router.HeaderMatch;
 
 /// One CIDR prefix a `client` predicate admits (#177). The address is
 /// canonical for its prefix — host bits are rejected at load — so
@@ -312,7 +307,7 @@ fn responseMatches(match: ResponseMatch, view: ResponseView) bool {
         }
     }
     for (match.headers) |header_match| {
-        if (!headerMatches(header_match, view.headers)) {
+        if (!router.headerMatches(header_match, view.headers)) {
             return false;
         }
     }
@@ -547,7 +542,7 @@ fn matches(match: Match, view: RequestView) bool {
         }
     }
     for (match.headers) |header_match| {
-        if (!headerMatches(header_match, view.headers)) {
+        if (!router.headerMatches(header_match, view.headers)) {
             return false;
         }
     }
@@ -568,31 +563,6 @@ fn clientMatches(cidrs: []const Cidr, client: *const std.Io.net.IpAddress) bool 
         assert(cidr.prefix_len <= 64);
         if (cidr.contains(client)) {
             return true;
-        }
-    }
-    return false;
-}
-
-/// Whether some header satisfies the predicate. Name comparison is
-/// case-insensitive (RFC 9110); `equals`/`contains` compare the value
-/// byte-exact / by substring. Multiple headers of the same name each get
-/// a chance — the predicate holds if any does.
-fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool {
-    assert(header_match.name.len >= 1); // A validated RFC 9110 token.
-    assert(headers.len <= constants.headers_max);
-    for (headers) |header| {
-        if (!std.ascii.eqlIgnoreCase(header.name, header_match.name)) {
-            continue;
-        }
-        switch (header_match.kind) {
-            .present => return true,
-            .equals => if (std.mem.eql(u8, header.value, header_match.value)) return true,
-            // Config rejects an empty `contains` needle, so this is a real
-            // substring test — never the always-true `indexOf(x, "")`.
-            .contains => {
-                assert(header_match.value.len >= 1);
-                if (std.mem.indexOf(u8, header.value, header_match.value) != null) return true;
-            },
         }
     }
     return false;

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1066,7 +1066,7 @@ pub fn Proxy(comptime IoType: type) type {
                     .respond => |page| return respondWithPage(server, conn, page),
                 }
             }
-            conn.stream.cluster_index = router.route(conn.routes, keys.host, keys.views.match) orelse {
+            conn.stream.cluster_index = router.route(conn.routes, keys.host, keys.views.match, request.headers) orelse {
                 return respond(server, conn, 404, "l7_no_route");
             };
 

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -10,30 +10,86 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
+const parser = @import("parser.zig");
+
 const assert = std.debug.assert;
 
+/// One header predicate. Here rather than in `filter.zig` because both
+/// matchers use it since #302, and two matchers judging one header have
+/// to judge it identically — the same argument that made `prefixMatches`
+/// public for filters to share. `filter.HeaderMatch` aliases this.
+///
+/// The route table only ever builds `present` and `equals`: a substring
+/// scan is a different cost on a path every request walks, and §7 draws
+/// the line where a route dimension would become a second match engine.
+/// The `contains` arm is the filter table's, and lives here so one
+/// evaluator answers for both.
+pub const HeaderMatch = struct {
+    name: []const u8,
+    kind: Kind,
+    /// Unused for `.present`; the compared value otherwise.
+    value: []const u8,
+
+    pub const Kind = enum(u8) { present, equals, contains };
+};
+
 /// One routing rule: a canonical path prefix and the cluster it selects,
-/// optionally scoped to a canonical host (`null` = any host). Both keys
-/// are validated canonical at config load (§7), so they compare directly
-/// against the request's canonical host/path with no per-request work.
+/// optionally scoped to a canonical host (`null` = any host) and to a
+/// header the request must carry (`null` = any request, #302). Every key
+/// is validated at config load (§7), so each compares directly against
+/// the request with no per-request work.
+///
+/// The three are a **conjunction**: a route matches when every constraint
+/// it states holds, which is how Envoy's `RouteMatch` composes its own
+/// and what keeps this one table rather than two engines. What differs is
+/// the tie-break — Envoy takes the first route in config order, where
+/// this table is sorted at load, so config order cannot change which of
+/// two differently-specific routes wins.
 pub const Route = struct {
     host: ?[]const u8 = null,
     prefix: []const u8,
+    header: ?HeaderMatch = null,
     cluster_index: u16,
 };
 
 /// The cluster for a request's canonical `host` (null when the request
-/// carried no usable Host) and canonical `path`, or null when nothing
-/// matches (the caller's 404, §8). `routes` is sorted host-specific-first
-/// then longest-prefix-first, so the first matching route is the most
-/// specific: any route scoped to the request's host beats every any-host
-/// route, and within a group the longest prefix wins.
-pub fn route(routes: []const Route, host: ?[]const u8, path: []const u8) ?u16 {
+/// carried no usable Host), canonical `path` and headers, or null when
+/// nothing matches (the caller's 404, §8).
+///
+/// `routes` is sorted most-specific-first at config load, so the first
+/// match is the answer: **host, then header, then prefix** (#302). A
+/// route scoped to the request's host beats every any-host route; within
+/// that group one naming a header beats one that does not; and within
+/// that, the longest prefix wins.
+///
+/// That ordering is a decision rather than an inevitability. No peer
+/// ranks routing dimensions at all — Envoy and HAProxy take the first
+/// match in *config order*, Traefik sorts by rule length — and this table
+/// faces the question only because it sorts, which is what makes the
+/// answer independent of the order an operator happened to write the
+/// rules in — for every pair these tiers can separate. Two routes that
+/// share a host and a prefix while naming different headers are distinct
+/// rules of equal specificity, and `config.zig` breaks that one tie by
+/// config order, explicitly. Host outermost is Envoy's own nesting, where a
+/// `virtual_host` is selected by domain and header matching happens on
+/// the routes inside it; it also reads right for the case #302 exists
+/// for, since a canary is a variant of a service, not a different one.
+pub fn route(
+    routes: []const Route,
+    host: ?[]const u8,
+    path: []const u8,
+    headers: []const parser.Header,
+) ?u16 {
     assert(routes.len >= 1);
     assert(path.len >= 1);
     assert(path[0] == '/');
     for (routes) |candidate| {
-        if (hostMatches(candidate.host, host) and prefixMatches(candidate.prefix, path)) {
+        if (!hostMatches(candidate.host, host)) continue;
+        if (candidate.header) |header_match| {
+            if (!headerMatches(header_match, headers)) continue;
+        }
+        if (prefixMatches(candidate.prefix, path)) {
             return candidate.cluster_index;
         }
     }
@@ -82,26 +138,26 @@ test "router: longest-prefix wins at segment boundaries" {
         .{ .prefix = "/api", .cluster_index = 2 },
         .{ .prefix = "/", .cluster_index = 0 },
     };
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2"));
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2/x"));
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api"));
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api/v1"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2", &.{}));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/api/v2/x", &.{}));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api", &.{}));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, null, "/api/v1", &.{}));
     // A segment-splitting string prefix is not a match: "/api" must not
     // capture "/apihost", so it falls through to the catch-all.
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/apihost"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/other"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/apihost", &.{}));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/other", &.{}));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/", &.{}));
 }
 
 test "router: no catch-all means no match is null (404)" {
     const routes = [_]Route{
         .{ .prefix = "/api", .cluster_index = 1 },
     };
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api"));
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api/deep/path"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/apix"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/elsewhere"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api", &.{}));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api/deep/path", &.{}));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/", &.{}));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/apix", &.{}));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/elsewhere", &.{}));
 }
 
 test "router: a slash-terminated prefix matches its whole subtree" {
@@ -109,9 +165,9 @@ test "router: a slash-terminated prefix matches its whole subtree" {
         .{ .prefix = "/assets/", .cluster_index = 5 },
         .{ .prefix = "/", .cluster_index = 0 },
     };
-    try std.testing.expectEqual(@as(?u16, 5), route(&routes, null, "/assets/img.png"));
+    try std.testing.expectEqual(@as(?u16, 5), route(&routes, null, "/assets/img.png", &.{}));
     // "/assets" (no trailing slash) is not under "/assets/"; catch-all.
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/assets"));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/assets", &.{}));
 }
 
 test "router: a host-specific route beats an any-host one, whatever the prefix" {
@@ -123,26 +179,118 @@ test "router: a host-specific route beats an any-host one, whatever the prefix" 
         .{ .prefix = "/", .cluster_index = 0 },
     };
     // Host a.example: its own routes win, longest-prefix among them.
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "a.example", "/api/x"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "a.example", "/api/x", &.{}));
     // Host a.example, /deep/x: no host route matches except its own
     // catch-all "/", which STILL beats the longer any-host "/deep" —
     // host-specificity dominates prefix length.
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/deep/x"));
-    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/other"));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/deep/x", &.{}));
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "a.example", "/other", &.{}));
     // A different host falls entirely to the any-host routes.
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "b.example", "/deep/x"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "b.example", "/api"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "b.example", "/deep/x", &.{}));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "b.example", "/api", &.{}));
     // No usable Host matches only any-host routes.
-    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/deep"));
-    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/whatever"));
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, null, "/deep", &.{}));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/whatever", &.{}));
 }
 
 test "router: a host-scoped table 404s a request whose host is absent" {
     const routes = [_]Route{
         .{ .host = "only.example", .prefix = "/", .cluster_index = 1 },
     };
-    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "only.example", "/x"));
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "only.example", "/x", &.{}));
     // Wrong host, or no host at all: nothing any-host to fall back to.
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, "other.example", "/x"));
-    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/x"));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, "other.example", "/x", &.{}));
+    try std.testing.expectEqual(@as(?u16, null), route(&routes, null, "/x", &.{}));
+}
+
+/// Whether some header satisfies the predicate. Name comparison is
+/// case-insensitive (RFC 9110); `equals`/`contains` compare the value
+/// byte-exact / by substring. Multiple headers of the same name each get
+/// a chance — the predicate holds if any does.
+pub fn headerMatches(header_match: HeaderMatch, headers: []const parser.Header) bool {
+    assert(header_match.name.len >= 1); // A validated RFC 9110 token.
+    assert(headers.len <= constants.headers_max);
+    for (headers) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, header_match.name)) {
+            continue;
+        }
+        switch (header_match.kind) {
+            .present => return true,
+            .equals => if (std.mem.eql(u8, header.value, header_match.value)) return true,
+            // Config rejects an empty `contains` needle, so this is a real
+            // substring test — never the always-true `indexOf(x, "")`.
+            .contains => {
+                assert(header_match.value.len >= 1);
+                if (std.mem.indexOf(u8, header.value, header_match.value) != null) return true;
+            },
+        }
+    }
+    return false;
+}
+
+test "router: a header route is the narrower rule within its host group" {
+    // The #302 order, as config.zig sorts it: host, then header, then
+    // prefix. The canary rule and the rule it is a variant of share a
+    // host and a prefix, so only the header tier can separate them —
+    // and it must put the canary first, or a pinned client would never
+    // reach it.
+    const canary: HeaderMatch = .{ .name = "X-Canary", .kind = .present, .value = "" };
+    const routes = [_]Route{
+        .{ .host = "api.example.com", .header = canary, .prefix = "/", .cluster_index = 3 },
+        .{ .host = "api.example.com", .prefix = "/", .cluster_index = 2 },
+        .{ .header = canary, .prefix = "/", .cluster_index = 1 },
+        .{ .prefix = "/", .cluster_index = 0 },
+    };
+    const pinned = [_]parser.Header{parser.Header.init("x-canary", "1")};
+    const plain: []const parser.Header = &.{};
+
+    // Host beats header: a pinned request for the named host takes that
+    // host's canary, not the any-host one.
+    try std.testing.expectEqual(@as(?u16, 3), route(&routes, "api.example.com", "/", &pinned));
+    // Header beats bare within a host group.
+    try std.testing.expectEqual(@as(?u16, 2), route(&routes, "api.example.com", "/", plain));
+    // And the any-host group repeats the rule one tier down.
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, "other.example.com", "/", &pinned));
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, "other.example.com", "/", plain));
+}
+
+test "router: the three dimensions are a conjunction, not a ranking" {
+    // A route states what must hold, and every stated key must hold. A
+    // request matching the header but not the prefix falls through to
+    // whatever does — it does not "win" on the strength of the header.
+    const routes = [_]Route{
+        .{
+            .header = .{ .name = "X-Canary", .kind = .equals, .value = "v2" },
+            .prefix = "/api",
+            .cluster_index = 1,
+        },
+        .{ .prefix = "/", .cluster_index = 0 },
+    };
+    const v2 = [_]parser.Header{parser.Header.init("X-Canary", "v2")};
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/api/x", &v2));
+    // Right header, wrong path.
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/other", &v2));
+    // Right path, wrong value.
+    const v1 = [_]parser.Header{parser.Header.init("X-Canary", "v1")};
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/api/x", &v1));
+    // Right path, header absent.
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/api/x", &.{}));
+}
+
+test "router: a header name matches case-insensitively, a value does not" {
+    // RFC 9110's rule for names; a value is bytes the client chose and is
+    // compared as such — the same split `filters` have always used, now
+    // through the same evaluator.
+    const routes = [_]Route{
+        .{
+            .header = .{ .name = "X-Canary", .kind = .equals, .value = "Yes" },
+            .prefix = "/",
+            .cluster_index = 1,
+        },
+        .{ .prefix = "/", .cluster_index = 0 },
+    };
+    const lower_name = [_]parser.Header{parser.Header.init("x-canary", "Yes")};
+    try std.testing.expectEqual(@as(?u16, 1), route(&routes, null, "/", &lower_name));
+    const lower_value = [_]parser.Header{parser.Header.init("X-Canary", "yes")};
+    try std.testing.expectEqual(@as(?u16, 0), route(&routes, null, "/", &lower_value));
 }


### PR DESCRIPTION
Closes #302.

Endpoint weights (#174) already cover the **probabilistic** canary — put
the new version's endpoints in the same cluster at low weight and every
pick policy honours it. What they cannot express is the **pinned** case: a
specific client, a test account, an internal gateway's header. §7
deliberately refused to make cluster selection a filter action (*"one
precedence rule, not two engines competing"*), which left that shape with
no expression at all.

```json
"routes": [
    { "header": { "name": "X-Canary", "present": true },
      "prefix": "/", "cluster": "next" },
    { "prefix": "/", "cluster": "stable" }
]
```

```
no header     -> STABLE
X-Canary: 1   -> NEXT
x-canary: any -> NEXT      (RFC 9110: names are case-insensitive)
```

A third dimension on the one table, not a second engine. The three keys
are a **conjunction** — every key a route states must hold — which is how
Envoy's `RouteMatch` composes its own.

## The precedence question, and what the peers actually do

The issue called this its central question: *host → header → prefix*, or
*header → host → prefix*? The answer turned out to be that **no peer
proxy makes this decision at all.**

| proxy | how it picks between matching routes |
|---|---|
| Envoy | routes within a `virtual_host` in **config order** — *"The first route that matches will be used"* |
| HAProxy | `use_backend … if <acl>` in **declaration order**, first match wins |
| Traefik | explicit `priority`, defaulting to **rule length** |
| nginx | headers are not a routing dimension at all — `map` + a variable |

Where a specificity *ranking* exists it is always **within one
dimension** — Envoy's domain search order, nginx's `location`
precedence — never across two.

zoxy faces the question only because §7 **sorts** the table at load, which
is what makes an answer independent of the order an operator wrote the
rules in. Host outermost is then Envoy's own nesting, where a
`virtual_host` is chosen by domain and header matching happens on the
routes *inside* it — and it reads right for the case, since a canary is a
variant of a service rather than a different service.

That reasoning is recorded in DESIGN §7 rather than left as taste.

## The claim the review made honest

Order-independence is **not unconditional**, and I had asserted it in
three places before the review caught it.

Two routes sharing a host and a prefix while naming *different* headers
are distinct rules — not duplicates — of equal specificity, and a request
carrying both matches both. Something has to decide. Rejecting such
configs would forbid two header canaries on one prefix, which is
reasonable to want; so the earlier route wins, which is what every peer
does for *every* route, here narrowed to the one case the tiers cannot
separate.

The comparator now sorts an index permutation and says so **explicitly**,
rather than inheriting the behaviour from `std.mem.sort` happening to be
stable — a guarantee this table makes should belong to this table. A test
pins it from three spellings of one route set, and the docs say it.

## Two kinds of predicate, not three

`equals` is one `mem.eql` on a zero-copy head slice; `present` is one
lookup. `contains` is a scan whose cost grows with what a client sent, on
a table every request walks — §7 draws the line where a route dimension
would become the second match engine, and a substring test is the near
side of it. It is **absent from the route DTO** rather than rejected by a
rule, so the strict parser refuses it structurally.

## One move, one thing checked rather than assumed

`HeaderMatch` and its evaluator move from `filter.zig` to `router.zig`,
which `filter` already imports: two matchers judging one header must judge
it identically, and that is the argument that already made
`prefixMatches` public for filters to share. `filter.HeaderMatch` aliases
it.

I had assumed a proxy-managed name like `Content-Length` would be rejected
for a route, and wrote a test asserting that. **It isn't** — the reserved
check applies only to filter *edit* targets, because rewriting one
smuggles a framing change past the render. Reading one to pick a backend
changes nothing, and routing runs before any edit. The test is inverted to
pin that consistency, and the doc comment that had claimed otherwise is
fixed.

## Also worth knowing

A request that gains or loses the header **moves to a different cluster**,
so a `hash` pick still holds within each cluster but not across the
change — "sticky" and "canary" together is exactly where that surprises
people. And the header is a routing key *and* is forwarded, so the origin
can log which side of the cut served it. Both are in the docs.

`zig build ci` and `zig fmt --check` pass (593 unit tests, 4096 sim seeds,
both smoke runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)