### PR TITLE
metrics: answer Errors and Duration, not only Rate (#299)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2016,6 +2016,34 @@ origin, not one this proxy can pick for them.
   clusters x endpoints (#179), reaching 1.6 MB, which a blocking write on
   a slow stderr pipe turned into a parked loop. The drain's exit tally
   survives both objections: once per process, after `run` has returned.
+- **The exposition answers Rate, Errors and Duration** (#299). Of the RED
+  triad a scrape could answer Rate thoroughly and Errors only about
+  *zoxy* — every proxy-generated status had a counter and the origin's
+  own had none, so a backend returning `500` to every request was
+  invisible to metrics and visible only in the access log. Duration had
+  no answer at all. `cluster_responses{class}` and a
+  `cluster_duration_seconds` histogram close both.
+
+  Labelled by cluster rather than endpoint, which is a measured trade
+  rather than a taste: the per-endpoint families are the term that grows
+  (5 MB of exposition at 4096 endpoints, against ~22 KB for these two at
+  sixteen clusters), and per-endpoint `5xx` is already observed by
+  passive ejection (#230). Buckets are compiled in — eighteen boundaries
+  at a steady 2.5x from 25 us to 10 s — so every deployment's histogram
+  is comparable, the render bound stays a closed form of the cluster
+  count, and a ladder that suits one deployment badly still yields an
+  exact mean through `_sum`/`_count`.
+
+  Observed at `finishExchange` and nowhere else: that is where the
+  response has reached the client in full, where `l7_responses` is
+  incremented and where `ok` is earned, so `_count` equals the responses
+  it measures **by construction** — an identity `reconciles` asserts on
+  every seed rather than a convention. Only completed exchanges are
+  observed, so p99 measures service rather than teardown; an aborted one
+  is still witnessed by its outcome. The request's start is stamped
+  whether or not an access log is configured, which it previously was
+  not — a histogram that stopped when logging was off would have been
+  worse than none.
 - **The exposition says which backend, not only how many** (#179,
   settled 2026-08-02). Beside the process totals, labeled families:
   per-endpoint counters for dial failures, responses served and health

--- a/docs/README.md
+++ b/docs/README.md
@@ -1231,6 +1231,48 @@ re-derives from a live scrape. Label cardinality is bounded by your
 config — endpoints and cluster names, never request data — and the
 startup banner prices what the labels and their render buffers cost.
 
+#### Rate, Errors, Duration
+
+Two families answer the halves of the RED triad a scrape could not:
+
+```text
+zoxy_cluster_responses{cluster="api",class="2xx"} 4182
+zoxy_cluster_responses{cluster="api",class="5xx"} 17
+zoxy_cluster_duration_seconds_bucket{cluster="api",le="0.005000000"} 3910
+zoxy_cluster_duration_seconds_bucket{cluster="api",le="+Inf"} 4199
+zoxy_cluster_duration_seconds_sum{cluster="api"} 12.884901888
+zoxy_cluster_duration_seconds_count{cluster="api"} 4199
+```
+
+**Errors** used to mean zoxy's own. Every status the proxy *generates* had
+a counter — the whole `shed_` ladder, `l7_bad_gateway`, `l7_gateway_timeout`
+— while an origin returning `500` to every request was invisible to a
+scrape and showed up only in the access log. `cluster_responses` closes
+that: it is the status the client actually received, classed.
+
+**Duration** had no answer at all — no p50, no p99, nothing to alert on.
+`cluster_duration_seconds` is a standard Prometheus histogram, so
+`histogram_quantile` works on it directly.
+
+Both are labelled by **cluster**, not endpoint, and that is a deliberate
+trade: the per-endpoint families are what make a large deployment's
+exposition large, and per-endpoint `5xx` is already watched — [passive
+ejection](#detecting-a-dead-backend-from-real-traffic) acts on it and
+counts what it ejected. Cluster is the granularity that answers "which
+backend got slow" without multiplying the axis that already dominates.
+
+The bucket ladder is compiled in — eighteen boundaries, a steady 2.5×
+apart from 25 µs to 10 s — so every zoxy's histogram is directly
+comparable to every other's, and `_sum`/`_count` give an exact mean
+whatever the buckets do.
+
+Only **completed** exchanges are observed: an exchange the client cut off
+mid-response is not in the histogram, so p99 measures how long serving
+takes rather than how long clients wait before giving up. Those are still
+visible — as `outcome: aborted` in the access log. `_count` therefore
+equals `zoxy_l7_responses` exactly, an identity the simulator asserts on
+every seed.
+
 ### Access log
 
 One JSON object per line — one per HTTP exchange (rejects, `503` sheds and

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -3337,8 +3337,16 @@ pub fn Server(comptime IoType: type) type {
         /// first head byte lands — which is when the request begins, not
         /// when its head finishes parsing, so a slowloris's line reports
         /// the whole time it spent dribbling.
-        pub fn beginLogRequest(server: *Self, conn: *ConnType) void {
-            if (server.access_log.sink == null) return;
+        ///
+        /// Stamped whether or not an access log is configured, and that
+        /// is #299's doing: the §8 latency histogram measures the same
+        /// interval this starts, so gating the stamp on a sink would have
+        /// left every deployment without an access log — the default —
+        /// reporting no latency at all, or worse, a duration measured
+        /// from zero. The cost is one `CLOCK_REALTIME` read per request
+        /// where there was none: a vDSO call, against the ~25 us of loop
+        /// time a request already costs at the Tier-1 band.
+        pub fn beginRequest(server: *Self, conn: *ConnType) void {
             if (conn.stream.log.started_wall_ns != 0) return;
             conn.stream.log.started_wall_ns = server.io.nowWallNs();
             assert(conn.stream.log.started_wall_ns != 0);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -150,6 +150,59 @@ pub const relay_buffer_bytes_max: u32 = 16 * 1024;
 /// the TLVs real senders append (AWS NLB's VPCE id); v1 bounds itself at
 /// 107. Must fit the relay buffer, where the receive phase stages the
 /// header and whatever payload arrived coalesced behind it.
+/// The §8 latency histogram's bucket ladder (#299), in nanoseconds, as
+/// `le` upper bounds. Compiled in rather than configured: every zoxy's
+/// p99 is then directly comparable to every other's, the exposition's
+/// closed form stays a function of the cluster count alone, and a ladder
+/// is not the kind of thing a deployment should have to get right before
+/// it can see its own latency.
+///
+/// Chosen against what this proxy actually measures rather than against a
+/// library default. The Tier-1 band settles at p50 ~43 us, so the ladder
+/// has to resolve tens of microseconds at the bottom or every request
+/// lands in one bucket; the top end reaches ten seconds because a request
+/// that slow is the one an operator is looking for. Eighteen boundaries,
+/// a steady 2.5x apart the whole way — the step stays constant to the top
+/// on purpose, because the decade between 100ms and 1s is exactly where
+/// "slow" lives and a ladder that coarsens there answers worst where it
+/// is asked most. Each boundary is one row per cluster, which is what
+/// keeps the density affordable.
+///
+/// A ladder that turns out wrong for a deployment costs a recompile, and
+/// the `_sum`/`_count` pair reports an exact mean whatever the buckets
+/// do — so this is the cheap thing to get approximately right, not the
+/// expensive thing to get exactly right.
+pub const duration_buckets_ns = [_]u64{
+    25_000, // 25us
+    50_000,
+    100_000,
+    250_000,
+    500_000,
+    1_000_000, // 1ms
+    2_500_000,
+    5_000_000,
+    10_000_000,
+    25_000_000,
+    50_000_000,
+    100_000_000, // 100ms
+    250_000_000,
+    500_000_000,
+    1_000_000_000, // 1s
+    2_500_000_000,
+    5_000_000_000,
+    10_000_000_000, // 10s
+};
+
+comptime {
+    // Ascending and distinct: the render emits cumulative counts in this
+    // order, and a ladder out of order would publish a histogram whose
+    // buckets shrink as `le` grows.
+    for (duration_buckets_ns[1..], duration_buckets_ns[0 .. duration_buckets_ns.len - 1]) |next, previous| {
+        assert(next > previous);
+    }
+    assert(duration_buckets_ns.len >= 2);
+}
+
 pub const proxy_header_bytes_max: u32 = 512;
 
 /// The most of a client's opening bytes an `l4` listener with SNI routes

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -965,6 +965,30 @@ pub const Labeled = struct {
     /// *no* endpoint could be picked, so a per-endpoint label would be an
     /// invention — the cluster is everything the witness knows.
     l7_shed_inflight: []Value,
+    /// Responses by status class, per cluster (#299): `clusters x
+    /// StatusClass.count`, indexed `cluster * count + class`. The gap
+    /// this closes is that an origin returning 500 to every request was
+    /// invisible to a scrape — every proxy-generated status had a
+    /// counter, and the origin's own had none.
+    ///
+    /// Per cluster rather than per endpoint, and that is a measured
+    /// choice: the per-endpoint families are what make a large
+    /// deployment's exposition large (5 MB at 4096 endpoints), and
+    /// per-endpoint 5xx is already observed — passive ejection (#230)
+    /// ejects on it and counts what it ejected.
+    cluster_responses: []Value,
+    /// The §8 latency histogram, per cluster (#299): `clusters x
+    /// (buckets + 1)`, indexed `cluster * stride + bucket`, with the
+    /// final slot the `+Inf` overflow. Counts are per bucket, not
+    /// cumulative — the render accumulates, so an observation is one
+    /// atomic add rather than a walk.
+    cluster_duration_buckets: []Value,
+    /// Nanoseconds observed and observations made, per cluster: the
+    /// `_sum` and `_count` a Prometheus histogram owes. `_count` equals
+    /// this cluster's completed exchanges by construction — both are
+    /// written at `finishExchange` — which `reconciles` asserts.
+    cluster_duration_sum_ns: []Value,
+    cluster_duration_count: []Value,
     l4_shed_inflight: []Value,
     /// Exact byte bound on one `render` of this config — the runtime
     /// sibling of `Counters.render_bytes_max`, tight the same way, and
@@ -1011,6 +1035,51 @@ pub const Labeled = struct {
         }
     };
 
+    /// The status classes a response is bucketed into (#299). Closed and
+    /// small on purpose: `passive_ejection` already reasons in classes
+    /// (`status_class` in its config), so this is an observation zoxy
+    /// makes turned into one an operator can alert on, not a new
+    /// vocabulary. A status below 100 or above 599 cannot reach here —
+    /// the parser refuses it — so there is no "other" arm to render.
+    pub const StatusClass = enum(u8) {
+        informational,
+        success,
+        redirection,
+        client_error,
+        server_error,
+
+        pub const count = @typeInfo(StatusClass).@"enum".fields.len;
+
+        /// The `class` label's value, which is Prometheus convention and
+        /// the same spelling `passive_ejection`'s config accepts.
+        fn label(class: StatusClass) []const u8 {
+            return switch (class) {
+                .informational => "1xx",
+                .success => "2xx",
+                .redirection => "3xx",
+                .client_error => "4xx",
+                .server_error => "5xx",
+            };
+        }
+
+        pub fn of(status: u16) StatusClass {
+            assert(status >= 100);
+            assert(status <= 599);
+            return switch (status / 100) {
+                1 => .informational,
+                2 => .success,
+                3 => .redirection,
+                4 => .client_error,
+                5 => .server_error,
+                else => unreachable, // The asserts above bound the divide.
+            };
+        }
+    };
+
+    /// Buckets plus the `+Inf` overflow every Prometheus histogram ends
+    /// with — the stride of one cluster's row in `cluster_duration_buckets`.
+    pub const duration_bucket_count = constants.duration_buckets_ns.len + 1;
+
     pub const ClusterFamily = enum {
         l7_shed_inflight,
         l4_shed_inflight,
@@ -1052,6 +1121,12 @@ pub const Labeled = struct {
         labeled.health_down = try allocValues(arena, keys.count);
         labeled.health_up = try allocValues(arena, keys.count);
         labeled.l7_shed_inflight = try allocValues(arena, cluster_count);
+        labeled.cluster_responses =
+            try allocValues(arena, cluster_count * StatusClass.count);
+        labeled.cluster_duration_buckets =
+            try allocValues(arena, cluster_count * duration_bucket_count);
+        labeled.cluster_duration_sum_ns = try allocValues(arena, cluster_count);
+        labeled.cluster_duration_count = try allocValues(arena, cluster_count);
         labeled.l4_shed_inflight = try allocValues(arena, cluster_count);
         // Holes stay empty — the one answer to "what did init leave
         // here", and the tripwire `incrementEndpoint` asserts against.
@@ -1077,6 +1152,41 @@ pub const Labeled = struct {
         const values = try arena.alloc(Value, count);
         for (values) |*value| value.* = Value.init(0);
         return values;
+    }
+
+    /// What `,class="5xx"` adds to a cluster label, minus the `}` the
+    /// splice replaces. Every class token is three bytes, so this is
+    /// exact rather than a bound.
+    const class_suffix_bytes = ",class=\"5xx\"}".len - "}".len;
+
+    comptime {
+        // The constant above reads one class token's width off a literal,
+        // which is only sound while every token is that width. Tied to
+        // the labels themselves rather than left as a coincidence: a
+        // class spelled differently would otherwise shrink the render
+        // bound with nothing to say so.
+        for (std.enums.values(StatusClass)) |class| {
+            assert(class.label().len == "5xx".len);
+        }
+    }
+
+    /// The widest `_sum`: nanoseconds rendered as seconds, so the integer
+    /// part is bounded by `maxInt(u64) / 1e9` — eleven digits, not the
+    /// twenty a bare u64 would take — plus the point and nine fractional
+    /// digits.
+    const sum_digits_max = std.fmt.count("{d}.{d:0>9}", .{
+        std.math.maxInt(u64) / std.time.ns_per_s,
+        std.math.maxInt(u64) % std.time.ns_per_s,
+    });
+
+    /// What `,le="<bound>"` adds to a cluster label, for one bound. The
+    /// render writes seconds as `{d}.{d:0>9}` from the ladder's integer
+    /// nanoseconds, so this counts the same thing the same way.
+    fn leSuffixBytes(comptime bound: u64) usize {
+        return ",le=\"\"}".len - "}".len + std.fmt.count("{d}.{d:0>9}", .{
+            bound / std.time.ns_per_s,
+            bound % std.time.ns_per_s,
+        });
     }
 
     /// Widest rendered endpoint literal: a bracketed IPv6 address with
@@ -1160,6 +1270,13 @@ pub const Labeled = struct {
         total += cluster_count * @sizeOf(bool); // cluster_checked
         total += 4 * @as(u64, keys.count) * @sizeOf(Value); // endpoint families
         total += 2 * cluster_count * @sizeOf(Value); // cluster families
+        // #299's four tables, priced here because `init` allocates them:
+        // §5's promise is that the printed total covers everything this
+        // process holds, and a table the banner does not know about is
+        // the one way that stops being true.
+        total += cluster_count * StatusClass.count * @sizeOf(Value);
+        total += cluster_count * duration_bucket_count * @sizeOf(Value);
+        total += 2 * cluster_count * @sizeOf(Value); // duration sum + count
         var scratch: [label_scratch_bytes]u8 = undefined;
         for (config.clusters) |*cluster| {
             total += renderClusterLabel(&scratch, cluster.name).len;
@@ -1201,6 +1318,56 @@ pub const Labeled = struct {
         assert(previous < std.math.maxInt(u64));
     }
 
+    /// Record one completed exchange (#299): its status class and how
+    /// long it took, both against the cluster that served it.
+    ///
+    /// One call rather than two because they are one event — the site
+    /// that has a status has the duration, and splitting them invites a
+    /// caller that reports half of it. `_count` therefore equals the
+    /// cluster's completed exchanges by construction, which is the
+    /// identity `reconciles` asserts rather than hopes for.
+    pub fn observeExchange(
+        labeled: *Labeled,
+        cluster_index: u16,
+        status: u16,
+        duration_ns: u64,
+    ) void {
+        assert(cluster_index < labeled.cluster_labels.len);
+        assert(status >= 100);
+        assert(status <= 599);
+        const class = StatusClass.of(status);
+        const class_at = @as(usize, cluster_index) * StatusClass.count + @intFromEnum(class);
+        assert(class_at < labeled.cluster_responses.len);
+        const class_previous = labeled.cluster_responses[class_at].fetchAdd(1, .monotonic);
+        assert(class_previous < std.math.maxInt(u64));
+
+        // The first bound this duration does not exceed, or the `+Inf`
+        // slot past the ladder's end. A linear walk over the ladder's
+        // eighteen comptime-known bounds, on a path that runs once per
+        // exchange — a binary search over eighteen entries would trade a
+        // predictable scan for a branch pattern, on no measurement.
+        var bucket: usize = constants.duration_buckets_ns.len;
+        for (constants.duration_buckets_ns, 0..) |bound, index| {
+            if (duration_ns <= bound) {
+                bucket = index;
+                break;
+            }
+        }
+        assert(bucket < duration_bucket_count);
+        const bucket_at = @as(usize, cluster_index) * duration_bucket_count + bucket;
+        assert(bucket_at < labeled.cluster_duration_buckets.len);
+        const bucket_previous = labeled.cluster_duration_buckets[bucket_at].fetchAdd(1, .monotonic);
+        assert(bucket_previous < std.math.maxInt(u64));
+        // The one counter here that does not add one: it takes a whole
+        // duration, so it is the only place in this file where the
+        // guard is about the *addend* as much as the total.
+        const sum_previous =
+            labeled.cluster_duration_sum_ns[cluster_index].fetchAdd(duration_ns, .monotonic);
+        assert(sum_previous <= std.math.maxInt(u64) - duration_ns);
+        const count_previous = labeled.cluster_duration_count[cluster_index].fetchAdd(1, .monotonic);
+        assert(count_previous < std.math.maxInt(u64));
+    }
+
     pub fn incrementCluster(
         labeled: *Labeled,
         comptime family: ClusterFamily,
@@ -1230,6 +1397,8 @@ pub const Labeled = struct {
         inline for (comptime std.enums.values(ClusterFamily)) |family| {
             labeled.renderClusterFamily(&writer, family);
         }
+        labeled.renderStatusClasses(&writer);
+        labeled.renderDuration(&writer);
         labeled.renderInflight(&writer, views);
         labeled.renderHealthy(&writer, views);
         const text = writer.buffered();
@@ -1283,6 +1452,90 @@ pub const Labeled = struct {
                 label,
                 value.load(.monotonic),
             }) catch unreachable;
+        }
+    }
+
+    /// Responses by class, per cluster (#299) — the half of the RED triad
+    /// a scrape could not answer, because every status this proxy
+    /// *generates* had a counter and the origin's own had none.
+    fn renderStatusClasses(labeled: *const Labeled, writer: *std.Io.Writer) void {
+        assert(labeled.cluster_responses.len ==
+            labeled.cluster_labels.len * StatusClass.count);
+        writer.print(
+            "# TYPE {s}cluster_responses counter\n",
+            .{metric_prefix},
+        ) catch unreachable;
+        for (labeled.cluster_labels, 0..) |label, cluster_index| {
+            inline for (comptime std.enums.values(StatusClass)) |class| {
+                const at = cluster_index * StatusClass.count + @intFromEnum(class);
+                // The label is rendered `{cluster="x"}`, so the class
+                // joins it by replacing the closing brace — one splice
+                // rather than a second label table to keep in step.
+                assert(label.len >= 2);
+                assert(label[label.len - 1] == '}');
+                writer.print("{s}cluster_responses{s},class=\"{s}\"}} {d}\n", .{
+                    metric_prefix,
+                    label[0 .. label.len - 1],
+                    comptime class.label(),
+                    labeled.cluster_responses[at].load(.monotonic),
+                }) catch unreachable;
+            }
+        }
+    }
+
+    /// The §8 latency histogram, per cluster (#299): the Duration half of
+    /// the RED triad, which a scrape could not answer at all.
+    ///
+    /// Buckets are stored per-bucket and accumulated here, because
+    /// Prometheus wants cumulative `le` counts and an observation should
+    /// be one atomic add rather than a walk over the ladder.
+    fn renderDuration(labeled: *const Labeled, writer: *std.Io.Writer) void {
+        assert(labeled.cluster_duration_buckets.len ==
+            labeled.cluster_labels.len * duration_bucket_count);
+        writer.print(
+            "# TYPE {s}cluster_duration_seconds histogram\n",
+            .{metric_prefix},
+        ) catch unreachable;
+        for (labeled.cluster_labels, 0..) |label, cluster_index| {
+            assert(label.len >= 2);
+            assert(label[label.len - 1] == '}');
+            const inner = label[0 .. label.len - 1];
+            var cumulative: u64 = 0;
+            const base = cluster_index * duration_bucket_count;
+            inline for (constants.duration_buckets_ns, 0..) |bound, index| {
+                cumulative += labeled.cluster_duration_buckets[base + index].load(.monotonic);
+                // Seconds, as Prometheus base units require, rendered from
+                // the integer nanoseconds the ladder is written in so the
+                // boundary text cannot drift from the comparison.
+                writer.print("{s}cluster_duration_seconds_bucket{s},le=\"{d}.{d:0>9}\"}} {d}\n", .{
+                    metric_prefix,
+                    inner,
+                    bound / std.time.ns_per_s,
+                    bound % std.time.ns_per_s,
+                    cumulative,
+                }) catch unreachable;
+            }
+            cumulative += labeled.cluster_duration_buckets[base + constants.duration_buckets_ns.len]
+                .load(.monotonic);
+            writer.print("{s}cluster_duration_seconds_bucket{s},le=\"+Inf\"}} {d}\n", .{
+                metric_prefix, inner, cumulative,
+            }) catch unreachable;
+            const sum_ns = labeled.cluster_duration_sum_ns[cluster_index].load(.monotonic);
+            writer.print("{s}cluster_duration_seconds_sum{s} {d}.{d:0>9}\n", .{
+                metric_prefix,
+                label,
+                sum_ns / std.time.ns_per_s,
+                sum_ns % std.time.ns_per_s,
+            }) catch unreachable;
+            writer.print("{s}cluster_duration_seconds_count{s} {d}\n", .{
+                metric_prefix,
+                label,
+                labeled.cluster_duration_count[cluster_index].load(.monotonic),
+            }) catch unreachable;
+            // The `+Inf` bucket is every observation, which is what
+            // `_count` reports — a histogram whose two disagreed would be
+            // rejected by a scraper rather than merely wrong.
+            assert(cumulative == labeled.cluster_duration_count[cluster_index].load(.monotonic));
         }
     }
 
@@ -1369,6 +1622,8 @@ pub const Labeled = struct {
             total += typeLineLen(family.name(), "counter");
         }
         total += typeLineLen("endpoint_inflight", "gauge");
+        total += typeLineLen("cluster_responses", "counter");
+        total += typeLineLen("cluster_duration_seconds", "histogram");
         var checked_clusters: usize = 0;
         var scratch: [label_scratch_bytes]u8 = undefined;
         for (config.clusters) |*cluster| {
@@ -1377,6 +1632,33 @@ pub const Labeled = struct {
             inline for (comptime std.enums.values(ClusterFamily)) |family| {
                 total += rowLen(family.name(), cluster_label_len, u64_digits_max);
             }
+            // #299's two families, priced exactly like the rest. The
+            // label widens by `,class="5xx"` or `,le="..."`, so each row
+            // is the cluster label plus that suffix — the reason the
+            // cardinality decision was to keep both per *cluster*: this
+            // whole block is multiplied by clusters, where the endpoint
+            // block below is multiplied by endpoints.
+            total += StatusClass.count *
+                rowLen("cluster_responses", cluster_label_len + class_suffix_bytes, u64_digits_max);
+            // Summed per bound rather than the widest times the count:
+            // the bound this file promises is *exactly reachable*, and a
+            // ladder whose short `le` values were priced as the longest
+            // would make it merely sufficient.
+            inline for (constants.duration_buckets_ns) |bound| {
+                total += rowLen(
+                    "cluster_duration_seconds_bucket",
+                    cluster_label_len + comptime leSuffixBytes(bound),
+                    u64_digits_max,
+                );
+            }
+            total += rowLen(
+                "cluster_duration_seconds_bucket",
+                cluster_label_len + ",le=\"+Inf\"}".len - "}".len,
+                u64_digits_max,
+            );
+            // `_sum` renders seconds with nine fractional digits.
+            total += rowLen("cluster_duration_seconds_sum", cluster_label_len, sum_digits_max);
+            total += rowLen("cluster_duration_seconds_count", cluster_label_len, u64_digits_max);
             if (cluster_checked) checked_clusters += 1;
             for (cluster.endpoints) |*address| {
                 const label_len =
@@ -1438,6 +1720,16 @@ pub const Labeled = struct {
             counters.get("l7_shed_endpoint_inflight"));
         assert(tableTotal(labeled.l4_shed_inflight) ==
             counters.get("l4_shed_endpoint_inflight"));
+        // #299's two families partition the same total, because both are
+        // written at `finishExchange` beside the `l7_responses` it
+        // increments — one observation per completed exchange, and every
+        // completed exchange observed. A histogram whose `_count` drifted
+        // from the responses it claims to measure would be worse than
+        // absent: it would read as a latency distribution over some other
+        // population.
+        assert(tableTotal(labeled.cluster_responses) == counters.get("l7_responses"));
+        assert(tableTotal(labeled.cluster_duration_count) == counters.get("l7_responses"));
+        assert(tableTotal(labeled.cluster_duration_buckets) == counters.get("l7_responses"));
     }
 };
 
@@ -1805,15 +2097,37 @@ test "counters: labeled render speaks the exposition dialect" {
     try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_healthy{cluster=\"api\",endpoint=\"10.0.0.1:8080\"} 1\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "zoxy_endpoint_healthy{cluster=\"solo\"") == null);
 
+    // #299's two families. The class joins the cluster label rather than
+    // replacing it, and every class renders even at zero — a scrape that
+    // saw 5xx appear only once it was non-zero could not alert on the
+    // transition.
+    labeled.observeExchange(0, 503, 3_000_000);
+    labeled.observeExchange(0, 200, 30_000);
+    const with_observations = labeled.render(&views, buffer);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "# TYPE zoxy_cluster_responses counter\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_responses{cluster=\"api\",class=\"5xx\"} 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_responses{cluster=\"api\",class=\"2xx\"} 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_responses{cluster=\"api\",class=\"4xx\"} 0\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_responses{cluster=\"solo\",class=\"2xx\"} 0\n") != null);
+    // The histogram is cumulative: the 30us observation is inside every
+    // bound, the 3ms one only from 5ms up.
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "# TYPE zoxy_cluster_duration_seconds histogram\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_duration_seconds_bucket{cluster=\"api\",le=\"0.000050000\"} 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_duration_seconds_bucket{cluster=\"api\",le=\"0.005000000\"} 2\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_duration_seconds_bucket{cluster=\"api\",le=\"+Inf\"} 2\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_duration_seconds_count{cluster=\"api\"} 2\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_observations, "zoxy_cluster_duration_seconds_sum{cluster=\"api\"} 0.003030000\n") != null);
+
     // One TYPE line per family: four endpoint counters, two cluster
-    // counters, the inflight gauge, and healthy (a checked cluster exists).
+    // counters, #299's status classes and histogram, the inflight gauge,
+    // and healthy (a checked cluster exists).
     var type_lines: usize = 0;
     var search: usize = 0;
     while (std.mem.indexOfPos(u8, text, search, "# TYPE ")) |at| {
         type_lines += 1;
         search = at + "# TYPE ".len;
     }
-    try std.testing.expectEqual(@as(usize, 9), type_lines);
+    try std.testing.expectEqual(@as(usize, 11), type_lines);
 }
 
 test "counters: labeled render bound is exact at the maximum values" {
@@ -1825,12 +2139,22 @@ test "counters: labeled render bound is exact at the maximum values" {
     try labeled.init(arena_state.allocator(), &config, labeled_test_keys);
 
     for ([_][]Counters.Value{
-        labeled.connect_failed,   labeled.responses,
-        labeled.no_response,      labeled.health_down,
-        labeled.health_up,        labeled.l7_shed_inflight,
-        labeled.l4_shed_inflight,
+        labeled.connect_failed,          labeled.responses,
+        labeled.no_response,             labeled.health_down,
+        labeled.health_up,               labeled.l7_shed_inflight,
+        labeled.l4_shed_inflight,        labeled.cluster_responses,
+        labeled.cluster_duration_sum_ns, labeled.cluster_duration_count,
     }) |table| {
         for (table) |*value| value.store(std.math.maxInt(u64), .monotonic);
+    }
+    // The histogram is the one table that cannot be saturated slot by
+    // slot: its rows render *cumulatively*, so a maximal reading is the
+    // first bucket holding everything and the rest holding nothing —
+    // every `le` row then reports the same maximum, which is exactly
+    // what the bound prices and the only way it can be reached.
+    for (labeled.cluster_duration_buckets, 0..) |*value, index| {
+        const first = index % Labeled.duration_bucket_count == 0;
+        value.store(if (first) std.math.maxInt(u64) else 0, .monotonic);
     }
     // The widest live view either owner can produce: both u16 tables
     // saturated (the inflight bound is their sum, not a u32's), and a
@@ -1894,10 +2218,17 @@ test "counters: the labeled families partition their process totals" {
     // one labeled cell. The sums then agree, whatever the distribution.
     counters.increment("upstream_connect_failed");
     labeled.incrementEndpoint(.connect_failed, labeled_test_keys.key(0, 0));
+    // A completed exchange moves three labeled views, not one: the
+    // endpoint that served it, and #299's class and duration against the
+    // cluster. `observeExchange` writes the last two together for exactly
+    // this reason — a caller that reported half an exchange would break
+    // the partition here rather than at a scrape nobody was reading.
     counters.increment("l7_responses");
     counters.increment("l7_responses");
     labeled.incrementEndpoint(.responses, labeled_test_keys.key(0, 1));
+    labeled.observeExchange(0, 200, 40_000);
     labeled.incrementEndpoint(.responses, labeled_test_keys.key(1, 0));
+    labeled.observeExchange(1, 503, 2_000_000_000);
     counters.increment("health_endpoint_down");
     labeled.incrementEndpoint(.health_down, labeled_test_keys.key(0, 0));
     counters.increment("l4_shed_endpoint_inflight");

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -169,7 +169,7 @@ pub fn Proxy(comptime IoType: type) type {
                     const capacity = headBytes(server, conn).len;
                     const pending = conn.tls_pending_len;
                     conn.tls_pending_len = 0;
-                    server.beginLogRequest(conn);
+                    server.beginRequest(conn);
                     // The handshake phase collects whatever the last
                     // flight carried without knowing what the protocol
                     // will make of it, so it can hold more than an L7
@@ -257,7 +257,7 @@ pub fn Proxy(comptime IoType: type) type {
                 // clock on the delivery opens a log entry for a request
                 // nobody made, which teardown then writes out as an
                 // aborted exchange with no method and no bytes.
-                server.beginLogRequest(conn);
+                server.beginRequest(conn);
                 conn.stream.log.bytes_in += head.appended;
             }
             if (conn.tls.?.peerClosed()) {
@@ -533,7 +533,7 @@ pub fn Proxy(comptime IoType: type) type {
             // would owe the log a line for a request nobody made. Nor at
             // the parse: a slowloris that dribbles for the whole head-read
             // deadline must report the time it spent doing it (§8).
-            server.beginLogRequest(conn);
+            server.beginRequest(conn);
             conn.stream.log.bytes_in += bound.len;
             fillHead(conn, bound.len, headBytes(server, conn).len);
             parseAndDispatch(server, conn);
@@ -3353,6 +3353,35 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.stream.upstream.?.cluster_index,
                 conn.stream.upstream.?.endpoint_index,
             );
+            // The §8 RED triad's other two answers (#299), taken here
+            // because this is where the exchange is *complete*: the
+            // status is known, the duration is final, and `l7_responses`
+            // is being incremented three lines up — so `_count` equals
+            // the responses it measures by construction rather than by
+            // agreement, which `reconciles` asserts.
+            //
+            // Deliberately not inside `logExchange`: that returns early
+            // when no access-log sink is configured, which is the
+            // default, and metrics that stopped when logging was off
+            // would be worse than metrics that were never added.
+            // Positively stated rather than guarded: `response_started`
+            // is asserted above, and the only site that sets it commits a
+            // status in the same breath — so a zero here is a regression
+            // upstream, and skipping the observation would hide it until
+            // `reconciles` noticed the histogram had drifted.
+            assert(conn.stream.log.status != 0);
+            {
+                server.labeled.observeExchange(
+                    conn.stream.upstream.?.cluster_index,
+                    conn.stream.log.status,
+                    // Saturating on `logExchange`'s reasoning: the wall
+                    // clock can step backwards under NTP, and a wrapped
+                    // duration would land every such exchange in the
+                    // `+Inf` bucket and add eighteen quintillion
+                    // nanoseconds to the sum.
+                    server.io.nowWallNs() -| conn.stream.log.started_wall_ns,
+                );
+            }
             // The whole response reached the client: the line goes out
             // now, before the turnaround below clears what it reports.
             // This is also the only place `ok` is earned — nothing between
@@ -3460,7 +3489,16 @@ pub fn Proxy(comptime IoType: type) type {
             // accounting resets with the rest of the per-request state
             // (§8). The captures are left in place: their lengths are what
             // gate every read, and this zeroes those.
-            assert(conn.stream.log.emitted or conn.stream.log.started_wall_ns == 0);
+            // Either the line went out, or there was no sink for it to go
+            // to, or nothing was asked of this connection. The middle arm
+            // is #299's: the request's start is stamped whether or not an
+            // access log is configured, because the §8 latency histogram
+            // measures that same interval — so "started" no longer
+            // implies "will be logged", and this assert used to read the
+            // two as one fact.
+            assert(conn.stream.log.emitted or
+                conn.server.access_log.sink == null or
+                conn.stream.log.started_wall_ns == 0);
             // The request's head buffer goes back to the ring before the
             // idle wait begins — an idle connection holds no head bytes
             // (§5). Conditional because the static-response path already


### PR DESCRIPTION
Closes #299.

Of the RED triad a scrape could answer **Rate** thoroughly, **Errors**
only about zoxy itself, and **Duration** not at all. Every status this
proxy *generates* had a counter — the whole `shed_` ladder,
`l7_bad_gateway`, `l7_gateway_timeout` — while an origin returning `500`
to every request was invisible to metrics and visible only in the access
log.

```text
zoxy_cluster_responses{cluster="app",class="2xx"} 4
zoxy_cluster_responses{cluster="app",class="5xx"} 1      ← the origin's 500
zoxy_cluster_duration_seconds_bucket{cluster="app",le="0.250000000"} 4
zoxy_cluster_duration_seconds_bucket{cluster="app",le="0.500000000"} 5
zoxy_cluster_duration_seconds_sum{cluster="app"} 0.301899833
zoxy_cluster_duration_seconds_count{cluster="app"} 5
```

Real `curl` traffic against a real origin, including a deliberate 300 ms
request. Standard Prometheus histogram, so `histogram_quantile` works
directly.

## The observation point is what makes the identity hold

The issue proposed hooking where the access log stamps its duration.
`finishExchange` is the right site: it is where the response has reached
the client in full, where `l7_responses` is incremented, and where `ok` is
earned. So `_count` equals the responses it claims to measure **by
construction**, and `reconciles` asserts that on every seed rather than
hoping for it.

It also matters that the log site is wrong for a second reason: it returns
early when no access-log sink is configured — the default — so metrics
would have silently stopped wherever logging was off.

## Cardinality: measured, not assumed

| config | endpoints | labeled metrics |
|---|---|---|
| 1 × 4 | 4 | 25 KB |
| 8 × 64 | 512 | 649 KB |
| 16 × 256 | 4096 | **5.06 MB** |

The per-endpoint families are the only term that grows. These two are
labelled by **cluster**, adding **73 KB at sixteen clusters — 1.45%**.
Per-endpoint `5xx` is already watched: passive ejection (#230) acts on it
and counts what it ejected. Cluster answers *"which backend got slow"*
without touching the axis that already dominates.

## Buckets

Eighteen boundaries, a steady 2.5× from 25 µs to 10 s, compiled in.

The step stays constant to the top **on purpose**. The first ladder I
wrote jumped 100 ms → 1 s → 10 s, and running it showed a 300 ms request
skipping straight past the decade where "slow" actually lives. Fixed
boundaries also keep every deployment's histogram comparable and the
render bound a closed form of the cluster count — and `_sum`/`_count`
give an exact mean whatever the buckets do.

## Two bugs this had to fix to work at all

**The start stamp was access-log-gated.** With logging off the duration
would have been `now - 0`: every exchange in `+Inf` and a sum of eighteen
quintillion nanoseconds.

**Making it unconditional then tripped a real invariant** —
`assert(emitted or started_wall_ns == 0)` in `beginNextRequest`, which had
quietly encoded "started implies logged". The assert did its job; the
invariant is restated with the third arm it now needs.

## What the arithmetic is mostly about

An existing test asserts the rendered exposition fills its buffer **to the
byte** — the bound must be exactly reachable, not merely sufficient. That
forced pricing each `le` row by its own bound's rendered width rather than
the widest, and capping `_sum` at nanoseconds-as-seconds (11+1+9 digits)
rather than a bare u64.

`tableBytes` grew with it too, so §5's promise that the startup banner
prices everything this process holds still covers the four new tables —
a gap the review caught after I extended the render bound but not the
memory one.

## Scope

Only **completed** exchanges are observed, so p99 measures how long
serving takes rather than how long a client waited before giving up; an
aborted exchange stays visible through its outcome. Separating upstream
time from total is a second histogram and a later, additive change.

`zig build ci` and `zig fmt --check` pass (586 unit tests, 4096 sim seeds,
both smoke runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)