### PR TITLE
l7: a listener may name why it refused, in Proxy-Status (#300)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1948,6 +1948,49 @@ origin, not one this proxy can pick for them.
   storm the date goes stale, never malformed. Every slot is stamped once
   at startup, where nothing is in flight by construction, so no response
   is ever the first user of an un-stamped one.
+- **A listener may make those responses name their cause** (#300, RFC
+  9209). The ambiguity the point above settles with `Server` is only
+  half-settled by it: `Server: zoxy` says *who* answered, not *why*, and
+  an operator reading a `503` still cannot tell the shed ladder from a
+  relayed origin failure without the access log. A `proxy_status`
+  listener adds a `Proxy-Status` field naming the cause from 9209's
+  registry, on the four rungs where the registry says something the
+  status line does not: no route matched → `destination_not_found` (the
+  origin was never asked), a §7 filter reject → `http_request_denied`
+  (this proxy's policy, not the origin's answer), any rung of the ladder
+  above → `connection_limit_reached` (they are one fact to a client:
+  zoxy is full), the request deadline → `http_response_timeout`.
+  The token is a function of the **rung, not the status**, and that is
+  the load-bearing choice: `filter.reject_statuses` includes `404`, so a
+  table indexed by status alone would have to answer a filter reject and
+  an empty routing table identically — the same three digits, opposite
+  causes, and the whole point of the field is telling them apart. The
+  rung is comptime at every `respond` call site (its counter name *is*
+  the identity, §9), so keying on it costs a template rather than a
+  branch, and a shed rung added later inherits its token from the
+  ladder's naming rule rather than from a table someone must remember.
+  The **silences are the design**. A `400`, `413`, `414` or `431` that is
+  the *request's own* fault gets no field: 9209's registry is written for
+  what goes wrong *upstream*, so its only fitting token restates the
+  status line, and a field that never distinguishes anything is worse
+  than an absent one. (A `400` a filter *chose* is a different rung and
+  does carry `http_request_denied` — which is the keying argument above,
+  seen from the other side.) `502` is skipped
+  for the opposite reason — a refused dial, a reset mid-response and a
+  malformed origin head are three distinct 9209 causes answered at one
+  call site, so any single token would be right by accident. `next-hop`
+  is never sent: it would publish backend topology to every client that
+  can provoke an error, and the endpoint is already in the access log.
+  Structurally this is a **second rendering of the same table**, not a
+  render path: the reachable (status, cause) pairs — seven of the
+  forty-eight the two vocabularies could form — × two persistences of
+  additional comptime templates and their stamped storage, selected at
+  the same lookup by the listener's flag and the call site's cause. Shedding still costs one send from server memory,
+  and §5's closed form grows by a bound the same comptime assert covers.
+  Off by default and per listener, on `forwarded`'s reasoning: the field
+  states which of *this proxy's* limits a caller hit, which is a
+  diagnostic inside a mesh and a capacity disclosure at an edge, and a
+  proxy cannot tell from the inside which it is behind.
 - **Those responses can carry a body, and bodies are a named table**
   (#159, settled 2026-08-03). `bodies` maps a name to bytes — a `file`
   read once at startup or an `inline` string, exactly one, plus the
@@ -2662,6 +2705,7 @@ is a trap rather than a synonym.
 | **9112** HTTP/1.1 | §3.2 target forms; §6.3 body length; §7 transfer codings and §7.1.2's trailer section; §9 connection management | §7 framing, §8 close announcement |
 | **6585** additional statuses | defines `429` and `431` — **9110 did not absorb these**, the registry still points here | §8's static set |
 | **8297** early hints | defines `103` | §7's interim relay (#232) |
+| **9209** `Proxy-Status` | defines the field and the error-token registry a proxy may name a cause from | §8's opt-in, with one deviation below |
 | **3986** URI syntax | §2.3 unreserved, §5.2.4 dot-segments | §7 canonical path |
 
 RFC 9111 (caching) binds only an implementation that caches, which §1
@@ -2700,6 +2744,16 @@ states what their authority does to the `Host` beside them — the missing
 one costs a response that used to be immutable, and `Max-Forwards`
 (§7.6.2) with #240, which §7 states beside the `TRACE` refusal that
 closed the other half of it.
+
+- **`destination_not_found` is sent with `404`, not the `500` RFC 9209
+  recommends** (§8, #300). The registry pairs that token with a
+  recommended status, and this proxy answers a different one on purpose:
+  "no route matched" means the request named something this gateway does
+  not serve, which is the client's answer and not an internal failure —
+  answering `500` would put a healthy proxy's routing table in every
+  origin-error dashboard downstream. The recommendation is advisory in
+  9209's own words; the token, which is the part a client parses, is
+  used exactly as registered.
 
 - **`Via` is not sent** (9110 §7.6.3, a MUST for intermediaries). The
   cost is real and worth naming: a request that loops through this proxy

--- a/docs/README.md
+++ b/docs/README.md
@@ -1416,6 +1416,82 @@ reopen also heals a sink that had broken: what broke was the fd the rotation
 just replaced. On a `stdout` sink, or with no log configured at all, `SIGHUP`
 is a no-op.
 
+### Telling a client zoxy refused (Proxy-Status)
+
+The access log answers *you*. This answers the client, and it exists
+because a proxy's refusal and an origin's are the same three digits: a
+`503` from an overloaded zoxy and a `503` from a healthy zoxy relaying an
+overloaded backend are indistinguishable on the wire, and only one of
+them is your problem. Setting `proxy_status` on an `http` listener makes
+the pages zoxy renders *itself* say so, in an RFC 9209 `Proxy-Status`
+field:
+
+```json
+{
+    "bind": "0.0.0.0:80",
+    "http": {
+        "cluster": "web",
+        "proxy_status": true
+    }
+}
+```
+
+```
+HTTP/1.1 503 Service Unavailable
+Content-Length: 0
+Date: Wed, 01 Jan 2020 00:00:00 GMT
+Server: zoxy
+Proxy-Status: zoxy; error=connection_limit_reached
+```
+
+Four causes carry a token, and only those four:
+
+| cause | status | `error=` |
+|---|---|---|
+| no route matched — zoxy never dialed a backend, so the origin was not asked about this path | `404` | `destination_not_found` |
+| a [filter](#filters) refused on policy — zoxy's rule, not the origin's answer | the status the rule names (`400`/`403`/`404`/`429`) | `http_request_denied` |
+| a zoxy limit, any rung of the shed ladder — slots, buffers, tunnels, per-endpoint in-flight | `503` | `connection_limit_reached` |
+| the backend was dialed and did not answer in time | `504` | `http_response_timeout` |
+
+The token names the **cause, not the status**, and the first two rows are
+why: a filter rejecting with `404` and an empty routing table answering
+`404` are the same three digits and different advice — one means "ask
+someone else", the other means "you were refused". A client reading only
+the status line cannot tell them apart, and that is the gap the field
+closes.
+
+Everything else is deliberately silent. A `400`, `413`, `414` or `431`
+that is the *request's* own fault gets nothing: 9209's only fitting token
+(`http_request_error`) restates the status line, and a field a client
+cannot act on is worse than no field. A `502` is skipped for the opposite
+reason — a refused dial, a reset mid-response and a malformed origin head
+are three different 9209 causes that zoxy answers at one place, so any
+single token would be right by accident. So a `Proxy-Status` from zoxy
+always carries something the status line didn't.
+
+Notes on what it does *not* do:
+
+- **No `next-hop`.** 9209 allows naming the backend; that publishes your
+  topology to every client that can provoke an error. The endpoint is in
+  the access log, where it belongs.
+- **An upstream proxy's field survives.** `Proxy-Status` is a List, and
+  zoxy sets it only on pages it renders itself — a relayed response
+  carries whatever the hop before it wrote, unedited, so a chain reads
+  back in order.
+- **Configured error pages win.** A status you gave a body for in
+  `error_pages` is sent exactly as you wrote it, header included or not
+  — your bytes are not edited.
+- **Forwarded responses are untouched.** Only pages zoxy renders itself
+  carry the field; an origin's own `503` is relayed as the origin wrote
+  it, which is precisely the distinction being drawn.
+
+> [!IMPORTANT]
+> Off by default, and per listener, on the same reasoning as
+> [`forwarded`](#telling-an-http-origin-x-forwarded-for): the field states
+> which of *this proxy's* limits a caller hit. Inside a mesh that is a
+> diagnostic; at an untrusted edge it is a capacity disclosure, and zoxy
+> cannot tell from the inside which side of that line a listener is on.
+
 ## Under load
 
 The defining behavior: **when a resource is exhausted, zoxy degrades the

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -388,6 +388,11 @@ pub fn Server(comptime IoType: type) type {
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
             forwarded: ?config_module.Config.Listener.Forwarded,
+            /// The listener's #300 opt-in: whether the pages this proxy
+            /// renders itself name why they refused. Per listener for the
+            /// same reason as `forwarded` — what may be said on the wire
+            /// depends on who is in front of this socket.
+            proxy_status: bool,
             /// The listener's PROXY protocol expectation (#142, null =
             /// first bytes are payload). Read at admission only — the
             /// receive phase is entered before the connection has any
@@ -1071,6 +1076,7 @@ pub fn Server(comptime IoType: type) type {
                     .request_filters = listener_config.request_filters,
                     .response_filters = listener_config.response_filters,
                     .forwarded = listener_config.forwarded,
+                    .proxy_status = listener_config.proxy_status,
                     .proxy_protocol = listener_config.proxy_protocol,
                     .protocol = listener_config.protocol,
                     .credentials = server.credentialsFor(index),
@@ -1898,6 +1904,7 @@ pub fn Server(comptime IoType: type) type {
             conn.upgrades = listener.upgrades;
             conn.max_body_bytes = listener.max_body_bytes;
             conn.forwarded = listener.forwarded;
+            conn.proxy_status = listener.proxy_status;
             // The exchange's starting cluster, from the same listener and
             // for the same reason as the tables above — the L7 path
             // overwrites it at routing once the head parses (§7).

--- a/src/config.zig
+++ b/src/config.zig
@@ -385,6 +385,13 @@ pub const Config = struct {
         /// listener applies to another byte of it, so which sockets may
         /// hand out that exemption is a property of the socket.
         upgrades: Upgrades = .{},
+        /// Whether refusals name their RFC 9209 cause on the wire
+        /// (#300). Per listener and off by default, on `forwarded`'s
+        /// reasoning: the header states which of *this proxy's* limits a
+        /// client hit, which is a diagnostic inside a mesh and a
+        /// disclosure at an edge — and a proxy cannot tell from the
+        /// inside which side of that line it is on.
+        proxy_status: bool = false,
         /// Cap on one request's body (#236), or `0` to accept any size.
         ///
         /// Per listener rather than in `limits`, and the distinction is
@@ -2018,6 +2025,9 @@ pub const HttpListenerJson = struct {
     /// Optional #236 request-body cap; absent means one MiB, `0` means
     /// no cap.
     max_body_bytes: ?u64 = null,
+    /// Whether this listener names *why* it refused, in an RFC 9209
+    /// `Proxy-Status` field (#300). Absent is off.
+    proxy_status: bool = false,
 
     pub const schema_doc =
         "An HTTP/1.1 listener's settings. Exactly one of `cluster` or " ++
@@ -2047,6 +2057,13 @@ pub const HttpListenerJson = struct {
                 "connection closes.",
             .minimum = 0,
             .maximum = constants.request_body_bytes_max,
+        },
+        .proxy_status = .{
+            .desc = "Name why this proxy refused a request, in an RFC 9209 " ++
+                "Proxy-Status field, so a client can tell a shed 503 from the " ++
+                "origin's own. Off by default: it states internal limits on " ++
+                "the wire, which an internal listener may want and an edge " ++
+                "one may not.",
         },
         .upgrades = .{
             .desc = "Protocol upgrades this listener will carry as tunnels; absent " ++
@@ -3479,6 +3496,7 @@ fn resolveHttpListener(
         .tls = tls,
         .upgrades = try resolveUpgrades(http_json.upgrades),
         .max_body_bytes = try resolveMaxBodyBytes(http_json.max_body_bytes),
+        .proxy_status = http_json.proxy_status,
     };
 }
 
@@ -7830,6 +7848,36 @@ test "config: max_inflight resolves, defaults to uncapped, rejects the useless" 
             parsed.clusters[0].max_inflight,
         );
     }
+}
+
+test "config: proxy_status is off unless asked for, and is http-only" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"";
+    const tail = "}}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // Absent means silent (#300): a config written before the feature
+    // must not start naming this proxy's limits on the wire.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ tail);
+        try std.testing.expect(!parsed.listeners[0].proxy_status);
+    }
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ ",\"proxy_status\":true" ++ tail);
+        try std.testing.expect(parsed.listeners[0].proxy_status);
+    }
+    // An l4 relay renders no HTTP response to put the field in, so the
+    // key does not exist there — the strict parser is the rule (#305).
+    try expectParseError(
+        error.UnknownField,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"l4\":{\"cluster\":\"a\"," ++
+            "\"proxy_status\":true}}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+    );
 }
 
 test "config: the forwarded block resolves a mode, and is http-only" {

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -3978,7 +3978,7 @@ pub fn Proxy(comptime IoType: type) type {
             const may_keep = comptime !std.mem.eql(u8, counter, "l7_shed_head_buffers");
             const keep = commitStaticVerdict(server, conn, status, counter, may_keep);
             conn.state = .l7_responding;
-            armStaticAnswer(server, conn, status, keep);
+            armStaticAnswer(server, conn, status, comptime shed.proxyStatusCauseFor(counter), keep);
         }
 
         /// Everything a static verdict does before its bytes are chosen:
@@ -4087,10 +4087,16 @@ pub fn Proxy(comptime IoType: type) type {
             server: *ServerType,
             conn: *ConnType,
             comptime status: u16,
+            comptime cause: shed.ProxyStatusCause,
             keep: bool,
         ) void {
             assert(conn.state == .l7_responding);
             assert(!conn.stream.l7.response_started);
+            // A rung that names a cause must have a page for it (#300).
+            // The failure this forbids is silent: a missing variant looks
+            // exactly like the listener never opting in, so the wrong
+            // half of the pair would be found by nobody.
+            comptime assert(cause == .none or shed.hasVariant(status, cause));
             // Keeping implies the head parsed (§7 resync), which is what
             // makes the HEAD decision below sound wherever it matters.
             if (keep) {
@@ -4100,7 +4106,7 @@ pub fn Proxy(comptime IoType: type) type {
                 return armPageWrite(server, conn, page, keep);
             }
             const persistence: shed.Persistence = if (keep) .keep else .close;
-            const answer = server.static_responses.get(status, persistence);
+            const answer = server.static_responses.get(status, cause, persistence, conn.proxy_status);
             // The `Date` this answer will carry (#234), written now
             // because now is when the server can still prove nothing is
             // reading these bytes — the claim taken below is what makes

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -654,6 +654,9 @@ const Http1Bed = struct {
         /// leaves `X-Forwarded-For` untouched, as every pre-existing
         /// scenario expects.
         forwarded: ?config_module.Config.Listener.Forwarded = null,
+        /// The #300 opt-in; off by default, so every pre-existing
+        /// scenario still asserts on pages with no `Proxy-Status`.
+        proxy_status: bool = false,
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
@@ -753,6 +756,7 @@ const Http1Bed = struct {
             .upgrades = options.upgrades,
             .max_body_bytes = options.max_body_bytes,
             .forwarded = options.forwarded,
+            .proxy_status = options.proxy_status,
             // Paths nothing reads: the bed embeds the PEMs, so what this
             // states is only that the listener terminates.
             .tls = if (options.tls)
@@ -1386,6 +1390,82 @@ test "l7: the origin sees the canonical path, query verbatim (§7)" {
     // Router and origin agree on the same canonical resource: /a/.. pops
     // to /, then /b/./c collapses to /b/c; the query rides along untouched.
     try std.testing.expectEqualStrings("/b/c?x=1%2F2", forwarded.target);
+    try bed.expectDrained();
+}
+
+test "l7: an opted-in listener names why it refused (#300)" {
+    // RFC 9209 exists for exactly the ambiguity §8 documents: this 404 is
+    // *this proxy* having no route, not the origin having no resource,
+    // and until the header the two were the same three digits. The origin
+    // is never dialed here, which is the fact the field states.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 13,
+        .route_prefix = "/api",
+        .proxy_status = true,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /elsewhere HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++ expected_date ++
+            "Proxy-Status: zoxy; error=destination_not_found\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 0), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: two 404s, two causes — the field says which (#300)" {
+    // The reason the token is keyed on the rung and not the status: a
+    // filter answering `404` and an empty routing table answering `404`
+    // are the same three digits, and a client acting on them differs —
+    // one is "ask someone else", the other is "you were refused".
+    const rules = [_]filter.Rule{.{
+        .match = .{ .path_prefix = "/api/private" },
+        .actions = &.{.{ .reject = 404 }},
+    }};
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 15,
+        .route_prefix = "/api",
+        .request_filters = &rules,
+        .proxy_status = true,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /api/private/x HTTP/1.1\r\nHost: o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++ expected_date ++
+            "Proxy-Status: zoxy; error=http_request_denied\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+    try std.testing.expectEqual(@as(u64, 0), bed.origin.requests_served);
+    try bed.expectDrained();
+}
+
+test "l7: the opt-in is silent where the registry has nothing to add" {
+    // A `400` is the request's own fault and 9209's only fitting token
+    // restates the status line. Emitting it would train a client to read
+    // a field that never distinguishes anything; this pins the silence,
+    // so a later "complete the table" cannot quietly undo the decision.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 14,
+        .proxy_status = true,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /one HTTP/1.1\r\nHost o\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n" ++ expected_date ++
+            "Connection: close\r\n\r\n",
+        bed.client.response(),
+    );
     try bed.expectDrained();
 }
 

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -122,6 +122,10 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's §7 client-address forwarding mode, same lifetime
         /// as `routes`; null leaves `X-Forwarded-For` untouched.
         forwarded: ?config_module.Config.Listener.Forwarded,
+        /// Whether this listener names an RFC 9209 cause on the refusals
+        /// it renders itself (#300), carried like the modes above so a
+        /// shed asks its own socket rather than the listener index.
+        proxy_status: bool,
         /// The endpoint this L4 connection is charged against in the
         /// server's per-endpoint in-flight table (§7), or `endpoint_none`
         /// when it is charged against none — every L7 connection, and
@@ -305,6 +309,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.max_body_bytes = 0;
             conn.requests_served = 0;
             conn.forwarded = null;
+            conn.proxy_status = false;
             conn.charged_endpoint = stream_module.LogState.endpoint_none;
             conn.charged_cluster = 0;
             conn.protocol = protocol;

--- a/src/shed.zig
+++ b/src/shed.zig
@@ -64,14 +64,28 @@ const Template = struct {
 /// copies it into writable memory at startup, and the arming path stamps
 /// the slot. The status set is closed in `reasonPhrase`: an unlisted
 /// status is a compile error.
-fn staticTemplate(comptime status: u16, comptime persistence: Persistence) Template {
+fn staticTemplate(
+    comptime status: u16,
+    comptime persistence: Persistence,
+    comptime cause: ProxyStatusCause,
+) Template {
     comptime assert(status >= 400);
     comptime assert(status <= 599);
     const prefix = comptime std.fmt.comptimePrint(
         "HTTP/1.1 {d} {s}\r\nContent-Length: 0\r\nDate: ",
         .{ status, reasonPhrase(status) },
     );
-    const suffix = "\r\n" ++ server_line ++ switch (persistence) {
+    // RFC 9209's answer to the thing §8 documents having: an origin's own
+    // `503` and this proxy's shed `503` are the same three digits and
+    // opposite events, and until now only the access log could tell them
+    // apart. Written only here, on a page this proxy renders itself — a
+    // relayed response keeps whatever the hop before it wrote (§7), so
+    // the List reads back as a chain rather than being overwritten.
+    const status_line = if (comptime causeToken(cause)) |token|
+        "Proxy-Status: " ++ proxy_status_identity ++ "; error=" ++ token ++ "\r\n"
+    else
+        "";
+    const suffix = "\r\n" ++ server_line ++ status_line ++ switch (persistence) {
         .keep => "",
         .close => "Connection: close\r\n",
     } ++ "\r\n";
@@ -79,6 +93,150 @@ fn staticTemplate(comptime status: u16, comptime persistence: Persistence) Templ
         .bytes = prefix ++ date_placeholder ++ suffix,
         .date_offset = prefix.len,
     };
+}
+
+/// What this proxy calls itself in a `Proxy-Status` field (#300). A
+/// bare token rather than a hostname: 9209 permits either, and a
+/// hostname would put deployment topology on the wire for every client
+/// — which is the same reason `next-hop` is deliberately not emitted.
+pub const proxy_status_identity = "zoxy";
+
+/// What a refusal is *about*, in the terms RFC 9209 registered (#300).
+///
+/// Keyed on the rung rather than on the status, because the two are
+/// different questions: a filter's `404` and an empty routing table's
+/// `404` are the same three digits and opposite causes, and a table
+/// indexed by status alone would have to answer one of them wrongly.
+/// The rung is comptime at every `respond` call site, so this costs a
+/// template rather than a branch.
+pub const ProxyStatusCause = enum {
+    /// Nothing 9209 says that the status line does not. Not an absence
+    /// of information — a decision, argued at `causeToken`.
+    none,
+    /// No route matched: this gateway does not serve what was named, and
+    /// the origin was never asked.
+    no_route,
+    /// A §7 filter refused on policy — this proxy's rule, not the
+    /// origin's answer.
+    denied,
+    /// Any rung of the §8 ladder: a limit of *this process* was reached.
+    limit,
+    /// The backend was dialed and did not answer inside the deadline.
+    timeout,
+};
+
+/// The registered token each cause is named by, or null where the
+/// registry has nothing to add.
+///
+/// The silences are the design. 9209's registry is written for what goes
+/// wrong *upstream*, and several of this proxy's rungs are request-side
+/// refusals: a `400`, `413`, `414` or `431` has no token but
+/// `http_request_error`, which says only "something about the request" —
+/// restating the status line in a field nobody can act on. A `502` is
+/// left out for the opposite reason: `l7_bad_gateway` answers a refused
+/// dial, a reset mid-leg and a malformed origin head at one call site,
+/// and 9209 has a distinct token for each, so any single one would be
+/// right by accident. So a `Proxy-Status` from zoxy always carries
+/// something the status line did not.
+fn causeToken(comptime cause: ProxyStatusCause) ?[]const u8 {
+    return switch (cause) {
+        .none => null,
+        // 9209 recommends `500` for this one and this proxy answers
+        // `404` — a deliberate deviation recorded in §12: the request
+        // named a resource this gateway does not serve, which is the
+        // client's answer rather than an internal error.
+        .no_route => "destination_not_found",
+        .denied => "http_request_denied",
+        // Every 503 rung is one fact to a client: zoxy is full, and the
+        // origin was never asked. Which pool ran out is the operator's
+        // question, and the access log and the counters answer it.
+        .limit => "connection_limit_reached",
+        .timeout => "http_response_timeout",
+    };
+}
+
+/// The cause a §8 rung refuses for, named by the rung's own counter —
+/// the identity `respond` already carries, so a call site cannot state a
+/// cause that disagrees with what it counted.
+///
+/// The shed ladder matches by prefix on purpose: every rung under it is
+/// a limit of this process by construction, so a rung added later is
+/// covered the day it is named rather than the day someone remembers
+/// this table.
+pub fn proxyStatusCauseFor(comptime rung: []const u8) ProxyStatusCause {
+    if (std.mem.startsWith(u8, rung, "l7_shed_")) return .limit;
+    if (std.mem.eql(u8, rung, "l7_no_route")) return .no_route;
+    if (std.mem.eql(u8, rung, "l7_filtered")) return .denied;
+    if (std.mem.eql(u8, rung, "l7_gateway_timeout")) return .timeout;
+    return .none;
+}
+
+/// One `Proxy-Status`-bearing page: a status and the cause it was
+/// refused for. A list of the pairs that actually occur rather than a
+/// second dimension on the table below — of twelve statuses and four
+/// causes, seven pairs are reachable, and the other forty-one would be
+/// slots nothing could ever select.
+const Variant = struct { status: u16, cause: ProxyStatusCause };
+
+const proxy_status_variants = [_]Variant{
+    .{ .status = 404, .cause = .no_route },
+    // The §7 filter reject vocabulary (`filter.reject_statuses`), each
+    // status carrying the same cause because the rung is the same one.
+    .{ .status = 400, .cause = .denied },
+    .{ .status = 403, .cause = .denied },
+    .{ .status = 404, .cause = .denied },
+    .{ .status = 429, .cause = .denied },
+    .{ .status = 503, .cause = .limit },
+    .{ .status = 504, .cause = .timeout },
+};
+
+comptime {
+    // Every variant must be a page this table can actually serve, and
+    // every one must say something: a variant for `.none` would be a
+    // byte-identical copy of the plain page, and a variant for a status
+    // outside the static set would be memory nothing selects.
+    for (proxy_status_variants) |variant| {
+        assert(causeToken(variant.cause) != null);
+        assert(staticStatusIndex(variant.status) != null);
+    }
+    // And the list must be a set: two rows for one pair would render the
+    // same page twice and leave `variantIndex` picking arbitrarily.
+    for (proxy_status_variants, 0..) |variant, index| {
+        for (proxy_status_variants[index + 1 ..]) |other| {
+            assert(variant.status != other.status or variant.cause != other.cause);
+        }
+    }
+}
+
+const proxy_status_templates: [proxy_status_variants.len][2]Template = blk: {
+    var table: [proxy_status_variants.len][2]Template = undefined;
+    for (proxy_status_variants, 0..) |variant, index| {
+        table[index] = .{
+            staticTemplate(variant.status, .keep, variant.cause),
+            staticTemplate(variant.status, .close, variant.cause),
+        };
+    }
+    const frozen = table;
+    break :blk frozen;
+};
+
+/// Whether a (status, cause) pair has a page to render — the check a
+/// caller makes at comptime so that naming a cause the table cannot
+/// serve is a compile error rather than a silent fall-back to the plain
+/// page, which would look exactly like the opt-in being off.
+pub fn hasVariant(comptime status: u16, comptime cause: ProxyStatusCause) bool {
+    return variantIndex(status, cause) != null;
+}
+
+/// Where one (status, cause) pair sits in the variant table, or null
+/// when the pair carries no field. Comptime-only: every caller knows
+/// both halves at the `respond` that raised them, so selecting a page
+/// costs nothing at runtime.
+fn variantIndex(comptime status: u16, comptime cause: ProxyStatusCause) ?usize {
+    for (proxy_status_variants, 0..) |variant, index| {
+        if (variant.status == status and variant.cause == cause) return index;
+    }
+    return null;
 }
 
 /// The `200` this proxy answers an `OPTIONS` with when it becomes the
@@ -117,7 +275,18 @@ pub const static_response_bytes_max: u32 = blk: {
     var widest: u32 = 0;
     for (static_statuses) |status| {
         for ([_]Persistence{ .keep, .close }) |persistence| {
-            const template = staticTemplate(status, persistence);
+            const template = staticTemplate(status, persistence, .none);
+            if (template.bytes.len > widest) {
+                widest = @intCast(template.bytes.len);
+            }
+        }
+    }
+    // The #300 variants share the slot width: a listener's flag chooses
+    // between two pages of the same status, so the slot must hold the
+    // wider one.
+    for (proxy_status_variants) |variant| {
+        for ([_]Persistence{ .keep, .close }) |persistence| {
+            const template = staticTemplate(variant.status, persistence, variant.cause);
             if (template.bytes.len > widest) {
                 widest = @intCast(template.bytes.len);
             }
@@ -146,21 +315,32 @@ comptime {
     // anything near it means a status grew a body it should not have.
     for (static_statuses) |status| {
         for ([_]Persistence{ .keep, .close }) |persistence| {
-            const template = staticTemplate(status, persistence);
+            const template = staticTemplate(status, persistence, .none);
+            assert(template.date_offset + date_bytes <= template.bytes.len);
+            assert(template.bytes.len <= static_response_bytes_max);
+        }
+    }
+    for (proxy_status_variants) |variant| {
+        for ([_]Persistence{ .keep, .close }) |persistence| {
+            const template = staticTemplate(variant.status, persistence, variant.cause);
             assert(template.date_offset + date_bytes <= template.bytes.len);
             assert(template.bytes.len <= static_response_bytes_max);
         }
     }
     assert(static_response_bytes_max > date_bytes);
-    assert(static_statuses.len * 2 * static_response_bytes_max <= 8 * 1024);
+    // The bound holds the shape it always did, widened by the rows #300
+    // adds — seven of the forty-eight (status, cause) pairs are
+    // reachable, which is why this is a `+` and not a multiplication.
+    assert((static_statuses.len + proxy_status_variants.len) * 2 *
+        static_response_bytes_max <= 12 * 1024);
 }
 
 const templates: [static_statuses.len][2]Template = blk: {
     var table: [static_statuses.len][2]Template = undefined;
     for (static_statuses, 0..) |status, index| {
         table[index] = .{
-            staticTemplate(status, .keep),
-            staticTemplate(status, .close),
+            staticTemplate(status, .keep, .none),
+            staticTemplate(status, .close, .none),
         };
     }
     const frozen = table;
@@ -192,11 +372,23 @@ pub const StaticTable = struct {
     /// it is the one static this proxy sends that is not a refusal, so it
     /// has no place in a table keyed by `static_statuses`.
     options: [2][static_response_bytes_max]u8,
+    /// The #300 variants: the same pages carrying an RFC 9209 error
+    /// token, for the three statuses that have one. Separate storage
+    /// rather than a dimension on `storage`, because nine of twelve
+    /// statuses would carry a slot nothing could ever select.
+    proxy_status_storage: [proxy_status_variants.len][2][static_response_bytes_max]u8,
 
     pub fn init(table: *StaticTable) void {
         for (&table.storage, 0..) |*variants, index| {
             for (variants, 0..) |*slot, persistence| {
                 const template = templates[index][persistence];
+                assert(template.bytes.len <= slot.len);
+                @memcpy(slot[0..template.bytes.len], template.bytes);
+            }
+        }
+        for (&table.proxy_status_storage, 0..) |*variants, index| {
+            for (variants, 0..) |*slot, persistence| {
+                const template = proxy_status_templates[index][persistence];
                 assert(template.bytes.len <= slot.len);
                 @memcpy(slot[0..template.bytes.len], template.bytes);
             }
@@ -222,9 +414,21 @@ pub const StaticTable = struct {
     /// Write `date` into every slot at once — what startup does, so no
     /// response can be the first user of an un-stamped one (#234).
     pub fn stampAll(table: *StaticTable, date: *const [date_bytes]u8) void {
-        for (static_statuses) |status| {
+        inline for (static_statuses) |status| {
             for ([_]Persistence{ .keep, .close }) |persistence| {
-                @memcpy(table.get(status, persistence).date, date);
+                @memcpy(table.get(status, .none, persistence, false).date, date);
+            }
+        }
+        // The #300 variants are separate storage, so "every slot" has to
+        // name them: a listener that opted in must not send the template
+        // date the first time it sheds. Walked through the storage rather
+        // than through `get`, because the pairs are the table's own shape
+        // and re-deriving them here is a second place to get it wrong.
+        for (&table.proxy_status_storage, 0..) |*variants, index| {
+            for (variants, 0..) |*slot, persistence| {
+                const template = proxy_status_templates[index][persistence];
+                assert(template.date_offset + date_bytes <= template.bytes.len);
+                @memcpy(slot[template.date_offset..][0..date_bytes], date);
             }
         }
         for ([_]Persistence{ .keep, .close }) |persistence| {
@@ -232,16 +436,38 @@ pub const StaticTable = struct {
         }
     }
 
-    /// The response for one verdict. `status` is a runtime value on the
-    /// filter-reject path, so membership is a lookup rather than a
-    /// comptime switch — but it is still the closed set, and a status
-    /// outside it is a caller that never consulted `isStaticStatus`.
+    /// The response for one verdict. `status` and `cause` are both
+    /// comptime, which the whole path can afford: every caller arrives
+    /// through `respond`, whose status and counter are comptime already,
+    /// so both lookups fold away and a status outside the closed set is
+    /// a compile error rather than a `null` unwrapped at runtime.
+    ///
+    /// `cause` is the rung that raised it (#300) and `proxy_status` the
+    /// listener's opt-in; both are needed, and only their conjunction
+    /// selects a variant — a listener that did not ask gets the plain
+    /// page, and so does a rung 9209 has no token for. That fall-back
+    /// is checkable rather than trusted: `hasVariant` lets the caller
+    /// assert at comptime that a named cause has a page, so a rung
+    /// cannot lose its token silently.
     pub fn get(
         table: *StaticTable,
-        status: u16,
+        comptime status: u16,
+        comptime cause: ProxyStatusCause,
         persistence: Persistence,
+        proxy_status: bool,
     ) StaticResponse {
-        const index = staticStatusIndex(status).?;
+        if (proxy_status) {
+            if (comptime variantIndex(status, cause)) |index| {
+                const template = proxy_status_templates[index][@intFromEnum(persistence)];
+                const slot = &table.proxy_status_storage[index][@intFromEnum(persistence)];
+                assert(template.date_offset + date_bytes <= template.bytes.len);
+                return .{
+                    .bytes = slot[0..template.bytes.len],
+                    .date = slot[template.date_offset..][0..date_bytes],
+                };
+            }
+        }
+        const index = comptime staticStatusIndex(status).?;
         const template = templates[index][@intFromEnum(persistence)];
         const slot = &table.storage[index][@intFromEnum(persistence)];
         assert(template.date_offset + date_bytes <= template.bytes.len);
@@ -422,6 +648,92 @@ pub fn closeQuietly(comptime IoType: type, io: *IoType, socket: IoType.Socket) v
     io.closeNow(socket);
 }
 
+test "shed: an opted-in listener names the cause it refused for" {
+    var table: StaticTable = undefined;
+    table.init();
+    // The variant is the same page with one field added, in the position
+    // 9209 asks for: after `Server`, before the terminator.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n" ++
+            "Proxy-Status: zoxy; error=connection_limit_reached\r\n" ++
+            "Connection: close\r\n\r\n",
+        table.get(503, .limit, .close, true).bytes,
+    );
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n" ++
+            "Proxy-Status: zoxy; error=http_response_timeout\r\n\r\n",
+        table.get(504, .timeout, .keep, true).bytes,
+    );
+    // The whole reason the table is keyed on the rung: one status, two
+    // causes, two different pages. A `404` from an empty routing table
+    // and a `404` a filter chose are indistinguishable by status.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n" ++
+            "Proxy-Status: zoxy; error=destination_not_found\r\n\r\n",
+        table.get(404, .no_route, .keep, true).bytes,
+    );
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n" ++
+            "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n" ++
+            "Proxy-Status: zoxy; error=http_request_denied\r\n\r\n",
+        table.get(404, .denied, .keep, true).bytes,
+    );
+    // A rung with no token ignores the opt-in rather than emitting an
+    // empty or a redundant field: a malformed head is the request's own
+    // fault and 9209 has nothing to add to the status line.
+    try std.testing.expectEqualStrings(
+        table.get(413, .none, .close, false).bytes,
+        table.get(413, .none, .close, true).bytes,
+    );
+    // The variants are separate storage, so the stamp has to reach them
+    // — a listener that opted in must not send the placeholder date.
+    table.stampAll("Sun, 06 Nov 1994 08:49:37 GMT");
+    try std.testing.expectEqualStrings(
+        "Sun, 06 Nov 1994 08:49:37 GMT",
+        table.get(404, .no_route, .keep, true).date,
+    );
+    // And that storage is its own: stamping the variant leaves the plain
+    // page alone, which is what says one listener cannot patch another's.
+    formatHttpDate(0, table.get(404, .no_route, .keep, true).date);
+    try std.testing.expectEqualStrings(
+        "Sun, 06 Nov 1994 08:49:37 GMT",
+        table.get(404, .none, .keep, false).date,
+    );
+}
+
+test "shed: every token this proxy emits is one the registry defines" {
+    // The set is closed and small, so it is checkable rather than
+    // asserted: a token invented here would be a field a client cannot
+    // interpret, which is worse than the header being absent.
+    const registry = [_][]const u8{
+        "destination_not_found",
+        "http_request_denied",
+        "connection_limit_reached",
+        "http_response_timeout",
+    };
+    var seen: usize = 0;
+    inline for (@typeInfo(ProxyStatusCause).@"enum".fields) |field| {
+        const cause: ProxyStatusCause = @enumFromInt(field.value);
+        const token = comptime causeToken(cause) orelse continue;
+        seen += 1;
+        var found = false;
+        for (registry) |entry| {
+            if (std.mem.eql(u8, entry, token)) found = true;
+        }
+        try std.testing.expect(found);
+    }
+    try std.testing.expectEqual(registry.len, seen);
+    // And every cause a rung can name has a variant to render it, or the
+    // opt-in would silently fall back to the plain page on that rung.
+    try std.testing.expectEqual(ProxyStatusCause.limit, proxyStatusCauseFor("l7_shed_tunnels"));
+    try std.testing.expectEqual(ProxyStatusCause.no_route, proxyStatusCauseFor("l7_no_route"));
+    try std.testing.expectEqual(ProxyStatusCause.denied, proxyStatusCauseFor("l7_filtered"));
+    try std.testing.expectEqual(ProxyStatusCause.none, proxyStatusCauseFor("l7_bad_gateway"));
+}
+
 test "shed: static responses are exact bytes with close announced" {
     var table: StaticTable = undefined;
     table.init();
@@ -430,25 +742,25 @@ test "shed: static responses are exact bytes with close announced" {
     try std.testing.expectEqualStrings(
         "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
             "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\nConnection: close\r\n\r\n",
-        table.get(503, .close).bytes,
+        table.get(503, .none, .close, false).bytes,
     );
     try std.testing.expectEqualStrings(
         "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
             "Date: " ++ date_placeholder ++ "\r\nServer: zoxy\r\n\r\n",
-        table.get(503, .keep).bytes,
+        table.get(503, .none, .keep, false).bytes,
     );
     // And a stamp lands in the response, not beside it: the slice the
     // send is handed changes under exactly those 29 bytes.
-    formatHttpDate(784_111_777, table.get(503, .keep).date);
+    formatHttpDate(784_111_777, table.get(503, .none, .keep, false).date);
     try std.testing.expectEqualStrings(
         "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n" ++
             "Date: Sun, 06 Nov 1994 08:49:37 GMT\r\nServer: zoxy\r\n\r\n",
-        table.get(503, .keep).bytes,
+        table.get(503, .none, .keep, false).bytes,
     );
     // Each entry owns its own slot: stamping one leaves the rest alone.
     try std.testing.expectEqualStrings(
         date_placeholder,
-        table.get(503, .close).date,
+        table.get(503, .none, .close, false).date,
     );
 }
 
@@ -538,8 +850,8 @@ test "shed: every static response parses as a valid bodiless head" {
     // than the placeholder's shape.
     inline for (static_statuses) |status| {
         inline for ([_]Persistence{ .keep, .close }) |persistence| {
-            formatHttpDate(1_577_836_800, table.get(status, persistence).date);
-            const bytes = table.get(status, persistence).bytes;
+            formatHttpDate(1_577_836_800, table.get(status, .none, persistence, false).date);
+            const bytes = table.get(status, .none, persistence, false).bytes;
             var storage: parser.HeaderStorage = undefined;
             const head = try parser.parseResponseHead(bytes, false, &storage, .get);
             try std.testing.expectEqual(status, head.status);


### PR DESCRIPTION
Closes #300.

§8 already documents the gap: an origin's own `503` and this proxy's shed `503` are the same three digits and opposite events, and only the access log could tell them apart — which answers the *operator*, not the client. RFC 9209 is the standards-track answer. `proxy_status: true` on an `http` listener makes the pages zoxy renders itself say why:

```
HTTP/1.1 503 Service Unavailable
Content-Length: 0
Date: Wed, 01 Jan 2020 00:00:00 GMT
Server: zoxy
Proxy-Status: zoxy; error=connection_limit_reached
```

## The token names the cause, not the status

This is the one place the implementation departs from the issue's table, and it is load-bearing. `filter.reject_statuses` includes `404`, so a table indexed by status alone has to answer a filter reject and an empty routing table identically — the same three digits, opposite advice ("you were refused" vs "ask someone else"), and telling them apart is the entire point of the field. The rung is comptime at every `respond` call site (its counter name *is* the identity, §9), so keying on it costs a template rather than a branch.

| cause | status | `error=` |
|---|---|---|
| no route matched | `404` | `destination_not_found` |
| a §7 filter reject | `400`/`403`/`404`/`429` | `http_request_denied` |
| any rung of the §8 ladder | `503` | `connection_limit_reached` |
| the request deadline | `504` | `http_response_timeout` |

## The silences are deliberate

- **`400`/`413`/`414`/`431` that are the request's own fault** get nothing. 9209's registry is written for what goes wrong *upstream*; its only fitting token (`http_request_error`) restates the status line, and a field a client cannot act on is worse than an absent one.
- **`502` is skipped** for the opposite reason: a refused dial, a reset mid-leg and a malformed origin head are three distinct 9209 causes answered at one call site, so any single token would be right by accident.
- **`next-hop` is never sent.** It publishes backend topology to every client that can provoke an error; the endpoint is already in the access log.

So a `Proxy-Status` from zoxy always carries something the status line did not.

## Structure

A second rendering of the same table, not a render path: the seven reachable `(status, cause)` pairs — of the forty-eight the two vocabularies could form — × two persistences, as comptime templates with their own stamped storage. `stampAll` names that storage, so #234's "no response is ever the first user of an un-stamped slot" still holds. A shed still costs one send from server memory, and the table's comptime size bound absorbs the growth (widest template ~164 B against a ~323 B slot).

`armStaticAnswer` carries `comptime assert(cause == .none or shed.hasVariant(status, cause))`. The failure it forbids is silent — a missing variant looks exactly like the listener never opting in. Verified it bites by mispairing a rung on purpose: `error: reached unreachable code`.

## Settled decisions

Off by default and **per listener**, on `forwarded`'s reasoning: the field states which of *this proxy's* limits a caller hit, which is a diagnostic inside a mesh and a capacity disclosure at an edge, and a proxy cannot tell from the inside which it is behind. Errors only. Configured `error_pages` win — your bytes are sent as you wrote them. Forwarded responses are untouched, which is precisely the distinction being drawn.

## §12

Gains the deviation this creates: `destination_not_found` is sent with `404` where 9209 *recommends* `500`. "No route matched" means the request named something this gateway does not serve — the client's answer, not an internal failure; answering `500` would put a healthy proxy's routing table in every origin-error dashboard downstream. The recommendation is advisory in 9209's own words; the token, which is the part a client parses, is used exactly as registered.

## Gates

`zig build ci` green (4096 sim seeds, both smoke runs), `zig fmt --check` clean. New coverage: two `shed.zig` unit tests (exact bytes per variant; every emitted token is one the registry defines, plus the rung→cause map), three directed `http_proxy_test.zig` scenarios (the no-route `404`, two `404`s with two causes, and the silence on a malformed `400`), and a config test for the flag's default and its `http`-only reach. `tiger-style-reviewer` run and its findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)