### PR TITLE
l7: a cluster endpoint may be a Unix socket (#303)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,15 +34,45 @@
     .dependencies = .{
         // Audited fork: zoxy-io/libxev branch zoxy-buffer-group = upstream
         // 9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf (the audited snapshot)
-        // plus five commits, each its own stacked PR:
+        // plus six commits, each its own stacked PR:
         //   c369817 expose io_uring setup flags through Options
         //   6bd950d expose the CQ depth (IORING_SETUP_CQSIZE) — the c10k
         //           lever
         //   b3d6b55 keep the raw errno on the Completion (zoxy-io/libxev#2)
         //   24da6d0 recv_group — provided-buffer receives (zoxy-io/libxev#3)
         //   fe5a07b leave readiness to the wait in submit (kqueue)
+        //   d3e0249 let connect address an AF_UNIX pathname socket (#303)
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
+        //
+        // Re-audit for d3e0249, signed off 2026-08-27. `Completion.connect`
+        // carries a `net.Address`, whose union members top out at 28 bytes;
+        // a `sockaddr_un` is 110, and `getOsSockLen`'s catch-all arm hands
+        // the kernel `@sizeOf(sockaddr)` — so an AF_UNIX destination was
+        // not merely unimplemented, it was inexpressible, and a path would
+        // have been truncated to thirteen characters. Both backends prep
+        // from `&v.addr.any` and that length, so the fix has to be in the
+        // union rather than at either call site.
+        //
+        // The diff is three things: a `un` member, an `initUnix` that
+        // rejects a path with no room for its terminator (and rejects the
+        // empty path, i.e. the abstract namespace, whose length is the
+        // caller's to state rather than the constructor's to derive), and
+        // an `AF.UNIX` arm deriving the length from that terminator as
+        // `unix(7)` documents. Nothing existing changes shape: the IP arms
+        // of `getOsSockLen`, `toIpAddress` and `fromIpAddress` are
+        // untouched, and no backend gained an op.
+        //
+        // What it costs, stated because §5 is closed-form: the kernel reads
+        // the address from one contiguous location that must outlive the
+        // submission, and the completion is the only storage the op has, so
+        // the path is inline and `Completion` grows 128 -> 152 bytes
+        // (io_uring) and 184 -> 208 (epoll). zoxy holds two per conn and
+        // four per stream, so the effective config's arena grows by
+        // 144 B x conn slots — 0.4% of the banner's total at the shipped
+        // shape, against relay buffers that dominate it. Upstream's two
+        // size-guard tests move with the number rather than being deleted;
+        // being told about exactly this is what they are for.
         //
         // Re-audit for fe5a07b, signed off 2026-08-27. **kqueue only**, and
         // the one commit in this stack that fixes upstream rather than
@@ -100,8 +130,8 @@
         // arms discard which errno failed, which is what left a c10k run
         // reporting 227,628 indistinguishable failures.
         .libxev = .{
-            .url = "git+https://github.com/zoxy-io/libxev#fe5a07b4c2920e254e0c4504e5814999696b63b6",
-            .hash = "libxev-0.0.0-86vtc_ZhFAAfG-sAVZbbuZfYYc7wdbZbUsDli3Sn0Afw",
+            .url = "git+https://github.com/zoxy-io/libxev#d3e0249d528742598065923cbaa2cdc76a4a34b5",
+            .hash = "libxev-0.0.0-86vtcw5yFACICkLeGxnTeKcrj2Mb20q8-wkx_bk25-R9",
         },
         // Load generator, §9 Tier 0/1 only — never linked into the proxy
         // (no `src/` file imports it), so a bump moves what the benchmark

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -41,11 +41,12 @@
         //   b3d6b55 keep the raw errno on the Completion (zoxy-io/libxev#2)
         //   24da6d0 recv_group — provided-buffer receives (zoxy-io/libxev#3)
         //   fe5a07b leave readiness to the wait in submit (kqueue)
-        //   d3e0249 let connect address an AF_UNIX pathname socket (#303)
+        //   010be2a let connect address an AF_UNIX pathname socket
+        //           (zoxy-io/libxev#5, #303)
         // Diff against that upstream commit to audit; the pin moves only
         // after re-audit.
         //
-        // Re-audit for d3e0249, signed off 2026-08-27. `Completion.connect`
+        // Re-audit for 010be2a, signed off 2026-08-27. `Completion.connect`
         // carries a `net.Address`, whose union members top out at 28 bytes;
         // a `sockaddr_un` is 110, and `getOsSockLen`'s catch-all arm hands
         // the kernel `@sizeOf(sockaddr)` — so an AF_UNIX destination was
@@ -61,7 +62,15 @@
         // an `AF.UNIX` arm deriving the length from that terminator as
         // `unix(7)` documents. Nothing existing changes shape: the IP arms
         // of `getOsSockLen`, `toIpAddress` and `fromIpAddress` are
-        // untouched, and no backend gained an op.
+        // untouched, and no backend gained an op. `TCPStream` grows
+        // `initAddress` and `connectAddress` — the same socket setup and
+        // op construction, entered with an address already in posix form
+        // — and `init`/`connect` become one-line delegations, so their
+        // `std.Io.net.IpAddress` surface is unchanged. `TCPDynamic` is
+        // untouched; nothing that can name a `net.Address` reaches it.
+        // `main.zig` re-exports the `net` namespace those two take, which
+        // is the only way a caller can name a family `std.Io.net` has no
+        // spelling for.
         //
         // What it costs, stated because §5 is closed-form: the kernel reads
         // the address from one contiguous location that must outlive the
@@ -130,8 +139,8 @@
         // arms discard which errno failed, which is what left a c10k run
         // reporting 227,628 indistinguishable failures.
         .libxev = .{
-            .url = "git+https://github.com/zoxy-io/libxev#d3e0249d528742598065923cbaa2cdc76a4a34b5",
-            .hash = "libxev-0.0.0-86vtcw5yFACICkLeGxnTeKcrj2Mb20q8-wkx_bk25-R9",
+            .url = "git+https://github.com/zoxy-io/libxev#010be2aa1a7e760031f213ad4ed8ff3f1b68a4d0",
+            .hash = "libxev-0.0.0-86vtc6d2FADTmwZO_3A6KLpUc8d0dzRsy018hm65aNuI",
         },
         // Load generator, §9 Tier 0/1 only — never linked into the proxy
         // (no `src/` file imports it), so a bump moves what the benchmark

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -294,6 +294,17 @@ primitives trusted institutionally.
   never `loop.stop()`, which does not wake a blocked loop from another
   thread (libxev #173). `SimIo` delivers drain as just another scheduled
   event.
+- **The data path never sees a `sockaddr` either.** `connect` takes an
+  `Io.Address` — an IP address or a Unix socket path (#303, §7) — and
+  each backend turns it into whatever the syscall wants. A union rather
+  than a `connectUnix` beside `connect`: every dial site stays one call,
+  and the family branch lives in the only file allowed to know what a
+  `sockaddr_un` is. The pinned libxev could not express the family at
+  all — its `connect` op carries an address union whose members top out
+  at 28 bytes against a `sockaddr_un`'s 110 — so this is where the fork
+  gained its sixth commit, priced in `build.zig.zon`'s audit note and in
+  the banner (§5): a completion grew 128 → 152 bytes, which is 144 B per
+  connection slot.
 - **The data path never sees a file descriptor.** The seam hands out an
   opaque `Io.Socket` handle; the fd itself never leaves `src/io/`, so a
   direct data syscall from the data path is unrepresentable. This
@@ -1568,7 +1579,44 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   Cluster endpoints are
   static socket addresses resolved once at config load, never on the
   loop (dynamic DNS is a non-goal, §1), each optionally weighted — two
-  bullets below.
+  bullets below — and in either family: an `IP:port` literal, or the
+  path of a Unix socket, the bullet after that.
+- **An endpoint may be a Unix socket** (#303, settled 2026-08-27).
+  `unix:/run/app.sock` beside `10.0.0.1:8080`, both spellings mixing
+  freely in one cluster. The prefix on the existing string is #305's
+  settled grammar: `endpoints` and `bind` are the two most-written
+  fields in any config and stay single scalars, nginx and HAProxy
+  already spell a socket path this way, and a prefix cannot collide with
+  an IP literal. What motivates it is not aesthetics — a proxy in front
+  of a local app exhausts the loopback's ephemeral range, suddenly and
+  while the backend is healthy, and a socket file has no port. The other
+  two reasons are filesystem permissions as the ACL, and no checksum or
+  TCP state machine on the leg that runs every request.
+  The seam takes an **address union** rather than a second entry point
+  (§4): one `connect` per dial site, with the branch pushed down to
+  where the syscall is, so `Server`, the L7 proxy and the health checker
+  are unchanged. Above the dial nothing knows: a Unix stream socket is a
+  stream socket, so framing, pooling, retries, health checks and
+  `max_inflight` all run as they were. `hash` stickiness keys on the
+  path, folded through the same finalizer the IP arms use, so a rolling
+  restart cannot re-shuffle which client lands on which socket.
+  The path is validated **at load, not repaired at the dial** (§5):
+  absolute, because a relative path resolves against a working directory
+  the operator did not name; within `unix_socket_path_bytes_max` (103 —
+  the smaller of Linux's 108 and macOS's 104, minus the terminator),
+  because the kernel would take a truncated path as a *different*
+  socket and could not say so; and free of interior NULs, which
+  truncate one layer down. The abstract namespace is out of scope: it
+  carries no filesystem permissions, which is most of the argument for
+  the feature.
+  **Listeners stay IP-only** for now. That half has to answer what a
+  client address *is* when there is none — a question `hash: source_ip`,
+  a filter's `match.client` (family-strict, #177), the access log and
+  `X-Forwarded-For` all ask at once — and `bind: "unix:…"` is refused at
+  load rather than half-accepted. A `proxy_protocol` send block is
+  unaffected in either direction: the header announces the *client's*
+  addresses, which is a fact about the connection that arrived and not
+  about the leg the header is written on.
 - **A pick chooses among the endpoints that are both healthy and under
   capacity**, in that order, and the two filters differ in what an empty
   result means. Health fails **open**: a cluster with every endpoint

--- a/docs/README.md
+++ b/docs/README.md
@@ -594,7 +594,8 @@ log records, and what the origin receives as the request's `Host`. Only
 
 ### Clusters and load balancing
 
-A cluster is a named set of endpoints — static `IP:port` literals, resolved
+A cluster is a named set of endpoints — static `IP:port` literals or
+[`unix:` socket paths](#reaching-a-local-app-over-a-unix-socket), resolved
 once at load, since dynamic DNS is deliberately out of scope — plus how one
 is chosen. Cluster and endpoint counts are bounded by your config, not
 by a compiled ceiling — the startup banner prints what the endpoint tables cost.
@@ -638,6 +639,72 @@ hosts. A weight of `0` **drains** the endpoint — still health-checked,
 never picked, not even when everything else is ejected — so taking a
 backend out of rotation no longer needs a restart. At least one endpoint
 must hold weight, or the config is rejected.
+
+#### Reaching a local app over a Unix socket
+
+When zoxy sits on the same host as the application it fronts, an endpoint
+can be a socket file instead of a loopback address:
+
+```json
+"clusters": {
+    "app": {
+        "endpoints": ["unix:/run/app.sock"]
+    }
+}
+```
+
+Three reasons, and the first is the one that usually forces the change:
+
+- **No ephemeral-port exhaustion.** A busy proxy in front of a local app
+  burns through the loopback's ephemeral range, and the failure arrives
+  suddenly — dials start failing while the backend is perfectly healthy.
+  A socket file has no port.
+- **Filesystem permissions as the ACL.** A socket in a directory the app
+  user owns is unreachable by anything else on the box, with no firewall
+  rule and nothing bound to an address something else could also reach.
+- **Less work per byte.** No checksum, no loopback routing, no TCP state
+  machine — on the leg that runs for every request.
+
+The `unix:` prefix is grammar, not part of the path: what reaches the
+kernel is the path you would `ls`. It must be **absolute** — a relative
+path resolves against a working directory you did not name and a service
+manager may change — and at most 103 bytes: a `sockaddr_un` carries 108
+on Linux and 104 on macOS, so 103 is the smaller of the two minus the
+terminator, and the same config file works on both. Neither is truncated
+at the dial; both are refused at load, because a shortened path names a
+*different* socket and nothing downstream could tell you so.
+
+The path must also be printable ASCII with no quote or backslash. POSIX
+permits stranger ones and nothing that runs a service creates them, and
+the reason to refuse is what an endpoint address is used *for*: it lands
+verbatim in every access-log line and every Prometheus label, where one
+control byte does not spoil a field — it invalidates the whole line and
+the whole scrape.
+
+Everything above the dial is unchanged. The two forms mix freely in one
+cluster, so a migration moves one endpoint at a time; weights, `pick`,
+health checks, retries and per-endpoint in-flight caps all work as they
+do on an IP endpoint; and `hash` stickiness keys on the path, so a client
+pinned to a socket stays pinned across restarts. The access log, the
+`endpoint` metrics label and the startup banner all print the endpoint
+exactly as you spelled it, `unix:` included:
+
+```json
+{"upstream":"unix:/run/app.sock", ...}
+```
+
+A [`proxy_protocol`](#telling-an-l4-origin-proxy-protocol) send block
+still works and still announces the *client's* addresses — the header
+describes the connection that arrived, not the leg it is written on.
+
+> [!NOTE]
+> Listeners are still IP-only: `bind` does not take a `unix:` path yet.
+> That half needs an answer for what a client address *is* when there is
+> none, which `hash: source_ip`, a filter's `match.client` and
+> `X-Forwarded-For` all ask, and shipping it half-answered would be
+> worse than not shipping it. The abstract namespace (a leading NUL) is
+> deliberately out of scope — it has no filesystem permissions, which is
+> most of the argument above.
 
 ### Sticky sessions
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -106,11 +106,11 @@ comptime {
 
 io: SimIo,
 server: ServerSim,
-endpoints_l4: [1]std.Io.net.IpAddress,
+endpoints_l4: [1]zoxy.Io.Address,
 /// The http cluster's endpoints: the origin at index 0 always, and on a
 /// #181 retry seed a second one nothing is listening on (`deriveRetries`).
 /// How many are configured is `endpoints_http_count`.
-endpoints_http: [2]std.Io.net.IpAddress,
+endpoints_http: [2]zoxy.Io.Address,
 endpoints_http_count: u16,
 /// The #174 weight tables the clusters may reference, each as long as
 /// the endpoint list it parallels.
@@ -612,7 +612,7 @@ fn deriveRetries(harness: *Harness, random: std.Random) void {
     }
     harness.retries_http = budget;
     harness.endpoints_http_count = 2;
-    harness.endpoints_http[1] = refusingEndpointAddress();
+    harness.endpoints_http[1] = .{ .ip = refusingEndpointAddress() };
     assert(harness.retries_http >= 1);
     assert(harness.retries_http <= zoxy.constants.cluster_retries_max);
 }
@@ -645,8 +645,11 @@ fn deriveUpgrades(harness: *Harness, random: std.Random) void {
 }
 
 fn deriveTopology(harness: *Harness, random: std.Random) void {
-    harness.endpoints_l4 = .{originAddress()};
-    harness.endpoints_http = .{ httpOriginAddress(), httpOriginAddress() };
+    harness.endpoints_l4 = .{.{ .ip = originAddress() }};
+    harness.endpoints_http = .{
+        .{ .ip = httpOriginAddress() },
+        .{ .ip = httpOriginAddress() },
+    };
     deriveRetries(harness, random);
     deriveUpgrades(harness, random);
     harness.max_body_bytes = deriveMaxBodyBytes(harness.clean, random);

--- a/sim/l4.zig
+++ b/sim/l4.zig
@@ -98,7 +98,7 @@ pub fn Client(comptime IoType: type) type {
         pub fn begin(client: *Self) void {
             assert(client.token_len >= 1);
             client.io.connect(
-                client.address,
+                &.{ .ip = client.address },
                 &client.connect_completion,
                 Self,
                 client,

--- a/sim/l7/client.zig
+++ b/sim/l7/client.zig
@@ -195,7 +195,7 @@ pub fn Client(comptime IoType: type) type {
                 assert(scripts.spec(client.script).expected_responses == 0);
             }
             client.io.connect(
-                client.address,
+                &.{ .ip = client.address },
                 &client.connect_completion,
                 Self,
                 client,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -3125,7 +3125,7 @@ pub fn Server(comptime IoType: type) type {
                 server.stageProxySendHeader(conn, version);
             }
             server.io.connect(
-                dial.address,
+                &dial.address,
                 &conn.stream.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -110,7 +110,7 @@ pub const Record = struct {
     client: std.Io.net.IpAddress,
     /// The endpoint this request or connection was served by, or null when
     /// none was ever picked — every reject that fires before routing.
-    upstream: ?std.Io.net.IpAddress,
+    upstream: ?Io.Address,
     /// The cluster's configured name, empty when routing never chose one.
     cluster: []const u8,
     /// Bytes received from the client, and bytes sent to it. Both are
@@ -223,6 +223,11 @@ fn renderInto(record: *const Record, writer: *std.Io.Writer) std.Io.Writer.Error
     try std.json.Stringify.encodeJsonString(record.cluster, .{}, writer);
     try writer.writeAll(",\"upstream\":");
     if (record.upstream) |address| {
+        // Unescaped, and the loader is what makes that safe: an IP
+        // literal has no escapable byte by construction and a socket
+        // path is held to `Address.pathIsRenderable` at load (§5). The
+        // stake is the line, not the field — this log's whole contract
+        // is one valid JSON object per event.
         try writer.print("\"{f}\"", .{address});
     } else {
         // Null rather than an empty string: "no endpoint was ever picked"
@@ -606,7 +611,7 @@ fn testRecord() Record {
         .started_wall_ns = 1_785_489_262 * std.time.ns_per_s + 481 * std.time.ns_per_ms,
         .duration_ns = 1_873_000,
         .client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:52344") catch unreachable,
-        .upstream = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable,
+        .upstream = .{ .ip = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable },
         .cluster = "api",
         .bytes_in = 142,
         .bytes_out = 4096,
@@ -640,7 +645,7 @@ test "access log: an L4 line omits the request fields and names no status" {
     entry.kind = .l4;
     entry.outcome = .closed;
     entry.cluster = "tcp";
-    entry.upstream = try std.Io.net.IpAddress.parseLiteral("10.0.0.7:9000");
+    entry.upstream = .{ .ip = try std.Io.net.IpAddress.parseLiteral("10.0.0.7:9000") };
     const line = try renderLine(&entry, &buffer);
 
     try testing.expectEqualStrings(
@@ -757,7 +762,7 @@ test "access log: a line at every cap still fits the bound (#140)" {
     entry.method = "M" ** constants.access_log_method_bytes_max;
     entry.cluster = "c" ** constants.cluster_name_bytes_max;
     entry.client = try std.Io.net.IpAddress.parseLiteral("[2001:db8::1]:65535");
-    entry.upstream = try std.Io.net.IpAddress.parseLiteral("[2001:db8::2]:65535");
+    entry.upstream = .{ .ip = try std.Io.net.IpAddress.parseLiteral("[2001:db8::2]:65535") };
     entry.duration_ns = std.math.maxInt(u64);
     entry.bytes_in = std.math.maxInt(u64);
     entry.bytes_out = std.math.maxInt(u64);
@@ -809,8 +814,15 @@ test "access log: every line is valid JSON, including hostile paths" {
 test "access log: the line bound holds at every field's maximum" {
     // `access_log_line_bytes_max` is what lets `record` treat NoSpaceLeft
     // as backpressure rather than arithmetic (§8), so it must survive the
-    // widest line the caps allow: full-width IPv6 on both ends, a path and
-    // a host of nothing but 6-byte escapes, and every number saturated.
+    // widest line the caps allow: full-width IPv6 for the client, a path
+    // and a host of nothing but 6-byte escapes, and every number
+    // saturated. The upstream half takes a socket path at the loader's
+    // bound instead (#303) — that is the wider of the two forms, and
+    // pinning the narrower one would leave the bound untested where it
+    // actually binds.
+    var socket_path: [constants.unix_socket_path_bytes_max]u8 = undefined;
+    @memset(&socket_path, 'p');
+    socket_path[0] = '/';
     var path: [constants.access_log_path_bytes_max]u8 = undefined;
     @memset(&path, '\x01');
     var host: [constants.host_bytes_max]u8 = undefined;
@@ -826,7 +838,7 @@ test "access log: the line bound holds at every field's maximum" {
         .started_wall_ns = std.math.maxInt(u32) * std.time.ns_per_s,
         .duration_ns = std.math.maxInt(u64),
         .client = try .parseLiteral("[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535"),
-        .upstream = try .parseLiteral("[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535"),
+        .upstream = .{ .unix = &socket_path },
         .cluster = &cluster,
         .bytes_in = std.math.maxInt(u64),
         .bytes_out = std.math.maxInt(u64),

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const access_log = @import("access_log.zig");
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
+const io_module = @import("io/io.zig");
 const router = @import("http/router.zig");
 const Server = @import("Server.zig").Server;
 const SimIo = @import("io/SimIo.zig");
@@ -32,10 +33,17 @@ fn originAddress() std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
 }
 
+/// The same origin as an endpoint (#303): every cluster's endpoint list
+/// is an address union now, and the harness dials and listens on the
+/// IP arm of it.
+fn originEndpoint() io_module.Address {
+    return .{ .ip = originAddress() };
+}
+
 const Harness = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
-    endpoints: [1]std.Io.net.IpAddress,
+    endpoints: [1]io_module.Address,
     clusters: [1]config_module.Config.Cluster,
     routes: [1]router.Route,
     listeners: [1]config_module.Config.Listener,
@@ -75,7 +83,7 @@ const Harness = struct {
             .adversary = .{ .partial_io = false, .log_write_stall_ns = stall_ns },
             .buffer_group_count = 4,
         });
-        harness.endpoints = .{originAddress()};
+        harness.endpoints = .{originEndpoint()};
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
         harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.listeners = .{.{
@@ -132,7 +140,7 @@ fn sampleRecord() access_log.Record {
         .started_wall_ns = 1_785_489_262 * std.time.ns_per_s,
         .duration_ns = 1000,
         .client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:52344") catch unreachable,
-        .upstream = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable,
+        .upstream = .{ .ip = std.Io.net.IpAddress.parseLiteral("10.0.0.7:8080") catch unreachable },
         .cluster = "origin",
         .bytes_in = 0,
         .bytes_out = 7,

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -14,6 +14,7 @@ const std = @import("std");
 const admin = @import("admin.zig");
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
+const io_module = @import("io/io.zig");
 const counters_module = @import("counters.zig");
 const router = @import("http/router.zig");
 const Io = @import("io/io.zig");
@@ -37,10 +38,17 @@ fn originAddress() std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
 }
 
+/// The same origin as an endpoint (#303): every cluster's endpoint list
+/// is an address union now, and the harness dials and listens on the
+/// IP arm of it.
+fn originEndpoint() io_module.Address {
+    return .{ .ip = originAddress() };
+}
+
 const Harness = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
-    endpoints: [1]std.Io.net.IpAddress,
+    endpoints: [1]io_module.Address,
     clusters: [1]config_module.Config.Cluster,
     routes: [1]router.Route,
     listeners: [1]config_module.Config.Listener,
@@ -59,7 +67,7 @@ const Harness = struct {
         var sim_options = sim;
         sim_options.buffer_group_count = 0;
         try harness.sim_io.init(arena, sim_options);
-        harness.endpoints = .{originAddress()};
+        harness.endpoints = .{originEndpoint()};
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
         harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.listeners = .{.{
@@ -163,7 +171,7 @@ const Scrape = struct {
     const Outcome = enum { pending, refused, eof, reset };
 
     fn start(scrape: *Scrape) void {
-        scrape.io.connect(adminAddress(), &scrape.connect_completion, Scrape, scrape, onConnect);
+        scrape.io.connect(&.{ .ip = adminAddress() }, &scrape.connect_completion, Scrape, scrape, onConnect);
     }
 
     fn onConnect(scrape: *Scrape, result: Io.ConnectError!SimIo.Socket) void {
@@ -295,7 +303,7 @@ const Holder = struct {
 
     fn start(holder: *Holder, io: *SimIo) void {
         holder.io = io;
-        io.connect(bindAddress(), &holder.connect_completion, Holder, holder, onConnect);
+        io.connect(&.{ .ip = bindAddress() }, &holder.connect_completion, Holder, holder, onConnect);
     }
 
     fn onConnect(holder: *Holder, result: Io.ConnectError!SimIo.Socket) void {

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -87,6 +87,7 @@ const std = @import("std");
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
 const upstream = @import("net/upstream.zig");
+const io_module = @import("io/io.zig");
 
 const assert = std.debug.assert;
 
@@ -155,18 +156,38 @@ fn bytesKeyOf(bytes: []const u8) u64 {
 /// An endpoint's stable identity for scoring: its address *and* port, so
 /// two endpoints sharing a host are distinct, and nothing positional, so
 /// the config list can grow or be reordered without remapping clients.
-fn endpointId(address: *const std.Io.net.IpAddress) u64 {
-    // The loader rejects a zero endpoint port (`EndpointPortZero`), and
-    // this folds the port into the identity — so a zero here would mean a
-    // caller reached past config validation, and two endpoints that
-    // differ only in a port nobody validated would be scored as one.
-    assert(address.getPort() != 0);
+fn endpointId(address: *const io_module.Address) u64 {
     return switch (address.*) {
-        .ip4 => |v4| mix64(
-            (@as(u64, std.mem.readInt(u32, &v4.bytes, .big)) << 16) | v4.port,
-        ),
-        .ip6 => |v6| mix64(mix64(std.mem.readInt(u64, v6.bytes[0..8], .big)) ^
-            mix64(std.mem.readInt(u64, v6.bytes[8..16], .big) ^ v6.port)),
+        // The loader rejects a zero endpoint port (`EndpointPortZero`),
+        // and this folds the port into the identity — so a zero here
+        // would mean a caller reached past config validation, and two
+        // endpoints that differ only in a port nobody validated would be
+        // scored as one.
+        .ip => |ip| switch (ip) {
+            .ip4 => |v4| id: {
+                assert(v4.port != 0);
+                break :id mix64(
+                    (@as(u64, std.mem.readInt(u32, &v4.bytes, .big)) << 16) | v4.port,
+                );
+            },
+            .ip6 => |v6| id: {
+                assert(v6.port != 0);
+                break :id mix64(mix64(std.mem.readInt(u64, v6.bytes[0..8], .big)) ^
+                    mix64(std.mem.readInt(u64, v6.bytes[8..16], .big) ^ v6.port));
+            },
+        },
+        // A socket path carries the whole identity — there is no port to
+        // fold in, and the path is what two spellings of one endpoint
+        // would have to share. Folded through the same `bytesKeyOf` the
+        // #178 header key uses, and through `mix64` like the IP arms, so
+        // every identity in this table comes out of one finalizer and a
+        // rendezvous score can compare them as whole words. Pinned for
+        // the reason `mix64` is: a rolling restart must not re-shuffle
+        // which client lands on which socket.
+        .unix => |path| id: {
+            assert(path.len >= 1); // The loader rejects an empty path.
+            break :id bytesKeyOf(path);
+        },
     };
 }
 
@@ -308,7 +329,7 @@ pub const Balancer = struct {
     /// gates use to compute the tag an endpoint *must* be spelled as,
     /// from nothing but its address, so an oracle can hold the running
     /// proxy to it from outside.
-    pub fn addressIdentity(address: *const std.Io.net.IpAddress) u64 {
+    pub fn addressIdentity(address: *const io_module.Address) u64 {
         return endpointId(address);
     }
 
@@ -389,7 +410,7 @@ pub const Balancer = struct {
     /// A pick names the endpoint both ways: the address to dial and the
     /// index the upstream pool keys its idle lists by (§5).
     pub const Pick = struct {
-        address: std.Io.net.IpAddress,
+        address: io_module.Address,
         endpoint_index: u16,
     };
 
@@ -925,8 +946,18 @@ const test_client = std.Io.net.IpAddress.parseLiteral("198.51.100.7:40000") catc
 /// has been dialed yet, so nothing is excluded.
 const test_untried: []const u16 = &.{};
 
+/// A *client* address for the fixtures below — the half that stays
+/// IP-only: a listener still binds an IP, so a peer address is always
+/// one. Endpoints use `ipEndpoint`.
 fn testAddress(comptime literal: []const u8) std.Io.net.IpAddress {
     return std.Io.net.IpAddress.parseLiteral(literal) catch unreachable;
+}
+
+/// One IP endpoint from its literal, for the fixtures below. `catch
+/// unreachable` is sound on a comptime literal this file wrote: an
+/// unparseable one is a compile-time-visible typo, not a runtime path.
+fn ipEndpoint(comptime literal: []const u8) io_module.Address {
+    return .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch unreachable };
 }
 
 fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Config {
@@ -944,10 +975,10 @@ fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Conf
 }
 
 test "balancer: rr cycles endpoints and wraps per cluster" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .rr },
     };
@@ -970,8 +1001,8 @@ test "balancer: rr cycles endpoints and wraps per cluster" {
 }
 
 test "balancer: a single-endpoint cluster short-circuits without a draw" {
-    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
-    const one = [_]std.Io.net.IpAddress{solo};
+    const solo = ipEndpoint("127.0.0.1:9");
+    const one = [_]io_module.Address{solo};
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "one", .endpoints = &one },
     };
@@ -995,10 +1026,10 @@ test "balancer: a single-endpoint cluster short-circuits without a draw" {
 }
 
 test "balancer: p2c prefers the less-loaded of its two candidates" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
     };
@@ -1022,10 +1053,10 @@ test "balancer: p2c prefers the less-loaded of its two candidates" {
 }
 
 test "balancer: p2c spreads across endpoints under equal load" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
     };
@@ -1051,9 +1082,9 @@ test "balancer: p2c spreads across endpoints under equal load" {
 }
 
 test "balancer: same seed, same picks — the p2c draw is deterministic" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
     };
@@ -1081,10 +1112,10 @@ test "balancer: same seed, same picks — the p2c draw is deterministic" {
 }
 
 test "balancer: rr rotates over the healthy endpoints only" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .rr },
     };
@@ -1108,9 +1139,9 @@ test "balancer: rr rotates over the healthy endpoints only" {
 }
 
 test "balancer: rr honors weights, and the schedule is smooth" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const weights = [_]u16{ 2, 1 };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "canary", .endpoints = &pair, .pick = .rr, .weights = &weights },
@@ -1135,10 +1166,10 @@ test "balancer: rr honors weights, and the schedule is smooth" {
 }
 
 test "balancer: rr weight zero drains an endpoint, past fail-open" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const weights = [_]u16{ 1, 0, 1 };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "draining", .endpoints = &trio, .pick = .rr, .weights = &weights },
@@ -1170,10 +1201,10 @@ test "balancer: rr weight zero drains an endpoint, past fail-open" {
 }
 
 test "balancer: p2c candidacy follows weight" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const weights = [_]u16{ 8, 1, 1 };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "weighted", .endpoints = &trio, .pick = .p2c, .weights = &weights },
@@ -1206,10 +1237,10 @@ test "balancer: p2c at unit weights draws exactly as the unweighted form" {
     // policy, draw for draw: the weighted path's unit case is the
     // uniform draw this grew from, which is what keeps unweighted §9
     // traces byte-stable across the change.
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const unit_weights = [_]u16{ 1, 1, 1 };
     const bare_clusters = [_]config_module.Config.Cluster{
         .{ .name = "bare", .endpoints = &trio, .pick = .p2c },
@@ -1241,10 +1272,10 @@ test "balancer: p2c at unit weights draws exactly as the unweighted form" {
 }
 
 test "balancer: p2c never picks an ejected endpoint" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
     };
@@ -1270,9 +1301,9 @@ test "balancer: p2c never picks an ejected endpoint" {
 }
 
 test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
     };
@@ -1298,10 +1329,10 @@ test "balancer: p2c narrowed to one healthy endpoint spends no draw" {
 }
 
 test "balancer: a fully-ejected cluster fails open to every endpoint" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .rr },
     };
@@ -1327,9 +1358,9 @@ test "balancer: a fully-ejected cluster fails open to every endpoint" {
 }
 
 test "balancer: policies keep independent state across clusters" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "rotating", .endpoints = &pair, .pick = .rr },
         .{ .name = "drawing", .endpoints = &pair, .pick = .p2c },
@@ -1352,13 +1383,13 @@ test "balancer: policies keep independent state across clusters" {
 }
 
 /// A cluster of `count` endpoints at 10.0.0.1..N, for the §7 hash tests.
-fn testHashEndpoints(comptime count: u16) [count]std.Io.net.IpAddress {
-    var endpoints: [count]std.Io.net.IpAddress = undefined;
+fn testHashEndpoints(comptime count: u16) [count]io_module.Address {
+    var endpoints: [count]io_module.Address = undefined;
     for (&endpoints, 0..) |*endpoint, index| {
-        endpoint.* = .{ .ip4 = .{
+        endpoint.* = .{ .ip = .{ .ip4 = .{
             .bytes = .{ 10, 0, 0, @intCast(index + 1) },
             .port = 8080,
-        } };
+        } } };
     }
     return endpoints;
 }
@@ -1645,7 +1676,7 @@ test "balancer: two processes agree, and so do a config's reorderings" {
     // without re-homing every client — identity is the address, not the
     // index.
     const forward = testHashEndpoints(8);
-    var reversed: [8]std.Io.net.IpAddress = undefined;
+    var reversed: [8]io_module.Address = undefined;
     for (forward, 0..) |endpoint, index| {
         reversed[7 - index] = endpoint;
     }
@@ -1798,7 +1829,7 @@ fn sourceKeyOf(comptime literal: []const u8) u64 {
 }
 
 fn endpointIdOf(comptime literal: []const u8) u64 {
-    const address = testAddress(literal);
+    const address = ipEndpoint(literal);
     return endpointId(&address);
 }
 
@@ -2001,10 +2032,10 @@ test "balancer: the header key is pinned, like every mapping hash here" {
 }
 
 test "balancer: p2c weighs L4 connections, not only L7 leases" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .p2c },
     };
@@ -2031,9 +2062,9 @@ test "balancer: p2c weighs L4 connections, not only L7 leases" {
 }
 
 test "balancer: p2c compares the sum of both protocols" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .p2c },
     };
@@ -2066,9 +2097,9 @@ test "balancer: p2c compares the sum of both protocols" {
 }
 
 test "balancer: a capped endpoint is skipped while another has room" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 2 },
     };
@@ -2095,9 +2126,9 @@ test "balancer: a capped endpoint is skipped while another has room" {
 }
 
 test "balancer: a fully capped cluster refuses rather than failing open" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .p2c, .max_inflight = 3 },
     };
@@ -2128,8 +2159,8 @@ test "balancer: a fully capped cluster refuses rather than failing open" {
 }
 
 test "balancer: the cap counts both protocols, and covers one endpoint" {
-    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
-    const one = [_]std.Io.net.IpAddress{solo};
+    const solo = ipEndpoint("127.0.0.1:9");
+    const one = [_]io_module.Address{solo};
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "one", .endpoints = &one, .max_inflight = 4 },
     };
@@ -2158,9 +2189,9 @@ test "balancer: the cap counts both protocols, and covers one endpoint" {
 }
 
 test "balancer: capacity is judged over the endpoints health left" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 1 },
     };
@@ -2193,10 +2224,10 @@ test "balancer: capacity is judged over the endpoints health left" {
 }
 
 test "balancer: a tried endpoint is excluded from the retry" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "trio", .endpoints = &trio, .pick = .rr },
     };
@@ -2225,9 +2256,9 @@ test "balancer: a tried endpoint is excluded from the retry" {
 }
 
 test "balancer: fail-open cannot resurrect the endpoint that just failed" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .rr },
     };
@@ -2254,10 +2285,10 @@ test "balancer: fail-open cannot resurrect the endpoint that just failed" {
 }
 
 test "balancer: every routable endpoint tried is exhausted, never capped" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const c = std.Io.net.IpAddress.parseLiteral("127.0.0.1:3") catch unreachable;
-    const trio = [_]std.Io.net.IpAddress{ a, b, c };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const c = ipEndpoint("127.0.0.1:3");
+    const trio = [_]io_module.Address{ a, b, c };
     // Endpoint 2 is drained (#174), so the routable set is {0, 1} and
     // trying both exhausts the cluster even though an endpoint remains.
     const weights = [_]u16{ 1, 1, 0 };
@@ -2287,8 +2318,8 @@ test "balancer: every routable endpoint tried is exhausted, never capped" {
 }
 
 test "balancer: a single-endpoint cluster cannot retry" {
-    const solo = std.Io.net.IpAddress.parseLiteral("127.0.0.1:9") catch unreachable;
-    const one = [_]std.Io.net.IpAddress{solo};
+    const solo = ipEndpoint("127.0.0.1:9");
+    const one = [_]io_module.Address{solo};
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "one", .endpoints = &one },
     };
@@ -2311,9 +2342,9 @@ test "balancer: a single-endpoint cluster cannot retry" {
 }
 
 test "balancer: a retry whose survivors are all full is capped, not exhausted" {
-    const a = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    const b = std.Io.net.IpAddress.parseLiteral("127.0.0.1:2") catch unreachable;
-    const pair = [_]std.Io.net.IpAddress{ a, b };
+    const a = ipEndpoint("127.0.0.1:1");
+    const b = ipEndpoint("127.0.0.1:2");
+    const pair = [_]io_module.Address{ a, b };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "pair", .endpoints = &pair, .pick = .rr, .max_inflight = 2 },
     };

--- a/src/config.zig
+++ b/src/config.zig
@@ -17,6 +17,7 @@ const filter = @import("http/filter.zig");
 const parser = @import("http/parser.zig");
 const render = @import("http/render.zig");
 const shed = @import("shed.zig");
+const io_module = @import("io/io.zig");
 
 const assert = std.debug.assert;
 
@@ -486,7 +487,7 @@ pub const Config = struct {
 
     pub const Cluster = struct {
         name: []const u8,
-        endpoints: []const std.Io.net.IpAddress,
+        endpoints: []const io_module.Address,
         /// Per-endpoint §7 pick weights, parallel to `endpoints` — or
         /// null when every endpoint carries the default weight of 1,
         /// which is what the bare-string config form says and what most
@@ -774,6 +775,13 @@ pub const ValidationError = error{
     EndpointsOverLimit,
     EndpointInvalid,
     EndpointPortZero,
+    /// A `unix:` endpoint whose path is empty, past what a `sockaddr_un`
+    /// carries, or carries a byte an address may not — a control byte, a
+    /// quote or a backslash, each of which would corrupt the access log
+    /// and the metrics exposition rather than one field of them (#303).
+    EndpointUnixPathInvalid,
+    /// A `unix:` endpoint path that is not absolute (#303).
+    EndpointUnixPathRelative,
     EndpointWeightOverLimit,
     EndpointWeightsAllZero,
     TimeoutZero,
@@ -2569,11 +2577,13 @@ pub const EndpointJson = struct {
     weight: u32 = 1,
 
     pub const schema_doc =
-        "One endpoint: an IP:port literal, or an object carrying the " ++
-        "literal and a relative pick weight.";
+        "One endpoint: an IP:port literal, a `unix:` socket path, or an " ++
+        "object carrying either and a relative pick weight.";
     pub const schema_fields = .{
         .address = .{
-            .desc = "IP:port endpoint literal (port must be non-zero).",
+            .desc = "Endpoint literal: `IP:port` (port must be non-zero), or " ++
+                "`unix:` followed by the absolute path of a stream socket " ++
+                "(printable ASCII, no quote or backslash).",
             .min_length = 1,
         },
         .weight = .{
@@ -3311,9 +3321,59 @@ fn rejectDuplicateClusterNames(
 /// every endpoint carries weight 1, so the unweighted common case
 /// allocates nothing beyond the addresses it always did.
 const ResolvedEndpoints = struct {
-    addresses: []const std.Io.net.IpAddress,
+    addresses: []const io_module.Address,
     weights: ?[]const u16,
 };
+
+/// The `unix:` prefix the #305 grammar settled on, for both `bind` and
+/// `endpoints`. A prefix on the existing string rather than a tagged
+/// object or a second key: the two most-written fields in any config
+/// stay single scalars, nginx and HAProxy already spell a socket path
+/// this way, and the prefix cannot collide with an IP literal.
+pub const unix_address_prefix = "unix:";
+
+/// One endpoint address: an IP literal, or a `unix:` path (#303).
+///
+/// The path is validated here and nowhere else, on §5's terms — refuse
+/// at load rather than repair at runtime. Absolute, because a relative
+/// path resolves against a working directory the operator did not name
+/// and a service manager may change; within the `sockaddr_un` bound,
+/// because the kernel would otherwise take a truncated path as a
+/// *different* socket; and printable ASCII without a quote or a
+/// backslash.
+///
+/// That last rule is the one worth arguing. An endpoint address is not
+/// free-form text: it lands verbatim in every access-log line and in
+/// every Prometheus label, and a quote or a control byte there does not
+/// spoil one field — it invalidates the whole line and the whole scrape
+/// (§8's "one uncontaminated JSON line per event"). The alternatives
+/// are escaping at both renderers, which multiplies the §5 render bound
+/// by six for bytes no operator will ever write, or accepting a config
+/// that silently corrupts observability. POSIX permits such a path;
+/// nothing that runs a service ever creates one.
+fn resolveEndpointAddress(
+    arena: std.mem.Allocator,
+    literal: []const u8,
+) ParseError!io_module.Address {
+    if (std.mem.startsWith(u8, literal, unix_address_prefix)) {
+        const path = literal[unix_address_prefix.len..];
+        if (path.len == 0 or path.len > io_module.Address.unix_path_bytes_max) {
+            return error.EndpointUnixPathInvalid;
+        }
+        if (path[0] != '/') {
+            return error.EndpointUnixPathRelative;
+        }
+        if (!io_module.Address.pathIsRenderable(path)) {
+            return error.EndpointUnixPathInvalid;
+        }
+        // Duped so the address outlives the parsed JSON document, the
+        // same lifetime every other resolved string here takes.
+        return .{ .unix = try arena.dupe(u8, path) };
+    }
+    return .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch {
+        return error.EndpointInvalid;
+    } };
+}
 
 fn resolveEndpoints(
     arena: std.mem.Allocator,
@@ -3332,14 +3392,12 @@ fn resolveEndpoints(
         return error.EndpointsOverLimit;
     }
 
-    const addresses = try arena.alloc(std.Io.net.IpAddress, endpoints_json.len);
+    const addresses = try arena.alloc(io_module.Address, endpoints_json.len);
     var weighted = false;
     var weight_sum: u64 = 0;
     for (endpoints_json, addresses) |entry, *address| {
-        address.* = std.Io.net.IpAddress.parseLiteral(entry.address) catch {
-            return error.EndpointInvalid;
-        };
-        if (address.getPort() == 0) {
+        address.* = try resolveEndpointAddress(arena, entry.address);
+        if (address.* == .ip and address.ip.getPort() == 0) {
             return error.EndpointPortZero;
         }
         if (entry.weight > constants.endpoint_weight_max) {
@@ -5129,10 +5187,10 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
     try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
-    try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].getPort());
+    try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].ip.getPort());
     // The example carries both endpoint spellings (#174): a bare literal
     // at weight 1 beside a weighted object.
-    try std.testing.expectEqual(@as(u16, 9001), parsed.clusters[0].endpoints[1].getPort());
+    try std.testing.expectEqual(@as(u16, 9001), parsed.clusters[0].endpoints[1].ip.getPort());
     try std.testing.expectEqualSlices(u16, &.{ 1, 3 }, parsed.clusters[0].weights.?);
     // The example's tcp check resolves with its thresholds, and its
     // omitted budget inherits the connect timeout.
@@ -6770,7 +6828,7 @@ test "config: endpoint weights parse in both spellings" {
     // spelling — is carried, not rejected, while a sibling holds weight.
     try std.testing.expectEqual(@as(usize, 4), cluster.endpoints.len);
     try std.testing.expectEqualSlices(u16, &.{ 1, 3, 1, 0 }, cluster.weights.?);
-    try std.testing.expectEqual(@as(u16, 8080), cluster.endpoints[1].getPort());
+    try std.testing.expectEqual(@as(u16, 8080), cluster.endpoints[1].ip.getPort());
 }
 
 test "config: unweighted endpoints leave the weights table null" {
@@ -7848,6 +7906,103 @@ test "config: max_inflight resolves, defaults to uncapped, rejects the useless" 
             parsed.clusters[0].max_inflight,
         );
     }
+}
+
+test "config: an endpoint may be a Unix socket path (#303)" {
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"}}]," ++
+        "\"clusters\":{\"a\":{\"endpoints\":[";
+    const tail = "]}},\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // Both spellings in one cluster, which is the point of a prefix on
+    // the existing string rather than a second key (#305): a migration
+    // moves one endpoint at a time.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"127.0.0.1:9000\",\"unix:/run/app.sock\"," ++
+                "{\"address\":\"unix:/run/app2.sock\",\"weight\":3}" ++ tail,
+        );
+        const endpoints = parsed.clusters[0].endpoints;
+        try std.testing.expectEqual(@as(usize, 3), endpoints.len);
+        try std.testing.expectEqual(@as(u16, 9000), endpoints[0].ip.getPort());
+        try std.testing.expectEqualStrings("/run/app.sock", endpoints[1].unix);
+        // The `unix:` prefix is grammar, not part of the path: what
+        // reaches the kernel is what the operator would `ls`.
+        try std.testing.expectEqualStrings("/run/app2.sock", endpoints[2].unix);
+        // The #174 object form is unaffected — the grammar grew at one
+        // parse site and nothing that parsed before changed shape.
+        try std.testing.expectEqualSlices(u16, &.{ 1, 1, 3 }, parsed.clusters[0].weights.?);
+        // And the rendered spelling round-trips to what was written,
+        // which is what the access log and the metrics label print.
+        var scratch: [64]u8 = undefined;
+        var writer = std.Io.Writer.fixed(&scratch);
+        try writer.print("{f}", .{endpoints[1]});
+        try std.testing.expectEqualStrings("unix:/run/app.sock", writer.buffered());
+    }
+
+    // A relative path resolves against a working directory the operator
+    // did not name and a service manager may change — so it names a
+    // socket nobody can point at. Refused at load (§5), not at the dial.
+    try expectParseError(
+        error.EndpointUnixPathRelative,
+        head ++ "\"unix:run/app.sock\"" ++ tail,
+    );
+    // The empty path is the abstract namespace, which is out of scope
+    // (#303) and would otherwise be a silent second meaning for `unix:`.
+    try expectParseError(error.EndpointUnixPathInvalid, head ++ "\"unix:\"" ++ tail);
+    // Past what a `sockaddr_un` carries. Refused rather than truncated:
+    // a shortened path names a *different* socket, and the kernel would
+    // have no way to say so.
+    {
+        const too_long = "/" ++ ("p" ** constants.unix_socket_path_bytes_max);
+        try expectParseError(
+            error.EndpointUnixPathInvalid,
+            head ++ "\"unix:" ++ too_long ++ "\"" ++ tail,
+        );
+        // One byte shorter is the longest path that fits, and it parses
+        // — the bound is a real edge, not a round number near one.
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"unix:" ++ too_long[0 .. too_long.len - 1] ++ "\"" ++ tail,
+        );
+        try std.testing.expectEqual(
+            @as(usize, constants.unix_socket_path_bytes_max),
+            parsed.clusters[0].endpoints[0].unix.len,
+        );
+    }
+    // A zero-port rule cannot apply to a socket path, and must not be
+    // reached through one: the check is on the `ip` arm only.
+    try expectParseError(error.EndpointPortZero, head ++ "\"127.0.0.1:0\"" ++ tail);
+
+    // The bytes an address may not carry. POSIX permits them in a path;
+    // the access log and the metrics exposition do not — one of these
+    // reaching a renderer invalidates the whole line and the whole
+    // scrape, not one field, so they are refused where every other
+    // §5 bound is.
+    inline for (.{ "\\\"", "\\\\", "\\u0001", "\\u007f", " " }) |hostile| {
+        try expectParseError(
+            error.EndpointUnixPathInvalid,
+            head ++ "\"unix:/run/a" ++ hostile ++ "b.sock\"" ++ tail,
+        );
+    }
+}
+
+test "config: a listener still binds an IP, not a socket path (#303)" {
+    // The listener half of #303 is a later slice: it needs answers for
+    // what a peer address is when there is none, which `hash: source_ip`,
+    // `match.client` and `X-Forwarded-For` all ask. Until then the
+    // grammar is refused here rather than half-accepted, so a config
+    // that looks like it works cannot be one that does not.
+    try expectParseError(
+        error.ListenerBindInvalid,
+        "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"http\":{\"cluster\":\"a\"}}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+    );
 }
 
 test "config: proxy_status is off unless asked for, and is http-only" {

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1079,6 +1079,17 @@ pub const access_log_headers_max: u8 = 8;
 /// Bounded because the key is config text that lands in every line.
 pub const access_log_header_name_bytes_max: u8 = 64;
 
+/// The longest path a filesystem `AF_UNIX` socket address can carry
+/// (#303): what `sockaddr_un` holds, minus the terminator the kernel
+/// expects on a pathname socket.
+///
+/// A loader bound rather than a truncation point, on §5's terms: a
+/// silently shortened path names a *different* socket, so a config past
+/// this is refused at load instead of repaired at runtime. 108 is Linux;
+/// macOS carries 104, and the smaller of the two is what a config has to
+/// fit for the same file to work on both.
+pub const unix_socket_path_bytes_max: u8 = 103;
+
 /// Upper bound on one rendered access-log line, including its newline
 /// (§5: the caller sizes a fixed buffer to it, so a line never has to be
 /// dropped for want of room in an *empty* buffer). Derived from the field
@@ -1101,10 +1112,15 @@ pub fn accessLogLineBytes(header_count: u32) u32 {
     const timestamp = 30; // "2026-07-31T09:14:22.481Z"
     // "[" + 39 bytes of IPv6 + "]:" + 5 port digits, quoted.
     const address = 48;
+    // The upstream half can also be a socket path (#303): the `unix:`
+    // prefix and the loader's own path bound, which is wider than any IP
+    // literal. The client half cannot — an `l4`/`http` listener still
+    // binds an IP, so a peer address is always one.
+    const upstream_address: u32 =
+        @max(address, "unix:".len + @as(u32, unix_socket_path_bytes_max) + 2);
     const number = 20; // a u64 at its widest
-    const addresses = 2; // client and upstream
     const numbers = 4; // duration, bytes in, bytes out, status
-    const fixed = scaffolding + timestamp + addresses * address + numbers * number +
+    const fixed = scaffolding + timestamp + address + upstream_address + numbers * number +
         @as(u32, access_log_method_bytes_max) + @as(u32, cluster_name_bytes_max) +
         6 * @as(u32, host_bytes_max) + 6 * @as(u32, access_log_path_bytes_max);
     // Per named header: the quoted key, the escaped value at JSON's

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -1189,11 +1189,19 @@ pub const Labeled = struct {
         });
     }
 
-    /// Widest rendered endpoint literal: a bracketed IPv6 address with
-    /// its port — 47 bytes, and truly the widest, since `parseLiteral`
-    /// cannot carry a scope id and the `{f}` render omits scopes anyway.
-    /// 64 is round headroom over that, not a scope allowance.
-    const endpoint_literal_bytes_max = 64;
+    /// Widest rendered endpoint literal. A bracketed IPv6 address with
+    /// its port is 47 bytes, and truly the widest of that family, since
+    /// `parseLiteral` cannot carry a scope id and the `{f}` render omits
+    /// scopes anyway. A socket path is longer (#303): the `unix:` prefix
+    /// plus what a `sockaddr_un` carries, which the loader enforces
+    /// rather than truncating. Escaping cannot widen either — the loader
+    /// admits nothing an escape would touch (`Address.pathIsRenderable`,
+    /// asserted at the renderer below) — so this is a bound and not an
+    /// estimate.
+    const endpoint_literal_bytes_max = @max(
+        64,
+        io_module.Address.unix_path_bytes_max + config_module.unix_address_prefix.len,
+    );
 
     /// Scratch wide enough for any label this config could produce: the
     /// grammar, a fully-escaped cluster name (every byte doubling), and
@@ -1210,7 +1218,7 @@ pub const Labeled = struct {
     fn endpointLabel(
         arena: std.mem.Allocator,
         name: []const u8,
-        address: *const std.Io.net.IpAddress,
+        address: *const io_module.Address,
     ) error{OutOfMemory}![]const u8 {
         var scratch: [label_scratch_bytes]u8 = undefined;
         return try arena.dupe(u8, renderEndpointLabel(&scratch, name, address));
@@ -1236,14 +1244,21 @@ pub const Labeled = struct {
     fn renderEndpointLabel(
         scratch: []u8,
         name: []const u8,
-        address: *const std.Io.net.IpAddress,
+        address: *const io_module.Address,
     ) []const u8 {
         assert(name.len >= 1);
         assert(name.len <= constants.cluster_name_bytes_max);
         assert(scratch.len >= label_scratch_bytes);
         var writer = std.Io.Writer.fixed(scratch);
         // Same cannot-fill argument as `renderClusterLabel`; the address
-        // half is bounded by the bracketed-IPv6 term of the scratch.
+        // half is bounded by the widest endpoint literal above. It is
+        // written unescaped, which the loader is what makes safe: an
+        // address carries nothing an escape would touch, and a label
+        // that did carry one would corrupt the whole exposition rather
+        // than one series.
+        if (address.* == .unix) {
+            assert(io_module.Address.pathIsRenderable(address.unix));
+        }
         writer.writeAll("{cluster=\"") catch unreachable;
         writeEscaped(&writer, name) catch unreachable;
         writer.print("\",endpoint=\"{f}\"}}", .{address.*}) catch unreachable;
@@ -1972,21 +1987,21 @@ fn labeledTestConfig(clusters: []const config_module.Config.Cluster) config_modu
     };
 }
 
-fn labeledTestAddress(comptime literal: []const u8) std.Io.net.IpAddress {
-    return std.Io.net.IpAddress.parseLiteral(literal) catch unreachable;
+fn labeledTestAddress(comptime literal: []const u8) io_module.Address {
+    return .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch unreachable };
 }
 
 const labeled_test_keys: upstream_module.EndpointKeys = .init(2, 2);
 
 fn labeledTestClusters() [2]config_module.Config.Cluster {
     const api_endpoints = struct {
-        const list = [_]std.Io.net.IpAddress{
+        const list = [_]io_module.Address{
             labeledTestAddress("10.0.0.1:8080"),
             labeledTestAddress("10.0.0.2:8080"),
         };
     };
     const solo_endpoints = struct {
-        const list = [_]std.Io.net.IpAddress{
+        const list = [_]io_module.Address{
             labeledTestAddress("[2001:db8::1]:9000"),
         };
     };
@@ -2038,7 +2053,7 @@ test "counters: labeled labels escape what the exposition grammar reserves" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const endpoints = struct {
-        const list = [_]std.Io.net.IpAddress{labeledTestAddress("127.0.0.1:1")};
+        const list = [_]io_module.Address{labeledTestAddress("127.0.0.1:1")};
     };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "we\"ird\\name", .endpoints = &endpoints.list },
@@ -2181,7 +2196,7 @@ test "counters: labeled render drops the healthy family with nothing checked" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const endpoints = struct {
-        const list = [_]std.Io.net.IpAddress{labeledTestAddress("127.0.0.1:1")};
+        const list = [_]io_module.Address{labeledTestAddress("127.0.0.1:1")};
     };
     const clusters = [_]config_module.Config.Cluster{
         .{ .name = "quiet", .endpoints = &endpoints.list },

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -1404,7 +1404,7 @@ pub fn Proxy(comptime IoType: type) type {
             }
             conn.stream.arm(&conn.stream.op_connect, "connect");
             server.io.connect(
-                pick.address,
+                &pick.address,
                 &conn.stream.op_connect.completion,
                 ConnType,
                 conn,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -28,6 +28,7 @@ const expected_date = "Date: Wed, 01 Jan 2020 00:00:00 GMT\r\nServer: zoxy\r\n";
 /// silently replaced.
 const origin_date = "Date: Tue, 31 Dec 2019 23:59:59 GMT\r\nServer: origin/1.0\r\n";
 const constants = @import("constants.zig");
+const io_module = @import("io/io.zig");
 const counters_module = @import("counters.zig");
 const router = @import("http/router.zig");
 const filter = @import("http/filter.zig");
@@ -97,7 +98,7 @@ const HttpClient = struct {
         client.io = io;
         client.server = server;
         client.address = address;
-        io.connect(address, &client.connect_completion, HttpClient, client, onConnect);
+        io.connect(&.{ .ip = address }, &client.connect_completion, HttpClient, client, onConnect);
     }
 
     fn onConnect(client: *HttpClient, result: Io.ConnectError!SimIo.Socket) void {
@@ -464,6 +465,17 @@ const HttpOrigin = struct {
         origin.armAccept();
     }
 
+    /// The same origin on a socket path (#303): everything past the
+    /// listen is identical, which is the fact the scenarios below rest
+    /// on — a UDS is a stream socket with a different name, so the L7
+    /// path above the dial cannot tell which it got.
+    fn startUnix(origin: *HttpOrigin, io: *SimIo, path: []const u8) !void {
+        origin.io = io;
+        origin.listener = try io.listenUnix(path);
+        origin.listening = true;
+        origin.armAccept();
+    }
+
     fn armAccept(origin: *HttpOrigin) void {
         origin.io.accept(origin.listener, &origin.accept_completion, HttpOrigin, origin, onAccept);
     }
@@ -530,7 +542,7 @@ fn endpointCounter(
 const Http1Bed = struct {
     arena_state: std.heap.ArenaAllocator,
     sim_io: SimIo,
-    endpoints: [2]std.Io.net.IpAddress,
+    endpoints: [2]io_module.Address,
     endpoints_count: u16,
     clusters: [1]config_module.Config.Cluster,
     routes: [1]router.Route,
@@ -557,6 +569,10 @@ const Http1Bed = struct {
     fn originAddress() std.Io.net.IpAddress {
         return std.Io.net.IpAddress.parseLiteral("127.0.0.1:9000") catch unreachable;
     }
+
+    /// The same origin reached over a socket path (#303) — the shape a
+    /// zoxy on the same host as its application actually deploys in.
+    const origin_socket_path = "/run/zoxy-test/origin.sock";
 
     /// An address no origin binds, so `SimIo` refuses every dial to it
     /// through its own listener lookup — the same answer a kernel gives
@@ -657,6 +673,10 @@ const Http1Bed = struct {
         /// The #300 opt-in; off by default, so every pre-existing
         /// scenario still asserts on pages with no `Proxy-Status`.
         proxy_status: bool = false,
+        /// Reach the origin over a Unix socket instead of loopback
+        /// (#303). Off by default: every pre-existing scenario is about
+        /// something other than which family the upstream leg speaks.
+        unix_origin: bool = false,
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it; a test that turns it on
         /// reads the emitted lines straight out of SimIo's virtual sink.
@@ -721,6 +741,27 @@ const Http1Bed = struct {
         };
     }
 
+    /// The cluster's endpoint list for one scenario. Split from `setUp`
+    /// for the length limit, along the seam #303 made natural: which
+    /// family the upstream leg speaks is one decision, and every other
+    /// thing `setUp` wires is unaffected by it.
+    fn installEndpoints(bed: *Http1Bed, options: Options) void {
+        if (options.unix_origin) {
+            // The refusing endpoint is an IP literal nothing binds, and
+            // the two options answer the same question — a scenario that
+            // asked for both would be asking which family a refusal has.
+            assert(!options.refusing_endpoint_first);
+            bed.endpoints = .{ .{ .unix = origin_socket_path }, undefined };
+            bed.endpoints_count = 1;
+            return;
+        }
+        bed.endpoints = if (options.refusing_endpoint_first)
+            .{ .{ .ip = refusingEndpointAddress() }, .{ .ip = originAddress() } }
+        else
+            .{ .{ .ip = originAddress() }, .{ .ip = originAddress() } };
+        bed.endpoints_count = if (options.refusing_endpoint_first) 2 else 1;
+    }
+
     fn setUp(bed: *Http1Bed, gpa: std.mem.Allocator, options: Options) !void {
         bed.arena_state = std.heap.ArenaAllocator.init(gpa);
         errdefer bed.arena_state.deinit();
@@ -740,11 +781,7 @@ const Http1Bed = struct {
             .buffer_group_count = head_buffers,
             .buffer_group_bytes = options.head_buffer_bytes,
         });
-        bed.endpoints = if (options.refusing_endpoint_first)
-            .{ refusingEndpointAddress(), originAddress() }
-        else
-            .{ originAddress(), originAddress() };
-        bed.endpoints_count = if (options.refusing_endpoint_first) 2 else 1;
+        bed.installEndpoints(options);
         bed.clusters = .{.{ .name = "origin", .endpoints = bed.endpoints[0..bed.endpoints_count], .check = options.check, .passive_ejection = options.passive_ejection, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key, .retries = options.retries }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
         bed.listeners = .{.{
@@ -790,7 +827,11 @@ const Http1Bed = struct {
             .close_second_at_accept = options.close_second_at_accept,
         };
         if (options.origin_listens) {
-            try bed.origin.start(&bed.sim_io, originAddress());
+            if (options.unix_origin) {
+                try bed.origin.startUnix(&bed.sim_io, origin_socket_path);
+            } else {
+                try bed.origin.start(&bed.sim_io, originAddress());
+            }
         }
         bed.client = .{ .send_delay_ms = options.send_delay_ms };
         bed.client2 = .{};
@@ -1337,6 +1378,86 @@ test "l7: OPTIONS asterisk-form is forwarded as \"*\", not as the \"/\" it match
     const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqual(parser.Method.options, forwarded.method);
     try std.testing.expectEqualStrings("*", forwarded.target);
+    try bed.expectDrained();
+}
+
+test "l7: a Unix-socket endpoint carries a request end to end (#303)" {
+    // The deployment this exists for: zoxy on the same host as its
+    // application, reaching it over a socket file rather than loopback —
+    // no ephemeral port per request, and filesystem permissions as the
+    // ACL. Above the dial nothing changes, which is the claim: a UDS is
+    // a stream socket with a different kind of name.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 90,
+        .unix_origin = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+        bed.client.response(),
+    );
+    try std.testing.expect(bed.origin.conns[0].request_complete);
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try forwardedRequest(&bed, &storage);
+    try std.testing.expectEqualStrings("/path", forwarded.target);
+    // The `Host` the origin sees is the client's, untouched: which
+    // family this leg speaks is not a routing fact (§7).
+    try std.testing.expectEqualStrings("origin.example", forwarded.host.?);
+    try bed.expectDrained();
+}
+
+test "l7: a Unix endpoint is named as the config spells it (#303)" {
+    // One renderer for the access log, the metrics label and the banner,
+    // so an operator greps the same string everywhere — and it is the
+    // string they wrote, prefix included, rather than a path stripped of
+    // what says it is a path.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 91,
+        .unix_origin = true,
+        .access_log = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    const line = bed.sim_io.sinkBytes();
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        line,
+        "\"upstream\":\"unix:" ++ Http1Bed.origin_socket_path ++ "\"",
+    ) != null);
+    try bed.expectDrained();
+}
+
+test "l7: a dial to a socket nothing binds is refused, not hung (#303)" {
+    // The failure an operator actually meets first — a typo in the path,
+    // or an application that has not started yet. A UDS connect to an
+    // unbound path returns immediately; what matters is that it reaches
+    // the same §8 verdict a refused TCP dial does rather than parking
+    // the exchange on the request deadline.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 92,
+        .unix_origin = true,
+        .origin_listens = false,
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n" ++ expected_date ++
+            "Connection: close\r\n\r\n",
+        bed.client.response(),
+    );
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_bad_gateway"));
     try bed.expectDrained();
 }
 

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -142,11 +142,11 @@ trace_hash: u64,
 /// concurrent, so it extends §8's closed-form op budgets from
 /// "worst-case in flight" to "total consumed".
 delivered: [std.enums.values(OpKind).len]u64,
-blackholed_addresses: [blackholed_addresses_max]std.Io.net.IpAddress,
+blackholed_addresses: [blackholed_addresses_max]Io.Address,
 blackholed_count: u8,
 /// One-shot dial faults by address (`injectConnectError`): the next
 /// connect to a matching address fails with `error.Unexpected`.
-connect_error_addresses: [connect_error_addresses_max]std.Io.net.IpAddress,
+connect_error_addresses: [connect_error_addresses_max]Io.Address,
 connect_error_count: u8,
 /// The virtual access-log sink (§8): what the server wrote, in order, for
 /// the §9 oracle to parse back. Arena-allocated at init like every other
@@ -299,7 +299,7 @@ pub const OpKind = enum(u8) {
 const Op = union(OpKind) {
     none,
     accept: struct { listener_index: u16 },
-    connect: struct { address: std.Io.net.IpAddress, fate: ConnectFate, canceled: bool },
+    connect: struct { address: Io.Address, fate: ConnectFate, canceled: bool },
     recv: struct { socket: Socket, buffer: []u8 },
     recv_group: struct { socket: Socket },
     send: struct { socket: Socket, bytes: []const u8 },
@@ -400,7 +400,7 @@ const SocketEntry = struct {
 };
 
 const ListenerEntry = struct {
-    address: std.Io.net.IpAddress,
+    address: Io.Address,
     active: bool,
     accept_queue: [accept_queue_max]Socket,
     accept_queue_len: u16,
@@ -542,22 +542,45 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
 /// use this to pin one dial while the adversary stays off the harness's
 /// own connects.
 pub fn blackholeAddress(io: *SimIo, address: std.Io.net.IpAddress) void {
+    io.blackholeDestination(&.{ .ip = address });
+}
+
+/// `blackholeAddress` for a destination in either family (#303) — the
+/// form a scenario dialing a socket path needs.
+pub fn blackholeDestination(io: *SimIo, address: *const Io.Address) void {
     assert(io.blackholed_count < blackholed_addresses_max);
-    io.blackholed_addresses[io.blackholed_count] = address;
+    io.blackholed_addresses[io.blackholed_count] = address.*;
     io.blackholed_count += 1;
 }
 
 pub fn listen(io: *SimIo, address: std.Io.net.IpAddress) Io.ListenError!Listener {
-    assert(io.listeners_count <= listeners_max);
-    if (io.listeners_count == listeners_max) {
-        return error.AddressUnavailable;
-    }
     var effective = address;
     if (effective.getPort() == 0) {
         effective.setPort(ephemeral_port_base + io.listeners_count);
     }
+    return io.listenAt(.{ .ip = effective });
+}
+
+/// Register a virtual origin on a socket path (#303).
+///
+/// A scenario-construction affordance rather than a seam op, beside
+/// `blackholeAddress` and `injectConnectError`: the proxy's own `bind`
+/// is still IP-only, and what a UDS *endpoint* needs from the simulator
+/// is something on the other end of the dial. There is no socket file
+/// here and nothing to unlink — a simulated Unix socket is a stream with
+/// a name, which is exactly the part of it §9 has to model.
+pub fn listenUnix(io: *SimIo, path: []const u8) Io.ListenError!Listener {
+    assert(path.len >= 1);
+    return io.listenAt(.{ .unix = path });
+}
+
+fn listenAt(io: *SimIo, effective: Io.Address) Io.ListenError!Listener {
+    assert(io.listeners_count <= listeners_max);
+    if (io.listeners_count == listeners_max) {
+        return error.AddressUnavailable;
+    }
     for (io.listeners[0..io.listeners_count]) |*existing| {
-        if (existing.active and std.meta.eql(existing.address, effective)) {
+        if (existing.active and existing.address.eql(&effective)) {
             return error.AddressInUse;
         }
     }
@@ -577,8 +600,12 @@ pub fn listen(io: *SimIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
 pub fn listenerAddress(io: *const SimIo, listener: Listener) std.Io.net.IpAddress {
     assert(listener.index < io.listeners_count);
     const entry = &io.listeners[listener.index];
-    assert(entry.address.getPort() != 0);
-    return entry.address;
+    // The seam's `listen` is IP-only, so its effective address is too.
+    // A `listenUnix` origin is a scenario's own construction and its
+    // caller already holds the path it asked for (#303).
+    assert(entry.address == .ip);
+    assert(entry.address.ip.getPort() != 0);
+    return entry.address.ip;
 }
 
 /// Sync close of a listener (drain, §8): the armed accept — if any —
@@ -635,7 +662,7 @@ pub fn accept(
 
 pub fn connect(
     io: *SimIo,
-    address: std.Io.net.IpAddress,
+    address: *const Io.Address,
     completion: *Completion,
     comptime Userdata: type,
     userdata: *Userdata,
@@ -663,7 +690,7 @@ pub fn connect(
     else
         random.uintAtMost(u64, io.adversary.connect_delay_ns_max);
     completion.* = .{
-        .op = .{ .connect = .{ .address = address, .fate = fate, .canceled = false } },
+        .op = .{ .connect = .{ .address = address.*, .fate = fate, .canceled = false } },
         .ready_at_ns = if (fate == .blackhole) never_ns else io.now_ns_value + delay_ns,
         .userdata = userdata,
         .callback = erasedResult(Userdata, .connect, callback),
@@ -1312,8 +1339,13 @@ pub fn injectAcceptError(io: *SimIo, listener: Listener) void {
 /// socket table never would (§9). One-shot, unlike `blackholeAddress`,
 /// so a scenario can fail one dial and let the retry through.
 pub fn injectConnectError(io: *SimIo, address: std.Io.net.IpAddress) void {
+    io.injectConnectErrorAt(&.{ .ip = address });
+}
+
+/// `injectConnectError` for a destination in either family (#303).
+pub fn injectConnectErrorAt(io: *SimIo, address: *const Io.Address) void {
     assert(io.connect_error_count < connect_error_addresses_max);
-    io.connect_error_addresses[io.connect_error_count] = address;
+    io.connect_error_addresses[io.connect_error_count] = address.*;
     io.connect_error_count += 1;
 }
 
@@ -1591,7 +1623,7 @@ fn deliverOne(io: *SimIo, completion: *Completion) void {
         .none => unreachable,
         .accept => |op| .{ .accept = io.finishAccept(op.listener_index) },
         .connect => |op| .{
-            .connect = if (op.canceled) error.Canceled else io.finishConnect(op.address, op.fate),
+            .connect = if (op.canceled) error.Canceled else io.finishConnect(&op.address, op.fate),
         },
         .recv => |op| .{ .recv = io.finishRecv(op.socket, op.buffer) },
         .recv_group => |op| .{ .recv_group = io.finishRecvGroup(op.socket) },
@@ -1649,7 +1681,7 @@ fn finishAccept(io: *SimIo, listener_index: u16) Io.AcceptError!Socket {
 
 fn finishConnect(
     io: *SimIo,
-    address: std.Io.net.IpAddress,
+    address: *const Io.Address,
     fate: ConnectFate,
 ) Io.ConnectError!Socket {
     assert(fate != .blackhole);
@@ -1677,7 +1709,14 @@ fn finishConnect(
     // client that reached it. Ports climb so every simulated client is
     // distinguishable in the access log; the wrap keeps that bounded
     // rather than overflowing on a long-lived fuzz run.
-    client_entry.peer_address = address;
+    // A dialed Unix socket has no peer address to name (#303); the
+    // loopback stand-in keeps every socket entry answerable, which is
+    // what `peerAddress` and `localAddress` need, and the listener half
+    // that would make it a real question is not this slice's.
+    client_entry.peer_address = switch (address.*) {
+        .ip => |ip| ip,
+        .unix => .{ .ip4 = .loopback(0) },
+    };
     server_entry.peer_address = .{ .ip4 = .{
         .bytes = client_ip_bytes,
         .port = io.next_client_port,
@@ -1685,7 +1724,7 @@ fn finishConnect(
     // Local addresses mirror the pair: each end's own address is what
     // the other end names it (§6 send's destination field).
     client_entry.local_address = server_entry.peer_address;
-    server_entry.local_address = address;
+    server_entry.local_address = client_entry.peer_address;
     io.next_client_port = if (io.next_client_port == std.math.maxInt(u16))
         client_port_base
     else
@@ -1946,10 +1985,10 @@ fn socketHandle(io: *SimIo, entry: *SocketEntry) Socket {
 }
 
 /// Consume a pending one-shot dial fault for this address, if any.
-fn takeConnectError(io: *SimIo, address: std.Io.net.IpAddress) bool {
+fn takeConnectError(io: *SimIo, address: *const Io.Address) bool {
     assert(io.connect_error_count <= connect_error_addresses_max);
     for (io.connect_error_addresses[0..io.connect_error_count], 0..) |pending, index| {
-        if (std.meta.eql(pending, address)) {
+        if (pending.eql(address)) {
             assert(io.connect_error_count >= 1);
             io.connect_error_addresses[index] =
                 io.connect_error_addresses[io.connect_error_count - 1];
@@ -1960,18 +1999,18 @@ fn takeConnectError(io: *SimIo, address: std.Io.net.IpAddress) bool {
     return false;
 }
 
-fn isBlackholed(io: *const SimIo, address: std.Io.net.IpAddress) bool {
+fn isBlackholed(io: *const SimIo, address: *const Io.Address) bool {
     for (io.blackholed_addresses[0..io.blackholed_count]) |blackholed| {
-        if (std.meta.eql(blackholed, address)) {
+        if (blackholed.eql(address)) {
             return true;
         }
     }
     return false;
 }
 
-fn findListener(io: *SimIo, address: std.Io.net.IpAddress) ?*ListenerEntry {
+fn findListener(io: *SimIo, address: *const Io.Address) ?*ListenerEntry {
     for (io.listeners[0..io.listeners_count]) |*entry| {
-        if (entry.active and std.meta.eql(entry.address, address)) {
+        if (entry.active and entry.address.eql(address)) {
             return entry;
         }
     }

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -619,35 +619,31 @@ pub fn accept(
     }).adapter);
 }
 
+/// Dial one endpoint (§4). The address union's branch lives here, which
+/// is the point of taking a union at the seam: `AF_UNIX` needs a
+/// different socket family and a different `sockaddr`, and both are
+/// syscall-shaped facts that §4 confines to this file.
 pub fn connect(
     io: *XevIo,
-    address: std.Io.net.IpAddress,
+    address: *const Io.Address,
     completion: *Completion,
     comptime Userdata: type,
     userdata: *Userdata,
     comptime callback: fn (*Userdata, Io.ConnectError!Socket) void,
 ) void {
-    const tcp = xev.TCP.init(address) catch {
-        // Kernel pressure (§8): report as this op's failure, delivered
-        // asynchronously via a zero-delay timer so callbacks never run
-        // inline with submission.
-        io.timer.run(&io.loop, completion, 0, Userdata, userdata, (struct {
-            fn adapter(
-                context: ?*Userdata,
-                loop: *xev.Loop,
-                timer_completion: *xev.Completion,
-                result: xev.Timer.RunError!void,
-            ) xev.CallbackAction {
-                _ = loop;
-                _ = timer_completion;
-                result catch {};
-                callback(context.?, error.Unexpected);
-                return .disarm;
-            }
-        }).adapter);
-        return;
+    const posix_address = posixAddressOf(address) catch {
+        // A path the loader accepted cannot overflow a `sockaddr_un`, so
+        // this arm is a caller that reached past config validation —
+        // reported as this op's failure rather than asserted, because
+        // the seam's contract is that every dial reaches a completion.
+        return failConnect(io, completion, Userdata, userdata, callback);
     };
-    tcp.connect(&io.loop, completion, address, Userdata, userdata, (struct {
+    const tcp = xev.TCP.initAddress(posix_address) catch {
+        // Kernel pressure (§8): report as this op's failure, through
+        // the same deferred path the address arm above takes.
+        return failConnect(io, completion, Userdata, userdata, callback);
+    };
+    tcp.connectAddress(&io.loop, completion, posix_address, Userdata, userdata, (struct {
         fn adapter(
             context: ?*Userdata,
             loop: *xev.Loop,
@@ -676,6 +672,43 @@ pub fn connect(
                     else => error.Unexpected,
                 });
             }
+            return .disarm;
+        }
+    }).adapter);
+}
+
+/// The posix form of a seam address, built here because a `sockaddr` is
+/// a syscall's shape and §4 keeps those in this file.
+fn posixAddressOf(address: *const Io.Address) error{NameTooLong}!xev.net.Address {
+    return switch (address.*) {
+        .ip => |ip| xev.net.Address.fromIpAddress(ip),
+        .unix => |path| try xev.net.Address.initUnix(path),
+    };
+}
+
+/// Deliver a connect failure the caller can still act on: asynchronously,
+/// via a zero-delay timer, so a callback never runs inline with the
+/// submission that asked for it — the invariant every other op here
+/// holds, and the reason a failed dial still reaches a terminal
+/// completion and releases its slot (§5).
+fn failConnect(
+    io: *XevIo,
+    completion: *Completion,
+    comptime Userdata: type,
+    userdata: *Userdata,
+    comptime callback: fn (*Userdata, Io.ConnectError!Socket) void,
+) void {
+    io.timer.run(&io.loop, completion, 0, Userdata, userdata, (struct {
+        fn adapter(
+            context: ?*Userdata,
+            loop: *xev.Loop,
+            timer_completion: *xev.Completion,
+            result: xev.Timer.RunError!void,
+        ) xev.CallbackAction {
+            _ = loop;
+            _ = timer_completion;
+            result catch {};
+            callback(context.?, error.Unexpected);
             return .disarm;
         }
     }).adapter);

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -146,7 +146,7 @@ pub fn EchoScenario(comptime IoType: type) type {
                 onAccept,
             );
             scenario.io.connect(
-                scenario.io.listenerAddress(scenario.listener),
+                &.{ .ip = scenario.io.listenerAddress(scenario.listener) },
                 &scenario.connect_completion,
                 Scenario,
                 scenario,
@@ -357,7 +357,7 @@ fn GroupContract(comptime IoType: type) type {
             c.connect_completion = .{};
             c.io.accept(listener, &c.accept_completion, Contract, c, onAccept);
             c.io.connect(
-                c.io.listenerAddress(listener),
+                &.{ .ip = c.io.listenerAddress(listener) },
                 &c.connect_completion,
                 Contract,
                 c,
@@ -964,7 +964,7 @@ fn connectPair(xev_io: *XevIo) !ConnectedPair {
     );
     xev_io.accept(listener, &pair.accept_completion, Pair, &pair, Pair.onAccept);
     xev_io.connect(
-        xev_io.listenerAddress(listener),
+        &.{ .ip = xev_io.listenerAddress(listener) },
         &pair.connect_completion,
         Pair,
         &pair,
@@ -1014,7 +1014,7 @@ test "xevio: a send after our own write shutdown is Reset, not kernel pressure" 
     const listener = try xev_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
     xev_io.accept(listener, &pair.accept_completion, Pair, &pair, Pair.onAccept);
     xev_io.connect(
-        xev_io.listenerAddress(listener),
+        &.{ .ip = xev_io.listenerAddress(listener) },
         &pair.connect_completion,
         Pair,
         &pair,
@@ -1184,7 +1184,7 @@ test "xevio: a dial to a closed loopback port is Refused" {
 
     var outcome: ?(Io.ConnectError!XevIo.Socket) = null;
     var completion: XevIo.Completion = .{};
-    xev_io.connect(address, &completion, @TypeOf(outcome), &outcome, (struct {
+    xev_io.connect(&.{ .ip = address }, &completion, @TypeOf(outcome), &outcome, (struct {
         fn onConnect(
             state: *?(Io.ConnectError!XevIo.Socket),
             result: Io.ConnectError!XevIo.Socket,
@@ -1409,7 +1409,7 @@ test "xevio: canceling a stuck dial delivers Canceled and releases the op" {
     address.setPort(port);
     var outcome: ?(Io.ConnectError!XevIo.Socket) = null;
     var connect_completion: XevIo.Completion = .{};
-    xev_io.connect(address, &connect_completion, @TypeOf(outcome), &outcome, (struct {
+    xev_io.connect(&.{ .ip = address }, &connect_completion, @TypeOf(outcome), &outcome, (struct {
         fn onConnect(
             state: *?(Io.ConnectError!XevIo.Socket),
             result: Io.ConnectError!XevIo.Socket,

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -66,6 +66,8 @@
 
 const std = @import("std");
 
+const constants = @import("../constants.zig");
+
 pub const SimIo = @import("SimIo.zig");
 pub const XevIo = @import("XevIo.zig");
 
@@ -78,6 +80,78 @@ pub const Signal = enum(u8) {
     /// (§1 non-goal: the §5 pools are startup-fixed, so a config change
     /// is a restart), and claiming the signal for the log says so.
     reopen_log,
+};
+
+/// A dial destination (#303): an IP address, or the path of a
+/// filesystem `AF_UNIX` socket.
+///
+/// One union rather than a second `connectUnix` entry point, so the seam
+/// keeps one call site per operation and every dial site — `Server`, the
+/// L7 proxy, the health checker — stays a single call. The branch lives
+/// where the syscall does, which is the only place §4 lets it.
+///
+/// The path is borrowed, not owned: it points into the config arena,
+/// which outlives every dial by construction (§1, parse-once). Nothing
+/// here allocates and nothing copies the bytes until a backend builds
+/// the `sockaddr_un` a submission needs.
+pub const Address = union(enum) {
+    ip: std.Io.net.IpAddress,
+    unix: []const u8,
+
+    /// The loader's own bound on a socket path, which lives in
+    /// `constants.zig` beside every other §5 term rather than here: the
+    /// access log's line bound is a function of it too, and one number
+    /// with two homes is the one that goes stale.
+    pub const unix_path_bytes_max = constants.unix_socket_path_bytes_max;
+
+    /// Whether a socket path is safe to render verbatim: printable
+    /// ASCII with no quote and no backslash.
+    ///
+    /// The loader is the only caller that *decides* with this — an
+    /// address that fails it is refused at load (§5) — and the renderers
+    /// assert on it, because an endpoint literal goes into a JSON log
+    /// line and a Prometheus label unescaped, where one bad byte spoils
+    /// the whole line and the whole scrape rather than one field. One
+    /// definition, so the rule and the bound that rests on it cannot
+    /// drift apart.
+    pub fn pathIsRenderable(path: []const u8) bool {
+        for (path) |byte| {
+            if (byte <= 0x20 or byte >= 0x7f or byte == '"' or byte == '\\') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// The two forms compare by value, which stickiness and the endpoint
+    /// tables both need: a `hash` cluster's identity is derived from the
+    /// address, so two spellings of one endpoint must be one endpoint.
+    pub fn eql(a: *const Address, b: *const Address) bool {
+        return switch (a.*) {
+            .ip => |lhs| switch (b.*) {
+                .ip => |rhs| lhs.eql(&rhs),
+                .unix => false,
+            },
+            .unix => |lhs| switch (b.*) {
+                .ip => false,
+                .unix => |rhs| std.mem.eql(u8, lhs, rhs),
+            },
+        };
+    }
+
+    /// Render as the config spells it — an IP literal, or the `unix:`
+    /// prefix the #305 grammar settled on. One renderer, so the access
+    /// log, the metrics label and the startup banner cannot disagree
+    /// about what an endpoint is called.
+    pub fn format(address: Address, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        switch (address) {
+            .ip => |ip| try writer.print("{f}", .{ip}),
+            .unix => |path| {
+                try writer.writeAll("unix:");
+                try writer.writeAll(path);
+            },
+        }
+    }
 };
 
 pub const ShutdownHow = enum(u8) {

--- a/src/io/sim_io_test.zig
+++ b/src/io/sim_io_test.zig
@@ -56,7 +56,7 @@ const PairScenario = struct {
     fn establish(pair: *PairScenario) !void {
         pair.listener = try pair.io.listen(testAddress());
         pair.io.accept(pair.listener, &pair.accept_completion, PairScenario, pair, onAccept);
-        pair.io.connect(testAddress(), &pair.connect_completion, PairScenario, pair, onConnect);
+        pair.io.connect(&.{ .ip = testAddress() }, &pair.connect_completion, PairScenario, pair, onConnect);
         try pair.io.run();
         assert(pair.ready_count == 2);
         pair.io.listenClose(pair.listener);
@@ -159,7 +159,7 @@ test "sim: connect to an unlistened address is refused" {
     try sim_io.init(arena_state.allocator(), .{ .seed = 3 });
 
     var probe: ConnectProbe = .{};
-    sim_io.connect(testAddress(), &probe.completion, ConnectProbe, &probe, ConnectProbe.onConnect);
+    sim_io.connect(&.{ .ip = testAddress() }, &probe.completion, ConnectProbe, &probe, ConnectProbe.onConnect);
     try sim_io.run();
     try std.testing.expectError(error.Refused, probe.result.?);
     try std.testing.expect(sim_io.sockets.isFullyReleased());
@@ -189,7 +189,7 @@ test "sim: an injected connect error fails one dial with Unexpected and records 
 
     var probe: ConnectPressureProbe = .{ .io = &sim_io };
     sim_io.connect(
-        testAddress(),
+        &.{ .ip = testAddress() },
         &probe.completion,
         ConnectPressureProbe,
         &probe,
@@ -200,7 +200,7 @@ test "sim: an injected connect error fails one dial with Unexpected and records 
     try std.testing.expectEqual(Io.Pressure.Cause.address_unavailable, probe.pressure.?.cause);
 
     var retry: ConnectProbe = .{};
-    sim_io.connect(testAddress(), &retry.completion, ConnectProbe, &retry, ConnectProbe.onConnect);
+    sim_io.connect(&.{ .ip = testAddress() }, &retry.completion, ConnectProbe, &retry, ConnectProbe.onConnect);
     try sim_io.run();
     const socket = try retry.result.?;
     sim_io.closeNow(socket);

--- a/src/io/xev_smoke_test.zig
+++ b/src/io/xev_smoke_test.zig
@@ -126,6 +126,80 @@ test "tcp: loopback echo across the full watcher surface" {
     try std.testing.expectEqual(@as(u32, 3), echo.close_count);
 }
 
+test "unix: the same echo over a socket path (#303)" {
+    // The half the simulator cannot prove: an AF_UNIX dial is a real
+    // `sockaddr_un` reaching a real kernel, and the pinned libxev's
+    // `connect` op could not carry one until 010be2a. Reusing the TCP
+    // echo's context verbatim is the assertion worth making — above the
+    // connect, a Unix stream socket is indistinguishable from a TCP one.
+    var thread_pool = if (comptime xev.backend == .kqueue) xev.ThreadPool.init(.{}) else {};
+    defer if (comptime xev.backend == .kqueue) {
+        thread_pool.shutdown();
+        thread_pool.deinit();
+    };
+    var loop = try xev.Loop.init(.{
+        .entries = ring_entries,
+        .thread_pool = if (comptime xev.backend == .kqueue) &thread_pool else null,
+    });
+    defer loop.deinit();
+
+    // A short fixed path, because a `sockaddr_un` holds far less than a
+    // filesystem does and a temp directory's name would eat most of it.
+    // Removed before the bind rather than after: a bind onto an existing
+    // socket file is `EADDRINUSE`, which is the whole of the stale-file
+    // problem the listener half will have to answer, and a crashed
+    // previous run must not wedge every later one.
+    const path = "/tmp/zoxy-xev-unix-smoke.sock";
+    _ = std.posix.system.unlink(path);
+    defer _ = std.posix.system.unlink(path);
+
+    const address = try xev.net.Address.initUnix(path);
+    const listener = try xev.TCP.initAddress(address);
+    // Raw, because the stdlib's wrappers moved behind an `Io` in 0.16
+    // and this file is the one §4 lets name a syscall.
+    try std.testing.expect(
+        std.posix.system.bind(listener.fd, &address.any, address.getOsSockLen()) == 0,
+    );
+    try std.testing.expect(std.posix.system.listen(listener.fd, 1) == 0);
+
+    const client = try xev.TCP.initAddress(address);
+
+    var echo: EchoContext = .{ .listener = listener, .client = client };
+    listener.accept(&loop, &echo.completion_accept, EchoContext, &echo, EchoContext.onAccept);
+    client.connectAddress(
+        &loop,
+        &echo.completion_connect,
+        address,
+        EchoContext,
+        &echo,
+        EchoContext.onConnect,
+    );
+
+    try loop.run(.until_done);
+
+    try std.testing.expect(!echo.failed);
+    try std.testing.expect(echo.accept_ok);
+    try std.testing.expect(echo.connect_ok);
+    try std.testing.expectEqualStrings(echo_token, echo.server_buffer[0..echo.server_read_len]);
+    try std.testing.expectEqualStrings(echo_token, echo.client_buffer[0..echo.client_read_len]);
+    try std.testing.expectEqual(@as(u32, 3), echo.close_count);
+}
+
+test "unix: a path the length arithmetic gets wrong reaches the wrong socket" {
+    // The failure the `getOsSockLen` arm exists to prevent, pinned from
+    // the outside: the length a `sockaddr_un` is submitted with decides
+    // how much of the path the kernel reads, and the old catch-all arm
+    // (`@sizeOf(sockaddr)`, 16) would have cut every path to thirteen
+    // characters — so two different sockets would have been one.
+    const short = try xev.net.Address.initUnix("/run/aaaaaaaa");
+    const long = try xev.net.Address.initUnix("/run/aaaaaaaaXYZ");
+    try std.testing.expect(short.getOsSockLen() != long.getOsSockLen());
+    try std.testing.expectEqual(
+        @as(std.posix.socklen_t, @offsetOf(std.posix.sockaddr.un, "path") + 14),
+        short.getOsSockLen(),
+    );
+}
+
 const TimerContext = struct {
     fired_count: u32 = 0,
     canceled_count: u32 = 0,

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -305,7 +305,7 @@ pub fn Checker(comptime IoType: type) type {
                 );
                 probe.armed.connect = true;
                 server.io.connect(
-                    cluster.endpoints[endpoint_index],
+                    &cluster.endpoints[endpoint_index],
                     &probe.op_connect,
                     Probe,
                     probe,

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -34,6 +34,7 @@
 //! for a test, and issue #75 already measured the cost of the one it has.
 
 const std = @import("std");
+const io_module = @import("../io/io.zig");
 
 const config_module = @import("../config.zig");
 const constants = @import("../constants.zig");
@@ -573,7 +574,7 @@ const Harness = struct {
     routes: [1]router.Route = undefined,
     listeners: [1]config_module.Config.Listener = undefined,
     clusters: [1]config_module.Config.Cluster = undefined,
-    endpoints: [1]std.Io.net.IpAddress = undefined,
+    endpoints: [1]io_module.Address = undefined,
     config: config_module.Config = undefined,
 
     client_listener: SimIo.Listener = undefined,
@@ -616,7 +617,7 @@ const Harness = struct {
         var sim_options = options.sim;
         sim_options.buffer_group_count = 0;
         try bed.io.init(arena, sim_options);
-        bed.endpoints = .{originAddress()};
+        bed.endpoints = .{.{ .ip = originAddress() }};
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.listeners = .{.{
@@ -650,7 +651,7 @@ const Harness = struct {
         bed.origin_listener = try bed.io.listen(originAddress());
         bed.io.accept(bed.client_listener, &bed.accept_completion, Harness, bed, onProxyAccepted);
         bed.io.accept(bed.origin_listener, &bed.origin.accept_completion, Origin, &bed.origin, onOriginAccepted);
-        bed.io.connect(clientAddress(), &bed.client.connect_completion, Client, &bed.client, onClientConnected);
+        bed.io.connect(&.{ .ip = clientAddress() }, &bed.client.connect_completion, Client, &bed.client, onClientConnected);
     }
 
     fn tearDown(bed: *Harness) void {
@@ -661,7 +662,7 @@ const Harness = struct {
 
     fn onProxyAccepted(bed: *Harness, result: Io.AcceptError!SimIo.Socket) void {
         bed.proxy_client_socket = result catch unreachable;
-        bed.io.connect(originAddress(), &bed.connect_completion, Harness, bed, onProxyDialed);
+        bed.io.connect(&.{ .ip = originAddress() }, &bed.connect_completion, Harness, bed, onProxyDialed);
     }
 
     fn onProxyDialed(bed: *Harness, result: Io.ConnectError!SimIo.Socket) void {

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 
 const config_module = @import("config.zig");
 const constants = @import("constants.zig");
+const io_module = @import("io/io.zig");
 const Credentials = @import("tls/Credentials.zig");
 const router = @import("http/router.zig");
 const sni_router = @import("net/sni_router.zig");
@@ -143,7 +144,7 @@ pub const Client = struct {
 
     fn start(client: *Client, scenario: *Scenario, address: std.Io.net.IpAddress) void {
         client.scenario = scenario;
-        scenario.io.connect(address, &client.connect_completion, Client, client, onConnect);
+        scenario.io.connect(&.{ .ip = address }, &client.connect_completion, Client, client, onConnect);
     }
 
     fn onConnect(client: *Client, result: Io.ConnectError!SimIo.Socket) void {
@@ -260,7 +261,7 @@ pub const TestBed = struct {
     /// scenarios need — enough endpoints that a serial sweep and a
     /// concurrent one finish at times a test can tell apart — and it
     /// fits `SimIo`'s own `blackholed_addresses_max`.
-    endpoints: [4]std.Io.net.IpAddress,
+    endpoints: [4]io_module.Address,
     endpoints_count: u16,
     clusters: [1]config_module.Config.Cluster,
     routes: [1]router.Route,
@@ -343,7 +344,7 @@ pub const TestBed = struct {
         blackholed: u8,
     ) !void {
         assert(blackholed <= bed.endpoints.len - 1);
-        bed.endpoints = .{ originAddress(), undefined, undefined, undefined };
+        bed.endpoints = .{ .{ .ip = originAddress() }, undefined, undefined, undefined };
         bed.endpoints_count = 1 + blackholed;
         for (bed.endpoints[1..bed.endpoints_count], 0..) |*endpoint, index| {
             const literal = try std.fmt.allocPrintSentinel(
@@ -354,8 +355,8 @@ pub const TestBed = struct {
             );
             // The format is fixed and every port in range renders valid,
             // unlike the allocation above, which can genuinely fail.
-            endpoint.* = std.Io.net.IpAddress.parseLiteral(literal) catch unreachable;
-            bed.sim_io.blackholeAddress(endpoint.*);
+            endpoint.* = .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch unreachable };
+            bed.sim_io.blackholeDestination(endpoint);
         }
     }
 

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -317,6 +317,17 @@ pub fn Origin(comptime IoType: type) type {
             origin.armAccept();
         }
 
+        /// Start on a socket path instead (#303). A simulator affordance
+        /// — `SimIo.listenUnix` — because what a UDS *endpoint* needs
+        /// from §9 is something on the other end of the dial, and the
+        /// proxy's own `bind` is still IP-only.
+        pub fn startUnix(origin: *Self, io: *IoType, path: []const u8) !void {
+            origin.io = io;
+            origin.listener = try io.listenUnix(path);
+            origin.listening = true;
+            origin.armAccept();
+        }
+
         fn armAccept(origin: *Self) void {
             origin.io.accept(origin.listener, &origin.accept_completion, Self, origin, onAccept);
         }

--- a/src/tls/TestClient.zig
+++ b/src/tls/TestClient.zig
@@ -245,7 +245,7 @@ pub fn TestClient(comptime IoType: type) type {
             client.ticket = .{};
             client.ticket_captured = false;
             client.resume_with = options.resume_with;
-            io.connect(address, &client.connect_completion, Self, client, onConnect);
+            io.connect(&.{ .ip = address }, &client.connect_completion, Self, client, onConnect);
         }
 
         /// The `Options` combinations that are not merely unusual but


### PR DESCRIPTION
Implements the **endpoints half** of #303. Listeners stay IP-only on purpose — see the last section.

```json
"clusters": {
    "app": { "endpoints": ["127.0.0.1:9000", "unix:/run/app.sock"] }
}
```

The motivating failure is not aesthetic and arrives suddenly: a proxy in front of a local app burns through the loopback's ephemeral range while the backend is perfectly healthy. A socket file has no port. Filesystem permissions as the ACL, and no TCP state machine per byte on the leg that runs every request, are the other two.

## Two commits

**`acd4241` — the libxev pin moves.** The pinned fork could not express an AF_UNIX dial: `Completion.connect` carries an address union whose members top out at 28 bytes against a `sockaddr_un`'s 110, and `getOsSockLen`'s catch-all arm returns `@sizeOf(sockaddr)` (16), which would truncate every path to thirteen characters. Both backends prep from `&v.addr.any` and that length, so the fix belongs in the union, not at a call site. Sixth stacked commit, audit vehicle at zoxy-io/libxev#5, reasoning and sign-off in `build.zig.zon`.

It is not free, and §5 says so out loud. The kernel reads the address from one contiguous location that outlives the submission, so the path is inline and `Completion` grows 128 → 152 bytes (io_uring). zoxy holds two per conn and four per stream, which the banner now prices exactly:

| | before | after |
|---|---|---|
| conn slots | 456 B | 504 B |
| stream slots | 1448 B | 1544 B |
| **total** | 47155 KiB | 47350 KiB |

+195 KiB, 0.41%, against relay buffers that are 45 MiB of that total.

**`27207d9` — the feature.**

## The seam takes an address union

`Io.Address = union(enum) { ip, unix }`, and `connect` takes `*const Io.Address`. One call per dial site, the family branch pushed down to where the syscall is — so `Server`, the L7 proxy and the health checker are unchanged. Above the dial nothing knows a Unix stream socket from a TCP one: framing, pooling, retries, health checks and `max_inflight` all run as they were. `hash` stickiness keys on the path through the same finalizer the IP arms use, so a rolling restart cannot re-shuffle which client lands on which socket.

## Three rules, all at load

Refused at load rather than repaired at the dial (§5):

- **Absolute** — a relative path resolves against a working directory the operator did not name and a service manager may change.
- **≤ 103 bytes** — a `sockaddr_un` carries 108 on Linux and 104 on macOS, so 103 is the smaller minus the terminator, and one config file works on both. Not truncated: a shortened path names a *different* socket and the kernel could not say so.
- **Printable ASCII, no quote or backslash.** This is the rule worth arguing, and it came out of review. An endpoint address lands verbatim in every access-log line and every Prometheus label, so a control byte there does not spoil a field — it invalidates the whole line and the whole scrape. Escaping instead would multiply the §5 render bound by six for bytes no operator will ever write. `Address.pathIsRenderable` is the single definition: the loader decides with it, the label renderer asserts on it.

## Tests

The simulator models a UDS origin — `SimIo.listenUnix`, a scenario affordance beside `blackholeAddress`, since a simulated Unix socket is a stream with a name and there is no file to unlink:

- a request carried end to end, with the origin seeing the client's `Host` untouched;
- the `unix:` spelling appearing in the access log exactly as configured;
- a dial to a path nothing binds reaching the same 502 a refused TCP dial does, rather than parking on the request deadline.

Config tests pin the grammar, both spellings in one cluster with #174 weights intact, the render round-trip, and every rejection — relative, empty, over-length (with the longest fitting path accepted, so the bound is a real edge), and each hostile byte.

The half the simulator structurally cannot prove — a real `sockaddr_un` reaching a real kernel — is an AF_UNIX echo through the production backend that reuses the TCP echo's context **verbatim**, which is exactly the claim being made. Plus a test pinning that two paths differing past byte thirteen get different submitted lengths, which is the failure the `getOsSockLen` arm exists to prevent.

## What is deliberately not here

- **Listeners.** `bind: "unix:…"` is refused, not half-accepted. That half must answer what a client address *is* when there is none — `hash: source_ip`, a filter's `match.client` (family-strict, #177), the access log and `X-Forwarded-For` all ask at once — and a config that looks like it works must not be one that does not.
- **The abstract namespace.** It carries no filesystem permissions, which is most of the argument for the feature.
- **`proxy_protocol` needed no change** in either direction: the header announces the *client's* addresses, a fact about the connection that arrived rather than about the leg the header is written on.

## Gates

`zig build ci` green (4096 sim seeds, both smoke runs), `zig fmt --check` clean. `tiger-style-reviewer` run; it caught the escaping hole above, and that finding is what the third loader rule answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)