### PR TITLE
l7: a listener may bind a socket file (#303)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1609,14 +1609,39 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   truncate one layer down. The abstract namespace is out of scope: it
   carries no filesystem permissions, which is most of the argument for
   the feature.
-  **Listeners stay IP-only** for now. That half has to answer what a
-  client address *is* when there is none — a question `hash: source_ip`,
-  a filter's `match.client` (family-strict, #177), the access log and
-  `X-Forwarded-For` all ask at once — and `bind: "unix:…"` is refused at
-  load rather than half-accepted. A `proxy_protocol` send block is
-  unaffected in either direction: the header announces the *client's*
-  addresses, which is a fact about the connection that arrived and not
-  about the leg the header is written on.
+  **A listener takes the same grammar**, and answers the question that
+  half turns on: a request arriving on a socket file has no client IP,
+  because the kernel has none to give. `Conn.client_address` becomes
+  optional rather than acquiring a sentinel — a fabricated `0.0.0.0`
+  would be believed by every consumer — and the loader refuses the four
+  features that would have to read one: a `forwarded` block, a filter
+  matching on `match.client` (#177), a route to a cluster sticky on
+  `source_ip`, and a route to a cluster announcing a PROXY header (which
+  names a source *and* a destination, and this listener has neither).
+  The last two are asked of every cluster the listener can *reach*, and
+  `routes` is not that set: an l4 listener with an SNI table (#298)
+  resolves `routes` to one provisional entry — the admitted cluster —
+  while `finishSniPeek` replaces the exchange's cluster with the matched
+  one before any dial, so a check reading only `routes` would hold the
+  first name to the rule and wave every other one through.
+  Each is a startup error naming the pair; the access log states `null`
+  for the same reason it does for an unpicked `upstream`, and every
+  unwrap left in the serving path cites the rule that makes it sound.
+  **The socket file's lifecycle is startup's problem, not the loop's.**
+  A path that does not exist is created; one that *is* a socket is
+  removed first, because a killed process leaves its file behind and
+  `EADDRINUSE` forever is a proxy that cannot return after the incident
+  that killed it; and one that is anything else — a file, a directory, a
+  symlink, judged as itself rather than followed — refuses the start. The
+  conditional is the point: a typo in `bind` must never be a delete. A
+  clean `listenClose` removes what it made, which is tidiness rather than
+  correctness — the startup rule is what makes an unclean stop survivable.
+  An optional `mode` chmods the socket after the bind, taken as an octal
+  *string* because `0660` is not JSON and `660` is decimal, and the two
+  readings differ eightfold in the direction that widens access.
+  One thing this family cannot do: **`SO_REUSEPORT` does not reach it**
+  (§3). Two processes cannot bind one path, so a socket-file listener is
+  for chaining on one host, never for spreading across processes.
 - **A pick chooses among the endpoints that are both healthy and under
   capacity**, in that order, and the two filters differ in what an empty
   result means. Health fails **open**: a cluster with every endpoint

--- a/docs/README.md
+++ b/docs/README.md
@@ -697,14 +697,86 @@ A [`proxy_protocol`](#telling-an-l4-origin-proxy-protocol) send block
 still works and still announces the *client's* addresses — the header
 describes the connection that arrived, not the leg it is written on.
 
+A listener can take the same grammar — see
+[accepting on a socket file](#accepting-on-a-socket-file).
+
 > [!NOTE]
-> Listeners are still IP-only: `bind` does not take a `unix:` path yet.
-> That half needs an answer for what a client address *is* when there is
-> none, which `hash: source_ip`, a filter's `match.client` and
-> `X-Forwarded-For` all ask, and shipping it half-answered would be
-> worse than not shipping it. The abstract namespace (a leading NUL) is
-> deliberately out of scope — it has no filesystem permissions, which is
-> most of the argument above.
+> The abstract namespace (a leading NUL) is deliberately out of scope: it
+> has no filesystem permissions, which is most of the argument above.
+
+#### Accepting on a socket file
+
+The mirror: `bind` takes the same `unix:` grammar, so something local
+reaches zoxy through a file rather than a port.
+
+```json
+{
+    "bind": "unix:/run/zoxy.sock",
+    "mode": "0660",
+    "http": { "cluster": "app" }
+}
+```
+
+The path rules are the endpoint's, exactly — absolute, ≤ 103 bytes,
+printable ASCII with no quote or backslash — and two listeners on one
+path are the same duplicate two on one `IP:port` are.
+
+**The socket file's lifecycle** is the part every implementation of this
+gets wrong, so it is worth stating plainly:
+
+| at startup, the path… | zoxy |
+|---|---|
+| does not exist | creates it |
+| is a socket | removes it, then creates it — a killed process must not wedge every later start |
+| is anything else (file, directory, symlink) | **refuses to start** and says so |
+
+A clean stop removes the file it made. A `SIGKILL` cannot, which is what
+the second row is for. The third row is why the second is conditional: a
+typo in `bind` must never be a delete, and a symlink is judged as itself
+rather than followed.
+
+**`mode`** sets the socket's permission bits after the bind, as the octal
+string every other tool takes. It is a string and not a number because
+`0660` is not valid JSON and `660` is decimal — two readings of one
+intent that differ by a factor of eight, in the direction that widens
+access. Absent leaves whatever the umask gives, which under a typical one
+is world-connectable; if the socket itself is meant to be the ACL rather
+than the directory holding it, write the field.
+
+**What a `unix:` listener may not also ask for.** A request arriving on a
+socket file has no client IP — the kernel has none to give — and rather
+than invent one, the loader refuses the four things that would need it:
+
+| rejected | because |
+|---|---|
+| a `forwarded` block | `X-Forwarded-For` would state an address nobody connected from |
+| a filter with `match.client` | an allowlist would be comparing against a fiction |
+| routing to a `hash` cluster keyed on `source_ip` | every local client would land on one endpoint while looking sticky |
+| routing to a cluster with `proxy_protocol` send | the header announces source *and* destination addresses; this listener has neither |
+
+The last two are checked against every cluster the listener can *reach*,
+which on an `l4` listener means each name in its
+[SNI table](#routing-an-l4-listener-by-tls-name-sni) as well as the one
+it admits under — a table routes to a different cluster per name, and
+the check would otherwise hold only the first name to the rule.
+
+Each is a startup error naming the pair, not a runtime surprise. The
+access log states the absence rather than hiding it:
+
+```json
+{"client":null, "upstream":"10.0.0.1:8080", ...}
+```
+
+Everything that does not depend on a client address is untouched: routing,
+header and path filters, `hash` on a header or cookie, TLS termination,
+upgrades, body limits, timeouts and the shed ladder all behave as they do
+on a TCP listener.
+
+> [!NOTE]
+> A `unix:` listener is not part of the `SO_REUSEPORT` scale-out story
+> (see [Under load](#under-load)): two processes cannot bind one path, so
+> the option is meaningless here. Run N processes behind a TCP listener,
+> or one process behind a socket file.
 
 ### Sticky sessions
 

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -1388,13 +1388,15 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
     const terminates_http = harness.tls_protocol == .http;
     harness.listener_configs = .{
         .{
-            .bind_address = bindAddress(),
+            .bind_address = .{ .ip = bindAddress() },
+            .bind_mode = null,
             .routes = &harness.routes_l4,
             .protocol = .l4,
             .proxy_protocol = harness.proxy_protocol_l4,
         },
         .{
-            .bind_address = httpBindAddress(),
+            .bind_address = .{ .ip = httpBindAddress() },
+            .bind_mode = null,
             .routes = &harness.routes_http,
             .request_filters = &harness.request_filters_http,
             .response_filters = &harness.response_filters_http,
@@ -1404,7 +1406,8 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .max_body_bytes = harness.max_body_bytes,
         },
         .{
-            .bind_address = tlsBindAddress(),
+            .bind_address = .{ .ip = tlsBindAddress() },
+            .bind_mode = null,
             // No #236 body cap, stated rather than inherited. The draw is
             // a *plaintext-leg* one, and that is exactly what makes
             // `routed_canonical`'s per-leg argument in `scripts.zig`

--- a/sim/l7/origin.zig
+++ b/sim/l7/origin.zig
@@ -557,7 +557,7 @@ pub fn HttpOrigin(comptime IoType: type) type {
 
         pub fn start(origin: *Self, io: *IoType, address: std.Io.net.IpAddress) !void {
             origin.io = io;
-            origin.listener = try io.listen(address);
+            origin.listener = try io.listen(&.{ .ip = address }, null);
             origin.listening = true;
             origin.armAccept();
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -393,6 +393,11 @@ pub fn Server(comptime IoType: type) type {
             /// same reason as `forwarded` — what may be said on the wire
             /// depends on who is in front of this socket.
             proxy_status: bool,
+            /// Whether this listener binds a socket file (#303), so
+            /// admission knows there is no peer address to ask for.
+            /// Copied like everything else here rather than reached back
+            /// through the config, on `installListenerState`'s reasoning.
+            unix_bind: bool,
             /// The listener's PROXY protocol expectation (#142, null =
             /// first bytes are payload). Read at admission only — the
             /// receive phase is entered before the connection has any
@@ -1062,7 +1067,10 @@ pub fn Server(comptime IoType: type) type {
                 const state = &server.listeners[index];
                 state.* = .{
                     .server = server,
-                    .listener = try server.io.listen(listener_config.bind_address),
+                    .listener = try server.io.listen(
+                        &listener_config.bind_address,
+                        listener_config.bind_mode,
+                    ),
                     .accept_completion = .{},
                     .retry_completion = .{},
                     // L4 has one route (the whole listener → one cluster);
@@ -1078,6 +1086,7 @@ pub fn Server(comptime IoType: type) type {
                     .forwarded = listener_config.forwarded,
                     .proxy_status = listener_config.proxy_status,
                     .proxy_protocol = listener_config.proxy_protocol,
+                    .unix_bind = listener_config.bind_address == .unix,
                     .protocol = listener_config.protocol,
                     .credentials = server.credentialsFor(index),
                     .accepting = false,
@@ -1971,8 +1980,13 @@ pub fn Server(comptime IoType: type) type {
                 entryState(listener.protocol),
                 listener.protocol,
                 // Asked once, here, and kept: at log time the socket may
-                // already be closed (§8).
-                server.io.peerAddress(client_socket),
+                // already be closed (§8). A socket file has no peer to
+                // ask about (#303), and the seam says so rather than
+                // inventing one.
+                if (listener.unix_bind)
+                    null
+                else
+                    server.io.peerAddress(client_socket),
             );
             server.io.setNodelay(client_socket) catch |err| {
                 server.witnessKernelPressure(.set_option, err);
@@ -3039,10 +3053,15 @@ pub fn Server(comptime IoType: type) type {
             assert(conn.state == .connecting);
             assert(conn.stream.relay_buffer != null);
             var header_buffer: [proxy_protocol.send_bytes_max]u8 = undefined;
+            // Both halves exist because the loader says so: a `unix:`
+            // listener has neither a peer address nor a local one, and
+            // routing one to a cluster that announces a header is
+            // refused as a pair (`ListenerUnixBindClusterSend`, #303).
+            const client_address = &conn.client_address.?;
             const local_address = server.io.localAddress(conn.client_socket);
             const header = switch (version) {
-                .v1 => proxy_protocol.writeV1(&header_buffer, &conn.client_address, &local_address),
-                .v2 => proxy_protocol.writeV2(&header_buffer, &conn.client_address, &local_address),
+                .v1 => proxy_protocol.writeV1(&header_buffer, client_address, &local_address),
+                .v2 => proxy_protocol.writeV2(&header_buffer, client_address, &local_address),
             };
             const direction = &conn.stream.directions[
                 @intFromEnum(StreamType.Direction.client_to_upstream)
@@ -3080,7 +3099,7 @@ pub fn Server(comptime IoType: type) type {
                 cluster_index,
                 &server.endpointLoad(),
                 server.health.healthy,
-                &conn.client_address,
+                if (conn.client_address) |*address| address else null,
                 // L4 parses no head, so there is nothing request-derived
                 // to key on — and the loader keeps request-keyed clusters
                 // off l4 listeners (#178), so `.none` is exact, not a

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -107,7 +107,13 @@ pub const Record = struct {
     /// and `duration_us` already says where each one ended.
     started_wall_ns: u64,
     duration_ns: u64,
-    client: std.Io.net.IpAddress,
+    /// Who connected, or null on a `unix:` listener (#303) — a local
+    /// process reached this proxy through a file, and there is no
+    /// address to name it by. Null rather than a stand-in for the same
+    /// reason `upstream` is when none was picked: "there is none" and
+    /// "here is one" are different facts, and a reader should not have
+    /// to guess which an address is.
+    client: ?std.Io.net.IpAddress,
     /// The endpoint this request or connection was served by, or null when
     /// none was ever picked — every reject that fires before routing.
     upstream: ?Io.Address,
@@ -203,7 +209,15 @@ fn renderInto(record: *const Record, writer: *std.Io.Writer) std.Io.Writer.Error
         record.kind,
         record.outcome,
     });
-    try writer.print(",\"client\":\"{f}\"", .{record.client});
+    if (record.client) |address| {
+        try writer.print(",\"client\":\"{f}\"", .{address});
+    } else {
+        // A `unix:` listener has no client address (#303). Null rather
+        // than an empty string or a stand-in, on the same reasoning
+        // `upstream` uses: "there is none" and "here is one" are
+        // different facts, and a consumer must not have to guess.
+        try writer.writeAll(",\"client\":null");
+    }
     if (record.kind == .http) {
         try renderHttpFields(record, writer);
     }

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -87,7 +87,8 @@ const Harness = struct {
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
         harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.listeners = .{.{
-            .bind_address = bindAddress(),
+            .bind_address = .{ .ip = bindAddress() },
+            .bind_mode = null,
             .routes = &harness.routes,
             .protocol = .http,
         }};

--- a/src/admin.zig
+++ b/src/admin.zig
@@ -158,7 +158,10 @@ pub fn Admin(comptime IoType: type) type {
             assert(admin.state == .off);
             assert(!admin.listening);
             const bind = admin.bind_address orelse return;
-            admin.listener = try admin.server.io.listen(bind);
+            // The admin endpoint is IP-only and stays that way: it is
+            // reached by a scrape from elsewhere on the network, which
+            // is the one thing a socket file cannot serve (#303).
+            admin.listener = try admin.server.io.listen(&.{ .ip = bind }, null);
             admin.listening = true;
             admin.armAccept();
         }

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -71,7 +71,8 @@ const Harness = struct {
         harness.clusters = .{.{ .name = "origin", .endpoints = &harness.endpoints }};
         harness.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         harness.listeners = .{.{
-            .bind_address = bindAddress(),
+            .bind_address = .{ .ip = bindAddress() },
+            .bind_mode = null,
             .routes = &harness.routes,
             .protocol = .l4,
         }};

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -448,7 +448,7 @@ pub const Balancer = struct {
         cluster_index: u16,
         load: *const upstream.Load,
         healthy: []const bool,
-        client_address: *const std.Io.net.IpAddress,
+        client_address: ?*const std.Io.net.IpAddress,
         request_key: RequestKey,
         tried: []const u16,
     ) Outcome {
@@ -747,7 +747,7 @@ pub const Balancer = struct {
         cluster_index: u16,
         eligible: []const u16,
         load: *const upstream.Load,
-        client_address: *const std.Io.net.IpAddress,
+        client_address: ?*const std.Io.net.IpAddress,
         request_key: RequestKey,
     ) u16 {
         assert(balancer.config.clusters[cluster_index].pick == .hash);
@@ -758,7 +758,13 @@ pub const Balancer = struct {
                 // else: an L7 request need not have been parsed yet, an
                 // L4 connection has nothing to parse.
                 assert(std.meta.activeTag(request_key) == .none);
-                return balancer.rendezvous(cluster_index, eligible, sourceKey(client_address));
+                // A listener with no client address cannot route to a
+                // source-IP-keyed cluster: the loader refuses the pair
+                // (`ListenerUnixBindSourceIpHash`, #303). Reaching here
+                // without one is a caller past validation, and any
+                // stand-in would send every local client to one
+                // endpoint while looking like stickiness.
+                return balancer.rendezvous(cluster_index, eligible, sourceKey(client_address.?));
             },
             .header => switch (request_key) {
                 .key => |key| return balancer.rendezvous(cluster_index, eligible, key),

--- a/src/config.zig
+++ b/src/config.zig
@@ -318,7 +318,10 @@ pub const Config = struct {
     };
 
     pub const Listener = struct {
-        bind_address: std.Io.net.IpAddress,
+        bind_address: io_module.Address,
+        /// The #303 permission bits for a `unix:` bind's socket file, or
+        /// null for the umask's default. Always null on an IP bind.
+        bind_mode: ?io_module.FileMode,
         /// The §7 path-routing table, sorted longest-prefix-first and
         /// never empty. A listener configured with a single `"cluster"`
         /// resolves to one catch-all route (`prefix = "/"`); `l4`
@@ -675,6 +678,30 @@ pub const ValidationError = error{
     ListenersEmpty,
     ListenersOverLimit,
     ListenerBindInvalid,
+    /// A `unix:` bind path that is empty, past what a `sockaddr_un`
+    /// carries, or carries a byte an address may not (#303).
+    ListenerBindUnixPathInvalid,
+    /// A `unix:` bind path that is not absolute (#303).
+    ListenerBindUnixPathRelative,
+    /// A `mode` on a listener whose `bind` is an IP literal (#303):
+    /// there is no file to chmod.
+    ListenerModeWithoutUnixBind,
+    /// A `mode` that is not three or four octal digits, or that sets
+    /// setuid/setgid/sticky (#303).
+    ListenerModeInvalid,
+    /// A `unix:` listener with a `forwarded` block (#303): there is no
+    /// client address to state.
+    ListenerUnixBindForwarded,
+    /// A `unix:` listener with a filter matching on the client address
+    /// (#303): there is none to match.
+    ListenerUnixBindClientMatch,
+    /// A `unix:` listener routing to a cluster that is sticky on the
+    /// source IP (#303): there is none to key on.
+    ListenerUnixBindSourceIpHash,
+    /// A `unix:` listener routing to a cluster that announces a PROXY
+    /// header upstream (#303): the header names the client's source and
+    /// destination addresses, and this listener has neither.
+    ListenerUnixBindClusterSend,
     ListenerBindDuplicate,
     ListenerHttpOrL4,
     ClusterUnknown,
@@ -1984,6 +2011,12 @@ pub const LimitsJson = struct {
 /// not a body field — "both speak over a terminated session (§4, §7)".
 pub const ListenerJson = struct {
     bind: []const u8,
+    /// Permission bits for a `unix:` bind's socket file, as an octal
+    /// string (#303); absent leaves whatever the process umask gives.
+    /// Shared like `tls` because it is a property of the socket, not of
+    /// what is spoken over it — and rejected on an IP bind, which
+    /// creates no file to chmod.
+    mode: ?[]const u8 = null,
     /// Optional TLS termination (#125); absent is a plaintext socket.
     /// Shared, unlike everything in the bodies below.
     tls: ?TlsJson = null,
@@ -1998,7 +2031,17 @@ pub const ListenerJson = struct {
         "shared by both.";
     pub const schema_one_of = [_][]const u8{ "http", "l4" };
     pub const schema_fields = .{
-        .bind = .{ .desc = "IP:port literal to bind (hostnames are rejected — DNS is a non-goal)." },
+        .bind = .{
+            .desc = "What to bind: an `IP:port` literal (hostnames are rejected — " ++
+                "DNS is a non-goal), or `unix:` followed by the absolute path of " ++
+                "a socket file to create.",
+        },
+        .mode = .{
+            .desc = "Permission bits for a unix: socket file, as an octal string " ++
+                "(\"0660\"). Absent leaves the process umask's default. Rejected " ++
+                "on an IP bind, which creates no file.",
+            .min_length = 1,
+        },
         .tls = .{
             .desc = "Terminate TLS on this listener with the given certificate " ++
                 "and key; absent is a plaintext socket. Inbound only — the " ++
@@ -3356,22 +3399,146 @@ fn resolveEndpointAddress(
     literal: []const u8,
 ) ParseError!io_module.Address {
     if (std.mem.startsWith(u8, literal, unix_address_prefix)) {
-        const path = literal[unix_address_prefix.len..];
-        if (path.len == 0 or path.len > io_module.Address.unix_path_bytes_max) {
-            return error.EndpointUnixPathInvalid;
-        }
-        if (path[0] != '/') {
-            return error.EndpointUnixPathRelative;
-        }
-        if (!io_module.Address.pathIsRenderable(path)) {
-            return error.EndpointUnixPathInvalid;
-        }
-        // Duped so the address outlives the parsed JSON document, the
-        // same lifetime every other resolved string here takes.
-        return .{ .unix = try arena.dupe(u8, path) };
+        return .{ .unix = resolveUnixPath(arena, literal) catch |err| switch (err) {
+            error.Relative => return error.EndpointUnixPathRelative,
+            error.Invalid => return error.EndpointUnixPathInvalid,
+            error.OutOfMemory => return error.OutOfMemory,
+        } };
     }
     return .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch {
         return error.EndpointInvalid;
+    } };
+}
+
+/// A `unix:` literal's path, validated and arena-duped. The rules argued
+/// at `resolveEndpointAddress`, applied once for both fields that take
+/// the grammar — an endpoint and a listener's `bind` — so the two cannot
+/// come to disagree about what a socket path is.
+fn resolveUnixPath(
+    arena: std.mem.Allocator,
+    literal: []const u8,
+) error{ Invalid, Relative, OutOfMemory }![]const u8 {
+    assert(std.mem.startsWith(u8, literal, unix_address_prefix));
+    const path = literal[unix_address_prefix.len..];
+    if (path.len == 0 or path.len > io_module.Address.unix_path_bytes_max) {
+        return error.Invalid;
+    }
+    if (path[0] != '/') {
+        return error.Relative;
+    }
+    if (!io_module.Address.pathIsRenderable(path)) {
+        return error.Invalid;
+    }
+    // Duped so the address outlives the parsed JSON document, the same
+    // lifetime every other resolved string here takes.
+    return try arena.dupe(u8, path);
+}
+
+/// The `mode` a `unix:` bind asks for its socket file (#303), as the
+/// octal string an operator writes in every other tool.
+///
+/// A string rather than a JSON number, because `0660` in JSON is not
+/// valid and `660` is decimal — the two spellings of the same intent
+/// differ by a factor of eight, and a mode that is silently wider than
+/// asked for is the failure this feature exists to avoid.
+fn resolveBindMode(
+    mode_json: ?[]const u8,
+    bind_address: io_module.Address,
+) ParseError!?io_module.FileMode {
+    const text = mode_json orelse return null;
+    // An IP bind creates no file, so a mode on one describes nothing.
+    if (bind_address != .unix) {
+        return error.ListenerModeWithoutUnixBind;
+    }
+    if (text.len == 0 or text.len > 4) {
+        return error.ListenerModeInvalid;
+    }
+    var bits: u16 = 0;
+    for (text) |digit| {
+        if (digit < '0' or digit > '7') {
+            return error.ListenerModeInvalid;
+        }
+        bits = bits * 8 + (digit - '0');
+    }
+    assert(bits <= io_module.FileMode.bits_max);
+    // setuid, setgid and sticky mean nothing on a socket and everything
+    // on the file it is confused with — refused rather than passed
+    // through to a chmod nobody meant to write.
+    if (bits & 0o7000 != 0) {
+        return error.ListenerModeInvalid;
+    }
+    return .{ .bits = bits };
+}
+
+/// The #303 refusals: what a `unix:` listener may not also ask for,
+/// because a request arriving on one has no client address to answer
+/// with. Refused at load rather than answered with a sentinel — a
+/// fabricated `0.0.0.0` would make `hash: source_ip` send every local
+/// client to one endpoint, `match.client` compare against a fiction, and
+/// `X-Forwarded-For` state an address no one connected from.
+fn rejectUnixClientAddressUsers(
+    listener: *const Config.Listener,
+    clusters: []const Config.Cluster,
+) ParseError!void {
+    if (listener.forwarded != null) {
+        return error.ListenerUnixBindForwarded;
+    }
+    for (listener.request_filters) |rule| {
+        if (rule.match.clients.len >= 1) {
+            return error.ListenerUnixBindClientMatch;
+        }
+    }
+    for (listener.routes) |route| {
+        try rejectUnixCluster(route.cluster_index, clusters);
+    }
+    // The SNI table is a *second* set of reachable clusters (#298), and
+    // `routes` does not summarise it: an l4 listener with a name table
+    // resolves `routes` to one provisional entry — the admitted cluster
+    // — and `finishSniPeek` replaces the exchange's cluster with the
+    // matched one before any dial. Checking only `routes` would hold the
+    // first name to these rules and let every other name past them.
+    for (listener.sni_routes) |route| {
+        try rejectUnixCluster(route.cluster_index, clusters);
+    }
+}
+
+/// One reachable cluster's half of the #303 refusals.
+fn rejectUnixCluster(
+    cluster_index: u16,
+    clusters: []const Config.Cluster,
+) ParseError!void {
+    assert(cluster_index < clusters.len);
+    const cluster = clusters[cluster_index];
+    if (cluster.pick == .hash and cluster.hash_key == .source_ip) {
+        return error.ListenerUnixBindSourceIpHash;
+    }
+    // A PROXY header announces the client's source and destination
+    // addresses. On this listener there is neither: the accepted socket
+    // has no peer address and no local one either, so the header could
+    // only be written with fictions. Refused as a pair, the shape
+    // `rejectTlsClusterSend` above already has.
+    if (cluster.proxy_protocol_send != null) {
+        return error.ListenerUnixBindClusterSend;
+    }
+}
+
+/// A listener's `bind` (#303): the same grammar as an endpoint, and the
+/// same validation, under this field's own error names — an operator
+/// reading `ListenerBindUnixPathRelative` should not have to work out
+/// which of the two fields the loader meant.
+fn resolveBindAddress(
+    arena: std.mem.Allocator,
+    literal: []const u8,
+) ParseError!io_module.Address {
+    if (std.mem.startsWith(u8, literal, unix_address_prefix)) {
+        return .{ .unix = resolveUnixPath(arena, literal) catch |err| switch (err) {
+            error.Relative => return error.ListenerBindUnixPathRelative,
+            error.Invalid => return error.ListenerBindUnixPathInvalid,
+            error.OutOfMemory => return error.OutOfMemory,
+        } };
+    }
+    return .{ .ip = std.Io.net.IpAddress.parseLiteral(literal) catch {
+        return error.ListenerBindInvalid;
     } };
 }
 
@@ -3467,16 +3634,15 @@ fn resolveListeners(
     const ByBind = struct {
         listeners: []const Config.Listener,
         fn lessThan(ctx: @This(), a: u16, b: u16) bool {
-            return bindOrder(ctx.listeners[a].bind_address) <
-                bindOrder(ctx.listeners[b].bind_address);
+            return bindLessThan(
+                &ctx.listeners[a].bind_address,
+                &ctx.listeners[b].bind_address,
+            );
         }
     };
     std.mem.sort(u16, order, ByBind{ .listeners = listeners }, ByBind.lessThan);
     for (order[1..], order[0 .. order.len - 1]) |current, previous| {
-        if (std.meta.eql(
-            listeners[current].bind_address,
-            listeners[previous].bind_address,
-        )) {
+        if (listeners[current].bind_address.eql(&listeners[previous].bind_address)) {
             return error.ListenerBindDuplicate;
         }
     }
@@ -3500,15 +3666,13 @@ fn resolveListener(
 ) ParseError!Config.Listener {
     assert(clusters.len >= 1);
     assert(head_buffer_bytes >= 1);
-    const bind_address = std.Io.net.IpAddress.parseLiteral(listener_json.bind) catch {
-        return error.ListenerBindInvalid;
-    };
+    const bind_address = try resolveBindAddress(arena, listener_json.bind);
     const tls = try resolveTls(listener_json.tls);
     // The tag dispatches, and every field it does not carry is one this
     // arm cannot be handed (#305): the seven "this key is meaningless on
     // that protocol" errors this replaced were the loader restating a
     // shape it now simply has.
-    const listener: Config.Listener = switch (try protocolOf(listener_json)) {
+    var listener: Config.Listener = switch (try protocolOf(listener_json)) {
         .http => try resolveHttpListener(
             arena,
             bind_address,
@@ -3520,6 +3684,10 @@ fn resolveListener(
         ),
         .l4 => try resolveL4Listener(arena, bind_address, tls, &listener_json.l4.?, clusters),
     };
+    listener.bind_mode = try resolveBindMode(listener_json.mode, bind_address);
+    if (bind_address == .unix) {
+        try rejectUnixClientAddressUsers(&listener, clusters);
+    }
     if (listener.protocol == .http) {
         try rejectHttpClusterSend(listener.routes, clusters);
     }
@@ -3534,7 +3702,7 @@ fn resolveListener(
 /// three §7 policies only a parsed request can mean anything to.
 fn resolveHttpListener(
     arena: std.mem.Allocator,
-    bind_address: std.Io.net.IpAddress,
+    bind_address: io_module.Address,
     tls: ?Config.Listener.Tls,
     http_json: *const HttpListenerJson,
     clusters: []const Config.Cluster,
@@ -3545,6 +3713,9 @@ fn resolveHttpListener(
     assert(head_buffer_bytes >= 1);
     return .{
         .bind_address = bind_address,
+        // Filled by `resolveListener`, which is where the `mode` field
+        // and the bind it describes are both in scope.
+        .bind_mode = null,
         .routes = try resolveRoutes(arena, http_json, clusters, head_buffer_bytes),
         .request_filters = try resolveRequestFilters(arena, http_json, head_buffer_bytes, bodies),
         .response_filters = try resolveResponseFilters(arena, http_json),
@@ -3568,7 +3739,7 @@ fn resolveHttpListener(
 /// byte has been read — see `admittedCluster`.
 fn resolveL4Listener(
     arena: std.mem.Allocator,
-    bind_address: std.Io.net.IpAddress,
+    bind_address: io_module.Address,
     tls: ?Config.Listener.Tls,
     l4_json: *const L4ListenerJson,
     clusters: []const Config.Cluster,
@@ -3594,6 +3765,8 @@ fn resolveL4Listener(
     assert(routes.len == 1);
     const listener: Config.Listener = .{
         .bind_address = bind_address,
+        // Filled by `resolveListener`, as on the http arm.
+        .bind_mode = null,
         .routes = routes,
         .sni_routes = sni_routes,
         .protocol = .l4,
@@ -3625,6 +3798,22 @@ fn resolveL4Listener(
 /// the ordering matters, never the value: equal keys are re-checked with
 /// `std.meta.eql`, so a collision costs a comparison rather than a wrong
 /// verdict.
+/// A total order on bind addresses, so duplicates fall adjacent after
+/// one sort. Not a single integer key any more (#303): a socket path
+/// does not fit one, so the families are ordered by tag first and the
+/// paths lexicographically within theirs.
+fn bindLessThan(a: *const io_module.Address, b: *const io_module.Address) bool {
+    const a_family: u8 = if (a.* == .ip) 0 else 1;
+    const b_family: u8 = if (b.* == .ip) 0 else 1;
+    if (a_family != b_family) {
+        return a_family < b_family;
+    }
+    return switch (a.*) {
+        .ip => |ip| bindOrder(ip) < bindOrder(b.ip),
+        .unix => |path| std.mem.order(u8, path, b.unix) == .lt,
+    };
+}
+
 fn bindOrder(address: std.Io.net.IpAddress) u160 {
     return switch (address) {
         .ip4 => |v4| (@as(u160, 0) << 152) |
@@ -5185,7 +5374,7 @@ test "config: the shipped example parses and resolves" {
     try std.testing.expectEqualStrings("/", parsed.listeners[0].routes[0].prefix);
     try std.testing.expectEqual(@as(u16, 0), parsed.listeners[0].routes[0].cluster_index);
     try std.testing.expectEqual(Config.Listener.Protocol.l4, parsed.listeners[0].protocol);
-    try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.getPort());
+    try std.testing.expectEqual(@as(u16, 8080), parsed.listeners[0].bind_address.ip.getPort());
     try std.testing.expectEqualStrings("origin", parsed.clusters[0].name);
     try std.testing.expectEqual(@as(u16, 9000), parsed.clusters[0].endpoints[0].ip.getPort());
     // The example carries both endpoint spellings (#174): a bare literal
@@ -7991,18 +8180,169 @@ test "config: an endpoint may be a Unix socket path (#303)" {
     }
 }
 
-test "config: a listener still binds an IP, not a socket path (#303)" {
-    // The listener half of #303 is a later slice: it needs answers for
-    // what a peer address is when there is none, which `hash: source_ip`,
-    // `match.client` and `X-Forwarded-For` all ask. Until then the
-    // grammar is refused here rather than half-accepted, so a config
-    // that looks like it works cannot be one that does not.
+test "config: a listener may bind a socket path (#303)" {
+    const tail = ",\"http\":{\"cluster\":\"a\"}}]," ++
+        "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const head = "{\"listeners\":[{\"bind\":";
+
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ "\"unix:/run/zoxy.sock\"" ++ tail,
+        );
+        try std.testing.expectEqualStrings("/run/zoxy.sock", parsed.listeners[0].bind_address.unix);
+        // Absent leaves whatever the umask gives, which is what every
+        // other tool does and what an operator's directory permissions
+        // are already expressed against.
+        try std.testing.expect(parsed.listeners[0].bind_mode == null);
+    }
+    // The same path validation as an endpoint, under this field's own
+    // error names — an operator should not have to work out which of the
+    // two fields the loader meant.
     try expectParseError(
-        error.ListenerBindInvalid,
-        "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"http\":{\"cluster\":\"a\"}}]," ++
+        error.ListenerBindUnixPathRelative,
+        head ++ "\"unix:run/zoxy.sock\"" ++ tail,
+    );
+    try expectParseError(error.ListenerBindUnixPathInvalid, head ++ "\"unix:\"" ++ tail);
+    try expectParseError(
+        error.ListenerBindUnixPathInvalid,
+        head ++ "\"unix:/run/a\\\"b.sock\"" ++ tail,
+    );
+    // Two listeners on one path are the same duplicate an IP:port pair
+    // is — and the check had to stop being a single integer key to see
+    // it, since a path does not fit one.
+    try expectParseError(
+        error.ListenerBindDuplicate,
+        "{\"listeners\":[{\"bind\":\"unix:/run/a.sock\",\"http\":{\"cluster\":\"a\"}}," ++
+            "{\"bind\":\"unix:/run/a.sock\",\"http\":{\"cluster\":\"a\"}}]," ++
             "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
             "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
     );
+}
+
+test "config: a socket file's mode is octal, and only a socket has one (#303)" {
+    const tail = ",\"http\":{\"cluster\":\"a\"}}]," ++
+        "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const unix_head = "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\"";
+
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            unix_head ++ ",\"mode\":\"0660\"" ++ tail,
+        );
+        try std.testing.expectEqual(@as(u16, 0o660), parsed.listeners[0].bind_mode.?.bits);
+    }
+    // A string, not a number: `0660` is not valid JSON and `660` is
+    // decimal, and the two readings of one intent differ by a factor of
+    // eight — in the direction that widens the mode.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, unix_head ++ ",\"mode\":\"660\"" ++ tail);
+        try std.testing.expectEqual(@as(u16, 0o660), parsed.listeners[0].bind_mode.?.bits);
+    }
+    // An IP bind creates no file, so a mode on one describes nothing.
+    try expectParseError(
+        error.ListenerModeWithoutUnixBind,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"mode\":\"0660\"" ++ tail,
+    );
+    inline for (.{ "0680", "9", "", "00660", "abc" }) |bad| {
+        try expectParseError(
+            error.ListenerModeInvalid,
+            unix_head ++ ",\"mode\":\"" ++ bad ++ "\"" ++ tail,
+        );
+    }
+    // setuid, setgid and sticky mean nothing on a socket and everything
+    // on the file it would be confused with.
+    try expectParseError(
+        error.ListenerModeInvalid,
+        unix_head ++ ",\"mode\":\"4660\"" ++ tail,
+    );
+}
+
+test "config: a unix listener refuses what needs a client address (#303)" {
+    // A request arriving on a socket file has no client IP, and there is
+    // no honest sentinel: a fabricated `0.0.0.0` would make each of
+    // these quietly wrong rather than absent. Refused at load (§5).
+    const tail = "}}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+    const head = "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"http\":{\"cluster\":\"a\"";
+
+    try expectParseError(
+        error.ListenerUnixBindForwarded,
+        head ++ ",\"forwarded\":{\"mode\":\"replace\"}" ++ tail,
+    );
+    try expectParseError(
+        error.ListenerUnixBindClientMatch,
+        head ++ ",\"request_filters\":[{\"match\":{\"client\":[\"10.0.0.0/8\"]}," ++
+            "\"actions\":[{\"reject\":403}]}]" ++ tail,
+    );
+    try expectParseError(
+        error.ListenerUnixBindSourceIpHash,
+        "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"http\":{\"cluster\":\"a\"}}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]," ++
+            "\"pick\":{\"policy\":\"hash\",\"key\":\"source_ip\"}}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+    );
+    // A hash on something the request carries is unaffected: the key is
+    // in the request, not in the connection.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        _ = try expectParseOk(
+            &arena_state,
+            "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"http\":{\"cluster\":\"a\"}}]," ++
+                "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]," ++
+                "\"pick\":{\"policy\":\"hash\",\"key\":\"header\",\"name\":\"x-tenant\"}}}," ++
+                "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+        );
+    }
+    // An SNI table is a second set of reachable clusters (#298), and
+    // the listener's `routes` does not summarise it: with a name table
+    // `routes` holds one provisional entry, and `finishSniPeek` replaces
+    // the exchange's cluster with the matched one before any dial. So a
+    // rule that walked only `routes` would hold the *first* name to it
+    // and wave every other one through — into an unwrap of the client
+    // address that is not there.
+    inline for (.{
+        "{\"policy\":\"hash\",\"key\":\"source_ip\"}",
+        "\"p2c\"",
+    }, .{
+        error.ListenerUnixBindSourceIpHash,
+        error.ListenerUnixBindClusterSend,
+    }) |pick, expected| {
+        const send = if (expected == error.ListenerUnixBindClusterSend)
+            ",\"proxy_protocol\":{\"send\":\"v2\"}"
+        else
+            "";
+        try expectParseError(
+            expected,
+            "{\"listeners\":[{\"bind\":\"unix:/run/zoxy.sock\",\"l4\":{\"routes\":[" ++
+                "{\"sni\":\"a.example\",\"cluster\":\"plain\"}," ++
+                "{\"sni\":\"b.example\",\"cluster\":\"second\"}]}}]," ++
+                "\"clusters\":{\"plain\":{\"endpoints\":[\"127.0.0.1:2\"]}," ++
+                "\"second\":{\"endpoints\":[\"127.0.0.1:3\"],\"pick\":" ++ pick ++
+                send ++ "}}," ++
+                "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+        );
+    }
+    // And an IP listener still takes all three, which is what says the
+    // rule is about the bind and not about the feature.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        _ = try expectParseOk(
+            &arena_state,
+            "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"," ++
+                "\"forwarded\":{\"mode\":\"replace\"}" ++ tail,
+        );
+    }
 }
 
 test "config: proxy_status is off unless asked for, and is http-only" {

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -343,7 +343,12 @@ pub const RequestView = struct {
     /// address here (32 bytes, past TIGER_STYLE's by-value threshold).
     /// No default: a site that forgot to wire it must not compile, or a
     /// `client` allowlist would silently judge a zero address.
-    client: *const std.Io.net.IpAddress,
+    ///
+    /// Null on a `unix:` listener, where there is none (#303). Nothing
+    /// here has to answer for that: the loader refuses a `client` match
+    /// on such a listener, so a rule that would read it cannot reach one
+    /// — which `clientMatches` asserts rather than assumes.
+    client: ?*const std.Io.net.IpAddress,
 };
 
 /// A terminal filter answer: the request is responded to here and never
@@ -557,11 +562,16 @@ fn matches(match: Match, view: RequestView) bool {
 /// Whether any prefix admits the client (#177) — the one any-of among
 /// the conjunction's predicates, because a `client` list reads as "from
 /// these ranges" and a client holds exactly one address.
-fn clientMatches(cidrs: []const Cidr, client: *const std.Io.net.IpAddress) bool {
+fn clientMatches(cidrs: []const Cidr, client: ?*const std.Io.net.IpAddress) bool {
     assert(cidrs.len >= 1);
+    // A rule carrying prefixes on a listener with no client address is
+    // a config the loader refuses (`ListenerUnixBindClientMatch`, #303),
+    // so reaching here without one is a caller past validation — and
+    // guessing an answer would be an allowlist judging a fiction.
+    const observed = client.?;
     for (cidrs) |*cidr| {
         assert(cidr.prefix_len <= 64);
-        if (cidr.contains(client)) {
+        if (cidr.contains(observed)) {
             return true;
         }
     }

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -839,7 +839,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .host = host,
                 .path = views.match,
                 .headers = request.headers,
-                .client = &conn.client_address,
+                .client = clientAddressOf(conn),
             };
             // One scan yields both the rewrite and the header edits (§7).
             const forward = filter.collectForward(conn.request_filters, view, edit_buffer);
@@ -1056,7 +1056,7 @@ pub fn Proxy(comptime IoType: type) type {
                 .host = keys.host,
                 .path = keys.views.match,
                 .headers = request.headers,
-                .client = &conn.client_address,
+                .client = clientAddressOf(conn),
             })) |verdict| {
                 switch (verdict) {
                     .reject => |status| return respondFilter(server, conn, status),
@@ -1202,7 +1202,7 @@ pub fn Proxy(comptime IoType: type) type {
                 conn.stream.cluster_index,
                 &server.endpointLoad(),
                 server.health.healthy,
-                &conn.client_address,
+                clientAddressOf(conn),
                 request_key,
                 conn.stream.l7.tried[0..conn.stream.l7.tried_count],
             );
@@ -1711,7 +1711,11 @@ pub fn Proxy(comptime IoType: type) type {
                 len += 2;
             }
             var client_scratch: [constants.forwarded_client_bytes_max]u8 = undefined;
-            const client = bareAddress(&conn.client_address, &client_scratch);
+            // The loader refuses a `forwarded` block on a listener with
+            // no client address (`ListenerUnixBindForwarded`, #303), so
+            // this path is unreachable without one — and a fabricated
+            // address is exactly what `X-Forwarded-For` must never carry.
+            const client = bareAddress(&conn.client_address.?, &client_scratch);
             assert(client.len >= 1);
             // The scratch is the chain bound plus a separator plus the
             // widest address, so a chain that fit leaves room for these.
@@ -4202,6 +4206,17 @@ pub fn Proxy(comptime IoType: type) type {
                 if (page.status == status) {
                     return page;
                 }
+            }
+            return null;
+        }
+
+        /// The connection's client address as a borrowed pointer, or
+        /// null on a `unix:` listener (#303). One helper, so the three
+        /// consumers that take it by pointer spell the optional the same
+        /// way and none of them re-derives it.
+        fn clientAddressOf(conn: *const ConnType) ?*const std.Io.net.IpAddress {
+            if (conn.client_address) |*address| {
+                return address;
             }
             return null;
         }

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -95,10 +95,21 @@ const HttpClient = struct {
     const Outcome = enum(u8) { pending, fin, reset };
 
     fn start(client: *HttpClient, io: *SimIo, server: *ServerSim, address: std.Io.net.IpAddress) void {
+        client.startAt(io, server, .{ .ip = address });
+    }
+
+    /// Dial the proxy at whichever family this scenario binds (#303).
+    /// `start` is the IP-only sugar over it, kept because every
+    /// pre-existing scenario says `bindAddress()` and means one thing.
+    fn startAt(client: *HttpClient, io: *SimIo, server: *ServerSim, address: io_module.Address) void {
         client.io = io;
         client.server = server;
-        client.address = address;
-        io.connect(&.{ .ip = address }, &client.connect_completion, HttpClient, client, onConnect);
+        // Only the IP arm has an address to remember; a socket-file
+        // scenario never reads this field back.
+        if (address == .ip) {
+            client.address = address.ip;
+        }
+        io.connect(&address, &client.connect_completion, HttpClient, client, onConnect);
     }
 
     fn onConnect(client: *HttpClient, result: Io.ConnectError!SimIo.Socket) void {
@@ -460,7 +471,7 @@ const HttpOrigin = struct {
 
     fn start(origin: *HttpOrigin, io: *SimIo, address: std.Io.net.IpAddress) !void {
         origin.io = io;
-        origin.listener = try io.listen(address);
+        origin.listener = try io.listen(&.{ .ip = address }, null);
         origin.listening = true;
         origin.armAccept();
     }
@@ -574,6 +585,11 @@ const Http1Bed = struct {
     /// zoxy on the same host as its application actually deploys in.
     const origin_socket_path = "/run/zoxy-test/origin.sock";
 
+    /// Where a `unix_listener` scenario accepts (#303) — the other half
+    /// of the same deployment, zoxy reached through a file by something
+    /// local rather than over a port.
+    const listener_socket_path = "/run/zoxy-test/zoxy.sock";
+
     /// An address no origin binds, so `SimIo` refuses every dial to it
     /// through its own listener lookup — the same answer a kernel gives
     /// for a port nothing is on, and the failure #181 exists to survive.
@@ -673,6 +689,10 @@ const Http1Bed = struct {
         /// The #300 opt-in; off by default, so every pre-existing
         /// scenario still asserts on pages with no `Proxy-Status`.
         proxy_status: bool = false,
+        /// Accept on a socket file instead of a TCP port (#303). Off by
+        /// default: every pre-existing scenario is about something other
+        /// than which family the *client* leg speaks.
+        unix_listener: bool = false,
         /// Reach the origin over a Unix socket instead of loopback
         /// (#303). Off by default: every pre-existing scenario is about
         /// something other than which family the upstream leg speaks.
@@ -741,6 +761,34 @@ const Http1Bed = struct {
         };
     }
 
+    /// The listener this scenario binds. Split from `setUp` for the
+    /// length limit, on the seam #303 made natural: what a listener
+    /// accepts on is one decision, and everything `setUp` does around it
+    /// is the same either way.
+    fn installListener(bed: *Http1Bed, options: Options) void {
+        bed.listeners = .{.{
+            .bind_address = if (options.unix_listener)
+                .{ .unix = listener_socket_path }
+            else
+                .{ .ip = bindAddress() },
+            .bind_mode = null,
+            .routes = &bed.routes,
+            .request_filters = options.request_filters,
+            .response_filters = options.response_filters,
+            .protocol = .http,
+            .upgrades = options.upgrades,
+            .max_body_bytes = options.max_body_bytes,
+            .forwarded = options.forwarded,
+            .proxy_status = options.proxy_status,
+            // Paths nothing reads: the bed embeds the PEMs, so what this
+            // states is only that the listener terminates.
+            .tls = if (options.tls)
+                .{ .cert_path = "cert.pem", .key_path = "key.pem" }
+            else
+                null,
+        }};
+    }
+
     /// The cluster's endpoint list for one scenario. Split from `setUp`
     /// for the length limit, along the seam #303 made natural: which
     /// family the upstream leg speaks is one decision, and every other
@@ -784,23 +832,7 @@ const Http1Bed = struct {
         bed.installEndpoints(options);
         bed.clusters = .{.{ .name = "origin", .endpoints = bed.endpoints[0..bed.endpoints_count], .check = options.check, .passive_ejection = options.passive_ejection, .max_inflight = options.max_inflight, .pick = options.pick, .hash_key = options.hash_key, .retries = options.retries }};
         bed.routes = .{.{ .host = options.route_host, .prefix = options.route_prefix, .cluster_index = 0 }};
-        bed.listeners = .{.{
-            .bind_address = bindAddress(),
-            .routes = &bed.routes,
-            .request_filters = options.request_filters,
-            .response_filters = options.response_filters,
-            .protocol = .http,
-            .upgrades = options.upgrades,
-            .max_body_bytes = options.max_body_bytes,
-            .forwarded = options.forwarded,
-            .proxy_status = options.proxy_status,
-            // Paths nothing reads: the bed embeds the PEMs, so what this
-            // states is only that the listener terminates.
-            .tls = if (options.tls)
-                .{ .cert_path = "cert.pem", .key_path = "key.pem" }
-            else
-                null,
-        }};
+        bed.installListener(options);
         bed.buildConfig(options);
         try bed.server.init(arena, &bed.sim_io, &bed.config, .{
             .conn_slots = options.conn_slots,
@@ -905,7 +937,7 @@ const Http1Bed = struct {
     /// outcome and the pools have drained.
     fn exchange(bed: *Http1Bed, request: []const u8) !void {
         bed.client.request = request;
-        bed.client.start(&bed.sim_io, &bed.server, bindAddress());
+        bed.client.startAt(&bed.sim_io, &bed.server, bed.listeners[0].bind_address);
         try bed.sim_io.run();
         bed.origin.stopListening();
     }
@@ -1378,6 +1410,61 @@ test "l7: OPTIONS asterisk-form is forwarded as \"*\", not as the \"/\" it match
     const forwarded = try forwardedRequest(&bed, &storage);
     try std.testing.expectEqual(parser.Method.options, forwarded.method);
     try std.testing.expectEqualStrings("*", forwarded.target);
+    try bed.expectDrained();
+}
+
+test "l7: a listener on a socket file serves a request (#303)" {
+    // The other half of the local-origin shape: something on this host
+    // reaches zoxy through a file rather than a port. Above the accept
+    // nothing changes — routing, filters, framing and the upstream leg
+    // are all the same code answering the same way.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 93,
+        .unix_listener = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /path HTTP/1.1\r\nHost: origin.example\r\nConnection: close\r\n\r\n");
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+        bed.client.response(),
+    );
+    var storage: parser.HeaderStorage = undefined;
+    const forwarded = try forwardedRequest(&bed, &storage);
+    try std.testing.expectEqualStrings("/path", forwarded.target);
+    try bed.expectDrained();
+}
+
+test "l7: a socket-file listener logs no client address (#303)" {
+    // There is none, and the line says so rather than inventing one.
+    // `null` is the same answer `upstream` gives when no endpoint was
+    // picked — a reader can tell "there is none" from "here is one"
+    // without knowing which listener served the request.
+    var bed: Http1Bed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .seed = 94,
+        .unix_listener = true,
+        .access_log = true,
+        .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+    });
+    defer bed.tearDown();
+
+    try bed.exchange("GET /a HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+    const line = bed.sim_io.sinkBytes();
+    try std.testing.expect(std.mem.indexOf(u8, line, "\"client\":null") != null);
+    // Still one valid JSON object, which is the whole contract the field
+    // had to stay inside.
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, std.mem.trimEnd(u8, line, "\n"), .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(std.json.Value.null, parsed.value.object.get("client").?);
+    try std.testing.expectEqualStrings(
+        "127.0.0.1:9000",
+        parsed.value.object.get("upstream").?.string,
+    );
     try bed.expectDrained();
 }
 

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -553,25 +553,38 @@ pub fn blackholeDestination(io: *SimIo, address: *const Io.Address) void {
     io.blackholed_count += 1;
 }
 
-pub fn listen(io: *SimIo, address: std.Io.net.IpAddress) Io.ListenError!Listener {
-    var effective = address;
-    if (effective.getPort() == 0) {
-        effective.setPort(ephemeral_port_base + io.listeners_count);
+/// Bind a virtual listener. `mode` is accepted and ignored: a simulated
+/// socket has no file, so there is nothing to chmod — the permission
+/// story is a property of the real filesystem, which is why the §9 gate
+/// for it lives in the production backend's own tests (#303).
+pub fn listen(
+    io: *SimIo,
+    address: *const Io.Address,
+    mode: ?Io.FileMode,
+) Io.ListenError!Listener {
+    switch (address.*) {
+        .ip => |ip| {
+            assert(mode == null); // The loader rejects a mode on an IP bind.
+            var effective = ip;
+            if (effective.getPort() == 0) {
+                effective.setPort(ephemeral_port_base + io.listeners_count);
+            }
+            return io.listenAt(.{ .ip = effective });
+        },
+        .unix => |path| {
+            assert(path.len >= 1);
+            return io.listenAt(.{ .unix = path });
+        },
     }
-    return io.listenAt(.{ .ip = effective });
 }
 
-/// Register a virtual origin on a socket path (#303).
-///
-/// A scenario-construction affordance rather than a seam op, beside
-/// `blackholeAddress` and `injectConnectError`: the proxy's own `bind`
-/// is still IP-only, and what a UDS *endpoint* needs from the simulator
-/// is something on the other end of the dial. There is no socket file
-/// here and nothing to unlink — a simulated Unix socket is a stream with
-/// a name, which is exactly the part of it §9 has to model.
+/// Register a virtual origin on a socket path (#303) — the other end of
+/// a UDS *endpoint*'s dial. Sugar over `listen` rather than a second
+/// mechanism, kept because a scenario that wants an origin should not
+/// have to spell a mode it has no opinion about.
 pub fn listenUnix(io: *SimIo, path: []const u8) Io.ListenError!Listener {
     assert(path.len >= 1);
-    return io.listenAt(.{ .unix = path });
+    return io.listen(&.{ .unix = path }, null);
 }
 
 fn listenAt(io: *SimIo, effective: Io.Address) Io.ListenError!Listener {

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -173,7 +173,7 @@ pub const Completion = xev.Completion;
 
 const ListenerEntry = struct {
     fd: posix.socket_t,
-    address: std.Io.net.IpAddress,
+    address: Io.Address,
     armed_accept: ?*xev.Completion,
     cancel_completion: xev.Completion,
     open: bool,
@@ -401,11 +401,140 @@ pub fn deinit(io: *XevIo) void {
     }
 }
 
-pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener {
+pub fn listen(io: *XevIo, address: *const Io.Address, mode: ?Io.FileMode) Io.ListenError!Listener {
     assert(io.listeners_count <= io.listeners.len);
     if (io.listeners_count == io.listeners.len) {
         return error.AddressUnavailable;
     }
+    switch (address.*) {
+        .ip => |ip| {
+            // A `mode` is a property of a file, and an IP listener binds
+            // none. The loader rejects the pairing (#303), so reaching
+            // here with one is a caller past config validation.
+            assert(mode == null);
+            return listenIp(io, ip);
+        },
+        .unix => |path| return listenUnix(io, path, mode),
+    }
+}
+
+/// Bind and listen on a filesystem socket (#303).
+///
+/// No `SO_REUSEPORT`: the option is meaningless for a pathname socket —
+/// two processes cannot bind one path — so the §3 scale-out story does
+/// not reach this family, and the listener half of #303 is for chaining
+/// on one host rather than for spreading across processes.
+fn listenUnix(io: *XevIo, path: []const u8, mode: ?Io.FileMode) Io.ListenError!Listener {
+    assert(path.len >= 1);
+    assert(io.listeners_count < io.listeners.len);
+    const address = xev.net.Address.initUnix(path) catch {
+        // The loader bounds the path (§5), so this is a caller past it.
+        return error.Unexpected;
+    };
+    try clearStaleSocket(&address);
+    const socket = xev.TCP.initAddress(address) catch return error.Unexpected;
+    const bind_rc = posix.system.bind(socket.fd, &address.any, address.getOsSockLen());
+    if (posix.errno(bind_rc) != .SUCCESS) {
+        const failure = bindErrorOf(bind_rc);
+        closeFd(socket.fd);
+        return failure;
+    }
+    if (posix.errno(posix.system.listen(socket.fd, constants.accept_backlog)) != .SUCCESS) {
+        closeFd(socket.fd);
+        return error.Unexpected;
+    }
+    // After the bind, because the file does not exist before it — and
+    // the window between the two is why an operator who needs the socket
+    // itself to be the ACL should also own the directory (§7).
+    if (mode) |requested| {
+        const path_z: [*:0]const u8 = @ptrCast(&address.un.path);
+        const rc = posix.system.fchmodat(posix.AT.FDCWD, path_z, requested.bits, 0);
+        if (posix.errno(rc) != .SUCCESS) {
+            closeFd(socket.fd);
+            _ = posix.system.unlink(path_z);
+            return error.AccessDenied;
+        }
+    }
+    return registerListener(io, .{ .unix = path }, socket.fd);
+}
+
+/// What a stale socket file costs, answered once at startup (#303): a
+/// path left behind by a killed process makes `bind` fail with
+/// `EADDRINUSE` forever, so the file is removed — but *only* when it is
+/// a socket. Anything else is refused, because a typo in `bind` must not
+/// be a delete.
+///
+/// The window between the look and the unlink, and between the unlink
+/// and the bind, is real and deliberately not closed: another process
+/// can recreate the path in either. Closing it would mean binding a
+/// temporary name and renaming over the target, which trades this race
+/// for a different one — the rename would silently replace whatever the
+/// refusal above exists to protect. The exposure is bounded by who can
+/// write the directory, which is the same permission this feature asks
+/// an operator to set anyway (§7), and the loser of the race is a
+/// startup that fails loudly rather than a request served wrongly.
+fn clearStaleSocket(address: *const xev.net.Address) Io.ListenError!void {
+    const path: [*:0]const u8 = @ptrCast(&address.un.path);
+    // Nothing there is the ordinary case, and every other failure to
+    // look is answered by the bind that follows — reporting it here
+    // would name the wrong syscall.
+    const is_socket = fileTypeAt(path) orelse return;
+    if (!is_socket) {
+        return error.PathNotSocket;
+    }
+    if (posix.errno(posix.system.unlink(path)) != .SUCCESS) {
+        return error.AccessDenied;
+    }
+}
+
+/// Whether `path` names a socket, or null when it names nothing.
+///
+/// `AT_SYMLINK_NOFOLLOW` throughout, so a symlink is judged as itself: a
+/// link pointing at a socket is not a stale socket this proxy left
+/// behind, and unlinking it would delete somebody's pointer.
+///
+/// Two spellings because the stdlib has two: on Linux `std.c.fstatat` is
+/// deliberately absent (glibc's versioned `stat` symbols), so the raw
+/// `statx` syscall is the portable-within-Linux answer, and everywhere
+/// else `fstatat` is what exists. This file is the one §4 lets carry
+/// that knowledge.
+pub fn fileTypeAt(path: [*:0]const u8) ?bool {
+    if (comptime builtin.os.tag == .linux) {
+        var info: std.os.linux.Statx = undefined;
+        const rc = std.os.linux.statx(
+            posix.AT.FDCWD,
+            path,
+            posix.AT.SYMLINK_NOFOLLOW,
+            .{ .TYPE = true },
+            &info,
+        );
+        // The sign, not `posix.errno`: this is a raw syscall return,
+        // and `posix.errno` under libc only reads `errno` when the
+        // result is exactly -1 — a raw `-ENOENT` would read as success
+        // and hand back an uninitialised mode. Which error it is does
+        // not matter here; that it failed does.
+        if (@as(isize, @bitCast(rc)) < 0) return null;
+        return info.mode & posix.S.IFMT == posix.S.IFSOCK;
+    }
+    var info: posix.Stat = undefined;
+    const rc = posix.system.fstatat(posix.AT.FDCWD, path, &info, posix.AT.SYMLINK_NOFOLLOW);
+    if (posix.errno(rc) != .SUCCESS) return null;
+    return info.mode & posix.S.IFMT == posix.S.IFSOCK;
+}
+
+/// The bind failure map. Distinct diagnoses, because they send an
+/// operator to different places: a conflicting process, a permission
+/// wall, or a directory that is not there.
+fn bindErrorOf(rc: anytype) Io.ListenError {
+    return switch (posix.errno(rc)) {
+        .ADDRINUSE => error.AddressInUse,
+        .ACCES, .PERM => error.AccessDenied,
+        .NOENT, .NOTDIR, .ADDRNOTAVAIL => error.AddressUnavailable,
+        else => error.Unexpected,
+    };
+}
+
+fn listenIp(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener {
     const tcp = xev.TCP.init(address) catch return error.Unexpected;
     // SO_REUSEPORT before bind is what makes horizontal scale-out real
     // (§1, §3): N independent zoxy processes bind the same port and the
@@ -449,11 +578,17 @@ pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
         return error.Unexpected;
     });
     assert(effective.getPort() != 0);
+    return registerListener(io, .{ .ip = effective }, tcp.fd);
+}
 
+/// Take a bound, listening fd into the table. Shared by both families,
+/// so a listener's bookkeeping cannot differ by the address it answers.
+fn registerListener(io: *XevIo, address: Io.Address, fd: posix.socket_t) Listener {
+    assert(io.listeners_count < io.listeners.len);
     const index = io.listeners_count;
     io.listeners[index] = .{
-        .fd = tcp.fd,
-        .address = effective,
+        .fd = fd,
+        .address = address,
         .armed_accept = null,
         .cancel_completion = .{},
         .open = true,
@@ -467,7 +602,11 @@ pub fn listen(io: *XevIo, address: std.Io.net.IpAddress) Io.ListenError!Listener
 pub fn listenerAddress(io: *const XevIo, listener: Listener) std.Io.net.IpAddress {
     const entry = io.listenerEntryConst(listener);
     assert(entry.open);
-    return entry.address;
+    // The effective *port* is what this answers, which only an IP bind
+    // has: a socket file's effective address is the path the caller
+    // already holds, and nothing asks (#303).
+    assert(entry.address == .ip);
+    return entry.address.ip;
 }
 
 /// Hand the backend every op still queued, so an op armed during this
@@ -552,6 +691,26 @@ pub fn listenClose(io: *XevIo, listener: Listener) void {
     }
     closeFd(entry.fd);
     entry.open = false;
+    // A socket file outlives the socket, so a clean stop takes its own
+    // away (#303): the drain that closes listeners is the last moment
+    // this process knows the path was its own to remove. A kill leaves
+    // it behind, which is exactly what the startup unlink is for — this
+    // is the tidy path, not the correctness one.
+    if (entry.address == .unix) {
+        unlinkSocketPath(entry.address.unix);
+    }
+}
+
+/// Remove a socket file this process created. Best effort by
+/// construction: the path may already be gone, or replaced by something
+/// that is no longer ours, and a proxy on its way down has no verdict to
+/// deliver about either.
+fn unlinkSocketPath(path: []const u8) void {
+    // The same path bound successfully, so it fits — this cannot fail
+    // for a reason the caller could act on, and silently returning would
+    // leave the file behind with nothing said.
+    const address = xev.net.Address.initUnix(path) catch unreachable;
+    _ = posix.system.unlink(@as([*:0]const u8, @ptrCast(&address.un.path)));
 }
 
 /// Deliver the `Canceled` an armed accept is owed when its listener

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -137,7 +137,7 @@ pub fn EchoScenario(comptime IoType: type) type {
         };
 
         pub fn start(scenario: *Scenario, bind_address: std.Io.net.IpAddress) !void {
-            scenario.listener = try scenario.io.listen(bind_address);
+            scenario.listener = try scenario.io.listen(&.{ .ip = bind_address }, null);
             scenario.io.accept(
                 scenario.listener,
                 &scenario.accept_completion,
@@ -423,7 +423,7 @@ fn GroupContract(comptime IoType: type) type {
 fn runGroupContract(comptime IoType: type, io: *IoType) !void {
     const Contract = GroupContract(IoType);
     var c: Contract = .{ .io = io };
-    const listener = try io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
+    const listener = try io.listen(&.{ .ip = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") }, null);
 
     // Selection, and the classic-recv continuation into the bound buffer.
     const client_a, const server_a = try c.pair(listener);
@@ -610,7 +610,7 @@ test "simio: a dropped accept is never delivered, where a live one is" {
     var live_io: SimIo = undefined;
     try live_io.init(arena_state.allocator(), .{ .seed = 3 });
     var live: DroppedAccept = .{ .io = &live_io };
-    const live_listener = try live_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301"));
+    const live_listener = try live_io.listen(&.{ .ip = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301") }, null);
     live_io.accept(live_listener, &live.completion, DroppedAccept, &live, DroppedAccept.onAccept);
     live_io.listenClose(live_listener);
     try live_io.run();
@@ -628,7 +628,7 @@ test "simio: a dropped accept is never delivered, where a live one is" {
         .dump_on_deadlock = false,
     });
     var stuck: DroppedAccept = .{ .io = &stuck_io };
-    const stuck_listener = try stuck_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301"));
+    const stuck_listener = try stuck_io.listen(&.{ .ip = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:9301") }, null);
     stuck_io.accept(
         stuck_listener,
         &stuck.completion,
@@ -960,7 +960,8 @@ const ConnectedPair = struct {
 fn connectPair(xev_io: *XevIo) !ConnectedPair {
     var pair: Pair = .{ .io = xev_io };
     const listener = try xev_io.listen(
-        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+        &.{ .ip = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable },
+        null,
     );
     xev_io.accept(listener, &pair.accept_completion, Pair, &pair, Pair.onAccept);
     xev_io.connect(
@@ -1011,7 +1012,7 @@ test "xevio: a send after our own write shutdown is Reset, not kernel pressure" 
     // A connected loopback pair through the seam's own API — the echo
     // scenario closes both ends when it finishes, so this needs its own.
     var pair: Pair = .{ .io = &xev_io };
-    const listener = try xev_io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
+    const listener = try xev_io.listen(&.{ .ip = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") }, null);
     xev_io.accept(listener, &pair.accept_completion, Pair, &pair, Pair.onAccept);
     xev_io.connect(
         &.{ .ip = xev_io.listenerAddress(listener) },
@@ -1064,7 +1065,7 @@ test "xevio: bind failures are diagnosed distinctly, not all AddressInUse" {
     defer xev_io.deinit();
 
     const unavailable = std.Io.net.IpAddress.parseLiteral("203.0.113.1:0") catch unreachable;
-    try std.testing.expectError(error.AddressUnavailable, xev_io.listen(unavailable));
+    try std.testing.expectError(error.AddressUnavailable, xev_io.listen(&.{ .ip = unavailable }, null));
 }
 
 test "xevio: SO_REUSEPORT lets two listeners share one port" {
@@ -1083,7 +1084,8 @@ test "xevio: SO_REUSEPORT lets two listeners share one port" {
 
     // First listener takes an ephemeral port; read the concrete port back.
     const first = try xev_io.listen(
-        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+        &.{ .ip = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable },
+        null,
     );
     const port = xev_io.listenerAddress(first).getPort();
     try std.testing.expect(port != 0);
@@ -1091,7 +1093,7 @@ test "xevio: SO_REUSEPORT lets two listeners share one port" {
     // A second listener on the very same port must also succeed.
     var shared = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable;
     shared.setPort(port);
-    const second = try xev_io.listen(shared);
+    const second = try xev_io.listen(&.{ .ip = shared }, null);
     try std.testing.expectEqual(port, xev_io.listenerAddress(second).getPort());
 }
 
@@ -1138,7 +1140,7 @@ test "xevio: a port squatted without SO_REUSEPORT is AddressInUse" {
 
     var shared = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable;
     shared.setPort(port);
-    try std.testing.expectError(error.AddressInUse, xev_io.listen(shared));
+    try std.testing.expectError(error.AddressInUse, xev_io.listen(&.{ .ip = shared }, null));
 }
 
 test "xevio: binding a privileged port without the capability is AccessDenied" {
@@ -1156,7 +1158,7 @@ test "xevio: binding a privileged port without the capability is AccessDenied" {
     defer xev_io.deinit();
 
     const privileged = std.Io.net.IpAddress.parseLiteral("127.0.0.1:1") catch unreachable;
-    if (xev_io.listen(privileged)) |listener| {
+    if (xev_io.listen(&.{ .ip = privileged }, null)) |listener| {
         xev_io.listenClose(listener);
         return error.SkipZigTest;
     } else |err| {
@@ -1176,7 +1178,8 @@ test "xevio: a dial to a closed loopback port is Refused" {
     defer xev_io.deinit();
 
     const listener = try xev_io.listen(
-        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+        &.{ .ip = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable },
+        null,
     );
     const address = xev_io.listenerAddress(listener);
     assert(address.getPort() != 0);
@@ -1228,7 +1231,8 @@ test "xevio: closing a listener cancels its armed accept" {
     defer xev_io.deinit();
 
     const listener = try xev_io.listen(
-        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+        &.{ .ip = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable },
+        null,
     );
     var outcome: ?(Io.AcceptError!XevIo.Socket) = null;
     var completion: XevIo.Completion = .{};
@@ -1308,7 +1312,8 @@ test "xevio: closing a listener cancels an accept armed in the same tick" {
     defer xev_io.deinit();
 
     const listener = try xev_io.listen(
-        std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable,
+        &.{ .ip = std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") catch unreachable },
+        null,
     );
     var drain: SameTickDrain = .{ .io = &xev_io, .listener = listener };
     // Both at zero: one tick's timer batch runs both callbacks, with no
@@ -1449,14 +1454,14 @@ test "xevio: the listener table reserves a slot for the admin listener" {
     defer xev_io.deinit();
 
     const loopback = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0");
-    const configured = try xev_io.listen(loopback);
+    const configured = try xev_io.listen(&.{ .ip = loopback }, null);
     _ = configured;
     // The admin listener: this is the bind that used to fail.
-    const admin = try xev_io.listen(loopback);
+    const admin = try xev_io.listen(&.{ .ip = loopback }, null);
     _ = admin;
 
     // And the reservation is exactly one — not open-ended.
-    try std.testing.expectError(error.AddressUnavailable, xev_io.listen(loopback));
+    try std.testing.expectError(error.AddressUnavailable, xev_io.listen(&.{ .ip = loopback }, null));
 }
 
 /// The §4 contract a head-read verdict rests on (#247): a read-half
@@ -1477,7 +1482,7 @@ test "xevio: the listener table reserves a slot for the admin listener" {
 fn runReadShutdownContract(comptime IoType: type, io: *IoType) !void {
     const Contract = GroupContract(IoType);
     var c: Contract = .{ .io = io };
-    const listener = try io.listen(try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0"));
+    const listener = try io.listen(&.{ .ip = try std.Io.net.IpAddress.parseLiteral("127.0.0.1:0") }, null);
     defer io.listenClose(listener);
     const client, const server = try c.pair(listener);
     defer io.closeNow(client);

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -154,6 +154,20 @@ pub const Address = union(enum) {
     }
 };
 
+/// The permission bits a `unix:` listener asks for its socket file
+/// (#303). A struct rather than a bare integer so a caller cannot pass a
+/// decimal literal where an octal one was meant — the classic way to
+/// widen a mode by accident.
+pub const FileMode = struct {
+    bits: u16,
+
+    /// Every bit a mode may set: the nine permission bits plus setuid,
+    /// setgid and sticky. A listener has no use for the top three, and
+    /// the loader refuses them, but the type states the file-system
+    /// vocabulary rather than one caller's subset.
+    pub const bits_max: u16 = 0o7777;
+};
+
 pub const ShutdownHow = enum(u8) {
     /// Force an armed *recv* to completion while the connection stays
     /// writable (#247). The write half is untouched, which is the whole
@@ -170,6 +184,13 @@ pub const ListenError = error{
     AddressUnavailable,
     /// Privileged port without the capability, or similar permission wall.
     AccessDenied,
+    /// A `unix:` bind path names something that already exists and is not
+    /// a socket (#303). Distinct from `AddressInUse` because the operator
+    /// action differs: `AddressInUse` sends them hunting a process, while
+    /// this one says the path itself is wrong — and a proxy that cleared
+    /// the way by deleting whatever it found would make a typo in `bind`
+    /// destructive.
+    PathNotSocket,
     Unexpected,
 };
 

--- a/src/io/sim_io_test.zig
+++ b/src/io/sim_io_test.zig
@@ -54,7 +54,7 @@ const PairScenario = struct {
     ready_count: u8 = 0,
 
     fn establish(pair: *PairScenario) !void {
-        pair.listener = try pair.io.listen(testAddress());
+        pair.listener = try pair.io.listen(&.{ .ip = testAddress() }, null);
         pair.io.accept(pair.listener, &pair.accept_completion, PairScenario, pair, onAccept);
         pair.io.connect(&.{ .ip = testAddress() }, &pair.connect_completion, PairScenario, pair, onConnect);
         try pair.io.run();
@@ -183,7 +183,7 @@ test "sim: an injected connect error fails one dial with Unexpected and records 
 
     // A live listener proves the fault wins over an otherwise-successful
     // connect — and, below, that it is one-shot: the retry goes through.
-    const listener = try sim_io.listen(testAddress());
+    const listener = try sim_io.listen(&.{ .ip = testAddress() }, null);
     sim_io.setPressureCause(.address_unavailable);
     sim_io.injectConnectError(testAddress());
 

--- a/src/io/xev_smoke_test.zig
+++ b/src/io/xev_smoke_test.zig
@@ -7,6 +7,7 @@
 //! under `src/io/`, the only place allowed to name xev and raw syscalls.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const xev = @import("xev");
 
 const XevIo = @import("XevIo.zig");
@@ -124,6 +125,111 @@ test "tcp: loopback echo across the full watcher surface" {
     try std.testing.expectEqualStrings(echo_token, echo.server_buffer[0..echo.server_read_len]);
     try std.testing.expectEqualStrings(echo_token, echo.client_buffer[0..echo.client_read_len]);
     try std.testing.expectEqual(@as(u32, 3), echo.close_count);
+}
+
+test "unix listener: the socket file's lifecycle (#303)" {
+    // The half no simulator can hold an opinion about: a real path in a
+    // real filesystem, which is where every UDS implementation keeps its
+    // bugs. Three facts, in the order an operator meets them.
+    var io: XevIo = undefined;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    try io.init(arena_state.allocator(), 0, 2, 2, 512, XevIo.log_sink_stdout, null);
+    defer io.deinit();
+
+    const path = "/tmp/zoxy-xev-listener.sock";
+    _ = std.posix.system.unlink(path);
+    defer _ = std.posix.system.unlink(path);
+
+    // 1. A clean bind creates the file, and closing takes it away —
+    //    so an ordinary stop leaves nothing for the next start to trip
+    //    over.
+    {
+        const listener = try io.listen(&.{ .unix = path }, null);
+        try std.testing.expect(pathIsSocket(path));
+        io.listenClose(listener);
+        try std.testing.expect(!pathExists(path));
+    }
+
+    // 2. A file left behind by a killed process does not wedge the next
+    //    start. Bind, then leak it the way a SIGKILL would, then bind
+    //    again: without the startup unlink this is EADDRINUSE forever,
+    //    which is a proxy that cannot come back up after the incident
+    //    that killed it.
+    {
+        const abandoned = try io.listen(&.{ .unix = path }, null);
+        _ = abandoned;
+        try std.testing.expect(pathIsSocket(path));
+        var second: XevIo = undefined;
+        var second_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer second_arena.deinit();
+        try second.init(second_arena.allocator(), 0, 2, 2, 512, XevIo.log_sink_stdout, null);
+        defer second.deinit();
+        const listener = try second.listen(&.{ .unix = path }, null);
+        try std.testing.expect(pathIsSocket(path));
+        second.listenClose(listener);
+    }
+
+    // 3. A path that names something that is *not* a socket is refused,
+    //    not cleared. A typo in `bind` must not be a delete — this is
+    //    the whole reason the startup unlink is conditional.
+    {
+        _ = std.posix.system.unlink(path);
+        const fd = std.posix.system.open(
+            path,
+            .{ .ACCMODE = .WRONLY, .CREAT = true },
+            @as(std.posix.mode_t, 0o600),
+        );
+        try std.testing.expect(std.posix.errno(fd) == .SUCCESS);
+        _ = std.posix.system.close(@intCast(fd));
+        defer _ = std.posix.system.unlink(path);
+        try std.testing.expectError(error.PathNotSocket, io.listen(&.{ .unix = path }, null));
+        // And it is still there: the refusal did not take it.
+        try std.testing.expect(pathExists(path));
+    }
+}
+
+test "unix listener: a mode lands on the file (#303)" {
+    // The permission story the feature is sold on. Asserted against the
+    // filesystem rather than against the config, because the config is
+    // not what a connecting process is judged by.
+    var io: XevIo = undefined;
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    try io.init(arena_state.allocator(), 0, 1, 2, 512, XevIo.log_sink_stdout, null);
+    defer io.deinit();
+
+    const path = "/tmp/zoxy-xev-listener-mode.sock";
+    _ = std.posix.system.unlink(path);
+    defer _ = std.posix.system.unlink(path);
+
+    const listener = try io.listen(&.{ .unix = path }, .{ .bits = 0o660 });
+    defer io.listenClose(listener);
+    try std.testing.expectEqual(@as(u16, 0o660), permissionBitsOf(path));
+}
+
+fn pathExists(path: [*:0]const u8) bool {
+    return XevIo.fileTypeAt(path) != null;
+}
+
+fn pathIsSocket(path: [*:0]const u8) bool {
+    return XevIo.fileTypeAt(path) orelse false;
+}
+
+/// The permission bits on `path`, read the way `XevIo.fileTypeAt` reads
+/// a file type — the stdlib exposes no `stat` on Linux, so the raw
+/// `statx` syscall is the portable-within-Linux answer.
+fn permissionBitsOf(path: [*:0]const u8) u16 {
+    if (comptime builtin.os.tag == .linux) {
+        var info: std.os.linux.Statx = undefined;
+        const rc = std.os.linux.statx(std.posix.AT.FDCWD, path, 0, .{ .MODE = true }, &info);
+        assert(@as(isize, @bitCast(rc)) >= 0);
+        return @intCast(info.mode & 0o777);
+    }
+    var info: std.posix.Stat = undefined;
+    const rc = std.posix.system.fstatat(std.posix.AT.FDCWD, path, &info, 0);
+    assert(std.posix.errno(rc) == .SUCCESS);
+    return @intCast(info.mode & 0o777);
 }
 
 test "unix: the same echo over a socket path (#303)" {

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -152,7 +152,16 @@ pub fn Conn(comptime IoType: type) type {
         /// Kept rather than asked for at log time: by then the socket may
         /// already be closed, and `getpeername` on a closed fd names
         /// whoever inherited the number.
-        client_address: std.Io.net.IpAddress,
+        ///
+        /// Null on a `unix:` listener (#303), where there is no such
+        /// thing — a local process connected through a file, and the
+        /// kernel has no address to name it by. Optional rather than a
+        /// sentinel because every consumer would have believed the
+        /// sentinel: the loader refuses the three features that would
+        /// have to (`forwarded`, a filter's client match, `hash` on the
+        /// source IP), and the access log states `null` rather than an
+        /// address nobody connected from.
+        client_address: ?std.Io.net.IpAddress,
 
         op_deadline: Op,
         op_deadline_cancel: Op,
@@ -278,7 +287,7 @@ pub fn Conn(comptime IoType: type) type {
             engine: ?*TlsEngine,
             state: State,
             protocol: config_module.Config.Listener.Protocol,
-            client_address: std.Io.net.IpAddress,
+            client_address: ?std.Io.net.IpAddress,
         ) void {
             assert(state == .connecting or state == .l7_reading_head);
             conn.server = server;

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -621,7 +621,8 @@ const Harness = struct {
         bed.clusters = .{.{ .name = "origin", .endpoints = &bed.endpoints }};
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.listeners = .{.{
-            .bind_address = clientAddress(),
+            .bind_address = .{ .ip = clientAddress() },
+            .bind_mode = null,
             .routes = &bed.routes,
             .protocol = .l4,
         }};
@@ -647,8 +648,8 @@ const Harness = struct {
         bed.origin.harness = bed;
         bed.origin.canned = options.origin_canned;
 
-        bed.client_listener = try bed.io.listen(clientAddress());
-        bed.origin_listener = try bed.io.listen(originAddress());
+        bed.client_listener = try bed.io.listen(&.{ .ip = clientAddress() }, null);
+        bed.origin_listener = try bed.io.listen(&.{ .ip = originAddress() }, null);
         bed.io.accept(bed.client_listener, &bed.accept_completion, Harness, bed, onProxyAccepted);
         bed.io.accept(bed.origin_listener, &bed.origin.accept_completion, Origin, &bed.origin, onOriginAccepted);
         bed.io.connect(&.{ .ip = clientAddress() }, &bed.client.connect_completion, Client, &bed.client, onClientConnected);

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -413,7 +413,8 @@ pub const TestBed = struct {
         bed.routes = .{.{ .prefix = "/", .cluster_index = 0 }};
         bed.sni_routes = options.sni_routes;
         bed.listeners = .{.{
-            .bind_address = bindAddress(),
+            .bind_address = .{ .ip = bindAddress() },
+            .bind_mode = null,
             .routes = &bed.routes,
             .sni_routes = bed.sni_routes,
             .protocol = .l4,

--- a/src/testing/origin.zig
+++ b/src/testing/origin.zig
@@ -312,7 +312,7 @@ pub fn Origin(comptime IoType: type) type {
 
         pub fn start(origin: *Self, io: *IoType, address: std.Io.net.IpAddress) !void {
             origin.io = io;
-            origin.listener = try io.listen(address);
+            origin.listener = try io.listen(&.{ .ip = address }, null);
             origin.listening = true;
             origin.armAccept();
         }


### PR DESCRIPTION
Closes #303 — the listener half, after #320 shipped the endpoints half.

```json
{
    "bind": "unix:/run/zoxy.sock",
    "mode": "0660",
    "http": { "cluster": "app" }
}
```

## The client address is the whole design

A request arriving on a socket file has no client IP, because the kernel has none to give. `Conn.client_address` becomes `?IpAddress` rather than acquiring a sentinel — a fabricated `0.0.0.0` would be *believed*:

- `hash: source_ip` would send every local client to one endpoint while looking sticky,
- `match.client` would compare an allowlist against a fiction,
- `X-Forwarded-For` would state an address nobody connected from.

So the loader refuses the four features that would have to read one, each a startup error naming the pair:

| rejected | because |
|---|---|
| a `forwarded` block | XFF would state an address nobody connected from |
| a filter with `match.client` | an allowlist comparing against a fiction |
| a route to a `hash`/`source_ip` cluster | every local client on one endpoint, looking sticky |
| a route to a cluster with `proxy_protocol` send | the header names a source *and* a destination; this listener has neither |

The access log states `null` — the same answer `upstream` already gives when no endpoint was picked — and every `.?` left in the serving path cites the rule that makes it sound.

**The review caught a real hole in that reasoning, and it is worth calling out.** `routes` is not the set of clusters a listener can reach: an `l4` listener with an [SNI table](https://github.com/zoxy-io/zoxy/issues/298) resolves `routes` to *one* provisional entry — the admitted cluster — while `finishSniPeek` replaces the exchange's cluster with the matched one before any dial. So the check held the first name to the rule and waved every other one through, into an unwrap of the address that is not there. Reproduced with `--check` before fixing (a two-name table where only the second is sticky loaded clean), fixed by walking `sni_routes` too, and pinned by a config test that fails without the fix.

## The socket file's lifecycle

Startup's problem, not the loop's:

| at startup, the path… | zoxy |
|---|---|
| does not exist | creates it |
| is a socket | removes it, then creates it |
| is anything else — file, directory, symlink (judged as itself, not followed) | **refuses to start** |

Row two exists because a killed process leaves its file behind, and `EADDRINUSE` forever is a proxy that cannot return after the incident that killed it. Row three is why row two is conditional: a typo in `bind` must never be a delete. A clean close removes what it made — that is tidiness; the startup rule is what makes an unclean stop survivable.

The stat→unlink→bind window is real and deliberately left open; the reasoning is recorded at `clearStaleSocket`. Closing it means bind-to-temp + rename, which trades this race for one where the rename silently replaces exactly what row three protects.

## `mode`

An octal **string**, because `0660` is not valid JSON and `660` is decimal — two readings of one intent that differ by a factor of eight, in the direction that widens access. Applied after the bind. Absent leaves the umask's default. setuid/setgid/sticky are refused: they mean nothing on a socket and everything on the file it would be confused with.

## One limitation, stated

`SO_REUSEPORT` does not reach this family (§3): two processes cannot bind one path. A socket-file listener is for chaining on one host, never for spreading across processes.

## Tests

The filesystem is the part no simulator can hold an opinion about, so it is tested against the real one in the production backend: bind and close (the file appears, then goes), abandon a socket and bind again (the stale path does not wedge the next start), and refuse a non-socket path **while leaving it in place**. The mode is asserted against the filesystem, not the config — the config is not what a connecting process is judged by.

The simulator covers the serving path: a request carried end to end over a socket file, and a log line whose `client` parses back as JSON `null` with `upstream` still present.

Config tests cover the grammar (including a duplicate bind, which needed the ordering to stop being a single integer key), the mode vocabulary, and all four refusals — each paired with a case proving the rule is about the bind and not the feature, plus the SNI-table cases above.

## Gates

`zig build ci` green (4096 sim seeds, both smoke runs), `zig fmt --check` clean. `tiger-style-reviewer` run; both findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)