### PR TITLE
config: hold the schema and the loader to each other (#305)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -839,6 +839,41 @@ Rules:
   document without the proxy refusing to start over the pointer. It buys no
   general laxity — `$schemas`, or a `$schema` nested inside any other
   object, is still an unknown field.
+- **The schema and the loader are held to each other by a differential
+  gate** (#305 Part 2). Counting concessions in prose was the cheap half;
+  the expensive half is checking that the emitted document and the loader
+  actually agree, and it runs on every rejection stated through
+  `expectParseError` — which is most but not all of them: a handful of
+  `ValidationError` members have no test, and four are asserted against
+  `parse` directly, so the measured gap list is a floor rather than a
+  census of the error set.
+  `src/json_schema.zig` validates the dialect the emitter emits — not a
+  general validator, which would be a dependency (§4) or a second
+  reading of a spec nobody here has open, but a closed keyword set whose
+  `census` walks a rendered document and fails on anything it does not
+  implement. That census is what makes the gate mean something: a
+  validator that skips what it does not recognise reports "valid" by not
+  looking.
+  Two directions, and they are not symmetric. **The schema must accept
+  whatever the loader accepts** — no exemptions, ever: a schema that
+  refuses a working config is not conservative, it is a lie told to
+  every editor that reads it, and the operator who believes it deletes a
+  key that was fine. **What the loader refuses, the schema should refuse
+  too** — and where it cannot, `schema_gaps` names the rejection and why.
+  Seven of its categories are closed by what a schema *is*: no document
+  grammar parses an address, sums a list of weights against a budget,
+  resolves a name into another block, computes canonical equality, reads
+  the filesystem, bounds an object *key*, or holds two blocks at once.
+  Two are **debt** — a fork inside one block that `oneOf` could carry,
+  and a bound the emitter does not derive yet — and their counts are
+  pinned, so the shape work that remains is a number rather than an
+  opinion. The pin runs one way: removing a row that is still needed
+  fails the build, while a row whose rule *became* expressible has to be
+  struck by whoever made it so, because one error is raised by several
+  cases and the schema catching one of them proves nothing about the
+  rest. That is the measurable definition of the
+  freeze being done, and it replaces a review's judgement with a build
+  failure.
 - **A slot is released only when its armed-op set is empty.** Teardown is
   where the races live — a lesson paid for in implementation time and
   simulator seeds last iteration. Every op references a completion

--- a/src/config.zig
+++ b/src/config.zig
@@ -18,6 +18,7 @@ const parser = @import("http/parser.zig");
 const render = @import("http/render.zig");
 const shed = @import("shed.zig");
 const io_module = @import("io/io.zig");
+const json_schema = @import("json_schema.zig");
 
 const assert = std.debug.assert;
 
@@ -6861,6 +6862,284 @@ fn expectParseError(expected: ParseError, json_bytes: []const u8) !void {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     try std.testing.expectError(expected, parse(arena_state.allocator(), json_bytes));
+    try expectSchemaAgrees(expected, json_bytes);
+}
+
+/// #305's differential gate, run on every rejection this file states.
+///
+/// `zig build schema` says what a config may *look* like and the loader
+/// says what it may *mean*, and until this nothing checked that the two
+/// agree. A config the schema admits and the loader refuses is a
+/// cross-field rule that a shape could have carried instead — Part 1's
+/// whole argument — so each one has to be named here with the reason it
+/// stays the loader's. What the gate forbids is a *new* one appearing
+/// quietly.
+///
+/// Riding on `expectParseError` rather than on a corpus of its own is
+/// the point: there is no second list to drift, and a rejection added
+/// tomorrow is graded the day it is written.
+fn expectSchemaAgrees(expected: ParseError, json_bytes: []const u8) !void {
+    // A malformed document is the JSON parser's verdict, not the
+    // loader's, and the schema never sees one — `parseFromSlice` below
+    // would fail on exactly the same bytes for exactly the same reason.
+    if (!isValidationError(expected)) {
+        return;
+    }
+    var schema = try renderedSchema();
+    defer schema.deinit();
+    var instance = std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        json_bytes,
+        .{},
+    ) catch return;
+    defer instance.deinit();
+
+    var storage: [json_schema.path_bytes_max]u8 = undefined;
+    const failure = json_schema.validate(schema.value, instance.value, &storage);
+    if (failure == null and schemaGapOf(expected) == null) {
+        std.debug.print(
+            "\nthe schema admits what the loader refuses as {t}. Either the schema " ++
+                "should express it — in which case teach the emitter — or it cannot, " ++
+                "in which case add it to `schema_gaps` with the reason (#305).\n",
+            .{expected},
+        );
+        return error.TestUnexpectedResult;
+    }
+}
+
+/// Why the schema cannot reject a config the loader refuses.
+///
+/// Not an excuse list: the categories are the argument. Seven of them
+/// are closed — a schema describes documents, and no document grammar
+/// can parse an address, sum a list of weights, or read another block —
+/// so entries there are permanent and correct. Two are **debt**: a fork or
+/// a bound the schema could carry and does not yet, which is exactly
+/// what #305 Part 1 called a cross-field rule that should have been a
+/// shape. Their counts are pinned below so they only ever fall.
+const SchemaGap = enum {
+    /// The value is text whose *meaning* only a parser knows: an address
+    /// literal, a canonical path or host, a CIDR, a header-name token, a
+    /// media type, an octal mode. A grammar can say "string"; it cannot
+    /// say "and it parses".
+    literal_syntax,
+    /// A length bound on a name the schema has no place to attach one.
+    /// Strictly an object *key* — `clusters`, `bodies` and `error_pages`
+    /// are keyed by operator-chosen names, and a key has no schema of
+    /// its own in this dialect (`propertyNames` is a keyword the emitter
+    /// deliberately does not reach for, #305's closed vocabulary). A
+    /// bound on a *value* is not this: it has somewhere to attach, so it
+    /// belongs in `expressible_bound` and two rows were moved there when
+    /// review caught them filed here.
+    name_length,
+    /// A name that must exist in another block — `cluster` naming a
+    /// cluster, `body` naming a body. A schema validates one document
+    /// against one grammar, not a document against itself.
+    cross_reference,
+    /// Uniqueness judged by a key the schema cannot compute: two binds
+    /// that differ as text and match as addresses, two routes that
+    /// differ in spelling and match after canonicalization.
+    duplicate,
+    /// The filesystem answered, not the document.
+    filesystem,
+    /// §5 arithmetic: a limit judged against another limit, against the
+    /// ring, or against whether any listener asked for the feature it
+    /// sizes. Closed-form budget reasoning, and the banner is where it
+    /// is explained.
+    budget,
+    /// A rule between two blocks the schema cannot hold at once — a
+    /// listener's shape against a cluster's, or against a sibling of its
+    /// own body.
+    cross_block,
+    /// **Debt.** A fork inside one block that `oneOf` could carry: a
+    /// field required exactly when a sibling takes a given value. Every
+    /// one of these is a cross-field rule the loader states in prose and
+    /// a shape could state instead.
+    expressible_fork,
+    /// **Debt.** A bound the schema could carry and the emitter does not
+    /// derive yet: an array's `maxItems`, or a string's `maxLength`
+    /// (`min_length` is emitted already, so only half of that pair
+    /// exists).
+    expressible_bound,
+};
+
+const SchemaGapEntry = struct { name: []const u8, gap: SchemaGap };
+
+/// Every loader rejection the schema does not catch, measured rather
+/// than guessed: the gate above prints what is missing, and this is the
+/// list it printed with a reason attached to each.
+///
+/// One direction only, and worth stating rather than discovering. A row
+/// that is *needed* is proved by the gate: remove it and the case that
+/// escapes the schema fails the build. A row that has become *stale* —
+/// its rule since made expressible — is not caught, and cannot be
+/// cheaply: one error is raised by several cases with different JSON,
+/// the schema may catch some of them and not others, so "the schema
+/// rejected this case" does not mean the row is unnecessary. Deciding
+/// that needs every case for an error collected before any verdict,
+/// which this harness has no hook for. So a paid-off rule has to be
+/// struck from here by whoever pays it off, and re-running the gate
+/// with the row removed is how they check.
+const schema_gaps = [_]SchemaGapEntry{
+    .{ .name = "AccessLogHeaderDuplicate", .gap = .duplicate },
+    .{ .name = "AccessLogHeaderNameInvalid", .gap = .literal_syntax },
+    .{ .name = "AccessLogHeaderNameTooLong", .gap = .expressible_bound },
+    .{ .name = "AccessLogPathMissing", .gap = .expressible_fork },
+    .{ .name = "AccessLogPathOnStdout", .gap = .expressible_fork },
+    .{ .name = "AdminBindInvalid", .gap = .literal_syntax },
+    .{ .name = "BodyContentTypeInvalid", .gap = .literal_syntax },
+    .{ .name = "BodyFileUnreadable", .gap = .filesystem },
+    .{ .name = "BodyNameEmpty", .gap = .name_length },
+    .{ .name = "BodyNameTooLong", .gap = .name_length },
+    .{ .name = "BodySourceAmbiguous", .gap = .expressible_fork },
+    .{ .name = "BodySourceMissing", .gap = .expressible_fork },
+    .{ .name = "BodyUnknown", .gap = .cross_reference },
+    .{ .name = "ClusterCheckHostInvalid", .gap = .literal_syntax },
+    .{ .name = "ClusterCheckHttpFieldOnTcp", .gap = .expressible_fork },
+    .{ .name = "ClusterCheckPathMissing", .gap = .expressible_fork },
+    .{ .name = "ClusterCheckPathNotCanonical", .gap = .literal_syntax },
+    .{ .name = "ClusterNameEmpty", .gap = .name_length },
+    .{ .name = "ClusterNameTooLong", .gap = .name_length },
+    .{ .name = "ClusterPickKeyMissing", .gap = .expressible_fork },
+    .{ .name = "ClusterPickKeyWithoutHash", .gap = .expressible_fork },
+    .{ .name = "ClusterPickNameInvalid", .gap = .literal_syntax },
+    .{ .name = "ClusterPickNameMissing", .gap = .expressible_fork },
+    .{ .name = "ClusterPickNameTooLong", .gap = .expressible_bound },
+    .{ .name = "ClusterPickNameUnexpected", .gap = .expressible_fork },
+    .{ .name = "ClusterProxyProtocolOnHttpListener", .gap = .cross_block },
+    .{ .name = "ClusterProxyProtocolOnTlsListener", .gap = .cross_block },
+    .{ .name = "ClusterUnknown", .gap = .cross_reference },
+    .{ .name = "EndpointInvalid", .gap = .literal_syntax },
+    .{ .name = "EndpointPortZero", .gap = .literal_syntax },
+    .{ .name = "EndpointUnixPathInvalid", .gap = .literal_syntax },
+    .{ .name = "EndpointUnixPathRelative", .gap = .literal_syntax },
+    .{ .name = "EndpointWeightsAllZero", .gap = .budget },
+    .{ .name = "ErrorPageStatusInvalid", .gap = .literal_syntax },
+    .{ .name = "FilterClientCidrHostBits", .gap = .literal_syntax },
+    .{ .name = "FilterClientCidrInvalid", .gap = .literal_syntax },
+    .{ .name = "FilterClientPrefixInvalid", .gap = .literal_syntax },
+    .{ .name = "FilterClientPrefixTooNarrow", .gap = .literal_syntax },
+    .{ .name = "FilterHeaderEditsOverLimit", .gap = .expressible_bound },
+    .{ .name = "FilterHeaderNameInvalid", .gap = .literal_syntax },
+    .{ .name = "FilterHeaderNameReserved", .gap = .literal_syntax },
+    .{ .name = "FilterHeaderValueInvalid", .gap = .literal_syntax },
+    .{ .name = "FilterRedirectTarget", .gap = .literal_syntax },
+    .{ .name = "LimitAccessLogBufferUnderLine", .gap = .budget },
+    .{ .name = "LimitAccessLogBufferWithoutSink", .gap = .budget },
+    .{ .name = "LimitConnSlotsOverCqFill", .gap = .budget },
+    .{ .name = "LimitHeadBuffersOutOfRange", .gap = .budget },
+    .{ .name = "LimitHeadBuffersOverConnSlots", .gap = .budget },
+    .{ .name = "LimitHeadBuffersWithoutHttpListener", .gap = .budget },
+    .{ .name = "LimitRelayBufferUnderSniRouting", .gap = .budget },
+    .{ .name = "LimitRelayBuffersOverConnSlots", .gap = .budget },
+    .{ .name = "LimitTlsEnginesOverConnSlots", .gap = .budget },
+    .{ .name = "LimitTlsEnginesWithoutTlsListener", .gap = .budget },
+    .{ .name = "LimitTunnelsOverConnSlots", .gap = .budget },
+    .{ .name = "LimitTunnelsRequired", .gap = .budget },
+    .{ .name = "LimitTunnelsWithoutUpgrades", .gap = .budget },
+    .{ .name = "LimitUpstreamHeadBuffersOutOfRange", .gap = .budget },
+    .{ .name = "LimitUpstreamHeadBuffersOverUpstreamSlots", .gap = .budget },
+    .{ .name = "LimitUpstreamHeadBuffersWithoutHttpListener", .gap = .budget },
+    .{ .name = "ListenerBindDuplicate", .gap = .duplicate },
+    .{ .name = "ListenerBindInvalid", .gap = .literal_syntax },
+    .{ .name = "ListenerBindUnixPathInvalid", .gap = .literal_syntax },
+    .{ .name = "ListenerBindUnixPathRelative", .gap = .literal_syntax },
+    .{ .name = "ListenerL4RequestKeyedHash", .gap = .cross_block },
+    .{ .name = "ListenerModeInvalid", .gap = .literal_syntax },
+    .{ .name = "ListenerModeWithoutUnixBind", .gap = .cross_block },
+    .{ .name = "ListenerTlsWithSniRoutes", .gap = .cross_block },
+    .{ .name = "ListenerUnixBindClientMatch", .gap = .cross_block },
+    .{ .name = "ListenerUnixBindClusterSend", .gap = .cross_block },
+    .{ .name = "ListenerUnixBindForwarded", .gap = .cross_block },
+    .{ .name = "ListenerUnixBindSourceIpHash", .gap = .cross_block },
+    .{ .name = "ResponseFilterHeaderEditsOverLimit", .gap = .expressible_bound },
+    .{ .name = "ResponseFilterRedirect", .gap = .expressible_fork },
+    .{ .name = "ResponseFilterReject", .gap = .expressible_fork },
+    .{ .name = "ResponseFilterRespond", .gap = .expressible_fork },
+    .{ .name = "ResponseFilterRewrite", .gap = .expressible_fork },
+    .{ .name = "RouteDuplicate", .gap = .duplicate },
+    .{ .name = "RouteHostNotCanonical", .gap = .literal_syntax },
+    .{ .name = "RoutePrefixNotCanonical", .gap = .literal_syntax },
+    .{ .name = "RouteSniIsAddress", .gap = .literal_syntax },
+    .{ .name = "TimeoutOrderInvalid", .gap = .budget },
+};
+
+comptime {
+    // 81 rows against 146 error members is ~12k comparisons, well past
+    // the default budget and still trivial at compile time.
+    @setEvalBranchQuota(200_000);
+    // Every name here must be a real member, or a renamed error would
+    // leave a row that excuses nothing and hides its successor.
+    for (schema_gaps) |entry| {
+        var found = false;
+        for (@typeInfo(ValidationError).error_set.?) |candidate| {
+            if (std.mem.eql(u8, candidate.name, entry.name)) found = true;
+        }
+        if (!found) @compileError("schema_gaps names no such ValidationError: " ++ entry.name);
+    }
+    // And no name twice, or one row would shadow a second reason.
+    for (schema_gaps, 0..) |entry, index| {
+        for (schema_gaps[index + 1 ..]) |other| {
+            if (std.mem.eql(u8, entry.name, other.name)) {
+                @compileError("schema_gaps names " ++ entry.name ++ " twice");
+            }
+        }
+    }
+}
+
+fn schemaGapOf(expected: ParseError) ?SchemaGap {
+    inline for (schema_gaps) |entry| {
+        if (expected == @field(ValidationError, entry.name)) return entry.gap;
+    }
+    return null;
+}
+
+test "config: the schema's debt to the loader only ever falls (#305)" {
+    // The measurable definition of the freeze being done. Seven gap
+    // categories are closed by what a schema *is*; these two are things
+    // the emitter could express and does not, so they are the work that
+    // remains — pinned, so a new one cannot arrive quietly and an old
+    // one cannot be paid off without saying so.
+    var forks: usize = 0;
+    var bounds: usize = 0;
+    for (schema_gaps) |entry| {
+        switch (entry.gap) {
+            .expressible_fork => forks += 1,
+            .expressible_bound => bounds += 1,
+            else => {},
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 14), forks);
+    try std.testing.expectEqual(@as(usize, 4), bounds);
+}
+
+/// Whether `expected` is the loader's own verdict rather than the JSON
+/// parser's. `ParseError` is the union of both, and only the loader's
+/// half is a claim about config *shape*.
+fn isValidationError(expected: ParseError) bool {
+    inline for (@typeInfo(ValidationError).error_set.?) |candidate| {
+        if (expected == @field(ValidationError, candidate.name)) return true;
+    }
+    return false;
+}
+
+/// The rendered schema, parsed fresh for each case rather than cached.
+///
+/// A cache would outlive the test that filled it and every allocator
+/// this suite runs under would call that a leak — which it would be. The
+/// document is 60 KiB and this is a test path, so re-rendering is the
+/// cheaper mistake to make.
+var schema_storage: [128 * 1024]u8 = undefined;
+
+fn renderedSchema() !std.json.Parsed(std.json.Value) {
+    var writer = std.Io.Writer.fixed(&schema_storage);
+    try @import("config_schema.zig").writeSchema(&writer);
+    return std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        writer.buffered(),
+        .{},
+    );
 }
 
 /// The success-path mirror of `expectParseError`: inits `arena_state`
@@ -6872,7 +7151,46 @@ fn expectParseError(expected: ParseError, json_bytes: []const u8) !void {
 /// early return would deinit an uninitialized arena.
 fn expectParseOk(arena_state: *std.heap.ArenaAllocator, json_bytes: []const u8) !Config {
     arena_state.* = std.heap.ArenaAllocator.init(std.testing.allocator);
-    return parse(arena_state.allocator(), json_bytes);
+    const parsed = try parse(arena_state.allocator(), json_bytes);
+    try expectSchemaAccepts(json_bytes);
+    return parsed;
+}
+
+/// The other half of #305's gate, and the cheaper one: whatever the
+/// loader accepts, the schema must accept too.
+///
+/// This direction has no exemptions and never will. A schema that
+/// rejects a working config is not a conservative schema — it is a lie
+/// told to every editor that reads it, and the operator who believes it
+/// deletes a key that was fine. `zig build schema` exists to be trusted
+/// by tools that will never run the loader.
+fn expectSchemaAccepts(json_bytes: []const u8) !void {
+    var schema = try renderedSchema();
+    defer schema.deinit();
+    var instance = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        json_bytes,
+        .{},
+    );
+    defer instance.deinit();
+
+    var storage: [json_schema.path_bytes_max]u8 = undefined;
+    if (json_schema.validate(schema.value, instance.value, &storage)) |failure| {
+        std.debug.print(
+            "\nthe schema rejects what the loader accepts: {s} at '{s}' (#305)\n",
+            .{ @tagName(failure.reason), failure.path },
+        );
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "config: the shipped example validates against its own schema (#305)" {
+    // The one config in the tree, held to the document `zig build schema`
+    // hands an editor. It is the example an operator starts from, so a
+    // schema that flags it would be wrong about the first file anybody
+    // writes.
+    try expectSchemaAccepts(@embedFile("example_config"));
 }
 
 test "config: a table far past the old caps parses, and is bounded only by itself" {

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -22,6 +22,7 @@
 const std = @import("std");
 
 const config = @import("config.zig");
+const json_schema = @import("json_schema.zig");
 const constants = @import("constants.zig");
 const filter = @import("http/filter.zig");
 const parser = @import("http/parser.zig");
@@ -682,6 +683,27 @@ fn expectOneOf(object: *const std.json.ObjectMap, arms_expected: usize) !void {
         for (object.get("required").?.array.items) |already| {
             try std.testing.expect(!std.mem.eql(u8, already.string, name));
         }
+    }
+}
+
+test "config_schema: the emitted dialect is one the validator implements" {
+    // The two halves of #305's gate held together. `json_schema.zig`
+    // validates only the keywords it knows and would otherwise report
+    // "valid" for a constraint it never read — so the emitter is not
+    // free to reach for a new one silently. Teach the emitter a keyword
+    // and this fails until the validator learns it too.
+    var buffer: [64 * 1024]u8 = undefined;
+    const text = try renderInto(&buffer);
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        text,
+        .{},
+    );
+    defer parsed.deinit();
+    if (json_schema.census(parsed.value)) |unknown| {
+        std.debug.print("\nemitted keyword the validator does not implement: {s}\n", .{unknown});
+        return error.TestUnexpectedResult;
     }
 }
 

--- a/src/json_schema.zig
+++ b/src/json_schema.zig
@@ -1,0 +1,664 @@
+//! A JSON Schema validator for exactly the dialect this repo emits
+//! (#305, DESIGN.md §5).
+//!
+//! Not a general one, and deliberately so. `config_schema.zig` renders
+//! the schema by reflecting over the loader's own DTOs, so the set of
+//! keywords that can appear in it is closed and known — `census` below
+//! walks a rendered document and fails on any keyword this file does not
+//! implement, which is what keeps "we validate the schema we emit" a
+//! fact rather than a hope. A general validator would be a dependency
+//! (§4) or a second implementation of a spec nobody here is reading.
+//!
+//! What it exists for: the differential gate. `zig build schema` says
+//! what a config may look like and the loader says what it may *mean*,
+//! and until now nothing checked that the two agree. A config the schema
+//! admits and the loader refuses is a cross-field rule that should have
+//! been a shape (#305 Part 1's whole argument); a config the schema
+//! refuses and the loader accepts is a schema that lies to every editor
+//! that reads it.
+//!
+//! Allocation: none. Both the schema and the instance arrive as parsed
+//! `std.json.Value` trees the caller owns, and validation is a walk over
+//! them — this runs in tests and in the schema tool, never on the loop
+//! (§3), but the discipline is free here so it is kept.
+
+const std = @import("std");
+
+const assert = std.debug.assert;
+
+/// Every keyword this validator understands. Two kinds: the ones that
+/// constrain an instance, and the annotations that describe it for a
+/// human or an editor and constrain nothing. Both are listed, because
+/// `census` has to tell "implemented" from "unrecognised" and an
+/// annotation left out would read as the latter.
+pub const Keyword = enum {
+    // Annotations — carried in the document, ignored here.
+    @"$schema",
+    @"$id",
+    title,
+    description,
+    default,
+
+    // Constraints.
+    type,
+    properties,
+    required,
+    additionalProperties,
+    items,
+    @"enum",
+    @"const",
+    oneOf,
+    anyOf,
+    minimum,
+    maximum,
+    minLength,
+    minItems,
+    maxItems,
+    minProperties,
+
+    /// Whether this keyword's value is itself a schema, a map of
+    /// schemas, or a list of schemas — which is what lets `census`
+    /// recurse without guessing, and what keeps a property named `type`
+    /// from being read as the keyword `type`.
+    pub const Shape = enum { annotation, scalar, schema, schema_map, schema_list };
+
+    pub fn shape(keyword: Keyword) Shape {
+        return switch (keyword) {
+            .@"$schema", .@"$id", .title, .description, .default => .annotation,
+            .type,
+            .required,
+            .@"enum",
+            .@"const",
+            .minimum,
+            .maximum,
+            .minLength,
+            .minItems,
+            .maxItems,
+            .minProperties,
+            => .scalar,
+            // `additionalProperties` is `false` in everything this repo
+            // emits; the schema form is legal in the dialect and costs
+            // nothing to accept.
+            .items, .additionalProperties => .schema,
+            .properties => .schema_map,
+            .oneOf, .anyOf => .schema_list,
+        };
+    }
+};
+
+/// Why an instance failed, as a path and a reason — enough for a gate to
+/// say which config and which field rather than just "no".
+pub const Failure = struct {
+    /// Dotted path to the offending value, `""` at the root. Written
+    /// into caller storage so this allocates nothing.
+    path: []const u8,
+    reason: Reason,
+
+    pub const Reason = enum {
+        type_mismatch,
+        missing_required,
+        unknown_property,
+        not_in_enum,
+        not_const,
+        below_minimum,
+        above_maximum,
+        too_short,
+        too_few_items,
+        too_few_properties,
+        too_many_items,
+        no_branch_matched,
+        many_branches_matched,
+    };
+};
+
+/// How deep a schema may nest before this file refuses to walk it.
+///
+/// TIGER_STYLE forbids unbounded recursion, and a schema is a tree, so
+/// the walk carries its depth and asserts against this rather than
+/// trusting the document. The emitted schema nests about six deep
+/// (root → listeners → items → http → request_filters → items →
+/// match); 32 is room for the shape to grow several times over without
+/// being room for a cycle to hide in.
+pub const depth_max = 32;
+
+/// The longest dotted path a failure can name. The emitted schema nests
+/// a handful deep and every segment is a DTO field name, so this is
+/// generous rather than tight — and it is a test-path bound, not a §5
+/// one.
+pub const path_bytes_max = 512;
+
+/// Validate `instance` against `schema`, both already parsed. Null is a
+/// pass; a `Failure` names the first thing wrong, in document order.
+///
+/// `path_storage` is where the failure's path is written — the caller
+/// owns it, and it must outlive the returned failure.
+pub fn validate(
+    schema: std.json.Value,
+    instance: std.json.Value,
+    path_storage: *[path_bytes_max]u8,
+) ?Failure {
+    var path: Path = .{ .storage = path_storage, .len = 0 };
+    return check(schema, instance, &path, 0);
+}
+
+/// A dotted path built as the walk descends and truncated as it returns
+/// — one buffer for the whole validation, so a deep tree costs no more
+/// than a shallow one.
+const Path = struct {
+    storage: *[path_bytes_max]u8,
+    len: u16,
+
+    fn push(path: *Path, segment: []const u8) u16 {
+        const saved = path.len;
+        // A path past the bound is a schema deeper than this file is
+        // built for, and silently truncating it would name the wrong
+        // field in a failure. Nothing here recurses without a schema
+        // that produced it, so the bound is checkable rather than
+        // hopeful.
+        assert(path.len + segment.len + 1 <= path_bytes_max);
+        if (path.len >= 1) {
+            path.storage[path.len] = '.';
+            path.len += 1;
+        }
+        @memcpy(path.storage[path.len..][0..segment.len], segment);
+        path.len += @intCast(segment.len);
+        return saved;
+    }
+
+    fn pushIndex(path: *Path, index: usize) u16 {
+        var digits: [24]u8 = undefined;
+        const rendered = std.fmt.bufPrint(&digits, "[{d}]", .{index}) catch unreachable;
+        const saved = path.len;
+        assert(path.len + rendered.len <= path_bytes_max);
+        @memcpy(path.storage[path.len..][0..rendered.len], rendered);
+        path.len += @intCast(rendered.len);
+        return saved;
+    }
+
+    fn restore(path: *Path, saved: u16) void {
+        assert(saved <= path.len);
+        path.len = saved;
+    }
+
+    fn fail(path: *const Path, reason: Failure.Reason) Failure {
+        return .{ .path = path.storage[0..path.len], .reason = reason };
+    }
+};
+
+fn check(
+    schema: std.json.Value,
+    instance: std.json.Value,
+    path: *Path,
+    depth: u8,
+) ?Failure {
+    // The one bound this walk has. A schema deeper than `depth_max` is
+    // one this file was not built for, and descending anyway is how a
+    // cyclic or hostile document turns a validator into a stack
+    // overflow — the emitter's own output is checked against it by the
+    // census, so a breach here is a document from somewhere else.
+    assert(depth < depth_max);
+    // A schema that is not an object constrains nothing in this dialect;
+    // the emitter never writes one, and the census proves it.
+    const object = switch (schema) {
+        .object => |map| map,
+        else => return null,
+    };
+    if (object.get("type")) |wanted| {
+        if (!typeMatches(wanted, instance)) {
+            return path.fail(.type_mismatch);
+        }
+    }
+    if (object.get("const")) |wanted| {
+        if (!valuesEqual(wanted, instance)) {
+            return path.fail(.not_const);
+        }
+    }
+    if (object.get("enum")) |choices| {
+        if (!inEnum(choices, instance)) {
+            return path.fail(.not_in_enum);
+        }
+    }
+    if (checkNumeric(object, instance, path)) |failure| {
+        return failure;
+    }
+    if (checkString(object, instance, path)) |failure| {
+        return failure;
+    }
+    if (checkArray(object, instance, path, depth)) |failure| {
+        return failure;
+    }
+    if (checkObject(object, instance, path, depth)) |failure| {
+        return failure;
+    }
+    return checkCombinators(object, instance, path, depth);
+}
+
+fn checkNumeric(
+    object: std.json.ObjectMap,
+    instance: std.json.Value,
+    path: *Path,
+) ?Failure {
+    const observed = numberOf(instance) orelse return null;
+    if (object.get("minimum")) |bound| {
+        if (observed < numberOf(bound).?) {
+            return path.fail(.below_minimum);
+        }
+    }
+    if (object.get("maximum")) |bound| {
+        if (observed > numberOf(bound).?) {
+            return path.fail(.above_maximum);
+        }
+    }
+    return null;
+}
+
+fn checkString(
+    object: std.json.ObjectMap,
+    instance: std.json.Value,
+    path: *Path,
+) ?Failure {
+    const text = switch (instance) {
+        .string => |value| value,
+        else => return null,
+    };
+    if (object.get("minLength")) |bound| {
+        if (@as(f64, @floatFromInt(text.len)) < numberOf(bound).?) {
+            return path.fail(.too_short);
+        }
+    }
+    return null;
+}
+
+fn checkArray(
+    object: std.json.ObjectMap,
+    instance: std.json.Value,
+    path: *Path,
+    depth: u8,
+) ?Failure {
+    assert(depth < depth_max);
+    const items = switch (instance) {
+        .array => |value| value,
+        else => return null,
+    };
+    if (object.get("minItems")) |bound| {
+        if (@as(f64, @floatFromInt(items.items.len)) < numberOf(bound).?) {
+            return path.fail(.too_few_items);
+        }
+    }
+    if (object.get("maxItems")) |bound| {
+        if (@as(f64, @floatFromInt(items.items.len)) > numberOf(bound).?) {
+            return path.fail(.too_many_items);
+        }
+    }
+    if (object.get("items")) |item_schema| {
+        for (items.items, 0..) |element, index| {
+            const saved = path.pushIndex(index);
+            defer path.restore(saved);
+            if (check(item_schema, element, path, depth + 1)) |failure| {
+                return failure;
+            }
+        }
+    }
+    return null;
+}
+
+fn checkObject(
+    object: std.json.ObjectMap,
+    instance: std.json.Value,
+    path: *Path,
+    depth: u8,
+) ?Failure {
+    assert(depth < depth_max);
+    const members = switch (instance) {
+        .object => |value| value,
+        else => return null,
+    };
+    if (object.get("minProperties")) |bound| {
+        if (@as(f64, @floatFromInt(members.count())) < numberOf(bound).?) {
+            return path.fail(.too_few_properties);
+        }
+    }
+    if (object.get("required")) |names| {
+        for (names.array.items) |name| {
+            if (members.get(name.string) == null) {
+                const saved = path.push(name.string);
+                defer path.restore(saved);
+                return path.fail(.missing_required);
+            }
+        }
+    }
+    const properties = object.get("properties");
+    // `additionalProperties` carries both jobs this dialect needs, and
+    // conflating them is easy to do and expensive to miss. As `false` it
+    // closes the object: an unknown key is a typo the loader would
+    // reject anyway, and saying so in the schema is what makes an editor
+    // catch it first. As a *schema* it types every member a `properties`
+    // map does not name — which is how a table keyed by operator-chosen
+    // names is described at all, and `clusters`, `bodies` and
+    // `error_pages` are all that shape.
+    const additional = object.get("additionalProperties");
+    const closed = if (additional) |value| value == .bool and value.bool == false else false;
+    const member_default: ?std.json.Value = if (additional) |value|
+        (if (value == .object) value else null)
+    else
+        null;
+    var it = members.iterator();
+    while (it.next()) |entry| {
+        const named = if (properties) |map| map.object.get(entry.key_ptr.*) else null;
+        const member_schema = named orelse member_default;
+        if (member_schema) |sub| {
+            const saved = path.push(entry.key_ptr.*);
+            defer path.restore(saved);
+            if (check(sub, entry.value_ptr.*, path, depth + 1)) |failure| {
+                return failure;
+            }
+        } else if (closed) {
+            const saved = path.push(entry.key_ptr.*);
+            defer path.restore(saved);
+            return path.fail(.unknown_property);
+        }
+    }
+    return null;
+}
+
+fn checkCombinators(
+    object: std.json.ObjectMap,
+    instance: std.json.Value,
+    path: *Path,
+    depth: u8,
+) ?Failure {
+    assert(depth < depth_max);
+    if (object.get("anyOf")) |branches| {
+        var matched = false;
+        for (branches.array.items) |branch| {
+            if (check(branch, instance, path, depth + 1) == null) {
+                matched = true;
+            }
+        }
+        if (!matched) {
+            return path.fail(.no_branch_matched);
+        }
+    }
+    if (object.get("oneOf")) |branches| {
+        var matches: u32 = 0;
+        for (branches.array.items) |branch| {
+            if (check(branch, instance, path, depth + 1) == null) {
+                matches += 1;
+            }
+        }
+        if (matches == 0) {
+            return path.fail(.no_branch_matched);
+        }
+        // Exactly one, which is what makes `oneOf` the "exactly one of"
+        // the loader used to enforce in prose (#305 Part 1).
+        if (matches > 1) {
+            return path.fail(.many_branches_matched);
+        }
+    }
+    return null;
+}
+
+fn typeMatches(wanted: std.json.Value, instance: std.json.Value) bool {
+    return switch (wanted) {
+        .string => |name| typeNameMatches(name, instance),
+        // The union form: any one of the listed types will do.
+        .array => |names| {
+            for (names.items) |name| {
+                if (typeNameMatches(name.string, instance)) return true;
+            }
+            return false;
+        },
+        else => true,
+    };
+}
+
+fn typeNameMatches(name: []const u8, instance: std.json.Value) bool {
+    if (std.mem.eql(u8, name, "object")) return instance == .object;
+    if (std.mem.eql(u8, name, "array")) return instance == .array;
+    if (std.mem.eql(u8, name, "string")) return instance == .string;
+    if (std.mem.eql(u8, name, "boolean")) return instance == .bool;
+    if (std.mem.eql(u8, name, "null")) return instance == .null;
+    if (std.mem.eql(u8, name, "integer")) {
+        return switch (instance) {
+            .integer => true,
+            // JSON has one number type, so an integral float is an
+            // integer — `1.0` and `1` are the same value, and rejecting
+            // the first would fail a config no human wrote differently.
+            .float => |value| @floor(value) == value,
+            else => false,
+        };
+    }
+    if (std.mem.eql(u8, name, "number")) {
+        return instance == .integer or instance == .float;
+    }
+    // An unrecognised type name is a keyword the census should have
+    // caught; treating it as satisfied here would hide that.
+    unreachable;
+}
+
+fn numberOf(value: std.json.Value) ?f64 {
+    return switch (value) {
+        .integer => |number| @floatFromInt(number),
+        .float => |number| number,
+        else => null,
+    };
+}
+
+fn inEnum(choices: std.json.Value, instance: std.json.Value) bool {
+    for (choices.array.items) |choice| {
+        if (valuesEqual(choice, instance)) return true;
+    }
+    return false;
+}
+
+fn valuesEqual(a: std.json.Value, b: std.json.Value) bool {
+    return switch (a) {
+        .null => b == .null,
+        .bool => |value| b == .bool and b.bool == value,
+        .integer, .float => blk: {
+            const other = numberOf(b) orelse break :blk false;
+            break :blk numberOf(a).? == other;
+        },
+        .string => |value| b == .string and std.mem.eql(u8, b.string, value),
+        // The emitter writes no composite `enum` or `const` values, and
+        // comparing them structurally would be a feature nothing asks
+        // for — the census is what keeps that true.
+        else => false,
+    };
+}
+
+/// Walk a rendered schema and fail on the first keyword this file does
+/// not implement.
+///
+/// This is the half that makes the validator trustworthy. A validator
+/// that silently ignores what it does not know is worse than none: it
+/// reports "valid" for a document whose constraints it never read, and
+/// the gate built on it would pass by not looking. So the emitter and
+/// this file are held together — teach the emitter a keyword and this
+/// census fails until the validator learns it too.
+pub fn census(schema: std.json.Value) ?[]const u8 {
+    return censusAt(schema, 0);
+}
+
+fn censusAt(schema: std.json.Value, depth: u8) ?[]const u8 {
+    // Same bound as the validation walk, and for the same reason: this
+    // one runs over a document the emitter produced, so a breach is a
+    // shape nobody meant to write.
+    assert(depth < depth_max);
+    const object = switch (schema) {
+        .object => |map| map,
+        else => return null,
+    };
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        const keyword = std.meta.stringToEnum(Keyword, entry.key_ptr.*) orelse {
+            return entry.key_ptr.*;
+        };
+        switch (keyword.shape()) {
+            .annotation, .scalar => {},
+            .schema => {
+                if (censusAt(entry.value_ptr.*, depth + 1)) |unknown| return unknown;
+            },
+            .schema_map => {
+                var members = entry.value_ptr.object.iterator();
+                while (members.next()) |member| {
+                    if (censusAt(member.value_ptr.*, depth + 1)) |unknown| return unknown;
+                }
+            },
+            .schema_list => {
+                for (entry.value_ptr.array.items) |branch| {
+                    if (censusAt(branch, depth + 1)) |unknown| return unknown;
+                }
+            },
+        }
+    }
+    return null;
+}
+
+const testing = std.testing;
+
+fn parse(text: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, testing.allocator, text, .{});
+}
+
+fn expectValid(schema_text: []const u8, instance_text: []const u8) !void {
+    var schema = try parse(schema_text);
+    defer schema.deinit();
+    var instance = try parse(instance_text);
+    defer instance.deinit();
+    var storage: [path_bytes_max]u8 = undefined;
+    const failure = validate(schema.value, instance.value, &storage);
+    if (failure) |found| {
+        std.debug.print(
+            "\nunexpected failure at '{s}': {t}\n",
+            .{ found.path, found.reason },
+        );
+        return error.TestUnexpectedResult;
+    }
+}
+
+fn expectInvalid(
+    schema_text: []const u8,
+    instance_text: []const u8,
+    reason: Failure.Reason,
+    path: []const u8,
+) !void {
+    var schema = try parse(schema_text);
+    defer schema.deinit();
+    var instance = try parse(instance_text);
+    defer instance.deinit();
+    var storage: [path_bytes_max]u8 = undefined;
+    const failure = validate(schema.value, instance.value, &storage) orelse {
+        return error.TestExpectedError;
+    };
+    try testing.expectEqual(reason, failure.reason);
+    try testing.expectEqualStrings(path, failure.path);
+}
+
+test "json schema: types, and an integral float is an integer" {
+    const schema =
+        \\{"type":"object","properties":{"n":{"type":"integer"},"s":{"type":"string"}}}
+    ;
+    try expectValid(schema, "{\"n\":7,\"s\":\"x\"}");
+    // JSON has one number type: `1.0` and `1` are the same value, and a
+    // config nobody wrote differently must not fail on the spelling.
+    try expectValid(schema, "{\"n\":1.0}");
+    try expectInvalid(schema, "{\"n\":1.5}", .type_mismatch, "n");
+    try expectInvalid(schema, "{\"n\":\"7\"}", .type_mismatch, "n");
+}
+
+test "json schema: required, closed objects, and the path names the field" {
+    const schema =
+        \\{"type":"object","required":["bind"],"additionalProperties":false,
+        \\ "properties":{"bind":{"type":"string"},"mode":{"type":"string"}}}
+    ;
+    try expectValid(schema, "{\"bind\":\"x\"}");
+    try expectValid(schema, "{\"bind\":\"x\",\"mode\":\"0660\"}");
+    try expectInvalid(schema, "{\"mode\":\"0660\"}", .missing_required, "bind");
+    // The typo an editor should catch before the loader does.
+    try expectInvalid(schema, "{\"bind\":\"x\",\"bnid\":1}", .unknown_property, "bnid");
+}
+
+test "json schema: additionalProperties types a table keyed by operator names" {
+    // How `clusters`, `bodies` and `error_pages` are described: no
+    // `properties` at all, every member typed by one schema. A validator
+    // that read this keyword only as the closed-object flag would walk
+    // straight past every cluster in the file and call it valid.
+    const schema =
+        \\{"type":"object","minProperties":1,"additionalProperties":
+        \\ {"type":"object","required":["endpoints"],"properties":
+        \\  {"endpoints":{"type":"array","minItems":1}}}}
+    ;
+    try expectValid(schema, "{\"api\":{\"endpoints\":[\"a\"]}}");
+    try expectInvalid(schema, "{}", .too_few_properties, "");
+    try expectInvalid(schema, "{\"api\":{\"endpoints\":[]}}", .too_few_items, "api.endpoints");
+    try expectInvalid(schema, "{\"api\":{}}", .missing_required, "api.endpoints");
+}
+
+test "json schema: nested paths name the whole route to the value" {
+    const schema =
+        \\{"type":"object","properties":{"listeners":{"type":"array","items":
+        \\ {"type":"object","properties":{"http":{"type":"object","properties":
+        \\ {"cluster":{"type":"string"}}}}}}}}
+    ;
+    try expectValid(schema, "{\"listeners\":[{\"http\":{\"cluster\":\"a\"}}]}");
+    try expectInvalid(
+        schema,
+        "{\"listeners\":[{\"http\":{\"cluster\":\"a\"}},{\"http\":{\"cluster\":7}}]}",
+        .type_mismatch,
+        "listeners[1].http.cluster",
+    );
+}
+
+test "json schema: oneOf is exactly one, which is the whole point of it" {
+    // The shape #305 Part 1 gave the listener: a tagged body, where
+    // naming both or neither is a document error rather than a loader
+    // rule stated in prose.
+    const schema =
+        \\{"type":"object","oneOf":[
+        \\ {"required":["http"]},
+        \\ {"required":["l4"]}],
+        \\ "properties":{"http":{"type":"object"},"l4":{"type":"object"}}}
+    ;
+    try expectValid(schema, "{\"http\":{}}");
+    try expectValid(schema, "{\"l4\":{}}");
+    try expectInvalid(schema, "{}", .no_branch_matched, "");
+    try expectInvalid(schema, "{\"http\":{},\"l4\":{}}", .many_branches_matched, "");
+}
+
+test "json schema: bounds, enums and item counts" {
+    const schema =
+        \\{"type":"object","properties":{
+        \\ "weight":{"type":"integer","minimum":0,"maximum":256},
+        \\ "mode":{"enum":["replace","append"]},
+        \\ "names":{"type":"array","minItems":1,"maxItems":2},
+        \\ "name":{"type":"string","minLength":1}}}
+    ;
+    try expectValid(schema, "{\"weight\":256,\"mode\":\"append\",\"names\":[\"a\"],\"name\":\"n\"}");
+    try expectInvalid(schema, "{\"weight\":257}", .above_maximum, "weight");
+    try expectInvalid(schema, "{\"weight\":-1}", .below_minimum, "weight");
+    try expectInvalid(schema, "{\"mode\":\"trust\"}", .not_in_enum, "mode");
+    try expectInvalid(schema, "{\"names\":[]}", .too_few_items, "names");
+    try expectInvalid(schema, "{\"names\":[\"a\",\"b\",\"c\"]}", .too_many_items, "names");
+    try expectInvalid(schema, "{\"name\":\"\"}", .too_short, "name");
+}
+
+test "json schema: the census names a keyword the validator does not implement" {
+    // The property *named* like a keyword must not be read as one — a
+    // config DTO is free to have a field called `type`, and the census
+    // only looks at schema positions.
+    var honest = try parse(
+        \\{"type":"object","properties":{"type":{"type":"string"},"pattern":{"type":"integer"}}}
+    );
+    defer honest.deinit();
+    try testing.expect(census(honest.value) == null);
+
+    // And a real unimplemented keyword is caught wherever it sits,
+    // including inside a branch — silently ignoring it would make the
+    // validator report "valid" for a constraint it never read.
+    var nested = try parse(
+        \\{"oneOf":[{"type":"object"},{"type":"object","patternProperties":{"^x":{}}}]}
+    );
+    defer nested.deinit();
+    try testing.expectEqualStrings("patternProperties", census(nested.value).?);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,6 +13,7 @@ pub const balancer = @import("balancer.zig");
 pub const Budget = @import("budget.zig").Budget;
 pub const config = @import("config.zig");
 pub const config_schema = @import("config_schema.zig");
+pub const json_schema = @import("json_schema.zig");
 pub const constants = @import("constants.zig");
 pub const counters = @import("counters.zig");
 /// L7 HTTP/1.1 modules (§7). `parser` wraps the vendored hparse behind
@@ -69,6 +70,7 @@ test {
     _ = @import("budget.zig");
     _ = config;
     _ = config_schema;
+    _ = json_schema;
     _ = constants;
     _ = counters;
     _ = http.parser;


### PR DESCRIPTION
#305 Part 2's differential gate. Part 1 (PR #309) reshaped the config; this is the thing that says whether the reshaping is *done*, and it replaces a review's judgement with a build failure.

The issue asked for exactly this:

> for every config under `config/` and every rejection case in the loader's tests, assert that the emitted schema and `--check` agree. Any config the schema admits and the loader refuses is a cross-field rule that Part 1 should have turned into a shape. That is the measurable definition of "the freeze is done".

## A validator for the dialect we emit, not a general one

`src/json_schema.zig`. A general validator would be a dependency (§4) or a second reading of a spec nobody here has open. The emitter reflects over the loader's own DTOs, so the keyword set that can appear is closed and known.

The load-bearing piece is `census`: it walks a rendered schema and returns the first keyword the validator does not implement. **A validator that silently skips what it does not recognise reports "valid" by not looking**, so the emitter is not free to reach for a new keyword quietly — teach the emitter one and the census fails until the validator learns it too. It earned itself on day one, naming two keywords (`$id`, `minProperties`) the emitter writes that I had not listed.

## Two directions, deliberately asymmetric

| direction | rule |
|---|---|
| the loader accepts → **the schema must accept** | no exemptions, ever |
| the loader refuses → the schema should refuse | unless `schema_gaps` names the reason |

The accept direction has no exemptions because a schema that refuses a working config is not conservative — it is a lie told to every editor that reads it, and the operator who believes it deletes a key that was fine. `zig build schema` exists to be trusted by tools that will never run the loader. The shipped `config/example.json` is held to it too.

## Measuring it found a hole in the validator first

`additionalProperties` as a **schema** (rather than the `false` closed-object flag) was never applied — which is exactly how `clusters`, `bodies` and `error_pages` type every operator-named member. Every cluster in every config was going unvalidated and coming back clean. Fixing it dropped the gap count from 94 to 81, and the behaviour now has a test of its own.

## What is left, as a number

Seven categories are closed by what a schema *is*: no document grammar parses an address, sums weights against a budget, resolves a name into another block, computes canonical equality, reads the filesystem, bounds an object key, or holds two blocks at once.

**Sixteen are debt**, and their counts are pinned:

- **14 `expressible_fork`** — a field required exactly when a sibling takes a given value, which `oneOf` could carry: `access_log`'s path-iff-file, `bodies`' exactly-one-source, `check`'s path-iff-http, `pick`'s key-iff-hash and name-iff-keyed, and the four response-filter actions that share the request-filter action union.
- **2 `expressible_bound`** — a `maxLength` the emitter does not derive (`min_length` is emitted already, so only half the pair exists).

That is the worklist for the leaf pass, and it is now a number rather than an opinion.

## Verified to bite

Not assumed. Removing one gap row fails three cases; a schema that wrongly requires a field fails sixty-three.

## Review findings, all applied

- **Unbounded recursion.** TIGER_STYLE forbids it; both walks now carry a depth against `depth_max`.
- **Two rows mis-filed.** `AccessLogHeaderNameTooLong` bounds an array item string and `ClusterPickNameTooLong` a field value — neither is an object key, so both have somewhere to attach and both are payable. They moved from the closed `name_length` bucket to `expressible_bound`, which is why that count is 4 and not 2. Filed as they were, the freeze looked two rows more finished than it is.
- **DESIGN overstated the coverage.** "Runs on every rejection this repo states" was false — a handful of `ValidationError` members have no test and four are asserted against `parse` directly, so the 81 is a floor rather than a census of the error set. And "five categories are closed" was wrong; there are seven. Both corrected.

## One thing this gate does not do

It proves a row is *needed*, never that one has gone **stale**. An error is raised by several cases with different JSON, so the schema catching one of them says nothing about the rest — deciding staleness needs every case for an error in hand before any verdict, which this harness has no hook for. I tried two ways and both were wrong (a flag array that depends on test declaration order, then a per-case check that immediately reported two false positives), so the limitation is written into the table's doc comment and into §5 rather than papered over with a check that gives wrong answers. A paid-off rule is struck by whoever pays it off, and re-running the gate with the row removed is how they check.

## Gates

`zig build ci` green (4096 sim seeds, both smoke runs), `zig fmt --check` clean. `tiger-style-reviewer` run; all three violations applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)