### PR TITLE
config: the leaf pass (#305)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -816,6 +816,34 @@ Rules:
   shape.
 - **The config arena is the only allocating region** — parse-once,
   immutable, shared read-only. (Carried verbatim; it worked.)
+- **`limits` holds reservations; policy lives where the policy applies.**
+  The rule sorts on one question — does the number decide what this
+  process *takes* at startup? — and it is written here rather than in a
+  field's doc comment because that is where the next field cannot find
+  it (#305 Part 2).
+  A pool size is a reservation: `conn_slots`, `relay_buffers`,
+  `head_buffers`, `tls_engines`, `tunnels`, `access_log_buffer_bytes`.
+  So is `cq_fill_eighths`, which is not a pool but sizes the ring this
+  process asks the kernel for — the block's rule is about reservation,
+  not about being a count of objects.
+  A cap that reserves nothing states policy and belongs on the thing it
+  governs. `max_body_bytes` argued this first, and `keepalive_requests`
+  was the standing exception until the freeze moved it beside that cap:
+  a per-connection request count takes nothing at startup either, and
+  the old defence — that a body cap says what an *origin* is asked to
+  carry while a request count bounds what a client occupies *here* — is
+  true and beside the point, since the rule asks about reservation and
+  neither is a pool.
+  **`timeouts` is a third home and stays one.** A deadline reserves
+  nothing and governs no single block, and `health_interval_ms` is why
+  the rule cannot simply push everything outward: it paces the *one*
+  global probe sweep (§7), sweep-end to sweep-start across every checked
+  cluster, and §5's closed-form probe reservation is derived from there
+  being exactly one. A cluster's `check` block holds what is genuinely
+  per cluster — `fall`, `rise`, `timeout_ms`, the HTTP fields — and the
+  pacing is not that. Moving it in would not be tidying two homes into
+  one; it would be a per-cluster prober, which is a different design and
+  a different budget.
 - **The config surface has a generated JSON Schema.** `zig build schema`
   reflects over the `*Json` parse structs and their co-located metadata
   (`src/config_schema.zig`) to emit a draft 2020-12 schema — structure,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1331,7 +1331,8 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   because relaying it as interim would carry on reading bytes that are no
   longer HTTP.
 - **One client connection serves a bounded number of requests** (#237).
-  `limits.keepalive_requests`, 1000 by default — nginx's figure, and one
+  An `http` listener's `keepalive_requests`, 1000 by default — nginx's
+  figure, and one
   zoxy can honestly borrow because unlike a body cap it bounds *this
   proxy's* slot occupancy rather than stating anything about an origin.
   It is the only bound that reaches a **busy** connection: `idle_ms`

--- a/docs/README.md
+++ b/docs/README.md
@@ -386,15 +386,21 @@ full handshake.
 
 By default any request carrying `Upgrade` is answered `501` — the same as
 `CONNECT`, and what every config that does not name an allowlist keeps
-getting. An `http` listener opts in by naming the tokens it will carry:
+getting. An `http` listener opts in by naming what it will carry:
 
 ```json
 "listeners": [
     { "bind": "0.0.0.0:80", "http": { "cluster": "web",
-      "upgrades": ["websocket"] } }
+      "upgrades": { "websocket": true } } }
 ],
 "limits": { "tunnels": 512 }
 ```
+
+One flag per protocol rather than a list of tokens, so the vocabulary
+lives in the schema: an editor rejects `"h2c"` before the loader does,
+and there is no way to write the same token twice. Omitting the block,
+writing `{}`, or setting every flag `false` all mean the same thing —
+allow none, reserve nothing.
 
 zoxy does not speak WebSocket. It forwards the handshake, recognises the
 origin's `101 Switching Protocols`, and from that point relays bytes both

--- a/docs/README.md
+++ b/docs/README.md
@@ -1333,8 +1333,7 @@ reserves nor demands the ceiling's resources.
     "head_buffers": 1024,
     "upstream_head_buffers": 512,
     "head_buffer_bytes": 16384,
-    "tunnels": 512,
-    "keepalive_requests": 1000
+    "tunnels": 512
 }
 ```
 
@@ -1368,8 +1367,10 @@ relay-buffer pair (8200 bytes), held for the tunnel's whole life rather than
 for the duration of a request, which is why they are reserved apart from
 `relay_buffers` instead of drawn from it.
 
-`keepalive_requests` bounds how many requests one client connection may
-serve — **1000 by default**, nginx's figure, and `0` is unlimited. It is
+`keepalive_requests` — on an `http` listener, beside `max_body_bytes`,
+not in `limits`, because it reserves nothing and states policy — bounds
+how many requests one client connection may serve. **1000 by default**,
+nginx's figure, and `0` is unlimited. It is
 the one bound that reaches a *busy* connection: `idle_ms` reaps one that
 stops speaking and `max_lifetime_ms` one that has been open too long, but
 neither touches a connection that keeps asking, which is exactly the one

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -206,6 +206,10 @@ upgrades_http: bool,
 /// on every clean seed, since a `413` is a status its scripts did not ask
 /// for.
 max_body_bytes: u64,
+/// The #237 keep-alive request cap this run's http listener carries.
+/// On the listener since the freeze (#305), so the harness derives it
+/// beside the body cap rather than into `limits`.
+keepalive_requests: u32,
 /// The seed's http origin prefixes an interim `100 Continue` to every
 /// answer (#232). Drawn once per seed rather than per accept, so a clean
 /// seed's transcript stays exact — which is the point: the golden oracle
@@ -653,6 +657,7 @@ fn deriveTopology(harness: *Harness, random: std.Random) void {
     deriveRetries(harness, random);
     deriveUpgrades(harness, random);
     harness.max_body_bytes = deriveMaxBodyBytes(harness.clean, random);
+    harness.keepalive_requests = deriveKeepaliveRequests(harness.clean, random);
     // A quarter of seeds. Clean ones included, deliberately: an
     // adversarial seed only holds the transcript to a legal *prefix*, so
     // a proxy that settled on the interim and dropped the real answer
@@ -850,7 +855,7 @@ fn deriveServerConfig(
         // capped connection announces a close its script did not ask for,
         // and a clean seed's golden transcript forbids that. `0` leaves it
         // unlimited, which is every clean seed and most others.
-        .limits = .{ .keepalive_requests = deriveKeepaliveRequests(harness.clean, random) },
+        .limits = .{},
         // Three seeds in four run with the access log on, so the sink,
         // its staging swap, and the per-request captures all take the
         // schedule fuzz; the fourth leaves it off, which is the shape
@@ -1404,6 +1409,7 @@ fn wireListeners(harness: *Harness, forwarded: ?zoxy.config.Config.Listener.Forw
             .forwarded = forwarded,
             .upgrades = .{ .websocket = harness.upgrades_http },
             .max_body_bytes = harness.max_body_bytes,
+            .keepalive_requests = harness.keepalive_requests,
         },
         .{
             .bind_address = .{ .ip = tlsBindAddress() },

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -384,6 +384,9 @@ pub fn Server(comptime IoType: type) type {
             /// own socket what it may carry.
             upgrades: config_module.Config.Listener.Upgrades,
             max_body_bytes: u64,
+            /// The listener's #237 keep-alive request cap (#305), carried
+            /// for the same reason as the caps beside it.
+            keepalive_requests: u32,
             /// The listener's §7 client-address forwarding mode (null = off),
             /// handed over the same way: trust depends on what is in front
             /// of this socket, so it cannot live on the cluster.
@@ -1081,6 +1084,7 @@ pub fn Server(comptime IoType: type) type {
                     .sni_routes = listener_config.sni_routes,
                     .upgrades = listener_config.upgrades,
                     .max_body_bytes = listener_config.max_body_bytes,
+                    .keepalive_requests = listener_config.keepalive_requests,
                     .request_filters = listener_config.request_filters,
                     .response_filters = listener_config.response_filters,
                     .forwarded = listener_config.forwarded,
@@ -1912,6 +1916,7 @@ pub fn Server(comptime IoType: type) type {
             conn.response_filters = listener.response_filters;
             conn.upgrades = listener.upgrades;
             conn.max_body_bytes = listener.max_body_bytes;
+            conn.keepalive_requests = listener.keepalive_requests;
             conn.forwarded = listener.forwarded;
             conn.proxy_status = listener.proxy_status;
             // The exchange's starting cluster, from the same listener and

--- a/src/config.zig
+++ b/src/config.zig
@@ -2072,9 +2072,12 @@ pub const HttpListenerJson = struct {
     /// Optional #180 upgrade allowlist; absent allows none, so an
     /// `Upgrade` stays the 501 it has always been.
     upgrades: ?UpgradesJson = null,
-    /// Optional #236 request-body cap; absent means one MiB, `0` means
-    /// no cap.
-    max_body_bytes: ?u64 = null,
+    /// The #236 request-body cap, `0` accepting any size (#305). Not
+    /// optional: `null` used to mean the default and `0` no cap, which
+    /// is three states for a two-state idea, and every other cap in this
+    /// config — `drain_deadline_ms`, `max_lifetime_ms`, `request_ms` —
+    /// already spells "no cap" as `0` with no third state to explain.
+    max_body_bytes: u64 = constants.request_body_bytes_default,
     /// Whether this listener names *why* it refused, in an RFC 9209
     /// `Proxy-Status` field (#300). Absent is off.
     proxy_status: bool = false,
@@ -2101,8 +2104,8 @@ pub const HttpListenerJson = struct {
                 "absent leaves the header untouched.",
         },
         .max_body_bytes = .{
-            .desc = "Cap on one request body in bytes; absent means 1 MiB, 0 " ++
-                "accepts any size. A body over the cap is refused 413 before the " ++
+            .desc = "Cap on one request body in bytes; 0 accepts any size, and " ++
+                "absent is 1 MiB. A body over the cap is refused 413 before the " ++
                 "origin is dialed where its length was declared, and the " ++
                 "connection closes.",
             .minimum = 0,
@@ -4939,8 +4942,7 @@ fn resolveRetries(retries: u16) ParseError!u16 {
 /// ignored: a byte relay parses no request to measure, so a cap there
 /// describes a proxy that is not running — the same refusal `forwarded`
 /// and `upgrades` get, for the same reason.
-fn resolveMaxBodyBytes(max_body_bytes: ?u64) ValidationError!u64 {
-    const cap = max_body_bytes orelse return constants.request_body_bytes_default;
+fn resolveMaxBodyBytes(cap: u64) ValidationError!u64 {
     if (cap > constants.request_body_bytes_max) {
         return error.ListenerMaxBodyBytesOutOfRange;
     }
@@ -4950,18 +4952,13 @@ fn resolveMaxBodyBytes(max_body_bytes: ?u64) ValidationError!u64 {
 /// Resolve a listener's #180 upgrade allowlist. Absent allows none, so
 /// an `Upgrade` keeps the `501` it has always got.
 ///
-/// The vocabulary is the `Upgrades` set's own field names, which *are*
-/// the JSON tokens — the same one-source-of-truth the `protocol` and
-/// `pick` matches use, so a token the proxy can carry and a token an
-/// operator may write cannot drift apart. Anything else is refused by
-/// name rather than ignored: a config that asked to tunnel `h2c` and got
-/// silence would believe it had, and after `101` there is no rule left
-/// to catch what came through.
-///
-/// An empty list is refused too. It reads as "allow nothing", which
-/// already has a spelling — omit the field — and configured this way it
-/// would demand a `limits.tunnels` for a listener that can never use
-/// one.
+/// The vocabulary is `UpgradesJson`'s own fields, held to the resolved
+/// set's by a comptime check there — so a protocol the proxy can carry
+/// and one an operator may write cannot drift apart. Anything else is
+/// refused by the strict parser rather than by a rule here (#305): a
+/// config that asked to tunnel `h2c` and got silence would believe it
+/// had, and after `101` there is no rule left to catch what came
+/// through.
 fn resolveUpgrades(
     upgrades_json: ?UpgradesJson,
 ) ValidationError!Config.Listener.Upgrades {
@@ -8410,6 +8407,65 @@ test "config: the body cap holds on both arms, exactly" {
             );
         }
     }
+}
+
+test "config: the body cap is two-valued, and 0 is how uncapped is spelled (#305)" {
+    // `null` used to mean 1 MiB and `0` no cap — three states for a
+    // two-state idea, and the odd one out in its own config:
+    // `drain_deadline_ms`, `max_lifetime_ms` and `request_ms` all spell
+    // "no cap" as `0` with nothing else to explain.
+    const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"";
+    const tail = "}}],\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+        "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}";
+
+    // Absent is still the default it always was, so a config that never
+    // named the key keeps its cap.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ tail);
+        try std.testing.expectEqual(
+            constants.request_body_bytes_default,
+            parsed.listeners[0].max_body_bytes,
+        );
+    }
+    // And `0` is uncapped, unchanged.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ ",\"max_body_bytes\":0" ++ tail);
+        try std.testing.expectEqual(@as(u64, 0), parsed.listeners[0].max_body_bytes);
+    }
+    // The ceiling holds at its edge rather than near it.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const at_limit = std.fmt.comptimePrint(
+            ",\"max_body_bytes\":{d}",
+            .{constants.request_body_bytes_max},
+        );
+        const parsed = try expectParseOk(&arena_state, head ++ at_limit ++ tail);
+        try std.testing.expectEqual(
+            constants.request_body_bytes_max,
+            parsed.listeners[0].max_body_bytes,
+        );
+    }
+    try expectParseError(
+        error.ListenerMaxBodyBytesOutOfRange,
+        head ++ std.fmt.comptimePrint(
+            ",\"max_body_bytes\":{d}",
+            .{constants.request_body_bytes_max + 1},
+        ) ++ tail,
+    );
+    // An l4 relay measures no request, so the key does not exist there —
+    // the strict parser's refusal, not a rule's (#305).
+    try expectParseError(
+        error.UnknownField,
+        "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"l4\":{\"cluster\":\"a\"," ++
+            "\"max_body_bytes\":500}}]," ++
+            "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++
+            "\"timeouts\":{\"connect_ms\":1,\"idle_ms\":2,\"drain_deadline_ms\":1}}",
+    );
 }
 
 test "config: max_inflight resolves, defaults to uncapped, rejects the useless" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -83,6 +83,15 @@ pub const Config = struct {
     /// HAProxy's `inter` (`constants.health_interval_ms_default`). Zero is
     /// rejected — a pause of nothing would probe in a tight loop. Each
     /// probe dials under `connect_timeout_ms`, its own budget.
+    ///
+    /// Here and not in the cluster's `check` block beside `fall`, `rise`
+    /// and `timeout_ms`, which #305 asked about. Those three are per
+    /// cluster; this is not. There is one sweep and one rest timer for
+    /// the whole process, pacing sweep-end to sweep-start across every
+    /// checked cluster at once, and §5's closed-form probe reservation
+    /// is derived from there being exactly one. A per-cluster interval
+    /// would be a per-cluster prober — a different design and a
+    /// different budget, not a tidier config.
     health_interval_ms: u32 = constants.health_interval_ms_default,
     /// Effective pool sizes (§5, §8). The comptime constants stay the
     /// hard, budget-asserted ceilings; config may only shrink below them

--- a/src/config.zig
+++ b/src/config.zig
@@ -406,6 +406,20 @@ pub const Config = struct {
         /// listener fronting an upload endpoint and another fronting an
         /// API want different numbers, and neither is a pool.
         max_body_bytes: u64 = constants.request_body_bytes_default,
+        /// Requests one client connection may serve before the next
+        /// response announces `Connection: close` (#237); `0` is
+        /// unlimited.
+        ///
+        /// Here for the reason above, applied to the field that used to
+        /// be the rule's standing exception (#305): a request count
+        /// reserves nothing either. It lived in `limits` on the argument
+        /// that a body cap states what an *origin* is asked to carry
+        /// while this bounds what a client occupies *here* — true, and
+        /// beside the point, since neither is a pool. One listener
+        /// fronting long-lived browser connections and another fronting
+        /// a service mesh want different numbers, which is the same
+        /// shape of answer as the cap above.
+        keepalive_requests: u32 = constants.keepalive_requests_default,
 
         /// The upgrade tokens a listener may allow, as a set rather than
         /// a list: the vocabulary is closed, so membership is a field

--- a/src/config.zig
+++ b/src/config.zig
@@ -760,8 +760,6 @@ pub const ValidationError = error{
     RouteHostNotCanonical,
     RouteDuplicate,
     ListenerMaxBodyBytesOutOfRange,
-    ListenerUpgradesEmpty,
-    ListenerUpgradeTokenUnknown,
     ListenerForwardedModeUnknown,
     ListenerProxyProtocolModeUnknown,
     ListenerTlsWithSniRoutes,
@@ -2073,7 +2071,7 @@ pub const HttpListenerJson = struct {
     forwarded: ?ForwardedJson = null,
     /// Optional #180 upgrade allowlist; absent allows none, so an
     /// `Upgrade` stays the 501 it has always been.
-    upgrades: ?[]const []const u8 = null,
+    upgrades: ?UpgradesJson = null,
     /// Optional #236 request-body cap; absent means one MiB, `0` means
     /// no cap.
     max_body_bytes: ?u64 = null,
@@ -2120,10 +2118,51 @@ pub const HttpListenerJson = struct {
         .upgrades = .{
             .desc = "Protocol upgrades this listener will carry as tunnels; absent " ++
                 "allows none and an Upgrade stays 501. Requires limits.tunnels.",
-            .min_items = 1,
-            .items = SchemaItems.upgrade_token,
         },
     };
+};
+
+/// The #180 upgrade allowlist, one flag per protocol this proxy can
+/// recognise (#305 Part 2).
+///
+/// An object rather than the list of tokens this replaced, and the
+/// argument is the vocabulary: §7 requires it closed — a token zoxy
+/// cannot reason about must be refused by name, never ignored — and a
+/// list of strings can only be closed by the loader, in rules a reader
+/// of the schema never sees. As fields, the schema states the whole
+/// vocabulary, `additionalProperties: false` rejects an unknown token,
+/// and duplicates stop being expressible at all: the list form accepted
+/// `["websocket", "websocket"]` because nothing checked, and there is no
+/// spelling of that here.
+pub const UpgradesJson = struct {
+    websocket: bool = false,
+
+    pub const schema_doc =
+        "Which protocol upgrades this listener carries as tunnels. Absent, or " ++
+        "every flag false, allows none.";
+    pub const schema_fields = .{
+        .websocket = .{
+            .desc = "Carry a WebSocket handshake (RFC 6455) as a tunnel once the " ++
+                "origin answers 101. Requires limits.tunnels.",
+        },
+    };
+
+    comptime {
+        // The JSON shape and the resolved one are one vocabulary. A
+        // protocol added to either and forgotten on the other would let
+        // the config name an upgrade the serving path cannot gate, or
+        // hide one it can.
+        const resolved = @typeInfo(Config.Listener.Upgrades).@"struct".fields;
+        const json = @typeInfo(UpgradesJson).@"struct".fields;
+        if (resolved.len != json.len) {
+            @compileError("UpgradesJson and Config.Listener.Upgrades disagree on the set");
+        }
+        for (resolved) |field| {
+            if (!@hasField(UpgradesJson, field.name)) {
+                @compileError("UpgradesJson is missing " ++ field.name);
+            }
+        }
+    }
 };
 
 /// What an `l4` listener carries. It forks on the upstream the way an
@@ -3146,9 +3185,11 @@ pub const ClustersJson = struct {
 
 /// Marker for array-item vocabularies reflection can't infer from the
 /// element type alone. `http_method` means "the items are the registered
-/// HTTP method tokens" and `upgrade_token` "the #180 upgrade set's field
-/// names", each of which `config_schema.zig` emits as a token enum.
-pub const SchemaItems = enum { http_method, upgrade_token };
+/// HTTP method tokens", which `config_schema.zig` emits as a token
+/// enum. #180's upgrade set used to be the second member; it is a flag
+/// object now (#305), so the schema states its vocabulary as fields and
+/// needs no item marker.
+pub const SchemaItems = enum { http_method };
 
 /// The attribute keys a `schema_fields` entry may carry beyond `.desc`.
 /// `assert_meta_matches` rejects any other key at comptime, so a typo'd
@@ -4922,27 +4963,20 @@ fn resolveMaxBodyBytes(max_body_bytes: ?u64) ValidationError!u64 {
 /// would demand a `limits.tunnels` for a listener that can never use
 /// one.
 fn resolveUpgrades(
-    upgrades_json: ?[]const []const u8,
+    upgrades_json: ?UpgradesJson,
 ) ValidationError!Config.Listener.Upgrades {
-    const tokens = upgrades_json orelse return .{};
-    if (tokens.len == 0) {
-        return error.ListenerUpgradesEmpty;
-    }
-    assert(tokens.len >= 1);
+    const asked = upgrades_json orelse return .{};
     var upgrades: Config.Listener.Upgrades = .{};
-    for (tokens) |token| {
-        var matched = false;
-        inline for (@typeInfo(Config.Listener.Upgrades).@"struct".fields) |field| {
-            if (std.mem.eql(u8, token, field.name)) {
-                @field(upgrades, field.name) = true;
-                matched = true;
-            }
-        }
-        if (!matched) {
-            return error.ListenerUpgradeTokenUnknown;
-        }
+    inline for (@typeInfo(UpgradesJson).@"struct".fields) |field| {
+        @field(upgrades, field.name) = @field(asked, field.name);
     }
-    assert(upgrades.any()); // A non-empty list of known tokens sets one.
+    // No rejection for "every flag false", and the shape is why. An
+    // empty *list* was a meaningless spelling of a set, so it was
+    // refused; a set of flags all false is the ordinary way to write
+    // "not this one" — which a templated config does constantly — and
+    // it already means exactly what omitting the block means. Nothing
+    // §5 rests on it either: the tunnel pool keys off `any()`, so an
+    // all-false block reserves nothing, same as absent.
     return upgrades;
 }
 
@@ -5139,7 +5173,17 @@ fn countListenerFeatures(listeners: []const ListenerJson) ParseError!ListenerFea
         if (try protocolOf(&listener_json) == .http) features.http += 1;
         if (listener_json.tls != null) features.tls += 1;
         if (listener_json.http) |http_json| {
-            if (http_json.upgrades != null) features.upgrades += 1;
+            // What the pool is sized against is a listener that *allows*
+            // an upgrade, not one that mentions the key. Under the list
+            // form those were the same thing, because an empty list was
+            // refused; under the flag object they are not — `{}` and
+            // `{"websocket": false}` mean the same as absent (#305), and
+            // counting them would demand a tunnel pool for a listener
+            // that can never open one.
+            if (http_json.upgrades) |upgrades| {
+                const allowed = try resolveUpgrades(upgrades);
+                if (allowed.any()) features.upgrades += 1;
+            }
         }
         if (listener_json.l4) |l4_json| {
             if (l4_json.routes != null) features.sni += 1;
@@ -9116,7 +9160,7 @@ test "config: the upgrade allowlist is closed, http-only, and never empty" {
     {
         var arena_state: std.heap.ArenaAllocator = undefined;
         defer arena_state.deinit();
-        const parsed = try expectParseOk(&arena_state, head ++ "[\"websocket\"]" ++ tail);
+        const parsed = try expectParseOk(&arena_state, head ++ "{\"websocket\":true}" ++ tail);
         try std.testing.expect(parsed.listeners[0].upgrades.websocket);
         try std.testing.expect(parsed.listeners[0].upgrades.any());
         // Per listener, and the l4 one beside it allows nothing — which is
@@ -9124,15 +9168,47 @@ test "config: the upgrade allowlist is closed, http-only, and never empty" {
         try std.testing.expect(!parsed.listeners[1].upgrades.any());
         try std.testing.expectEqual(@as(u32, 16), parsed.limits.tunnels);
     }
-    // A token this proxy cannot reason about is refused by name, never
-    // ignored: `h2c` would tunnel HTTP/2 to an origin it cannot parse,
-    // and a config that asked for it and got silence would believe it
-    // had — with no rule left after 101 to catch what came through.
-    try expectParseError(error.ListenerUpgradeTokenUnknown, head ++ "[\"h2c\"]" ++ tail);
-    try expectParseError(error.ListenerUpgradeTokenUnknown, head ++ "[\"websocket\",\"h2c\"]" ++ tail);
-    // "Allow nothing" already has a spelling — omit the field — and this
-    // one would demand a tunnel pool for a listener that can never use it.
-    try expectParseError(error.ListenerUpgradesEmpty, head ++ "[]" ++ tail);
+    // A protocol this proxy cannot reason about is refused by name,
+    // never ignored: `h2c` would tunnel HTTP/2 to an origin it cannot
+    // parse, and a config that asked for it and got silence would
+    // believe it had — with no rule left after 101 to catch what came
+    // through. As a field rather than a token, that refusal is the
+    // strict parser's and the schema's, not a rule of the loader's
+    // (#305) — and a duplicate stops being expressible at all, where
+    // the list form accepted `["websocket", "websocket"]` unchecked.
+    try expectParseError(error.UnknownField, head ++ "{\"h2c\":true}" ++ tail);
+    try expectParseError(
+        error.UnknownField,
+        head ++ "{\"websocket\":true,\"h2c\":true}" ++ tail,
+    );
+    // And "allow none" needs no rejection any more. An empty *list* was
+    // a meaningless spelling of a set; a set of flags all false is the
+    // ordinary way to write "not this one", means what omitting the
+    // block means, and reserves nothing — so the error this used to
+    // raise is gone rather than moved.
+    // Without a `tunnels` limit, because an all-false block reserves
+    // nothing — asking for a pool beside one is still the §5 mismatch
+    // it always was, and the case below pins that too.
+    const quiet_tail =
+        \\}},{"bind":"127.0.0.1:2","l4":{"cluster":"a"}}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    ;
+    inline for (.{ "{}", "{\"websocket\":false}" }) |spelling| {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ spelling ++ quiet_tail);
+        try std.testing.expect(!parsed.listeners[0].upgrades.any());
+        // Reserves nothing, which is what says it is absence rather than
+        // a listener asking for a pool it can never use (§5).
+        try std.testing.expectEqual(@as(u32, 0), parsed.limits.tunnels);
+        // And it is exactly absence: a pool beside it is the same
+        // mismatch omitting the block would earn.
+        try expectParseError(
+            error.LimitTunnelsWithoutUpgrades,
+            head ++ spelling ++ tail,
+        );
+    }
 }
 
 test "config: upgrades are refused on an l4 listener" {
@@ -9141,7 +9217,7 @@ test "config: upgrades are refused on an l4 listener" {
     // refusal is the strict parser's rather than a rule's — a block that
     // quietly did nothing was never the alternative.
     try expectParseError(error.UnknownField,
-        \\{"listeners":[{"bind":"127.0.0.1:1","l4":{"cluster":"a","upgrades":["websocket"]}}],
+        \\{"listeners":[{"bind":"127.0.0.1:1","l4":{"cluster":"a","upgrades":{"websocket":true}}}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
         \\ "limits":{"tunnels":4},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
@@ -9151,7 +9227,7 @@ test "config: upgrades are refused on an l4 listener" {
 test "config: the tunnel pool has no derived default, and binds to the allowlist" {
     const with_upgrades =
         \\{"listeners":[{"bind":"127.0.0.1:1","http":{"cluster":"a",
-        \\ "upgrades":["websocket"]}}],
+        \\ "upgrades":{"websocket":true}}}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}
     ;
@@ -9201,7 +9277,7 @@ test "config: the tunnel pool may not exceed the connections that hold one" {
         "{s}{d}{s}",
         .{
             \\{"listeners":[{"bind":"127.0.0.1:1","http":{"cluster":"a",
-            \\ "upgrades":["websocket"]}}],
+            \\ "upgrades":{"websocket":true}}}],
             \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
             \\ "limits":{"conn_slots":8,"tunnels":
             ,
@@ -9217,7 +9293,7 @@ test "config: the tunnel pool may not exceed the connections that hold one" {
 test "config: tunnel_ms defaults to an hour and has no off switch" {
     const head =
         \\{"listeners":[{"bind":"127.0.0.1:1","http":{"cluster":"a",
-        \\ "upgrades":["websocket"]}}],
+        \\ "upgrades":{"websocket":true}}}],
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:9"]}},
         \\ "limits":{"tunnels":4},
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -283,7 +283,6 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
             if (comptime @hasField(@TypeOf(meta), "items")) {
                 switch (meta.items) {
                     .http_method => try writeMethodEnum(out),
-                    .upgrade_token => try writeUpgradeEnum(out),
                 }
             } else {
                 try out.objectField("type");

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -2238,12 +2238,12 @@ pub fn Proxy(comptime IoType: type) type {
         /// connection has none — and the occupancy this bounds is a client's, not an
         /// origin's. If an origin wants its own bound it can announce it,
         /// and §7 already honors what an origin says about persistence.
-        fn requestsCapReached(server: *const ServerType, conn: *const ConnType) bool {
+        fn requestsCapReached(conn: *const ConnType) bool {
             // Every caller answers a request that `routeRequest` already
             // counted, so a zero here would mean the cap was consulted for
             // a request nobody served.
             assert(conn.requests_served >= 1);
-            const cap = server.config.limits.keepalive_requests;
+            const cap = conn.keepalive_requests;
             if (cap == 0) return false; // Unlimited.
             return conn.requests_served >= cap;
         }
@@ -2272,7 +2272,7 @@ pub fn Proxy(comptime IoType: type) type {
         /// already closing for one of those never reaches the check.
         fn applyRequestCap(server: *ServerType, conn: *const ConnType, would_keep: bool) bool {
             if (!would_keep) return false;
-            if (!requestsCapReached(server, conn)) return true;
+            if (!requestsCapReached(conn)) return true;
             server.counters.increment("l7_keepalive_requests_capped");
             return false;
         }
@@ -2316,7 +2316,7 @@ pub fn Proxy(comptime IoType: type) type {
                 !server.keepAliveSuppressed();
             if (!would_keep) return .{ .keep = false, .capped = false };
             const persistence: StaticPersistence = blk: {
-                const capped = requestsCapReached(server, conn);
+                const capped = requestsCapReached(conn);
                 break :blk .{ .keep = !capped, .capped = capped };
             };
             // The negative space the struct's doc promises, checked on the

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -738,11 +738,11 @@ const Http1Bed = struct {
         bed.config = .{
             .listeners = &bed.listeners,
             .clusters = &bed.clusters,
-            // The #237 cap is read off the *config*, which is where the
-            // loader puts it; `InitOptions` sizes the pools. The bed keeps
-            // the rest of `limits` at its struct defaults, which is what
-            // every test before this one was measuring against.
-            .limits = .{ .keepalive_requests = options.keepalive_requests },
+            // `InitOptions` sizes the pools; the bed keeps `limits` at
+            // its struct defaults, which is what every test before this
+            // one was measuring against. The #237 cap moved onto the
+            // listener with the freeze (#305) and is set there.
+            .limits = .{},
             .connect_timeout_ms = connect_timeout_ms,
             .idle_timeout_ms = idle_timeout_ms,
             // Mirrors the idle window unless a test is about the split
@@ -778,6 +778,7 @@ const Http1Bed = struct {
             .protocol = .http,
             .upgrades = options.upgrades,
             .max_body_bytes = options.max_body_bytes,
+            .keepalive_requests = options.keepalive_requests,
             .forwarded = options.forwarded,
             .proxy_status = options.proxy_status,
             // Paths nothing reads: the bed embeds the PEMs, so what this

--- a/src/net/Conn.zig
+++ b/src/net/Conn.zig
@@ -110,6 +110,10 @@ pub fn Conn(comptime IoType: type) type {
         /// The listener's #236 request-body cap, handed over at admission
         /// like the tables beside it; `0` accepts any size.
         max_body_bytes: u64,
+        /// The listener's #237 keep-alive request cap (#305), carried the
+        /// same way; `0` is unlimited. Per listener since the freeze, so
+        /// the serving path asks its own socket rather than the config.
+        keepalive_requests: u32,
         /// Requests this connection has served, for the #237 cap. On the
         /// connection rather than in `l7`, which resets at every
         /// turnaround — the whole point is a total that survives them.
@@ -316,6 +320,7 @@ pub fn Conn(comptime IoType: type) type {
             conn.response_filters = &.{};
             conn.upgrades = .{};
             conn.max_body_bytes = 0;
+            conn.keepalive_requests = 0;
             conn.requests_served = 0;
             conn.forwarded = null;
             conn.proxy_status = false;


### PR DESCRIPTION
#305 Part 2's leaf items, graded by the gate that landed in #323. Four commits; three land, one resolves.

## `upgrades` becomes a closed object

```diff
- "upgrades": ["websocket"]
+ "upgrades": { "websocket": true }
```

§7 already required this vocabulary closed — `h2c` would tunnel HTTP/2 to an origin that cannot parse it, and a config that asked and got silence would believe it had. A list of strings can only be closed by the loader, in rules a reader of the schema never sees. Two errors go away rather than move: `ListenerUpgradeTokenUnknown` becomes the strict parser's `UnknownField`, and duplicates stop being expressible at all — the list form accepted `["websocket", "websocket"]` because nothing checked, which is exactly the gap the issue named.

**The gate earned itself here, on its first use.** Making `upgrades` an object *added* debt — `minItems: 1` had been catching the empty list, and no keyword catches `{"websocket": false}` — so the build failed with "the schema admits what the loader refuses". That sent me to ask whether the rejection should exist at all, and it should not: an empty *list* was a meaningless spelling of a set, while a set of flags all false is how a templated config writes "not this one" and already means what omitting the block means. `ListenerUpgradesEmpty` is gone, debt is unchanged rather than up by one, and the build found it rather than a reviewer.

It also caught the knock-on: `countListenerFeatures` counted `upgrades != null`, equivalent to "allows something" only because the empty list was refused. A listener writing `{}` would have been charged a tunnel pool it can never open.

## `max_body_bytes` stops being three-valued

`?u64` where `null` meant 1 MiB and `0` meant no cap — three states for a two-state idea, and the odd one out in its own config, since `drain_deadline_ms`, `max_lifetime_ms` and `request_ms` all spell "no cap" as `0`. Now `u64` with the default as its default. Nothing an operator writes changes meaning; what goes is the reader learning that a missing key and a `0` differ.

The field had no config test at all — it was among the members the #323 review noted the gate never reaches, since the gate only grades rejections `expectParseError` states. It has one now: both spellings, the ceiling at its edge and one past it, and the l4 refusal.

## `keepalive_requests` leaves `limits`

```diff
- "limits": { "keepalive_requests": 1000 }
+ "http":   { "keepalive_requests": 1000 }
```

`limits` states its own placement rule and this was the standing exception. The old comment knew it was arguing uphill: a body cap states what an *origin* is asked to carry, this bounds what a client occupies *here*. True, and beside the point — the rule asks about reservation, and neither is a pool. `requestsCapReached` reads it off the connection now like every other per-listener setting, and loses the `server` parameter it only needed to reach the config with.

`cq_fill_eighths` stays: not a pool, but it sizes the ring this process asks the kernel for, and the rule sorts on reservation rather than on counting objects.

## Health config stays in two blocks — and now says why

This is the item that **did not land as scoped**, and the reason is the deliverable.

The ask was to move `timeouts.health_interval_ms` into a cluster's `check` block beside `fall`, `rise` and `timeout_ms`. Reading the prober says no: those three are per cluster and this is not. There is **one** sweep and **one** rest timer for the whole process, pacing sweep-end to sweep-start across every checked cluster at once, and §5's closed-form probe reservation — `health_probe_ops_max` ring ops and one fd per probe — is derived from there being exactly one. Moving the interval in would not tidy two homes into one; it would be a per-cluster prober, a different design and a different budget than the banner prints.

So the field stays and its doc comment answers the question rather than leaving it looking like an oversight.

## What replaced it: the rule is written down

The issue's third open point — *"whether §5's placement rule gets written into DESIGN.md rather than living in a field's doc comment where the next field cannot find it"* — is now answered. §5 states the question the block sorts on: **does the number decide what this process takes at startup?** Pool sizes do; `cq_fill_eighths` does; a cap that reserves nothing states policy and belongs on the thing it governs. `timeouts` is a third home and stays one, with `health_interval_ms` as the case that shows why the rule cannot simply push everything outward.

## Not in this PR

`bodies` + `error_pages` keeps its indirection, per the scoping decision: one body is one file read, one charge against `body_bytes_max`, and one rendered buffer per (body, status) however many places serve it — and a `respond` filter action already references bodies by name, so collapsing would mean duplicating bytes or inventing a second way to share them.

The 16 `expressible_fork`/`expressible_bound` rows from #323 are untouched here — they are emitter work, not config-shape work, and each needs the schema taught a `oneOf` or a `maxLength` rather than a field moved.

## Gates

`zig build ci` green after each commit (4096 sim seeds, both smoke runs), `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)