### PR TITLE
config: the schema's debt goes to zero (#305)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1545,9 +1545,11 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   conjunction over exact statuses, a status class (`"1xx"`..`"5xx"`)
   and response-header predicates — the request side's own header
   vocabulary, evaluated by the same code — and the actions are exactly
-  the three header verbs: reject and rewrite have no meaning on the
-  way out, and the loader refuses those arms by name rather than
-  ignoring them. Edits apply during the downstream re-render through
+  the three header verbs. The request-side actions have no meaning on
+  the way out, and since #305 they are not fields on a response action
+  at all — `ResponseActionJson` carries the three verbs and nothing
+  else, so naming one is the strict parser's refusal rather than four
+  rules the resolver used to carry, and the schema states it too. Edits apply during the downstream re-render through
   the same suppress-and-append machinery, under the same
   `header_edits_max` bound on the table's total — the render accepts
   one slot past it (`response_edits_max`), reserved for #178's

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -893,9 +893,12 @@ Rules:
   resolves a name into another block, computes canonical equality, reads
   the filesystem, bounds an object *key*, or holds two blocks at once.
   Two are **debt** — a fork inside one block that `oneOf` could carry,
-  and a bound the emitter does not derive yet — and their counts are
-  pinned, so the shape work that remains is a number rather than an
-  opinion. The pin runs one way: removing a row that is still needed
+  and a bound the emitter does not derive — and their counts are pinned,
+  so the work that remains is a number rather than an opinion. The
+  bounds are paid: the emitter learned `maxLength` and its per-item
+  form, and the two rows that looked like bounds and were not — a cap on
+  the *sum* of header edits across a whole filter table — moved to
+  `budget`, where a schema genuinely cannot follow. The pin runs one way: removing a row that is still needed
   fails the build, while a row whose rule *became* expressible has to be
   struck by whoever made it so, because one error is raised by several
   cases and the schema catching one of them proves nothing about the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -892,13 +892,21 @@ Rules:
   grammar parses an address, sums a list of weights against a budget,
   resolves a name into another block, computes canonical equality, reads
   the filesystem, bounds an object *key*, or holds two blocks at once.
-  Two are **debt** — a fork inside one block that `oneOf` could carry,
-  and a bound the emitter does not derive — and their counts are pinned,
-  so the work that remains is a number rather than an opinion. The
-  bounds are paid: the emitter learned `maxLength` and its per-item
-  form, and the two rows that looked like bounds and were not — a cap on
-  the *sum* of header edits across a whole filter table — moved to
-  `budget`, where a schema genuinely cannot follow. The pin runs one way: removing a row that is still needed
+  Two are **debt**, and both are now **empty**. A fork inside one block
+  that `oneOf` could carry is emitted from `SchemaVariants`: one arm per
+  value of a discriminating field, each naming what that value requires
+  and what it rules out, with the arm matching the field's Zig default
+  omitting `required` so an absent discriminator lands there and nowhere
+  else. A bound the emitter could derive is emitted too — `maxLength`
+  and its per-item form joined `minLength` and `maxItems`. What is left
+  in the closed categories includes two rows that looked like bounds and
+  were not: a cap on the *sum* of header edits across a whole filter
+  table, which is arithmetic no grammar performs.
+  The counts are pinned at zero, and zero is the interesting number to
+  pin. Above it, the pin said how much work remained; at it, the pin
+  says a new cross-field rule cannot be added without either giving it a
+  shape or arguing in `schema_gaps` why a schema cannot follow — which
+  is the discipline #305 was asking for, rather than the tally. The pin runs one way: removing a row that is still needed
   fails the build, while a row whose rule *became* expressible has to be
   struck by whoever made it so, because one error is raised by several
   cases and the schema catching one of them proves nothing about the

--- a/src/config.zig
+++ b/src/config.zig
@@ -772,7 +772,6 @@ pub const ValidationError = error{
     AccessLogHeaderDuplicate,
     LimitAccessLogBufferUnderLine,
     FilterRespondStatus,
-    ResponseFilterRespond,
     ErrorPagesOverLimit,
     ErrorPageStatusInvalid,
     ErrorPageStatusUnknown,
@@ -813,9 +812,6 @@ pub const ValidationError = error{
     FilterRedirectTarget,
     FilterRedirectSchemeUnknown,
     FilterHeaderEditsOverLimit,
-    ResponseFilterReject,
-    ResponseFilterRedirect,
-    ResponseFilterRewrite,
     ResponseFilterStatusInvalid,
     ResponseFilterStatusClassUnknown,
     ResponseFilterStatusEmpty,
@@ -2409,6 +2405,51 @@ pub const HeaderMatchJson = struct {
 /// One action object carries exactly one field (the action's kind), the
 /// same "struct of optionals, validate exactly-one" shape the listener's
 /// cluster/routes fork uses — no JSON union parsing.
+/// What a #175 response rule may do: edit headers, and nothing else.
+///
+/// A type of its own rather than `ActionJson` with four of its members
+/// refused at load (#305). The four are request-side answers — `reject`,
+/// `redirect` and `respond` decide what to send *instead* of asking the
+/// origin, and `rewrite_prefix` changes what is asked — while a response
+/// rule runs when the origin has already answered. Sharing the request's
+/// union made those states representable and then rejected them one at
+/// a time; here they cannot be written down, which is the same verdict
+/// reached by the type rather than by a rule, and the schema states it
+/// too.
+pub const ResponseActionJson = struct {
+    header_set: ?HeaderEditJson = null,
+    header_add: ?HeaderEditJson = null,
+    header_remove: ?[]const u8 = null,
+
+    pub const schema_doc =
+        "One response-filter action. Exactly one field is set — the edit's " ++
+        "kind. Response rules edit headers only: the request-side actions " ++
+        "(reject, redirect, respond, rewrite_prefix) answer instead of " ++
+        "forwarding, and by the time these rules run the origin already has.";
+    pub const schema_one_of = [_][]const u8{
+        "header_set",
+        "header_add",
+        "header_remove",
+    };
+    pub const schema_fields = .{
+        .header_set = .{ .desc = "Set (replace) a response header." },
+        .header_add = .{ .desc = "Append a response header." },
+        .header_remove = .{ .desc = "Remove a response header by name." },
+    };
+
+    comptime {
+        // Every member must exist on the request action and mean the
+        // same thing: the two tables share `resolveHeaderEdit`, and a
+        // member here the request lacks would be an edit the renderer
+        // has never seen.
+        for (@typeInfo(ResponseActionJson).@"struct".fields) |field| {
+            if (!@hasField(ActionJson, field.name)) {
+                @compileError("ResponseActionJson." ++ field.name ++ " is not an ActionJson field");
+            }
+        }
+    }
+};
+
 pub const ActionJson = struct {
     reject: ?u16 = null,
     redirect: ?RedirectJson = null,
@@ -2518,7 +2559,7 @@ pub const RedirectJson = struct {
 /// here by their own names.
 pub const ResponseFilterJson = struct {
     match: ResponseMatchJson = .{},
-    actions: []const ActionJson,
+    actions: []const ResponseActionJson,
 
     pub const schema_doc =
         "One response filter rule: a match over the origin's response and " ++
@@ -2527,8 +2568,9 @@ pub const ResponseFilterJson = struct {
         .match = .{ .desc = "Response-match predicate; absent fields match anything." },
         .actions = .{
             .desc = "Header edits (header_set / header_add / header_remove) applied " ++
-                "in order when the rule matches; reject and rewrite_prefix are " ++
-                "request-side only.",
+                "in order when the rule matches. The request-side actions are not " ++
+                "fields here at all: by the time these rules run the origin has " ++
+                "already answered.",
             .min_items = 1,
         },
     };
@@ -4276,7 +4318,7 @@ fn resolveResponseMatch(
 /// not transfer rather than handed a generic kind error.
 fn resolveResponseEdits(
     arena: std.mem.Allocator,
-    actions_json: []const ActionJson,
+    actions_json: []const ResponseActionJson,
 ) ParseError![]const filter.AppliedHeaderEdit {
     if (actions_json.len == 0) {
         return error.FilterActionsEmpty;
@@ -4290,30 +4332,12 @@ fn resolveResponseEdits(
     return edits;
 }
 
-fn resolveResponseEdit(action_json: *const ActionJson) ParseError!filter.AppliedHeaderEdit {
-    // The shared kind fork runs before the arm rejections, so a
-    // two-kind object is a kind error here too, never a misleading
-    // arm one.
-    try requireOneActionKind(action_json);
-    if (action_json.reject != null) {
-        return error.ResponseFilterReject;
-    }
-    if (action_json.redirect != null) {
-        // A redirect is a request-side answer (#176): the client asked
-        // and is sent elsewhere. An origin response already exists by
-        // the time these rules run.
-        return error.ResponseFilterRedirect;
-    }
-    if (action_json.respond != null) {
-        // Also a request-side answer (#159): a response rule runs when
-        // the origin has already answered, and replacing that answer is
-        // not an *edit* — it is a different feature, and one this table
-        // deliberately does not have.
-        return error.ResponseFilterRespond;
-    }
-    if (action_json.rewrite_prefix != null) {
-        return error.ResponseFilterRewrite;
-    }
+fn resolveResponseEdit(action_json: *const ResponseActionJson) ParseError!filter.AppliedHeaderEdit {
+    // The kind fork, which for this table is now the whole check: the
+    // four request-side actions are not fields here, so a config naming
+    // one is refused by the strict parser rather than by four rules
+    // this function used to carry (#305).
+    try requireOneResponseActionKind(action_json);
     if (action_json.header_set) |edit| {
         const resolved = try resolveHeaderEdit(&edit);
         return .{ .kind = .set, .name = resolved.name, .value = resolved.value };
@@ -4548,6 +4572,20 @@ fn resolveActions(
 /// Exactly one action field may carry the kind — the "exactly one of"
 /// fork both action resolvers share, so a seventh kind cannot be
 /// counted in one table and forgotten in the other.
+/// The response table's kind fork (#305). Three members rather than the
+/// request's seven, and the same verdict — a rule naming none or two
+/// has no single action to apply.
+fn requireOneResponseActionKind(action_json: *const ResponseActionJson) ParseError!void {
+    const set: u8 = @as(u8, @intFromBool(action_json.header_set != null)) +
+        @intFromBool(action_json.header_add != null) +
+        @intFromBool(action_json.header_remove != null);
+    assert(set <= 3); // The response action object has three kind fields.
+    if (set != 1) {
+        return error.FilterActionKind;
+    }
+    assert(set == 1);
+}
+
 fn requireOneActionKind(action_json: *const ActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
         @intFromBool(action_json.redirect != null) +
@@ -6380,10 +6418,10 @@ test "config: redirect validation has its own errors" {
     // A literal Location is a header value the render emits verbatim:
     // injection-safety is proven at load.
     try expectParseError(error.FilterHeaderValueInvalid, head ++ "{\"actions\":[{\"redirect\":{\"location\":\"https://x/\\r\\nSet-Cookie: a\"}}]}]}}]," ++ tail);
-    // Two kinds is still a kind error; a redirect on the way out is
-    // refused by name.
+    // Two kinds is still a kind error; a redirect on the way out is not
+    // a field a response action has (#305), so the parser refuses it.
     try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"redirect\":{\"scheme\":\"https\"},\"reject\":403}]}]}}]," ++ tail);
-    try expectParseError(error.ResponseFilterRedirect, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"," ++
+    try expectParseError(error.UnknownField, "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"," ++
         "\"response_filters\":[{\"actions\":[{\"redirect\":{\"scheme\":\"https\"}}]}]}}]," ++ tail);
 }
 
@@ -6486,12 +6524,23 @@ test "config: response filter schema rejects what has no meaning on the way out"
         \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
     ;
     const head = "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\",\"response_filters\":[";
-    // The two request-side arms are rejected by their own names, so an
-    // operator is told which idea does not transfer.
-    try expectParseError(error.ResponseFilterReject, head ++ "{\"actions\":[{\"reject\":403}]}]}}]," ++ tail);
-    try expectParseError(error.ResponseFilterRewrite, head ++ "{\"actions\":[{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b\"}}]}]}}]," ++ tail);
+    // The request-side actions are not fields on a response action at
+    // all (#305), so naming one is the strict parser's refusal rather
+    // than four rules this table used to carry — and the schema states
+    // the same thing, where before it could only be discovered at load.
+    inline for (.{
+        "{\"reject\":403}",
+        "{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b\"}}",
+        "{\"redirect\":{\"status\":301,\"location\":\"/x\"}}",
+        "{\"respond\":{\"status\":200,\"body\":\"b\"}}",
+    }) |action| {
+        try expectParseError(
+            error.UnknownField,
+            head ++ "{\"actions\":[" ++ action ++ "]}]}}]," ++ tail,
+        );
+    }
     // A two-kind action is still a kind error, never a misleading arm one.
-    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"reject\":403,\"header_remove\":\"X\"}]}]}}]," ++ tail);
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"header_set\":{\"name\":\"X\",\"value\":\"y\"},\"header_remove\":\"X\"}]}]}}]," ++ tail);
     try expectParseError(error.FilterActionsEmpty, head ++ "{\"actions\":[]}]}}]," ++ tail);
     // A status the parser can never produce is a rule that can never
     // fire — a typo, told at load.
@@ -7091,9 +7140,8 @@ const SchemaGap = enum {
     /// are keyed by operator-chosen names, and a key has no schema of
     /// its own in this dialect (`propertyNames` is a keyword the emitter
     /// deliberately does not reach for, #305's closed vocabulary). A
-    /// bound on a *value* is not this: it has somewhere to attach, so it
-    /// belongs in `expressible_bound` and two rows were moved there when
-    /// review caught them filed here.
+    /// bound on a *value* is not this: it has somewhere to attach, and
+    /// the emitter emits `maxLength` for it.
     name_length,
     /// A name that must exist in another block — `cluster` naming a
     /// cluster, `body` naming a body. A schema validates one document
@@ -7114,15 +7162,16 @@ const SchemaGap = enum {
     /// listener's shape against a cluster's, or against a sibling of its
     /// own body.
     cross_block,
-    /// **Debt.** A fork inside one block that `oneOf` could carry: a
-    /// field required exactly when a sibling takes a given value. Every
-    /// one of these is a cross-field rule the loader states in prose and
-    /// a shape could state instead.
+    /// **Debt, and currently empty.** A fork inside one block that
+    /// `oneOf` could carry: a field required exactly when a sibling
+    /// takes a given value. `SchemaVariants` carries these now, so a row
+    /// arriving here means a fork nobody declared rather than one the
+    /// emitter cannot state.
     expressible_fork,
-    /// **Debt.** A bound the schema could carry and the emitter does not
-    /// derive yet: an array's `maxItems`, or a string's `maxLength`
-    /// (`min_length` is emitted already, so only half of that pair
-    /// exists).
+    /// **Debt, and currently empty.** A bound the schema could carry:
+    /// an array's `maxItems`, or a string's `maxLength` and its
+    /// per-item form. All three are emitted, so a row here means a
+    /// field whose ceiling was never written down.
     expressible_bound,
 };
 
@@ -7204,10 +7253,6 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "ListenerUnixBindForwarded", .gap = .cross_block },
     .{ .name = "ListenerUnixBindSourceIpHash", .gap = .cross_block },
     .{ .name = "ResponseFilterHeaderEditsOverLimit", .gap = .budget },
-    .{ .name = "ResponseFilterRedirect", .gap = .expressible_fork },
-    .{ .name = "ResponseFilterReject", .gap = .expressible_fork },
-    .{ .name = "ResponseFilterRespond", .gap = .expressible_fork },
-    .{ .name = "ResponseFilterRewrite", .gap = .expressible_fork },
     .{ .name = "RouteDuplicate", .gap = .duplicate },
     .{ .name = "RouteHostNotCanonical", .gap = .literal_syntax },
     .{ .name = "RoutePrefixNotCanonical", .gap = .literal_syntax },
@@ -7246,11 +7291,20 @@ fn schemaGapOf(expected: ParseError) ?SchemaGap {
 }
 
 test "config: the schema's debt to the loader only ever falls (#305)" {
-    // The measurable definition of the freeze being done. Seven gap
-    // categories are closed by what a schema *is*; these two are things
-    // the emitter could express and does not, so they are the work that
-    // remains — pinned, so a new one cannot arrive quietly and an old
-    // one cannot be paid off without saying so.
+    // The measurable definition of the freeze being done, and it now
+    // reads zero. Seven gap categories are closed by what a schema *is*
+    // — no grammar parses an address, sums a list, resolves a name into
+    // another block, computes canonical equality, reads the filesystem,
+    // bounds an object key, or holds two blocks at once. These two are
+    // what the emitter *could* express, and everything that was in them
+    // has been expressed: the forks became `SchemaVariants`, the bounds
+    // became `maxLength` and its per-item form, and two rows that looked
+    // like bounds turned out to be sums and moved to `budget`.
+    //
+    // Zero is the interesting number to pin. Above zero it said how much
+    // work was left; at zero it says a new cross-field rule cannot be
+    // added without either shaping it or arguing, in this file, why a
+    // schema cannot follow.
     var forks: usize = 0;
     var bounds: usize = 0;
     for (schema_gaps) |entry| {
@@ -7260,7 +7314,7 @@ test "config: the schema's debt to the loader only ever falls (#305)" {
             else => {},
         }
     }
-    try std.testing.expectEqual(@as(usize, 4), forks);
+    try std.testing.expectEqual(@as(usize, 0), forks);
     try std.testing.expectEqual(@as(usize, 0), bounds);
 }
 
@@ -8470,9 +8524,10 @@ test "config: the respond action's vocabulary is closed, and request-side only" 
     );
     // And it is a request-side answer: a response rule runs when the
     // origin has already answered, so replacing that answer is not an
-    // edit this table has.
+    // edit this table has — and since #305 it is not a field there
+    // either, so the parser says so rather than a rule.
     try expectParseError(
-        error.ResponseFilterRespond,
+        error.UnknownField,
         "{\"listeners\":[{\"bind\":\"127.0.0.1:1\",\"http\":{\"cluster\":\"a\"," ++
             "\"response_filters\":[{\"actions\":[{\"respond\":{\"body\":\"x\"}}]}]}}]," ++
             "\"clusters\":{\"a\":{\"endpoints\":[\"127.0.0.1:2\"]}}," ++

--- a/src/config.zig
+++ b/src/config.zig
@@ -1878,6 +1878,11 @@ pub const AccessLogJson = struct {
                 "append-only at startup (one extra fd), never truncated — so a " ++
                 "copy-truncate rotation is safe. Required by `sink:\"file\"`, " ++
                 "rejected beside `stdout`, which cannot use it.",
+            // An empty path is the same refusal as a missing one and
+            // wants the same answer (#305): the loader raises
+            // `AccessLogPathMissing` for both, so the schema has to
+            // catch both or the row cannot go.
+            .min_length = 1,
         },
         .request_headers = .{
             .desc = "Request headers to record under `request_headers` on each " ++
@@ -1898,6 +1903,17 @@ pub const AccessLogJson = struct {
             .item_max_length = constants.access_log_header_name_bytes_max,
         },
     };
+
+    /// A file sink needs somewhere to write and a stdout sink has
+    /// nowhere to be given (#305). `sink` has no default, so both arms
+    /// name it.
+    pub const schema_variants = [_]SchemaVariants{.{
+        .on = "sink",
+        .branches = &.{
+            .{ .value = "stdout", .forbid = &.{"path"} },
+            .{ .value = "file", .require = &.{"path"} },
+        },
+    }};
 };
 
 pub const AdminJson = struct {
@@ -2799,6 +2815,34 @@ pub const PickJson = struct {
         },
     };
 
+    /// Two forks over one object (#305), conjoined rather than nested.
+    ///
+    /// `key` names what a `hash` cluster is sticky on and means nothing
+    /// beside `p2c` or `rr`; `name` names the header or cookie a
+    /// request-derived key reads and means nothing beside `source_ip`.
+    /// Both are `oneOf`s over their own discriminator, and the second
+    /// covers the keyless policies for free: with no `key` present its
+    /// default arm applies, and that arm forbids `name` — which is the
+    /// same verdict the first fork reaches by a different route.
+    pub const schema_variants = [_]SchemaVariants{
+        .{
+            .on = "policy",
+            .branches = &.{
+                .{ .value = "p2c", .forbid = &.{ "key", "name" } },
+                .{ .value = "rr", .forbid = &.{ "key", "name" } },
+                .{ .value = "hash", .require = &.{"key"} },
+            },
+        },
+        .{
+            .on = "key",
+            .branches = &.{
+                .{ .value = "source_ip", .default = true, .forbid = &.{"name"} },
+                .{ .value = "header", .require = &.{"name"} },
+                .{ .value = "cookie", .require = &.{"name"} },
+            },
+        },
+    };
+
     /// The object form as a plain struct, so `innerParse` reads it with
     /// the loader's own strictness (unknown fields rejected) without
     /// recursing back into `jsonParse` below.
@@ -3045,6 +3089,18 @@ pub const CheckJson = struct {
             .maximum = 599,
         },
     };
+
+    /// A `tcp` probe sends nothing and reads nothing, so every
+    /// HTTP-shaped field beside it would be inert; an `http` probe has
+    /// to be told what to ask for (#305). `type` defaults to `tcp`, so
+    /// that arm carries the absence too.
+    pub const schema_variants = [_]SchemaVariants{.{
+        .on = "type",
+        .branches = &.{
+            .{ .value = "tcp", .default = true, .forbid = &.{ "path", "host" } },
+            .{ .value = "http", .require = &.{"path"} },
+        },
+    }};
 };
 
 /// One cluster's passive-ejection block (§7, #230). Two numbers and no
@@ -3230,6 +3286,38 @@ pub const SchemaItems = enum { http_method };
 /// The attribute keys a `schema_fields` entry may carry beyond `.desc`.
 /// `assert_meta_matches` rejects any other key at comptime, so a typo'd
 /// attribute is a compile error, not silently-ignored data.
+/// One arm of a discriminated block: the value of the deciding field,
+/// and what that value makes required or impossible (#305).
+///
+/// This is the last shape of cross-field rule the loader stated in prose
+/// and the schema could not — "`path` is required, but only when `sink`
+/// is `file`". A `oneOf` over the discriminator carries it, so an editor
+/// refuses the config before the loader has to.
+pub const SchemaVariant = struct {
+    /// The discriminator's value on this arm.
+    value: []const u8,
+    /// Fields this arm requires beyond the DTO's own required set.
+    require: []const []const u8 = &.{},
+    /// Fields this arm rules out, emitted as a `false` schema — which
+    /// nothing satisfies, and is how the dialect says "not here".
+    forbid: []const []const u8 = &.{},
+    /// Whether the discriminator's *absence* selects this arm. True on
+    /// exactly the arm matching the field's Zig default, so a config
+    /// that omits the key lands where the loader would put it, and false
+    /// everywhere else — an arm that is not the default must say
+    /// `required`, or an absent discriminator would match every arm at
+    /// once and `oneOf` would reject a valid config.
+    default: bool = false,
+};
+
+/// A discriminated fork over one field. A DTO may declare several, each
+/// independent — `pick` forks twice, on `policy` and then on `key` — and
+/// they are conjoined with `allOf` so neither shadows the other.
+pub const SchemaVariants = struct {
+    on: []const u8,
+    branches: []const SchemaVariant,
+};
+
 const schema_attributes = [_][]const u8{
     "desc",       "minimum",         "maximum",         "min_items", "max_items",
     "min_length", "max_length",      "const_true",      "enum_type", "int_values",
@@ -7058,8 +7146,6 @@ const SchemaGapEntry = struct { name: []const u8, gap: SchemaGap };
 const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "AccessLogHeaderDuplicate", .gap = .duplicate },
     .{ .name = "AccessLogHeaderNameInvalid", .gap = .literal_syntax },
-    .{ .name = "AccessLogPathMissing", .gap = .expressible_fork },
-    .{ .name = "AccessLogPathOnStdout", .gap = .expressible_fork },
     .{ .name = "AdminBindInvalid", .gap = .literal_syntax },
     .{ .name = "BodyContentTypeInvalid", .gap = .literal_syntax },
     .{ .name = "BodyFileUnreadable", .gap = .filesystem },
@@ -7067,16 +7153,10 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "BodyNameTooLong", .gap = .name_length },
     .{ .name = "BodyUnknown", .gap = .cross_reference },
     .{ .name = "ClusterCheckHostInvalid", .gap = .literal_syntax },
-    .{ .name = "ClusterCheckHttpFieldOnTcp", .gap = .expressible_fork },
-    .{ .name = "ClusterCheckPathMissing", .gap = .expressible_fork },
     .{ .name = "ClusterCheckPathNotCanonical", .gap = .literal_syntax },
     .{ .name = "ClusterNameEmpty", .gap = .name_length },
     .{ .name = "ClusterNameTooLong", .gap = .name_length },
-    .{ .name = "ClusterPickKeyMissing", .gap = .expressible_fork },
-    .{ .name = "ClusterPickKeyWithoutHash", .gap = .expressible_fork },
     .{ .name = "ClusterPickNameInvalid", .gap = .literal_syntax },
-    .{ .name = "ClusterPickNameMissing", .gap = .expressible_fork },
-    .{ .name = "ClusterPickNameUnexpected", .gap = .expressible_fork },
     .{ .name = "ClusterProxyProtocolOnHttpListener", .gap = .cross_block },
     .{ .name = "ClusterProxyProtocolOnTlsListener", .gap = .cross_block },
     .{ .name = "ClusterUnknown", .gap = .cross_reference },
@@ -7180,7 +7260,7 @@ test "config: the schema's debt to the loader only ever falls (#305)" {
             else => {},
         }
     }
-    try std.testing.expectEqual(@as(usize, 12), forks);
+    try std.testing.expectEqual(@as(usize, 4), forks);
     try std.testing.expectEqual(@as(usize, 0), bounds);
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1886,12 +1886,16 @@ pub const AccessLogJson = struct {
                 "case-insensitively and logged lowercased; absent headers are " ++
                 "omitted from the line.",
             .max_items = constants.access_log_headers_max,
+            .item_min_length = 1,
+            .item_max_length = constants.access_log_header_name_bytes_max,
         },
         .response_headers = .{
             .desc = "Response headers to record under `response_headers`, on the " ++
                 "same terms — the origin's X-Cache, say. Ignored for l4 lines, " ++
                 "which have no response to read.",
             .max_items = constants.access_log_headers_max,
+            .item_min_length = 1,
+            .item_max_length = constants.access_log_header_name_bytes_max,
         },
     };
 };
@@ -2791,6 +2795,7 @@ pub const PickJson = struct {
             .desc = "The header or cookie name a request-derived key reads; " ++
                 "required for those keys, rejected for source_ip.",
             .min_length = 1,
+            .max_length = constants.pick_name_bytes_max,
         },
     };
 
@@ -2860,6 +2865,11 @@ pub const BodyJson = struct {
         "is served with. Referenced by name from error_pages (and any " ++
         "future body-serving feature), so one body is one buffer however " ++
         "many places serve it.";
+    /// The fork the doc above already describes, said in a way the
+    /// schema can act on (#305). It was expressible from the day
+    /// `oneOf` was emitted and simply never declared, which is what the
+    /// differential gate is for finding.
+    pub const schema_one_of = [_][]const u8{ "file", "inline" };
     pub const schema_fields = .{
         .file = .{
             .desc = "Path to the body's file, read once at startup; a change " ++
@@ -3221,8 +3231,9 @@ pub const SchemaItems = enum { http_method };
 /// `assert_meta_matches` rejects any other key at comptime, so a typo'd
 /// attribute is a compile error, not silently-ignored data.
 const schema_attributes = [_][]const u8{
-    "desc",       "minimum",    "maximum",   "min_items",  "max_items",
-    "min_length", "const_true", "enum_type", "int_values", "items",
+    "desc",       "minimum",         "maximum",         "min_items", "max_items",
+    "min_length", "max_length",      "const_true",      "enum_type", "int_values",
+    "items",      "item_min_length", "item_max_length",
 };
 
 /// Cross-check a DTO's schema metadata against its real fields at comptime:
@@ -7047,7 +7058,6 @@ const SchemaGapEntry = struct { name: []const u8, gap: SchemaGap };
 const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "AccessLogHeaderDuplicate", .gap = .duplicate },
     .{ .name = "AccessLogHeaderNameInvalid", .gap = .literal_syntax },
-    .{ .name = "AccessLogHeaderNameTooLong", .gap = .expressible_bound },
     .{ .name = "AccessLogPathMissing", .gap = .expressible_fork },
     .{ .name = "AccessLogPathOnStdout", .gap = .expressible_fork },
     .{ .name = "AdminBindInvalid", .gap = .literal_syntax },
@@ -7055,8 +7065,6 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "BodyFileUnreadable", .gap = .filesystem },
     .{ .name = "BodyNameEmpty", .gap = .name_length },
     .{ .name = "BodyNameTooLong", .gap = .name_length },
-    .{ .name = "BodySourceAmbiguous", .gap = .expressible_fork },
-    .{ .name = "BodySourceMissing", .gap = .expressible_fork },
     .{ .name = "BodyUnknown", .gap = .cross_reference },
     .{ .name = "ClusterCheckHostInvalid", .gap = .literal_syntax },
     .{ .name = "ClusterCheckHttpFieldOnTcp", .gap = .expressible_fork },
@@ -7068,7 +7076,6 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "ClusterPickKeyWithoutHash", .gap = .expressible_fork },
     .{ .name = "ClusterPickNameInvalid", .gap = .literal_syntax },
     .{ .name = "ClusterPickNameMissing", .gap = .expressible_fork },
-    .{ .name = "ClusterPickNameTooLong", .gap = .expressible_bound },
     .{ .name = "ClusterPickNameUnexpected", .gap = .expressible_fork },
     .{ .name = "ClusterProxyProtocolOnHttpListener", .gap = .cross_block },
     .{ .name = "ClusterProxyProtocolOnTlsListener", .gap = .cross_block },
@@ -7083,7 +7090,7 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "FilterClientCidrInvalid", .gap = .literal_syntax },
     .{ .name = "FilterClientPrefixInvalid", .gap = .literal_syntax },
     .{ .name = "FilterClientPrefixTooNarrow", .gap = .literal_syntax },
-    .{ .name = "FilterHeaderEditsOverLimit", .gap = .expressible_bound },
+    .{ .name = "FilterHeaderEditsOverLimit", .gap = .budget },
     .{ .name = "FilterHeaderNameInvalid", .gap = .literal_syntax },
     .{ .name = "FilterHeaderNameReserved", .gap = .literal_syntax },
     .{ .name = "FilterHeaderValueInvalid", .gap = .literal_syntax },
@@ -7116,7 +7123,7 @@ const schema_gaps = [_]SchemaGapEntry{
     .{ .name = "ListenerUnixBindClusterSend", .gap = .cross_block },
     .{ .name = "ListenerUnixBindForwarded", .gap = .cross_block },
     .{ .name = "ListenerUnixBindSourceIpHash", .gap = .cross_block },
-    .{ .name = "ResponseFilterHeaderEditsOverLimit", .gap = .expressible_bound },
+    .{ .name = "ResponseFilterHeaderEditsOverLimit", .gap = .budget },
     .{ .name = "ResponseFilterRedirect", .gap = .expressible_fork },
     .{ .name = "ResponseFilterReject", .gap = .expressible_fork },
     .{ .name = "ResponseFilterRespond", .gap = .expressible_fork },
@@ -7173,8 +7180,8 @@ test "config: the schema's debt to the loader only ever falls (#305)" {
             else => {},
         }
     }
-    try std.testing.expectEqual(@as(usize, 14), forks);
-    try std.testing.expectEqual(@as(usize, 4), bounds);
+    try std.testing.expectEqual(@as(usize, 12), forks);
+    try std.testing.expectEqual(@as(usize, 0), bounds);
 }
 
 /// Whether `expected` is the loader's own verdict rather than the JSON

--- a/src/config.zig
+++ b/src/config.zig
@@ -2438,13 +2438,18 @@ pub const ResponseActionJson = struct {
     };
 
     comptime {
-        // Every member must exist on the request action and mean the
-        // same thing: the two tables share `resolveHeaderEdit`, and a
+        // Every member must exist on the request action *and carry the
+        // same type*: the two tables share `resolveHeaderEdit`, so a
         // member here the request lacks would be an edit the renderer
-        // has never seen.
+        // has never seen, and one whose type diverged would be the same
+        // key meaning two things.
         for (@typeInfo(ResponseActionJson).@"struct".fields) |field| {
             if (!@hasField(ActionJson, field.name)) {
                 @compileError("ResponseActionJson." ++ field.name ++ " is not an ActionJson field");
+            }
+            if (@FieldType(ActionJson, field.name) != field.type) {
+                @compileError("ResponseActionJson." ++ field.name ++
+                    " has a different type than ActionJson's");
             }
         }
     }
@@ -3343,12 +3348,23 @@ pub const SchemaVariant = struct {
     /// Fields this arm rules out, emitted as a `false` schema — which
     /// nothing satisfies, and is how the dialect says "not here".
     forbid: []const []const u8 = &.{},
-    /// Whether the discriminator's *absence* selects this arm. True on
-    /// exactly the arm matching the field's Zig default, so a config
-    /// that omits the key lands where the loader would put it, and false
-    /// everywhere else — an arm that is not the default must say
-    /// `required`, or an absent discriminator would match every arm at
-    /// once and `oneOf` would reject a valid config.
+    /// Whether the discriminator's *absence* selects this arm — set on
+    /// the arm a config that omits the key should land on, and false
+    /// everywhere else. An arm that is not the default names the
+    /// discriminator in its `required`, or an absent key would satisfy
+    /// every arm's `properties` vacuously, `oneOf` would see several
+    /// matches, and a valid config would be rejected.
+    ///
+    /// Usually that is the arm matching the field's Zig default, and
+    /// `assertVariantsMatch` requires exactly one wherever the field can
+    /// be absent. `PickJson.key` is the case that shows what the rule
+    /// actually means: its Zig default is `null`, not `"source_ip"`, and
+    /// the `source_ip` arm is marked here because that is the *resolved*
+    /// fallback — `resolvePick` reads an absent key as `source_ip` for
+    /// the keyless policies. It stays sound because the sibling fork on
+    /// `policy` independently requires `key` whenever the policy is
+    /// `hash`, so the looser arm is unreachable exactly where it would
+    /// have been wrong.
     default: bool = false,
 };
 
@@ -3408,6 +3424,7 @@ pub fn assert_meta_matches(comptime T: type) void {
         }
     }
     assertOneOfMatches(T);
+    assertVariantsMatch(T);
 }
 
 /// A DTO's optional `schema_one_of` — the fields of which exactly one may
@@ -3420,6 +3437,92 @@ pub fn assert_meta_matches(comptime T: type) void {
 /// in `required`, so every branch would match at once and `oneOf` — which
 /// means exactly one — would reject every config. Both are silent in JSON
 /// Schema and loud here.
+/// Hold a DTO's declared forks to its real fields (#305), the way
+/// `assertOneOfMatches` holds its `schema_one_of`.
+///
+/// The emitter takes `on`, `require` and `forbid` as strings and writes
+/// them into the document; without this a typo would emit a keyword
+/// naming a field that does not exist — a dead constraint that looks
+/// like a live one, which is the failure `assert_meta_matches` exists to
+/// prevent one screen up.
+fn assertVariantsMatch(comptime T: type) void {
+    if (!@hasDecl(T, "schema_variants")) return;
+    for (T.schema_variants) |set| {
+        if (!@hasField(T, set.on)) {
+            @compileError(@typeName(T) ++ " schema_variants forks on '" ++ set.on ++
+                "', which is not a field");
+        }
+        // A fork needs arms to choose between; one arm is a constraint
+        // stated the hard way.
+        if (set.branches.len < 2) {
+            @compileError(@typeName(T) ++ " schema_variants on '" ++ set.on ++
+                "' needs at least two branches");
+        }
+        var defaults = 0;
+        for (set.branches) |branch| {
+            if (branch.default) defaults += 1;
+            if (branch.value.len == 0) {
+                @compileError(@typeName(T) ++ " schema_variants on '" ++ set.on ++
+                    "' has an empty branch value");
+            }
+            for (branch.require) |name| {
+                if (!@hasField(T, name)) {
+                    @compileError(@typeName(T) ++ " variant '" ++ branch.value ++
+                        "' requires '" ++ name ++ "', which is not a field");
+                }
+                if (std.mem.eql(u8, name, set.on)) {
+                    @compileError(@typeName(T) ++ " variant '" ++ branch.value ++
+                        "' names its own discriminator in require");
+                }
+            }
+            for (branch.forbid) |name| {
+                if (!@hasField(T, name)) {
+                    @compileError(@typeName(T) ++ " variant '" ++ branch.value ++
+                        "' forbids '" ++ name ++ "', which is not a field");
+                }
+                if (std.mem.eql(u8, name, set.on)) {
+                    @compileError(@typeName(T) ++ " variant '" ++ branch.value ++
+                        "' forbids its own discriminator");
+                }
+                // Requiring and forbidding the same key is an arm no
+                // document can satisfy — `oneOf` would then have one
+                // fewer arm than it appears to.
+                for (branch.require) |required| {
+                    if (std.mem.eql(u8, name, required)) {
+                        @compileError(@typeName(T) ++ " variant '" ++ branch.value ++
+                            "' both requires and forbids '" ++ name ++ "'");
+                    }
+                }
+            }
+        }
+        // Exactly one arm may absorb an absent discriminator, and only
+        // when the field can *be* absent. Two would make `oneOf` see
+        // both on an omitted key; none would reject a config the loader
+        // accepts by default.
+        const optional = @typeInfo(@FieldType(T, set.on)) == .optional or
+            defaultOf(T, set.on) != null;
+        if (optional and defaults != 1) {
+            @compileError(@typeName(T) ++ " schema_variants on '" ++ set.on ++
+                "' may be absent, so exactly one branch must be .default");
+        }
+        if (!optional and defaults != 0) {
+            @compileError(@typeName(T) ++ " schema_variants on '" ++ set.on ++
+                "' is required, so no branch may be .default");
+        }
+    }
+}
+
+/// Whether a field carries a Zig default, as an opaque marker — the
+/// value itself is not comparable across the types this walks.
+fn defaultOf(comptime T: type, comptime name: []const u8) ?void {
+    for (@typeInfo(T).@"struct".fields) |field| {
+        if (std.mem.eql(u8, field.name, name)) {
+            return if (field.defaultValue() == null) null else {};
+        }
+    }
+    return null;
+}
+
 fn assertOneOfMatches(comptime T: type) void {
     if (!@hasDecl(T, "schema_one_of")) return;
     const names = T.schema_one_of;
@@ -3465,7 +3568,7 @@ pub const dto_types = .{
     ForwardedJson,      ProxyProtocolJson,   ClusterProxyProtocolJson, EndpointJson,
     ResponseFilterJson, ResponseMatchJson,   RedirectJson,             BodyJson,
     TlsJson,            PassiveEjectionJson, HttpListenerJson,         L4ListenerJson,
-    L4RouteJson,        RouteHeaderJson,
+    L4RouteJson,        RouteHeaderJson,     ResponseActionJson,
 };
 
 comptime {
@@ -7125,10 +7228,14 @@ fn expectSchemaAgrees(expected: ParseError, json_bytes: []const u8) !void {
 /// Not an excuse list: the categories are the argument. Seven of them
 /// are closed — a schema describes documents, and no document grammar
 /// can parse an address, sum a list of weights, or read another block —
-/// so entries there are permanent and correct. Two are **debt**: a fork or
-/// a bound the schema could carry and does not yet, which is exactly
-/// what #305 Part 1 called a cross-field rule that should have been a
-/// shape. Their counts are pinned below so they only ever fall.
+/// so entries there are permanent and correct. Two are **debt** — a fork
+/// or a bound the schema could carry — and both are now **empty**: the
+/// forks became `SchemaVariants` and the bounds became `maxLength` and
+/// its per-item form. Their counts are pinned below at zero, which is
+/// the useful place to pin them: above zero the pin said how much work
+/// remained, and at zero it says a new cross-field rule cannot be added
+/// without either giving it a shape or arguing here why a schema cannot
+/// follow.
 const SchemaGap = enum {
     /// The value is text whose *meaning* only a parser knows: an address
     /// literal, a canonical path or host, a CIDR, a header-name token, a

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -97,6 +97,7 @@ fn writeObjectBody(out: *Stringify, comptime T: type, comptime with_doc: bool) W
     try out.write(false);
 
     try writeOneOf(out, T);
+    try writeVariants(out, T);
 }
 
 /// Emit a DTO's "exactly one of these fields" fork as `oneOf`, one
@@ -115,6 +116,66 @@ fn writeObjectBody(out: *Stringify, comptime T: type, comptime with_doc: bool) W
 /// `additionalProperties: false` is unaffected — in draft 2020-12 that
 /// keyword only considers `properties` declared in the same schema
 /// object, never a sibling subschema's.
+/// Emit a DTO's discriminated forks (#305): one `oneOf` per declared
+/// fork, conjoined under `allOf` when there is more than one.
+///
+/// Each arm pins the discriminator with `const` and states what that
+/// value requires or rules out. The arm matching the field's Zig default
+/// omits `required`, so an absent discriminator satisfies it and no
+/// other — which is what keeps `oneOf`'s "exactly one" honest for a
+/// field that may be left out.
+fn writeVariants(out: *Stringify, comptime T: type) Writer.Error!void {
+    if (!@hasDecl(T, "schema_variants")) return;
+    const sets = T.schema_variants;
+    comptime assert(sets.len >= 1);
+    try out.objectField("allOf");
+    try out.beginArray();
+    inline for (sets) |set| {
+        try out.beginObject();
+        try out.objectField("oneOf");
+        try out.beginArray();
+        inline for (set.branches) |branch| {
+            try writeVariantBranch(out, set.on, branch);
+        }
+        try out.endArray();
+        try out.endObject();
+    }
+    try out.endArray();
+}
+
+fn writeVariantBranch(
+    out: *Stringify,
+    comptime on: []const u8,
+    comptime branch: config.SchemaVariant,
+) Writer.Error!void {
+    try out.beginObject();
+    if (comptime !branch.default or branch.require.len >= 1) {
+        try out.objectField("required");
+        try out.beginArray();
+        // A non-default arm names the discriminator, or an absent one
+        // would satisfy every arm and the fork would reject what the
+        // loader accepts.
+        if (comptime !branch.default) try out.write(on);
+        inline for (branch.require) |name| try out.write(name);
+        try out.endArray();
+    }
+    try out.objectField("properties");
+    try out.beginObject();
+    try out.objectField(on);
+    try out.beginObject();
+    try out.objectField("const");
+    try out.write(branch.value);
+    try out.endObject();
+    inline for (branch.forbid) |name| {
+        try out.objectField(name);
+        // `false` accepts nothing, which is this dialect's way of saying
+        // the key has no meaning on this arm.
+        try out.write(false);
+    }
+    try out.endObject();
+    try out.endObject();
+}
+
 fn writeOneOf(out: *Stringify, comptime T: type) Writer.Error!void {
     if (!@hasDecl(T, "schema_one_of")) return;
     // `assertOneOfMatches` proved this at comptime; restated where the

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -244,6 +244,18 @@ fn writeStringShape(out: *Stringify, comptime meta: anytype) Writer.Error!void {
         try out.objectField("minLength");
         try out.write(meta.min_length);
     }
+    // The other half of the pair (#305). `min_length` shipped alone for
+    // as long as no field's ceiling was worth stating; the differential
+    // gate named two that were, and a bound the loader enforces and the
+    // schema omits is a rejection an editor cannot show you.
+    if (comptime @hasField(@TypeOf(meta), "max_length")) {
+        comptime assert(meta.max_length >= 1);
+        if (comptime @hasField(@TypeOf(meta), "min_length")) {
+            comptime assert(meta.max_length >= meta.min_length);
+        }
+        try out.objectField("maxLength");
+        try out.write(meta.max_length);
+    }
 }
 
 /// A slice field (`[]const Child`): an array with optional length bounds and
@@ -287,6 +299,22 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
             } else {
                 try out.objectField("type");
                 try out.write("string");
+                // Bounds on the *element*, not on the array — the field's
+                // own `min_length`/`max_length` would describe a string
+                // it does not have (#305). `access_log.request_headers`
+                // is the case that wanted this: the list is capped by
+                // `max_items` and each name by the loader, and only the
+                // second half was missing from the document.
+                if (comptime @hasField(@TypeOf(meta), "item_min_length")) {
+                    comptime assert(meta.item_min_length >= 1);
+                    try out.objectField("minLength");
+                    try out.write(meta.item_min_length);
+                }
+                if (comptime @hasField(@TypeOf(meta), "item_max_length")) {
+                    comptime assert(meta.item_max_length >= 1);
+                    try out.objectField("maxLength");
+                    try out.write(meta.item_max_length);
+                }
             }
         },
         // An integer element (the response-match `status` list, #175):

--- a/src/config_schema.zig
+++ b/src/config_schema.zig
@@ -128,6 +128,9 @@ fn writeVariants(out: *Stringify, comptime T: type) Writer.Error!void {
     if (!@hasDecl(T, "schema_variants")) return;
     const sets = T.schema_variants;
     comptime assert(sets.len >= 1);
+    // Each fork is a `oneOf`, and a `oneOf` needs arms to choose
+    // between — `assertVariantsMatch` refuses fewer than two.
+    inline for (sets) |set| comptime assert(set.branches.len >= 2);
     try out.objectField("allOf");
     try out.beginArray();
     inline for (sets) |set| {
@@ -148,6 +151,11 @@ fn writeVariantBranch(
     comptime on: []const u8,
     comptime branch: config.SchemaVariant,
 ) Writer.Error!void {
+    // `assertVariantsMatch` proved all three at comptime against the
+    // DTO's real fields; restated where this function depends on them.
+    comptime assert(on.len >= 1);
+    comptime assert(branch.value.len >= 1);
+    comptime assert(branch.require.len + branch.forbid.len >= 1);
     try out.beginObject();
     if (comptime !branch.default or branch.require.len >= 1) {
         try out.objectField("required");
@@ -373,6 +381,9 @@ fn writeItems(out: *Stringify, comptime Child: type, comptime meta: anytype) Wri
                 }
                 if (comptime @hasField(@TypeOf(meta), "item_max_length")) {
                     comptime assert(meta.item_max_length >= 1);
+                    if (comptime @hasField(@TypeOf(meta), "item_min_length")) {
+                        comptime assert(meta.item_max_length >= meta.item_min_length);
+                    }
                     try out.objectField("maxLength");
                     try out.write(meta.item_max_length);
                 }

--- a/src/json_schema.zig
+++ b/src/json_schema.zig
@@ -52,6 +52,7 @@ pub const Keyword = enum {
     minimum,
     maximum,
     minLength,
+    maxLength,
     minItems,
     maxItems,
     minProperties,
@@ -72,6 +73,7 @@ pub const Keyword = enum {
             .minimum,
             .maximum,
             .minLength,
+            .maxLength,
             .minItems,
             .maxItems,
             .minProperties,
@@ -103,6 +105,7 @@ pub const Failure = struct {
         below_minimum,
         above_maximum,
         too_short,
+        too_long,
         too_few_items,
         too_few_properties,
         too_many_items,
@@ -264,6 +267,11 @@ fn checkString(
     if (object.get("minLength")) |bound| {
         if (@as(f64, @floatFromInt(text.len)) < numberOf(bound).?) {
             return path.fail(.too_short);
+        }
+    }
+    if (object.get("maxLength")) |bound| {
+        if (@as(f64, @floatFromInt(text.len)) > numberOf(bound).?) {
+            return path.fail(.too_long);
         }
     }
     return null;

--- a/src/json_schema.zig
+++ b/src/json_schema.zig
@@ -49,6 +49,7 @@ pub const Keyword = enum {
     @"const",
     oneOf,
     anyOf,
+    allOf,
     minimum,
     maximum,
     minLength,
@@ -83,7 +84,7 @@ pub const Keyword = enum {
             // nothing to accept.
             .items, .additionalProperties => .schema,
             .properties => .schema_map,
-            .oneOf, .anyOf => .schema_list,
+            .oneOf, .anyOf, .allOf => .schema_list,
         };
     }
 };
@@ -111,6 +112,9 @@ pub const Failure = struct {
         too_many_items,
         no_branch_matched,
         many_branches_matched,
+        /// A `false` schema, which nothing satisfies — how this dialect
+        /// says a key is forbidden in the branch it appears under.
+        forbidden,
     };
 };
 
@@ -200,10 +204,14 @@ fn check(
     // overflow — the emitter's own output is checked against it by the
     // census, so a breach here is a document from somewhere else.
     assert(depth < depth_max);
-    // A schema that is not an object constrains nothing in this dialect;
-    // the emitter never writes one, and the census proves it.
+    // A boolean *is* a schema in draft 2020-12: `true` accepts anything
+    // and `false` accepts nothing. The emitter writes `false` to forbid
+    // a key inside a variant branch (#305) — `{"path": false}` under a
+    // `sink: "stdout"` arm says a stdout sink has no path — which is the
+    // whole reason this arm exists.
     const object = switch (schema) {
         .object => |map| map,
+        .bool => |accepts| return if (accepts) null else path.fail(.forbidden),
         else => return null,
     };
     if (object.get("type")) |wanted| {
@@ -385,6 +393,13 @@ fn checkCombinators(
         }
         if (!matched) {
             return path.fail(.no_branch_matched);
+        }
+    }
+    if (object.get("allOf")) |branches| {
+        for (branches.array.items) |branch| {
+            if (check(branch, instance, path, depth + 1)) |failure| {
+                return failure;
+            }
         }
     }
     if (object.get("oneOf")) |branches| {
@@ -632,6 +647,43 @@ test "json schema: oneOf is exactly one, which is the whole point of it" {
     try expectValid(schema, "{\"l4\":{}}");
     try expectInvalid(schema, "{}", .no_branch_matched, "");
     try expectInvalid(schema, "{\"http\":{},\"l4\":{}}", .many_branches_matched, "");
+}
+
+test "json schema: a variant branch pins a discriminator and forbids a key" {
+    // The shape #305's remaining forks take: one arm per value of a
+    // discriminating field, each naming what that value requires and
+    // what it rules out. `false` is how the ruling-out is said, and
+    // `allOf` is how two independent forks over the same object are
+    // conjoined without either shadowing the other.
+    const schema =
+        \\{"type":"object","properties":{"sink":{"type":"string"},"path":{"type":"string"}},
+        \\ "oneOf":[
+        \\  {"required":["sink"],"properties":{"sink":{"const":"stdout"},"path":false}},
+        \\  {"required":["sink","path"],"properties":{"sink":{"const":"file"}}}]}
+    ;
+    try expectValid(schema, "{\"sink\":\"stdout\"}");
+    try expectValid(schema, "{\"sink\":\"file\",\"path\":\"/var/log/z\"}");
+    // A file sink with nowhere to write: the rejection the loader used
+    // to own alone.
+    try expectInvalid(schema, "{\"sink\":\"file\"}", .no_branch_matched, "");
+    // And a stdout sink carrying a path it cannot use.
+    try expectInvalid(
+        schema,
+        "{\"sink\":\"stdout\",\"path\":\"/var/log/z\"}",
+        .no_branch_matched,
+        "",
+    );
+}
+
+test "json schema: allOf conjoins, and a false schema refuses on its own" {
+    try expectValid("true", "{}");
+    try expectInvalid("false", "{}", .forbidden, "");
+    const schema =
+        \\{"allOf":[{"type":"object"},{"required":["a"]}]}
+    ;
+    try expectValid(schema, "{\"a\":1}");
+    try expectInvalid(schema, "{}", .missing_required, "a");
+    try expectInvalid(schema, "[]", .type_mismatch, "");
 }
 
 test "json schema: bounds, enums and item counts" {


### PR DESCRIPTION
Takes the differential gate's two debt categories from 14 forks + 4 bounds to **zero**. Four commits, each with the full gate green.

## Two of the eighteen were never debt

`FilterHeaderEditsOverLimit` and its response twin cap the **sum** of header edits across a whole filter table — `header_edits += countHeaderEdits(rule.actions)` over every rule, compared to one constant. No schema sums across an array of objects. I filed them under `expressible_bound` when the table was first measured, which overstated the payable debt by two; they belong with the other closed-form arithmetic in `budget`.

## The cheap four

- **`BodyJson` never declared the fork its own doc comment describes.** "bytes from a file, or an inline string — exactly one of the two" was prose the loader enforced and the schema did not, when `schema_one_of` has emitted that shape since Part 1. One line, two rows.
- **`maxLength` shipped with only half its pair.** `min_length` existed and nothing bounded a string from above. Two fields wanted it, and one wanted it on the array *element* rather than the field, so `item_min_length`/`item_max_length` came with it.

## The eight forks

One shape of problem — a field required exactly when a sibling takes a given value — and one mechanism. `SchemaVariants` declares a fork per discriminator; each arm pins the value with `const` and names what it requires or rules out. Ruling out is a `false` schema, which nothing satisfies. Several forks on one object are conjoined with `allOf`, because `pick` forks twice and neither may shadow the other.

```
access_log   sink=stdout forbids path, sink=file requires it
check        type=tcp (default) forbids path and host, type=http requires path
pick         policy p2c/rr forbid key and name, hash requires key;
             key=source_ip (default) forbids name, header/cookie require it
```

**The `default` rule is the subtlety.** A defaulted discriminator may be absent, and an absent field satisfies every arm's `properties` vacuously — so without it `oneOf` would see three matches and reject a config the loader accepts. The default arm alone omits `required` and tolerates absence; every other names the discriminator.

**One row needed more than a fork.** `AccessLogPathMissing` is raised for a *missing* path and an *empty* one, and the fork caught only the first — the gate kept failing on `{"sink":"file","path":""}` until `path` gained the `min_length` its siblings already had. That is exactly the ambiguity the gap table's doc comment warns about, met in practice: one error, several cases, and a row cannot go until every case is covered.

## The last four were a type bug

`ResponseFilterJson.actions` was `[]const ActionJson` — the **request** action union — and the resolver then refused four of its seven members one at a time. `reject`, `redirect` and `respond` decide what to send instead of asking the origin; `rewrite_prefix` changes what is asked; a response rule runs when the origin has already answered.

`ResponseActionJson` has the three members that mean something. The four states stop being representable, the four rules go with them, and the strict parser gives the verdict — which the schema states too, for free. This is the one change here worth making even if the schema did not exist.

## Review findings, all applied

- **`ResponseActionJson` was not in `dto_types`**, so `assert_meta_matches` never ran on it. The metadata happened to be right; the safety net was simply gone.
- **`schema_variants` had no comptime check** where `schema_one_of` has `assertOneOfMatches` — a typo in `on`/`require`/`forbid` emitted a keyword naming a field that does not exist, a dead constraint that reads like a live one. `assertVariantsMatch` now refuses that, plus a fork with fewer than two arms, an arm that requires and forbids the same key, and — the one with teeth — a discriminator that can be absent without exactly one `.default` arm, or a required one with any. Both arms verified to fail the build.
- **Two stale doc claims**: DESIGN §7 still said the loader "refuses those arms by name" for response filters, and `SchemaGap`'s block comment still described live debt.
- `SchemaVariant.default`'s doc claimed the arm matches the field's *Zig* default. `PickJson.key` defaults to `null`, not `"source_ip"` — the marked arm is the loader's *resolved* fallback, sound only because the sibling fork on `policy` requires `key` whenever the policy is `hash`. That reasoning is written down now rather than relied on silently.
- `ResponseActionJson`'s member check compared names while claiming to compare meaning; it compares types now.

## Why zero is the useful number

Above zero the pin said how much work remained. At zero it says a new cross-field rule cannot be added without either giving it a shape or arguing, in `schema_gaps`, why a schema cannot follow — which is the discipline #305 was asking for rather than the tally.

The seven closed categories keep their 65 rows, and they are correct: no document grammar parses an address, sums a list, resolves a name into another block, computes canonical equality, reads the filesystem, bounds an object key, or holds two blocks at once.

## Gates

`zig build ci` green after each commit, `zig fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)