### PR TITLE
§8: a watchdog for the phase the process lives in (#311)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2551,6 +2551,52 @@ The simulator models the alarm as a deadline its run loop checks directly
 rather than a pending op, which is what lets §9 strand every timer a
 schedule has and still demand a diagnostic instead of a hang.
 
+### The serving loop has the same backstop (#311)
+
+Everything above bounds a *drain*. The phase a process spends its life in
+had nothing: every deadline zoxy owns is an op the loop delivers, so a
+loop that stops delivering stops delivering the one that would have said
+so, and the observable result is a process that is alive, health-checked,
+holding its listeners and answering none of them. `SO_REUSEPORT` makes it
+worse rather than better — the kernel keeps hashing new connections onto
+a process that has stopped serving them, so one stalled instance degrades
+the group instead of shedding to its siblings. A process that exits is
+replaced; a process that hangs is not.
+
+So `timeouts.loop_watchdog_ms` arms the same `alarm(2)`, and a timer the
+loop *does* have to deliver refreshes it every half-bound. A loop that
+keeps ticking never lets the alarm land; a loop that stops refreshing
+gets one line on stderr and `_exit` **6** — the third code, and distinct
+for the reason the other two are: 4 is a drain that could not finish and
+named what held it, 5 is a loop that stopped answering during a drain, 6
+is a loop that stopped answering while it was serving traffic.
+
+What that proves is *delivery*, not progress: a loop can tick while doing
+nothing useful and this would not notice. That is the honest reading of
+the mechanism, and it is the failure actually seen (#310 — a synchronous
+write to a pipe nobody was draining, which parked the loop in `writev`
+for as long as the reader took).
+
+**Absent is off**, which is why the key is optional rather than a zero:
+the mechanism has a floor — `alarm(2)` counts whole seconds and the
+refresh takes half the bound — so the legal values are "none" and "at
+least `loop_watchdog_ms_min`", with nothing between. Opt-in for #226's
+reason in the other direction: the process this kills is one an operator
+has no other way to notice, but a bound nobody named is a restart this
+proxy chose on their behalf, and what counts as a stall is a property of
+the box rather than of the proxy.
+
+The two watchdogs share the one alarm a process has, so the serving one
+stands down at `beginDrain`: the drain arms its own, or — on the uncapped
+branch, which arms none — the alarm is cancelled outright. An operator
+who declined `drain_deadline_ms` asked for a wait with no bound, and a
+watchdog still counting down into it would overrule that.
+
+Its refresh tick is charged to the ring budget unconditionally
+(`inFlightOps`, §5), armed or not: a budget that moved with a `timeouts`
+key would make the ring depth a property of watchdog policy, and turning
+a backstop on must never be the thing that refuses a config.
+
 ## 9. Testing — required from day 0
 
 The deterministic-simulation seam is the single highest-leverage testing

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -445,6 +445,67 @@ the strand hit. Disarming the watchdog fails exactly
 those two with `error.Deadlock`, which is what the whole class looked like
 before this existed.
 
+### The serving loop gets the same watchdog (#311)
+
+#226 built the mechanism and armed it for one phase. This arms it for the
+phase the process spends its life in, and the decisions worth recording
+are the three that were not obvious.
+
+**What refreshes it is a timer op, not a tick.** The issue's own sketch
+was per-tick, and per-tick is wrong twice here. `XevIo.run` is one
+`loop.run(.until_done)` call, so there is no tick to hook without turning
+it into a manual `.once` loop — and `.once` *blocks* until a completion
+arrives, so an idle proxy would sit in the wait, refresh nothing, and be
+killed for having no traffic. A timer the loop delivers has neither
+problem: it fires whether or not anyone is connected, and the loop
+delivering it is exactly the liveness being claimed. It costs one ring op,
+charged unconditionally in `inFlightOps` — which moved the listener
+ceiling in `cqFillFits` by one, and that test pins the new pair.
+
+**Half the bound, so one late tick is not a kill.** The alarm is re-armed
+at the full bound every half of it, so a delivery has to be missed twice
+before the kernel lands it. That division is also where
+`loop_watchdog_ms_min` comes from rather than taste: the seam refuses an
+alarm under a second (`alarm(2)` counts whole seconds, and rounding a
+finer bound would hand back a backstop nobody asked for), so the smallest
+bound whose refresh still clears that floor is two seconds.
+
+**The sweep does not arm it, deliberately.** Putting it in the 4096-seed
+draw looked free and is not: a tick every second of virtual time mixes
+into every seed's trace, so all 4096 schedules shift and the coverage this
+gate has accumulated goes with them. Worse, `.timer` is in the strand draw
+— the seeds that strand it are the ones that reach #226's drain watchdog,
+and a serving watchdog armed over them would end those runs in its own
+give-up instead. So the sweep stays as it was and the mechanism is gated
+by two directed simulator tests plus the live leg below.
+
+**What the live gate can say that the simulator cannot.** The simulator
+proves the wiring — strand the timer plane and the give-up still happens —
+but a virtual clock cannot be blocked, so it cannot show a real process
+that has stopped executing. `SIGSTOP` can: the process is off the CPU
+entirely, `alarm(2)` keeps counting because it is the kernel's clock, and
+on `SIGCONT` the pending SIGALRM is delivered before the process resumes
+what it was doing, so the handler wins the race against the refresh by
+construction rather than by timing. The smoke gate spawns a second proxy
+at the floor, stops it, and asserts exit 6 with the line. #310's
+provocation would have worked too, but it was fixed; this one needs no
+defect to exist.
+
+**It found one thing before it fired.** `main` installed its signal
+handlers *after* `Server.start`, and the seam refuses to arm an alarm
+whose handler is not installed (SIGALRM's default action is to terminate,
+so arming one first would turn a stall into a silent death). The order is
+now handlers-then-start, which also means a SIGTERM arriving during
+startup is recorded and drained rather than killing a process mid-bind.
+
+**Open: it proves delivery, not progress.** A loop that ticks while making
+no progress passes this, and refreshing on *completions delivered*
+instead would be a stronger claim and a fussier one — an idle proxy
+legitimately delivers nothing for a long time, so the refresh would need a
+notion of "idle" that this deliberately does not have. Delivery is the
+failure that has actually been seen (#310: a synchronous write parked in
+`writev`), so the weaker claim is the one worth shipping first.
+
 ### Rotating from the seal (#202)
 
 The interval was the open question, not the mechanism — six hours against

--- a/docs/README.md
+++ b/docs/README.md
@@ -1311,6 +1311,24 @@ dial or idle budget is a mistake rather than a policy.
 | `request_ms` | `0` | cap on one L7 exchange, **not** refreshed by activity — bounds a request that is merely slow, where `idle_ms` only bounds one that has stalled; `0` disables |
 | `tunnel_ms` | `3600000` | whole life of a [tunnelled upgrade](#tunnelled-upgrades-websocket), replacing the three above once one is established; 1 s to 1 day, and `0` is **not** legal |
 | `health_interval_ms` | `2000` | pause between health-probe sweeps |
+| `loop_watchdog_ms` | absent | kill this process if its event loop completes nothing for this long. Absent is off; 2 s minimum |
+
+`loop_watchdog_ms` is the one deadline here that is not about a
+connection. Every other row is a timer the event loop delivers, so none of
+them can bound the loop itself — a loop parked in a blocking call delivers
+nothing, including the timer that would have reported it, and what you see
+is a process that is alive, passing health checks, holding its listeners
+and answering nothing. Set this and the kernel gets a bound the loop
+cannot silence: `alarm(2)`, pushed out by a tick the loop has to deliver,
+which fires only when the loop stops. The process writes one line to
+stderr and exits **6**, so a supervisor replaces it.
+
+Off unless you name a number, because what counts as a stall is a
+property of your box — one that swaps has longer legitimate pauses than
+one that does not — and a false positive restarts a healthy proxy. Under
+`SO_REUSEPORT` it earns itself fastest: the kernel keeps hashing new
+connections onto a stalled process, so one that exits is replaced while
+one that hangs takes its share of the group down with it.
 
 `drain_deadline_ms` defaults to waiting indefinitely because there is no
 figure to borrow: nginx, HAProxy and Caddy all wait forever by default,
@@ -1663,6 +1681,10 @@ dies.** Every limit has a defined answer rather than an unbounded queue.
   shedding, so clients get an immediate signal rather than a timeout.
 - **`SIGTERM` drains.** Listeners close, keep-alive stops being honored,
   in-flight work finishes under `drain_deadline_ms`, then the process exits 0.
+- **A stalled loop is a death, not a hang** — if you ask for one.
+  `timeouts.loop_watchdog_ms` arms an `alarm(2)` that a tick the loop
+  delivers keeps pushing out, so a loop that stops delivering is ended by
+  the kernel with exit **6** and one line on stderr. Off unless configured.
 - **The budget is printed, not hoped for.** Startup prints the closed-form
   memory, file-descriptor and ring-op totals it will never exceed, and
   asserts the fd count against `RLIMIT_NOFILE` before serving anything.

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -838,6 +838,19 @@ fn deriveServerConfig(
             idle_timeout_ms,
         ),
         .drain_deadline_ms = deriveDrainDeadlineMs(harness.drain_at_ns, random),
+        // #311's serving watchdog is off for the whole sweep, and not
+        // because it is untested — `server_test.zig` provokes it and
+        // asserts the exit code. It is off because arming it here would
+        // change what this gate *measures*: a tick every second of
+        // virtual time mixes into every seed's trace, so all 4096
+        // schedules would shift and the coverage this sweep has
+        // accumulated would go with them. Worse, `.timer` is in the
+        // strand draw (#226) — the seeds that strand it are the ones that
+        // reach the drain watchdog, and a serving watchdog armed over
+        // them would end those runs in its own give-up instead, which is
+        // the sweep's most interesting cases answering a different
+        // question.
+        .loop_watchdog_ms = 0,
         // The §6 age cap: measured from the connection's birth, so the
         // clamp sometimes reaps an actively-relaying connection.
         .max_lifetime_ms = deriveOptionalDeadlineMs(random),

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -42,6 +42,11 @@ const work_directory = ".zig-cache/zoxy-smoke";
 const config_path = work_directory ++ "/zoxy.json";
 const access_log_path = work_directory ++ "/access.log";
 const zoxy_log_path = work_directory ++ "/zoxy.log";
+/// #311's leg runs a second proxy of its own, so it needs its own config
+/// and its own output: the point of that leg is a process that *dies*,
+/// and it must not be the one every other verdict here is reading.
+const watchdog_config_path = work_directory ++ "/watchdog.json";
+const watchdog_log_path = work_directory ++ "/watchdog.log";
 
 /// The #159 bodies this run configures. `robots_body` goes through the
 /// **file** arm — written here, read by the real binary at startup — so
@@ -238,6 +243,21 @@ const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2 
 /// the load is finished before SIGTERM is sent.
 const drain_deadline_ms: u32 = 300;
 
+/// #311's serving watchdog, armed for the whole run. The assertion it
+/// carries is the *negative* one, and it is the only tier that can make
+/// it: this gate spawns the real binary, so a watchdog that fired
+/// spuriously would take the process down and every verdict after it
+/// would fail — including the drain's own "exited 0". A simulator cannot
+/// say that, because the thing being claimed is that nothing real
+/// blocked the loop for this long.
+///
+/// Eight seconds, well above anything this run legitimately pauses for
+/// and well under the harness's own wedge deadline. A tighter number
+/// would be measuring the runner's scheduler rather than zoxy: the
+/// positive leg (`loopWatchdogPassed`) takes the floor instead, on a
+/// process it stops on purpose.
+const loop_watchdog_ms: u32 = 8_000;
+
 /// zoxy's pools, shrunk from the lean defaults (§5). Nothing here is a
 /// scenario — the load is a handful of connections — so the smallest
 /// config that serves it starts fastest and keeps the process's resident
@@ -335,7 +355,32 @@ comptime {
 /// most wants to catch loudly (a proxy that will not drain, #130's
 /// neighbourhood) is exactly the one that would otherwise wedge a build
 /// step until CI's own timeout killed it with no diagnosis.
-const watchdog_budget_ns: u64 = 30 * std.time.ns_per_s;
+const watchdog_budget_ns: u64 = 30 * std.time.ns_per_s + loop_watchdog_stall_ns;
+
+/// #311's leg, and the numbers it rests on.
+///
+/// The proxy under it is configured at the floor — the shortest bound the
+/// mechanism can express — because this is the one place a *tight*
+/// watchdog is safe: the process is stopped deliberately, so the stall is
+/// not the runner's scheduler being slow, it is `SIGSTOP`.
+const loop_watchdog_leg_ms: u32 = 2_000;
+
+/// How long the leg holds the proxy stopped. The alarm is refreshed every
+/// half-bound, so at the moment `SIGSTOP` lands it has somewhere between
+/// half a bound and a whole one left to run — `alarm(2)` counts real time
+/// and a stopped process does not stop the clock, so waiting a full bound
+/// past the longest of those is certain, and the rest is margin for a
+/// loaded runner's `SIGCONT` taking its time.
+const loop_watchdog_stall_ns: u64 =
+    (@as(u64, loop_watchdog_leg_ms) + 1_500) * std.time.ns_per_ms;
+
+/// What zoxy exits with when its serving watchdog fires (#311, §8), and
+/// what this leg is really asserting: 4 is a drain that could not finish,
+/// 5 is a loop that stopped answering during one, 6 is a loop that
+/// stopped answering while serving. Spelled out here rather than imported
+/// because this harness links no zoxy at all (§9) — it runs the real
+/// binary and reads what a supervisor would.
+const loop_watchdog_exit_code: u8 = 6;
 
 /// The origin's serve tasks take its address, and the clients hold
 /// readers and writers pointing into their own buffers — both want
@@ -378,6 +423,7 @@ const Stage = enum {
     https_request,
     https_close_notify,
     https_scrape,
+    watchdog_leg,
     drain,
     verdicts,
 
@@ -391,6 +437,7 @@ const Stage = enum {
             .sticky_leg => "the sticky leg (#178)",
             .bodies_leg => "the bodies leg (#159)",
             .https_handshake => "the https handshake",
+            .watchdog_leg => "the loop-watchdog leg (#311)",
             .https_request => "an https request",
             .https_close_notify => "the https close_notify",
             .https_scrape => "the https leg's scrape",
@@ -492,6 +539,12 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     // cannot cost the legs above their verdicts.
     const tls_ok = try tlsPassed(arena, io, &ports);
 
+    // Its own proxy, its own port, and it ends by killing it — so it runs
+    // after every leg that needs the main child alive, and before the
+    // drain that ends it.
+    enterStage(.watchdog_leg);
+    const watchdog_ok = try loopWatchdogPassed(arena, io, flags.zoxy_path);
+
     enterStage(.drain);
     const drained_cleanly = try drain(io, &child, &running);
     enterStage(.verdicts);
@@ -502,7 +555,7 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
     const passed = log_ok and counters.passed and sticky_ok and bodies_ok and
-        tls_ok and memory_ok and drain_ok and check_ok;
+        tls_ok and memory_ok and drain_ok and check_ok and watchdog_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -525,7 +578,8 @@ fn report(
     var memory_buffer: [64]u8 = undefined;
     std.debug.print(
         "smoke: {d} http + {d} l4 exchanges, {d} access-log lines, counters reconcile, " ++
-            "{d} probes in {d}ms, {s}, --check agrees, clean drain\n",
+            "{d} probes in {d}ms, {s}, --check agrees, watchdog ended a stopped " ++
+            "proxy, clean drain\n",
         .{
             lines.http,
             lines.l4,
@@ -1645,6 +1699,140 @@ fn readAccessLog(arena: std.mem.Allocator, io: Io) !LogCounts {
     return counts;
 }
 
+/// #311's positive leg: stop the loop for real, and watch the kernel
+/// finish the sentence.
+///
+/// This is the only tier that can make this claim. The simulator models
+/// the alarm as a deadline its run loop compares a virtual clock against,
+/// which proves the *wiring* — a stranded timer plane still reaches the
+/// give-up — but a virtual clock cannot be blocked, so what it cannot
+/// show is a real process, in a real kernel, that has stopped executing.
+/// `SIGSTOP` is exactly that: the process is off the CPU entirely, no
+/// completion is delivered, no timer runs, and `alarm(2)` keeps counting
+/// because it is the kernel's clock and not the loop's. On `SIGCONT` the
+/// pending SIGALRM is delivered before anything else the process was
+/// going to do, so the handler wins the race against the refresh by
+/// construction rather than by timing.
+///
+/// A separate proxy with its own config, port and log, because the
+/// assertion is that it *dies* — running this against the main child
+/// would take every verdict after it.
+fn loopWatchdogPassed(arena: std.mem.Allocator, io: Io, zoxy_path: []const u8) !bool {
+    const port = try reserveWatchdogPort(io);
+    try writeWatchdogConfig(arena, io, port, origin.port);
+    var child = try spawnWatchdogZoxy(io, zoxy_path);
+    var running = true;
+    // Every early return below leaves a stopped or dying process behind,
+    // and an orphan holding a port is what the next run trips over.
+    defer if (running) child.kill(io);
+    assert(child.id != null);
+    try awaitListening(io, port);
+
+    try std.posix.kill(child.id.?, .STOP);
+    // `try`, where the rest of this harness shrugs a sleep off as pacing:
+    // here the sleep *is* the argument. A short one would `SIGCONT` the
+    // proxy before the alarm was certain to have expired, and the leg
+    // would then report a watchdog that did not fire as a failure of the
+    // watchdog rather than of its own timing.
+    try io.sleep(Io.Duration.fromNanoseconds(loop_watchdog_stall_ns), .awake);
+    try std.posix.kill(child.id.?, .CONT);
+    const term = try child.wait(io);
+    running = false;
+
+    if (term != .exited or term.exited != loop_watchdog_exit_code) {
+        std.debug.print(
+            "FAIL: the loop watchdog (#311) did not end the stopped proxy: {any}\n",
+            .{term},
+        );
+        return false;
+    }
+    // The exit code is what a supervisor reads; the line is what an
+    // operator reads. A watchdog that took the process down without
+    // saying which silence it was reporting would be the hang it
+    // replaced, one layer down.
+    const said_so = try watchdogLogMentions(arena, io, "#311");
+    if (!said_so) {
+        std.debug.print(
+            "FAIL: the loop watchdog exited {d} without naming itself on stderr\n",
+            .{loop_watchdog_exit_code},
+        );
+    }
+    return said_so;
+}
+
+/// Whether the stopped proxy's own output carries `needle`. Read whole:
+/// this log is a banner and at most one watchdog line.
+fn watchdogLogMentions(arena: std.mem.Allocator, io: Io, needle: []const u8) !bool {
+    const bytes_max: usize = 64 * 1024;
+    const text = Io.Dir.cwd().readFileAlloc(
+        io,
+        watchdog_log_path,
+        arena,
+        .limited(bytes_max),
+    ) catch return false;
+    return std.mem.indexOf(u8, text, needle) != null;
+}
+
+/// One more kernel-assigned port, on `reservePorts`' terms and for its
+/// reason — this leg binds a listener of its own while the main proxy
+/// still holds all four of that one's.
+fn reserveWatchdogPort(io: Io) !u16 {
+    var address: Io.net.IpAddress = .{ .ip4 = .loopback(0) };
+    var listener = try address.listen(io, .{ .mode = .stream });
+    const port = listener.socket.address.getPort();
+    listener.deinit(io);
+    assert(port != 0);
+    return port;
+}
+
+/// The smallest config that serves: one http listener, one cluster, and
+/// the watchdog this leg is about. Deliberately not the main template —
+/// nothing here needs TLS, an access log, health checks or filters, and a
+/// config that carried them would put failure modes into a leg whose one
+/// job is to be stopped.
+fn writeWatchdogConfig(
+    arena: std.mem.Allocator,
+    io: Io,
+    port: u16,
+    origin_port: u16,
+) !void {
+    assert(port != 0);
+    assert(origin_port != 0);
+    const config_json = try std.fmt.allocPrint(arena, watchdog_config_template, .{
+        port,
+        origin_port,
+        loop_watchdog_leg_ms,
+    });
+    try Io.Dir.cwd().writeFile(io, .{
+        .sub_path = watchdog_config_path,
+        .data = config_json,
+    });
+}
+
+const watchdog_config_template =
+    \\{{
+    \\    "listeners": [
+    \\        {{ "bind": "127.0.0.1:{d}", "http": {{
+    \\          "routes": [{{ "prefix": "/", "cluster": "origin" }}] }} }}
+    \\    ],
+    \\    "clusters": {{ "origin": {{ "endpoints": ["127.0.0.1:{d}"] }} }},
+    \\    "timeouts": {{ "loop_watchdog_ms": {d} }}
+    \\}}
+;
+
+/// `spawnZoxy` for the leg's own child: its own log, so the main proxy's
+/// output stays the thing `printZoxyLog` shows a failing run.
+fn spawnWatchdogZoxy(io: Io, zoxy_path: []const u8) !std.process.Child {
+    assert(zoxy_path.len >= 1);
+    const log_file = try Io.Dir.cwd().createFile(io, watchdog_log_path, .{});
+    defer log_file.close(io);
+    return std.process.spawn(io, .{
+        .argv = &.{ zoxy_path, watchdog_config_path },
+        .stdout = .{ .file = log_file },
+        .stderr = .{ .file = log_file },
+    });
+}
+
 /// Two loopback ports the kernel is not using, held open together so it
 /// cannot hand out the same one twice, then released for zoxy to bind.
 /// There is a window between the release and zoxy's bind; nothing can
@@ -1700,6 +1888,7 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
         access_log_path,
         health_interval_ms,
         drain_deadline_ms,
+        loop_watchdog_ms,
         zoxy_limits.conn_slots,
         zoxy_limits.relay_buffers,
         zoxy_limits.upstream_slots,
@@ -1755,7 +1944,8 @@ const config_template =
     \\        "connect_ms": 2000,
     \\        "idle_ms": 30000,
     \\        "health_interval_ms": {d},
-    \\        "drain_deadline_ms": {d}
+    \\        "drain_deadline_ms": {d},
+    \\        "loop_watchdog_ms": {d}
     \\    }},
     \\    "limits": {{
     \\        "conn_slots": {d},

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -321,6 +321,12 @@ pub fn Server(comptime IoType: type) type {
         /// The backstop behind that deadline: a teardown that cannot
         /// finish has nothing else watching it (#203, `onDrainStuck`).
         drain_stuck_completion: IoType.Completion,
+        /// #311's serving watchdog, which is a tick rather than a
+        /// deadline: it refreshes an alarm the kernel owns, so what it
+        /// proves is that the loop is still delivering *something*.
+        /// Armed for the whole serving phase when a config names a bound,
+        /// and never re-armed once the drain starts (§8).
+        loop_watchdog_completion: IoType.Completion,
         /// The one timer covering every parked upstream (§5): a parked
         /// connection holds no armed op, so this sweep compares stored
         /// deadlines against the clock and reaps overdue connections with
@@ -857,6 +863,7 @@ pub fn Server(comptime IoType: type) type {
             server.last_pressure_errno = 0;
             server.drain_deadline_completion = .{};
             server.drain_stuck_completion = .{};
+            server.loop_watchdog_completion = .{};
             server.upstream_sweep_completion = .{};
             server.upstream_sweep_armed = false;
             assert(!server.draining);
@@ -1105,7 +1112,105 @@ pub fn Server(comptime IoType: type) type {
             try server.admin.start();
             server.health.start();
             server.io.signalWait(Self, server, onSignal);
+            // Last, and after every op above is armed: the watchdog bounds
+            // a loop that has work to deliver, so arming it before there
+            // is any would be counting a startup that has not finished
+            // against a proxy that has not begun.
+            if (server.config.loop_watchdog_ms != 0) server.armLoopWatchdog();
         }
+
+        /// #311's serving watchdog: the one bound in this proxy that is
+        /// not an op.
+        ///
+        /// Every deadline the server owns — the idle timer, the request
+        /// deadline, the drain's own two — is submitted to the loop and
+        /// delivered by it, so none of them can bound the loop itself. A
+        /// loop parked in a blocking syscall delivers nothing, including
+        /// the timer that would have said so, and the observable result
+        /// is a process that is alive, health-checked, holding its
+        /// listeners and answering none of them. Worse under
+        /// `SO_REUSEPORT`, where the kernel keeps hashing new connections
+        /// onto it: a process that exits is replaced, a process that
+        /// hangs takes its share of the group down with it.
+        ///
+        /// So the bound is `alarm(2)`, which the kernel raises whatever
+        /// this process is doing, and the thing that keeps pushing it out
+        /// is a timer the loop *does* have to deliver. A loop that keeps
+        /// ticking never lets the alarm land; a loop that stops delivering
+        /// stops refreshing, and the kernel finishes the sentence.
+        ///
+        /// What it proves is delivery, not progress — a loop can tick
+        /// while doing nothing useful, and this would not notice. That is
+        /// the honest reading of the mechanism and it is the failure
+        /// actually seen in the field (#310): not a busy loop, a blocked
+        /// one.
+        ///
+        /// Only when the operator names a bound. #226's lesson in the
+        /// other direction: a watchdog nobody asked for is a restart this
+        /// proxy chose on its own, and the number depends on what the
+        /// deployment considers a stall — a box that swaps has longer
+        /// legitimate pauses than one that does not.
+        fn armLoopWatchdog(server: *Self) void {
+            assert(!server.draining);
+            assert(server.config.loop_watchdog_ms != 0);
+            assert(server.config.loop_watchdog_ms >= constants.loop_watchdog_ms_min);
+            const bound_ns = @as(u64, server.config.loop_watchdog_ms) *
+                std.time.ns_per_ms;
+            // Re-arming replaces the pending alarm — `alarm(2)`'s own
+            // contract, and what makes the refresh one syscall instead of
+            // a cancel and an arm.
+            server.io.alarmStart(bound_ns, loop_watchdog_exit_code, .loop_stalled);
+            // Half the bound, so a tick has to be missed *twice* before
+            // the alarm lands and one late delivery is not a kill. It is
+            // also why `loop_watchdog_ms_min` is what it is: the seam
+            // refuses an alarm under a second, and this is the division
+            // that has to clear it.
+            const refresh_ns = bound_ns / 2;
+            assert(refresh_ns >= std.time.ns_per_s);
+            assert(refresh_ns < bound_ns);
+            server.io.timerStart(
+                &server.loop_watchdog_completion,
+                refresh_ns,
+                Self,
+                server,
+                onLoopWatchdogTick,
+            );
+        }
+
+        /// The loop is alive: push the alarm out and ask again.
+        ///
+        /// Reaching this at all is the whole signal. It carries no state
+        /// and inspects nothing — a tick that had to read the server to
+        /// decide anything would be a tick that could fail for reasons
+        /// other than the loop stopping.
+        fn onLoopWatchdogTick(server: *Self, result: Io.TimerError!void) void {
+            // Only ever armed by `armLoopWatchdog`, which the config gates
+            // — so reaching here without one is a tick from a watchdog
+            // that was never configured.
+            assert(server.config.loop_watchdog_ms != 0);
+            // Nothing cancels this timer: the drain lets the last one
+            // expire rather than reaping it, for the same reason the
+            // drain deadline is never cancelled either.
+            result catch unreachable;
+            // The drain owns the alarm from `beginDrain` onward, and the
+            // two want different bounds — a drain legitimately takes
+            // longer than a serving tick, so refreshing here would keep
+            // resetting a deadline the drain watchdog set deliberately.
+            // Standing down is also what leaves an uncapped drain
+            // uncapped: the operator who declined `drain_deadline_ms`
+            // asked for a wait with no bound, and a serving watchdog that
+            // kept firing into it would overrule that (§8).
+            if (server.draining) return;
+            server.armLoopWatchdog();
+        }
+
+        /// Distinct from the drain's two so a supervisor reading a status
+        /// with no output can tell the three silences apart: 4 is a drain
+        /// that could not finish and said which plane held it, 5 is a
+        /// loop that stopped answering *during* a drain, 6 is a loop that
+        /// stopped answering while serving traffic — the one that means
+        /// the connections it was holding were live.
+        pub const loop_watchdog_exit_code: u8 = 6;
 
         /// Drain, not just death (§8): close listeners (armed accepts
         /// cancel), let admitted work finish under one server-owned drain
@@ -1147,6 +1252,15 @@ pub fn Server(comptime IoType: type) type {
                 );
                 server.armDrainWatchdog();
             } else {
+                // No drain watchdog to take the alarm over, so #311's
+                // serving one has to let go of it here rather than at its
+                // next tick — which may be a second away, and by then the
+                // alarm it armed is counting down against a drain the
+                // operator explicitly declined to bound. Unconditional:
+                // `alarmCancel` on an unarmed alarm is a no-op on both
+                // sides of the seam, so this does not have to ask whether
+                // the watchdog was configured.
+                server.io.alarmCancel();
                 if (server.tunnel_buffers.slots.len >= 1) {
                     // A zero deadline says "wait for the last connection",
                     // and a tunnel has no message boundary to be the last
@@ -1273,6 +1387,7 @@ pub fn Server(comptime IoType: type) type {
             server.io.alarmStart(
                 deadline_ns + drain_stuck_grace_ns + drain_watchdog_margin_ns,
                 drain_watchdog_exit_code,
+                .drain_stalled,
             );
         }
 

--- a/src/access_log_test.zig
+++ b/src/access_log_test.zig
@@ -99,6 +99,7 @@ const Harness = struct {
             .idle_timeout_ms = 1000,
             .head_timeout_ms = 1000,
             .drain_deadline_ms = 1000,
+            .loop_watchdog_ms = 0,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
             .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/admin_test.zig
+++ b/src/admin_test.zig
@@ -83,6 +83,7 @@ const Harness = struct {
             .idle_timeout_ms = 1000,
             .head_timeout_ms = 1000,
             .drain_deadline_ms = 1000,
+            .loop_watchdog_ms = 0,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
             .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/balancer.zig
+++ b/src/balancer.zig
@@ -974,6 +974,7 @@ fn testConfig(clusters: []const config_module.Config.Cluster) config_module.Conf
         .idle_timeout_ms = 1,
         .head_timeout_ms = 1,
         .drain_deadline_ms = 1,
+        .loop_watchdog_ms = 0,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,
         .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/config.zig
+++ b/src/config.zig
@@ -28,6 +28,16 @@ pub const Config = struct {
     connect_timeout_ms: u32,
     idle_timeout_ms: u32,
     drain_deadline_ms: u32,
+    /// #311's serving-loop backstop, in milliseconds; `0` is off, which
+    /// is what an absent key resolves to.
+    ///
+    /// Every other deadline in this file is an op the loop delivers, so
+    /// none of them can bound the loop itself. This one is `alarm(2)`:
+    /// the kernel raises it whatever the process is doing, and a tick the
+    /// loop *does* deliver is what keeps pushing it out. So the number an
+    /// operator writes here is "how long may this proxy go without
+    /// completing anything before it is declared stalled and killed".
+    loop_watchdog_ms: u32,
     /// Absolute cap on a connection's age, regardless of activity (§6): it
     /// rides the same per-connection deadline timer as the idle timeout,
     /// clamping the activity-refreshed deadline so a continuously busy
@@ -833,6 +843,12 @@ pub const ValidationError = error{
     TimeoutOverLimit,
     TimeoutOrderInvalid,
     TimeoutTunnelOutOfRange,
+    /// A `timeouts.loop_watchdog_ms` under `loop_watchdog_ms_min` (#311).
+    /// Named apart from `TimeoutZero` because the two say different
+    /// things: that one is a deadline zeroed into meaninglessness, this
+    /// is a bound the mechanism cannot express — `alarm(2)` counts whole
+    /// seconds, and the tick refreshing it takes half the bound.
+    LoopWatchdogTooShort,
     LimitConnSlotsOutOfRange,
     LimitRelayBuffersOutOfRange,
     LimitRelayBuffersOverConnSlots,
@@ -973,6 +989,11 @@ pub fn parseWithFiles(
         .connect_timeout_ms = parsed.timeouts.connect_ms,
         .idle_timeout_ms = parsed.timeouts.idle_ms,
         .drain_deadline_ms = parsed.timeouts.drain_deadline_ms,
+        // Absent is off, and `0` is how the rest of this struct spells
+        // that — so the optional collapses here rather than travelling
+        // any further. See `TimeoutsJson.loop_watchdog_ms` for why the
+        // JSON side spells it as absence instead of a zero.
+        .loop_watchdog_ms = parsed.timeouts.loop_watchdog_ms orelse 0,
         .max_lifetime_ms = parsed.timeouts.max_lifetime_ms,
         .head_timeout_ms = resolveHeadTimeout(&parsed.timeouts),
         .request_timeout_ms = parsed.timeouts.request_ms,
@@ -3207,6 +3228,19 @@ pub const TimeoutsJson = struct {
     /// because a request deadline is a policy an operator sets against
     /// their own origin's latency, not a value zoxy can pick for them.
     request_ms: u32 = 0,
+    /// Optional #311 serving-loop watchdog. **Absent is off**, and that
+    /// is why it is optional rather than a `0` like the two caps above:
+    /// the mechanism has a floor — `alarm(2)` is whole seconds and the
+    /// tick that refreshes it is half the bound — so the legal values are
+    /// "none" and "at least `loop_watchdog_ms_min`", with nothing in
+    /// between. Absence carries the "none" and the minimum carries the
+    /// rest, which is one rule a schema states exactly; a zero would have
+    /// needed a fork to say the same thing.
+    ///
+    /// Opt-in for #226's reason in the other direction: the process this
+    /// kills is one an operator has no other way to notice, but a bound
+    /// nobody named is a restart this proxy chose on their behalf.
+    loop_watchdog_ms: ?u32 = null,
     /// Optional #235 head-read budget. Absent is *derived* rather than
     /// fixed — see `resolveHeadTimeout`, which is what keeps every config
     /// written before this field behaving exactly as it did.
@@ -3235,6 +3269,12 @@ pub const TimeoutsJson = struct {
         .drain_deadline_ms = .{
             .desc = "Graceful-drain deadline on shutdown; 0 waits indefinitely.",
             .minimum = 0,
+            .maximum = constants.timeout_ms_max,
+        },
+        .loop_watchdog_ms = .{
+            .desc = "Serving-loop watchdog: kill this process if the event " ++
+                "loop completes nothing for this long. Absent is off.",
+            .minimum = constants.loop_watchdog_ms_min,
             .maximum = constants.timeout_ms_max,
         },
         .max_lifetime_ms = .{
@@ -5606,6 +5646,19 @@ fn validateTimeouts(timeouts: *const TimeoutsJson) ValidationError!void {
             return error.TimeoutOverLimit;
         }
     }
+    // #311's watchdog spells "off" as absence rather than zero, so what
+    // is left to check is a present value against a floor the mechanism
+    // imposes — `alarm(2)`'s whole seconds, halved for the tick that
+    // refreshes it. A number under it is not a tighter backstop, it is a
+    // bound the seam would refuse to arm.
+    if (timeouts.loop_watchdog_ms) |watchdog_ms| {
+        if (watchdog_ms < constants.loop_watchdog_ms_min) {
+            return error.LoopWatchdogTooShort;
+        }
+        if (watchdog_ms > constants.timeout_ms_max) {
+            return error.TimeoutOverLimit;
+        }
+    }
     // The one ordering between two configured values this loader enforces,
     // and it is a correctness bound rather than taste: a connection's first
     // deadline is armed at `connect_ms` (`Server.entryTimeoutMs`) and the
@@ -5894,6 +5947,54 @@ test "config: max_lifetime_ms accepts zero (a legal zero timeout) and real value
         );
         try std.testing.expectEqual(@as(u32, 1_800_000), parsed.max_lifetime_ms);
     }
+}
+
+test "config: the loop watchdog is absent-is-off, floored, and capped" {
+    const head =
+        \\{"listeners":[{"bind":"127.0.0.1:1","l4":{"cluster":"a"}}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{
+    ;
+    const tail = "}}";
+    // Absent is off, and off is the `0` the resolved config spells it
+    // with — the whole reason the JSON side is optional instead (#311).
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(&arena_state, head ++ tail);
+        try std.testing.expectEqual(@as(u32, 0), parsed.loop_watchdog_ms);
+    }
+    // Present and at the floor: the smallest bound the mechanism can
+    // express, since `alarm(2)` counts whole seconds and the tick that
+    // refreshes it takes half.
+    {
+        var arena_state: std.heap.ArenaAllocator = undefined;
+        defer arena_state.deinit();
+        const parsed = try expectParseOk(
+            &arena_state,
+            head ++ std.fmt.comptimePrint(
+                "\"loop_watchdog_ms\":{d}",
+                .{constants.loop_watchdog_ms_min},
+            ) ++ tail,
+        );
+        try std.testing.expectEqual(constants.loop_watchdog_ms_min, parsed.loop_watchdog_ms);
+    }
+    // One millisecond under it is refused rather than rounded. A bound
+    // the seam would not arm is a backstop an operator believes they have
+    // and do not, which is worse than the hang it was meant to catch.
+    try expectParseError(error.LoopWatchdogTooShort, head ++ std.fmt.comptimePrint(
+        "\"loop_watchdog_ms\":{d}",
+        .{constants.loop_watchdog_ms_min - 1},
+    ) ++ tail);
+    // Zero is refused by the same rule, and deliberately: it is the
+    // spelling of "off" everywhere else in this block, and accepting it
+    // here would make one key mean off two ways.
+    try expectParseError(error.LoopWatchdogTooShort, head ++ "\"loop_watchdog_ms\":0" ++ tail);
+    // And the shared units-mistake ceiling still applies.
+    try expectParseError(error.TimeoutOverLimit, head ++ std.fmt.comptimePrint(
+        "\"loop_watchdog_ms\":{d}",
+        .{constants.timeout_ms_max + 1},
+    ) ++ tail);
 }
 
 test "config: a listener's body key is what names its protocol" {
@@ -7786,24 +7887,30 @@ test "config: listeners that overflow the ring budget are refused at load" {
     // Where that line falls says something about the budget worth pinning.
     // `conn_slots_max` is derived against the *worst case* the prober can
     // ask for (`health_probe_concurrency_max` probes, #132), which leaves
-    // 3 ops of the 57344-op fill budget spare at zero listeners. This
+    // 2 ops of the 57344-op fill budget spare at zero listeners. This
     // config sets no `check` block anywhere, so its prober reserves the
     // floor of one probe and the other 45 ops are slack it may spend on
-    // listeners: 24 fit, and the 25th is one too many. A config that did
+    // listeners: 23 fit, and the 24th is one too many. A config that did
     // configure 16 checked endpoints would find that slack already spent
     // and be refused at two — which is the effective-versus-ceiling split
     // (§5, §8) showing up as a real difference between two configs, not
     // an accounting detail.
+    //
+    // The pair moved by one when #311's loop-watchdog tick joined the
+    // fixed reservations, and that is the reservation being visible
+    // rather than a number drifting: one more op at zero listeners is one
+    // fewer listener at the ceiling, and this test is where the budget
+    // says so out loud.
     const at_ceiling = std.fmt.comptimePrint(
         "\"limits\":{{\"conn_slots\":{d},\"upstream_slots\":{d}}},",
         .{ constants.conn_slots_max, constants.upstream_slots_max },
     );
-    try expectParseError(error.LimitConnSlotsOverCqFill, comptime listenersJson(25, at_ceiling));
-    // Twenty-four still fit, so the refusal above is the budget talking
+    try expectParseError(error.LimitConnSlotsOverCqFill, comptime listenersJson(24, at_ceiling));
+    // Twenty-three still fit, so the refusal above is the budget talking
     // and not the pools alone.
     var arena_state: std.heap.ArenaAllocator = undefined;
     defer arena_state.deinit();
-    _ = try expectParseOk(&arena_state, comptime listenersJson(24, at_ceiling));
+    _ = try expectParseOk(&arena_state, comptime listenersJson(23, at_ceiling));
 }
 
 var fuzz_arena_buffer: [1 << 20]u8 = undefined;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -56,11 +56,12 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// config may pick (`cq_fill_eighths_default` = ⅞, 57344) with the
 /// parked-upstream, admin, access-log and health-probe reservations
 /// carved out first, this caps at
-/// `(57344 - 11) / (conn_ops_max + 1) = 11466` —
-/// comptime-derived below (the 11 is the fixed ops: two for the admin
+/// `(57344 - 12) / (conn_ops_max + 1) = 11466` —
+/// comptime-derived below (the 12 is the fixed ops: two for the admin
 /// listener [2], the admin client's op budget [3], the access log's
 /// in-flight sink write [1], the health prober's op budget [3], the signal
-/// wake [1], and the drain timer [1]). That clears a round 10k on a
+/// wake [1], the drain timer [1], and #311's loop-watchdog tick [1]).
+/// That clears a round 10k on a
 /// single ring; a deployment trades the ceiling back down for more burst
 /// headroom via `limits.cq_fill_eighths` (§8).
 ///
@@ -82,7 +83,7 @@ pub const admin_drain_scratch_bytes: u32 = 512;
 /// above the upstream ceiling is therefore capacity that cannot be served
 /// — slots that admit connections the pool has no upstream for — and one
 /// below it is a pool that can never be drawn down. `11466` is the
-/// largest N with `N * (conn_ops_max + 1) <= 57333`, which keeps both
+/// largest N with `N * (conn_ops_max + 1) <= 57332`, which keeps both
 /// ceilings clear of a round 10k: what §1 asks for, c10k reachable on
 /// either axis rather than a shape tuned for it.
 ///
@@ -921,6 +922,34 @@ pub const body_name_bytes_max: u16 = 64;
 /// this is almost certainly a units mistake in the config.
 pub const timeout_ms_max: u32 = 3_600_000;
 
+/// Floor on `timeouts.loop_watchdog_ms` (#311): the shortest serving-loop
+/// backstop an operator may name.
+///
+/// Two seconds because the mechanism is `alarm(2)` and the refresh is
+/// half the bound. The seam refuses to arm an alarm shorter than a second
+/// — production rounds up to whole seconds, so a finer bound would be one
+/// no deployment can actually have — and the tick that refreshes it must
+/// fit inside the bound with room to be late. Halving two seconds lands
+/// exactly on that floor, so this is the smallest number for which every
+/// assert below it holds rather than a round one chosen for taste.
+///
+/// It is also a floor worth having on its own terms: the alarm's whole
+/// value is that it fires when nothing else can, and a bound tight enough
+/// to be tripped by an ordinary scheduling hiccup would trade a hang for
+/// a restart loop. Whoever wants a tighter one wants a different
+/// mechanism.
+pub const loop_watchdog_ms_min: u32 = 2_000;
+
+comptime {
+    // The refresh is `loop_watchdog_ms / 2`, and the seam's floor is one
+    // whole second — so the smallest bound a config may name must still
+    // leave a legal tick under it. Stated here because the division lives
+    // in `Server` and the floor lives in the seam, and neither can see
+    // the other.
+    assert(loop_watchdog_ms_min / 2 >= 1000);
+    assert(loop_watchdog_ms_min <= timeout_ms_max);
+}
+
 /// Ceiling on `timeouts.tunnel_ms` (#180) — the one timeout allowed past
 /// `timeout_ms_max`, and deliberately. That bound exists because an
 /// ordinary timeout above an hour is almost certainly a units mistake;
@@ -1148,8 +1177,13 @@ pub const access_log_line_bytes_max: u32 = accessLogLineBytes(access_log_headers
 /// per admin client (its send/deadline/teardown peak), the access log's one
 /// in-flight sink write, `health_probe_ops_max` ops for each of the
 /// prober's `health_probes` concurrent probes (§7), the single async
-/// wakeup op for signals, and
-/// the server's one drain-deadline timer. Closed form so it can be
+/// wakeup op for signals, the server's one drain-deadline timer, and
+/// #311's loop-watchdog tick. That last one is reserved whether or not a
+/// config arms it, on the same terms as the admin and access-log
+/// reservations: a budget that moved with a `timeouts` key would make the
+/// ring depth a property of the operator's watchdog policy, and the point
+/// of reserving it here is that turning the backstop on can never be the
+/// thing that refuses a config. Closed form so it can be
 /// evaluated on the *effective* pool sizes too (XevIo's per-deployment CQ),
 /// not only the ceilings; the admin and access-log reservations are fixed
 /// — always covered even when a config leaves them off — and so is the
@@ -1186,7 +1220,7 @@ pub fn inFlightOps(
         streamSlotsFor(conn_slots) * stream_ops_max + upstream_slots +
         2 * (listeners + admin_listeners) +
         admin_conns * admin_conn_ops_max + access_log_ops_max +
-        health_probes * health_probe_ops_max + 1 + 1;
+        health_probes * health_probe_ops_max + 1 + 1 + 1;
 }
 
 /// Kernel maximum for an IORING_SETUP_CQSIZE completion queue
@@ -1494,6 +1528,11 @@ comptime {
     // count whose worst-case ops fit the ⅞-CQ budget (at the default =
     // loosest fill) after the fixed ops — the parked-upstream reservation
     // and the admin listener plus its one client op — are carved out (§8).
+    // The three bare `- 1`s below are the ones `inFlightOps` spells the
+    // same way and in the same order: the signal wake, the drain timer,
+    // and #311's loop-watchdog tick. They are the terms most easily left
+    // behind when one is added — `@divFloor` will absorb a missing op
+    // until it happens not to, which is a ceiling that is right by luck.
     // The pair is pinned (`upstream_slots_max = conn_slots_max`), so the
     // shared CQ line has one divisor — an admitted connection costs
     // `conn_ops_max` conn ops plus `stream_ops_max` for the one stream it
@@ -1504,7 +1543,7 @@ comptime {
         @divExact(completion_queue_entries, 8) * cq_fill_eighths_default -
             2 * admin_listeners -
             admin_conns * admin_conn_ops_max - access_log_ops_max -
-            health_probe_concurrency_max * health_probe_ops_max - 1 - 1,
+            health_probe_concurrency_max * health_probe_ops_max - 1 - 1 - 1,
         conn_ops_max + stream_ops_max + 1,
     ));
     assert(admin_listeners >= 1);

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -1981,6 +1981,7 @@ fn labeledTestConfig(clusters: []const config_module.Config.Cluster) config_modu
         .idle_timeout_ms = 1,
         .head_timeout_ms = 1,
         .drain_deadline_ms = 1,
+        .loop_watchdog_ms = 0,
         .max_lifetime_ms = 0,
         .request_timeout_ms = 0,
         .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -750,6 +750,7 @@ const Http1Bed = struct {
             // default would sit far above the window it must tighten.
             .head_timeout_ms = options.head_timeout_ms orelse idle_timeout_ms,
             .drain_deadline_ms = options.drain_deadline_ms,
+            .loop_watchdog_ms = 0,
             .max_lifetime_ms = options.max_lifetime_ms,
             .request_timeout_ms = options.request_timeout_ms,
             .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/io/SimIo.zig
+++ b/src/io/SimIo.zig
@@ -196,6 +196,10 @@ drop_next_taken: ?OpKind,
 /// from outside, and this is the thing that turns one into a diagnostic.
 alarm_at_ns: u64,
 alarm_exit_code: u8,
+/// Which watchdog armed it. Production picks the handler's line from
+/// this; here it is what a scenario asserts on to tell #311's serving
+/// watchdog from #226's drain one, since both give up the same way.
+alarm_reason: Io.AlarmReason,
 alarm_fired: bool,
 
 const blackholed_addresses_max: u8 = 4;
@@ -533,6 +537,7 @@ pub fn init(io: *SimIo, arena: std.mem.Allocator, options: Options) error{OutOfM
     io.drop_next_taken = null;
     io.alarm_at_ns = never_ns;
     io.alarm_exit_code = 0;
+    io.alarm_reason = .drain_stalled;
     io.alarm_fired = false;
     assert(io.sockets.isFullyReleased());
 }
@@ -1190,21 +1195,28 @@ fn kindBit(kind: OpKind) u16 {
     return @as(u16, 1) << @intCast(@intFromEnum(kind));
 }
 
-/// §8's drain watchdog (#226), the simulator's half. Production arms
+/// §8's two watchdogs (#226, #311), the simulator's half. Production arms
 /// `alarm(2)`; here it is a deadline the run loop compares the virtual
 /// clock against, with no completion in between — which is the property
 /// being modelled, not an implementation shortcut. A watchdog that rode
 /// the pending table would be exactly the timer this exists to replace.
-pub fn alarmStart(io: *SimIo, after_ns: u64, exit_code: u8) void {
+///
+/// Re-arming *replaces* the pending deadline rather than being refused,
+/// because that is what `alarm(2)` does and #311's serving watchdog is
+/// built on it: the refresh is one arm per tick, not a cancel and an arm.
+/// The assert that used to forbid it caught nothing a double-arm bug
+/// would show as here anyway — a replaced deadline is a later deadline,
+/// and a scenario asserting on `alarmFired` sees the difference.
+pub fn alarmStart(io: *SimIo, after_ns: u64, exit_code: u8, reason: Io.AlarmReason) void {
     assert(exit_code != 0); // A give-up is never a success.
     // The seam's floor, enforced here too: production rounds up to whole
     // seconds, so a scenario arming a shorter one would be testing a bound
     // no deployment can have.
     assert(after_ns >= std.time.ns_per_s);
-    assert(io.alarm_at_ns == never_ns);
     assert(!io.alarm_fired);
     io.alarm_at_ns = io.now_ns_value + after_ns;
     io.alarm_exit_code = exit_code;
+    io.alarm_reason = reason;
     assert(io.alarm_at_ns > io.now_ns_value);
     // Into the trace: a run that armed a watchdog is a different run from
     // one that did not, whether or not it ever fires.
@@ -1217,6 +1229,7 @@ pub fn alarmStart(io: *SimIo, after_ns: u64, exit_code: u8) void {
 pub fn alarmCancel(io: *SimIo) void {
     io.alarm_at_ns = never_ns;
     io.alarm_exit_code = 0;
+    io.alarm_reason = .drain_stalled;
     assert(io.alarm_at_ns == never_ns);
     io.mix(0);
 }
@@ -1226,6 +1239,12 @@ pub fn alarmCancel(io: *SimIo) void {
 /// bargain `abortedWith` makes.
 pub fn alarmFired(io: *const SimIo) bool {
     return io.alarm_fired;
+}
+
+/// Which watchdog is armed, or last fired — the assertion that tells
+/// #311's serving stall from #226's drain one.
+pub fn alarmReason(io: *const SimIo) Io.AlarmReason {
+    return io.alarm_reason;
 }
 
 /// The watchdog's whole behaviour: give up, with the code it was armed

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1394,6 +1394,11 @@ pub fn signalWait(
 /// nothing between the kernel and the exit is the loop's (#226).
 var alarm_exit_code = std.atomic.Value(u8).init(0);
 var alarm_handler_installed = std.atomic.Value(bool).init(false);
+/// Which watchdog is armed, so the handler's one line says which silence
+/// it is reporting. A single `u8` for the reason `Io.AlarmReason` gives:
+/// the handler reads it from a signal context, and one atomic cannot be
+/// caught half-written the way a pointer and a length can.
+var alarm_reason = std.atomic.Value(u8).init(@intFromEnum(Io.AlarmReason.drain_stalled));
 
 /// §8's drain watchdog (#226): a deadline that is not a completion.
 ///
@@ -1410,7 +1415,7 @@ var alarm_handler_installed = std.atomic.Value(bool).init(false);
 /// re-entering the loop. Coarse — whole seconds — which is right for a
 /// backstop measured in them, and the informative report still comes from
 /// `onDrainStuck` when the loop is alive to produce one.
-pub fn alarmStart(io: *XevIo, after_ns: u64, exit_code: u8) void {
+pub fn alarmStart(io: *XevIo, after_ns: u64, exit_code: u8, reason: Io.AlarmReason) void {
     _ = io;
     assert(exit_code != 0); // A give-up is never a success.
     assert(after_ns >= std.time.ns_per_s);
@@ -1422,7 +1427,13 @@ pub fn alarmStart(io: *XevIo, after_ns: u64, exit_code: u8) void {
     const seconds = (after_ns + std.time.ns_per_s - 1) / std.time.ns_per_s;
     assert(seconds >= 1);
     assert(seconds <= std.math.maxInt(c_uint));
+    alarm_reason.store(@intFromEnum(reason), .release);
     alarm_exit_code.store(exit_code, .release);
+    // `alarm(2)` replaces whatever was pending and returns the seconds
+    // that were left on it, which is what makes #311's refresh one
+    // syscall rather than a cancel and an arm — and what lets the drain
+    // watchdog take the alarm over from the serving one at `beginDrain`
+    // without either knowing about the other.
     _ = std.c.alarm(@intCast(seconds));
 }
 
@@ -1451,8 +1462,24 @@ pub fn alarmHandlerInstalled() void {
 /// are syscalls and those live here (§4); `main` owns only the sigaction
 /// that points at it.
 pub fn onAlarmFromHandler() noreturn {
-    const message = "zoxy: drain watchdog fired, the event loop stopped " ++
+    const drain_message = "zoxy: drain watchdog fired, the event loop stopped " ++
         "delivering (DESIGN.md §8, #226)\n";
+    const loop_message = "zoxy: loop watchdog fired, the event loop stopped " ++
+        "delivering while serving (DESIGN.md §8, #311)\n";
+    // Both are string literals, so both live in the binary's constant
+    // data for the whole process: nothing here dereferences anything a
+    // refresh could have moved.
+    // Switched on the raw byte rather than through `@enumFromInt`: that
+    // conversion carries a safety check whose failure path is a panic,
+    // and a panic is not async-signal-safe. Only `alarmStart` ever writes
+    // this and only from an `Io.AlarmReason`, so the else is unreachable
+    // by inspection — and answering it with the drain's line rather than
+    // asserting keeps the one thing this handler owes an operator, which
+    // is a line at all.
+    const message = switch (alarm_reason.load(.acquire)) {
+        @intFromEnum(Io.AlarmReason.loop_stalled) => loop_message,
+        else => drain_message,
+    };
     _ = std.c.write(2, message.ptr, message.len);
     const code = alarm_exit_code.load(.acquire);
     // Armed with a non-zero code, so a zero here would mean the alarm

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -791,7 +791,7 @@ test "simio: an armed watchdog answers where a stranded timer cannot" {
     try std.testing.expectEqual(@as(u32, 1), sim_io.dropPendingOps(.timer));
     // Past the stranded timer's own deadline, so what fires is the alarm
     // and not some artefact of the clock stopping short of it.
-    sim_io.alarmStart(2 * std.time.ns_per_s, 5);
+    sim_io.alarmStart(2 * std.time.ns_per_s, 5, .drain_stalled);
 
     try sim_io.run();
     try std.testing.expect(sim_io.alarmFired());

--- a/src/io/io.zig
+++ b/src/io/io.zig
@@ -34,13 +34,15 @@
 //!       file sink only — swap the sink fd between writes, never under one)
 //!   timerStart(io, c, delay_ns, U, u, cb(u, TimerError!void))
 //!   timerCancel(io, timer_c, cancel_c, U, u, cb(u))     (the one legal cancel)
-//!   alarmStart(io, after_ns, exit_code) void            (sync; §8's drain
-//!       watchdog — a deadline with no completion, so it survives a loop
+//!   alarmStart(io, after_ns, exit_code, reason) void    (sync; §8's two
+//!       watchdogs — a deadline with no completion, so it survives a loop
 //!       that has stopped delivering. Takes the process down itself.
 //!       `after_ns` is at least a second: production is `alarm(2)`, whose
 //!       granularity is whole seconds, and both sides enforce the floor so
 //!       a caller cannot ask the simulator for a bound production would
-//!       silently round.)
+//!       silently round. Re-arming replaces the pending deadline, which is
+//!       `alarm(2)`'s own contract and what lets #311's serving watchdog
+//!       refresh one rather than cancel and re-arm every tick.)
 //!   alarmCancel(io) void                                (sync)
 //!   signalWait(io, U, u, cb(u, Signal))                 (persistent waiter)
 //!   setNodelay / setLingerRst (io, socket) SetOptionError!void   (sync)
@@ -80,6 +82,25 @@ pub const Signal = enum(u8) {
     /// (§1 non-goal: the §5 pools are startup-fixed, so a config change
     /// is a restart), and claiming the signal for the log says so.
     reopen_log,
+};
+
+/// Which watchdog armed the alarm, and so which line the handler writes
+/// when it fires (§8).
+///
+/// The seam carries this rather than the message itself because the
+/// handler reads it from a signal context: one atomic `u8` cannot be
+/// read half-updated, where a pointer and a length refreshed on the loop
+/// thread can be — and a torn pair would have the handler write one
+/// message's bytes at another's length. What a caller loses is the
+/// freedom to invent wording; what it keeps is the only distinction an
+/// operator reading a status with no output actually has.
+pub const AlarmReason = enum(u8) {
+    /// The drain could not finish and nothing could say so (#226).
+    drain_stalled,
+    /// The serving loop stopped delivering (#311). Distinct because the
+    /// two happen in different phases and mean different things: one
+    /// process was on its way out, the other was answering traffic.
+    loop_stalled,
 };
 
 /// A dial destination (#303): an IP address, or the path of a

--- a/src/main.zig
+++ b/src/main.zig
@@ -153,8 +153,16 @@ fn serve(init: std.process.Init, arena: std.mem.Allocator, config_path: []const 
     if (resources.tls_credentials.len > 0) {
         server.setTlsCredentials(resources.tls_credentials);
     }
-    try server.start();
+    // Before `start`, which is a change #311 forced and an improvement on
+    // its own terms. The serving watchdog is armed at the end of `start`,
+    // and the seam refuses to arm an alarm whose handler is not installed
+    // — SIGALRM's default action is to terminate, so arming one first
+    // would turn a stall into a silent death. Installing here also means
+    // a SIGTERM that arrives *during* startup is recorded and drained
+    // once the loop runs, where before it took the default action and
+    // killed a process mid-bind.
     installSignalHandlers();
+    try server.start();
 
     try global_io.run();
 

--- a/src/net/pump_transform_test.zig
+++ b/src/net/pump_transform_test.zig
@@ -633,6 +633,7 @@ const Harness = struct {
             .idle_timeout_ms = 5000,
             .head_timeout_ms = 5000,
             .drain_deadline_ms = 1000,
+            .loop_watchdog_ms = 0,
             .max_lifetime_ms = 0,
             .request_timeout_ms = 0,
             .tunnel_timeout_ms = constants.tunnel_ms_default,

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -285,6 +285,12 @@ pub const TestBed = struct {
         max_lifetime_ms: u32 = 0,
         connect_timeout_ms: u32 = 50,
         drain_deadline_ms: u32 = 1000,
+        /// #311's serving watchdog. Off by default, exactly as a config
+        /// with no `loop_watchdog_ms` is: a bed that armed one would put
+        /// a re-arming timer under every scenario here, and a simulated
+        /// run with a timer that always has another tick has no quiet
+        /// point to end at.
+        loop_watchdog_ms: u32 = 0,
         /// Turn the §8 access log on. Off by default so every existing
         /// scenario keeps paying nothing for it.
         access_log: bool = false,
@@ -434,6 +440,7 @@ pub const TestBed = struct {
             .idle_timeout_ms = options.idle_timeout_ms,
             .head_timeout_ms = options.idle_timeout_ms,
             .drain_deadline_ms = options.drain_deadline_ms,
+            .loop_watchdog_ms = options.loop_watchdog_ms,
             .max_lifetime_ms = options.max_lifetime_ms,
             // L4 only: the §8 request deadline is an L7 exchange bound and
             // this bed never routes one.
@@ -762,6 +769,83 @@ test "server: kernel-pressure on the upstream dial is witnessed and the conn tor
     // the wire shape is the seed's.
     try std.testing.expectEqual(@as(u8, 1), bed.scenario.outcomeCount(.eof));
     try std.testing.expectEqual(@as(u8, 0), bed.scenario.origin.conns_count);
+    try bed.expectDrained();
+}
+
+test "watchdog: a loop that stops delivering is ended by the alarm it stopped refreshing" {
+    // #311, and the property is the one no timer in this proxy has: every
+    // other bound here is an op the loop delivers, so a loop that has
+    // stopped delivering has stopped delivering the thing that would have
+    // said so. The alarm is not an op — production is `alarm(2)`, raised
+    // by the kernel whatever the process is doing, and the simulator
+    // models it as a deadline the run loop compares its clock against
+    // (`SimIo.alarmStart`).
+    //
+    // Stranding the timer plane is how a stall is provoked here, and it
+    // is the same shape as the real one: `dropPendingOps(.timer)` takes
+    // the armed watchdog tick and never delivers it, exactly as a loop
+    // parked in a blocking syscall never gets round to it. Nothing else
+    // in the run can end it — that is what makes the assertion below
+    // about the alarm rather than about anything the loop did.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 41 },
+        // Long enough that neither can be what ends the run: the alarm at
+        // 2 s is the first deadline in play, and it is the only one that
+        // can fire through a stranded timer plane anyway.
+        .idle_timeout_ms = 60_000,
+        .loop_watchdog_ms = constants.loop_watchdog_ms_min,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, false);
+    // `start` armed the tick; taking it is taking the refresh.
+    try std.testing.expect(bed.sim_io.dropPendingOps(.timer) >= 1);
+    try bed.sim_io.run();
+
+    try std.testing.expect(bed.sim_io.alarmFired());
+    // The serving code, not the drain's: an operator reading a status
+    // with no output has only this to tell the two silences apart.
+    try std.testing.expectEqual(
+        @as(?u8, ServerSim.loop_watchdog_exit_code),
+        bed.sim_io.abortedWith(),
+    );
+    try std.testing.expectEqual(io_module.AlarmReason.loop_stalled, bed.sim_io.alarmReason());
+}
+
+test "watchdog: an uncapped drain is not killed by the watchdog that was serving" {
+    // The other half of #311, and the one that decides whether the
+    // feature is safe to turn on: `drain_deadline_ms: 0` asks for a drain
+    // that waits for the last connection however long it takes, and a
+    // serving watchdog still counting down into it would overrule that
+    // configuration rather than backstop it — #226's lesson in the other
+    // direction, and the reason `beginDrain` cancels the alarm on the
+    // branch that arms no drain watchdog of its own.
+    //
+    // The discriminator is that the run *ends by draining*. The watchdog
+    // bound is shorter than the drain this scenario takes, so a watchdog
+    // that kept its alarm would have fired first and `alarmFired` would
+    // say so.
+    var bed: TestBed = undefined;
+    try bed.setUp(std.testing.allocator, .{
+        .sim = .{ .seed = 41 },
+        // The straggler leaves on the idle deadline, which is what ends
+        // an uncapped drain — and it is deliberately past the watchdog's
+        // bound, so the two cannot both be right.
+        .idle_timeout_ms = 3_000,
+        .connect_timeout_ms = 10,
+        .drain_deadline_ms = 0,
+        .loop_watchdog_ms = constants.loop_watchdog_ms_min,
+    });
+    defer bed.tearDown();
+
+    bed.startClients(1, false);
+    bed.sim_io.scheduleSignal(.terminate, bed.sim_io.nowNs() + 5_000_000);
+    try bed.sim_io.run();
+
+    try std.testing.expect(!bed.sim_io.alarmFired());
+    try std.testing.expectEqual(@as(?u8, null), bed.sim_io.abortedWith());
+    try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("completed"));
     try bed.expectDrained();
 }
 


### PR DESCRIPTION
Closes #311.

Every bound in this proxy is an op the loop delivers, so none of them can bound the loop itself. #226 reached that conclusion and built the answer — `alarm(2)`, raised by the kernel whatever the process is doing, with a handler that writes one line and `_exit`s — but armed it for the drain alone. This arms it for the phase the process spends its life in.

```
"timeouts": { "loop_watchdog_ms": 5000 }
```

The alarm is armed at that bound; a timer at half of it re-arms both. A loop that keeps delivering never lets the alarm land, and one that stops refreshing gets a line on stderr and `_exit` **6**.

## The issue's five open points, answered

**Where the re-arm goes.** A timer op, not the per-tick refresh the issue sketched — and not because per-tick is unattractive, but because it is wrong twice here. `XevIo.run` is one `loop.run(.until_done)` call, so there is no tick to hook without turning it into a manual `.once` loop; and `.once` *blocks* until a completion arrives, so an idle proxy would sit in the wait, refresh nothing, and be killed for having no traffic. A timer fires whether or not anyone is connected, and the loop delivering it is exactly the liveness being claimed.

**The cost.** One ring op, charged in `inFlightOps` unconditionally — armed or not. A budget that moved with a `timeouts` key would make ring depth a property of watchdog policy, and turning a backstop on must never be the thing that refuses a config. The listener ceiling in `cqFillFits` moves by one (24 → 23 at the conn-slot ceiling) and that test pins the new pair rather than being loosened. No `alarm(2)` per tick: re-arming replaces the pending deadline, so a refresh is one syscall at half the bound, not a cancel and an arm.

**Whether the operator names it.** They do, and **absence is off** — but spelled as an *optional key* rather than a zero, which is the one shape decision worth arguing. The mechanism has a floor: `alarm(2)` counts whole seconds and the refresh takes half the bound, so the legal values are "none" and "at least 2 s", with nothing in between. Absence carries the "none" and `minimum` carries the rest, which is one rule the schema states exactly. A zero-means-off would have needed a `oneOf` fork — and #305's schema debt is at zero as of #325, so this key pays for itself rather than putting a row back.

**Whether exiting is right.** It exits. A report-only mode leaves the stalled process holding its listeners and its share of the `SO_REUSEPORT` hash, which is the failure scale-out handles worst: the kernel keeps hashing new connections onto a process that has stopped serving them, so one that exits is replaced while one that hangs degrades the group. The false-positive risk is bounded by the two things above — off unless asked for, and a bound the operator picks for their own box.

**What gate proves it.** Three tiers, each verified to fail with the feature disabled:

| tier | what it can claim |
|---|---|
| simulator (2 tests) | strand the timer plane and the give-up still happens, with the serving reason and code 6; and an uncapped drain is **not** killed by the watchdog that was serving |
| config (1 test) | absent is off, the floor is refused rather than rounded, the ceiling still applies |
| live (smoke leg) | a real process, stopped by `SIGSTOP`, is ended by the kernel with exit 6 and says so on stderr |

The live leg is the one the issue asked for and the simulator structurally cannot make: a virtual clock cannot be blocked. `SIGSTOP` takes the process off the CPU entirely — no completion delivered, no timer run — while `alarm(2)` keeps counting, because it is the kernel's clock and not the loop's. On `SIGCONT` the pending SIGALRM is delivered before the process resumes what it was doing, so the handler wins the race against the refresh **by construction rather than by timing**. #310 would have supplied a provocation too, but it was fixed; this one needs no defect to exist.

## It found a bug before it ever fired

`main` installed its signal handlers *after* `Server.start`, so the watchdog armed an alarm whose handler did not exist yet — and SIGALRM's default action is to **terminate**, so a stall would have become a silent death with less to say than the hang. The seam's `assert(alarm_handler_installed)` caught it on the first live run. Handlers-then-start now, which also means a SIGTERM arriving during startup is recorded and drained rather than killing a process mid-bind.

## Two watchdogs, one alarm

A process has one `alarm(2)`, so the serving watchdog stands down at `beginDrain`: the capped branch's `armDrainWatchdog` replaces the alarm, and the uncapped branch — which arms none — cancels it outright. An operator who declined `drain_deadline_ms` asked for a wait with no bound, and a watchdog still counting into it would overrule that configuration rather than backstop it. That is the second simulator test.

The seam learned which of the two is firing, as an `Io.AlarmReason` the handler reads from a **single atomic**. A message pointer and length would be two, and a handler that interrupted a refresh between them would write one message's bytes at the other's length. For the same reason the handler switches on the raw byte rather than through `@enumFromInt`, whose safety check ends in a panic — not async-signal-safe.

## Deliberately not in the sweep

The 4096-seed simulation does not arm it. A tick every second of virtual time mixes into every seed's trace, so all 4096 schedules would shift and the coverage this gate has accumulated would go with them. Worse, `.timer` is in the strand draw — the seeds that strand it are the ones that reach #226's drain watchdog, and a serving watchdog armed over them would end those runs in its own give-up instead, which is the sweep's most interesting cases answering a different question.

## Known limit, stated rather than papered over

It proves **delivery, not progress**. A loop that ticks while doing nothing useful passes this. Refreshing on completions delivered would be the stronger claim and a fussier one — an idle proxy legitimately delivers nothing for a long time — and delivery is the failure that has actually been seen (#310: a synchronous write parked in `writev` for as long as the pipe's reader took). IMPLEMENTATION_NOTES carries it as the open question.

## Gates

`zig build ci` green (680 tests, 4096 sim seeds, both smoke runs), `zig fmt --check` clean. `tiger-style-reviewer` run; both violations applied — a comptime assert that had not gained the third fixed-op term the paragraph above it now claims (the ceiling was right only because `@divFloor` absorbed it), and a `catch {}` on the leg's sleep, where the sleep *is* the certainty argument and now fails loudly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
