### PR TITLE
docs: the redirect example's second rule was dead

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1098,6 +1098,13 @@ top-down against each request. Each has a match predicate — absent fields
 match anything — and actions applied in order. As with routes, nothing caps
 the list but the file you write.
 
+Order is the rule here, not a tie-break: the first terminal action a
+matching rule carries — `reject`, `redirect` or `respond` — answers the
+request, and no rule beneath it is read. Write the specific rule above the
+general one. That is the opposite of [routes](#routing), which are sorted
+by specificity at load precisely so the sequence you wrote them in cannot
+decide them; a filter table is read in exactly that sequence.
+
 ```json
 "request_filters": [
     {
@@ -1155,16 +1162,27 @@ guess which.
 #### Redirects
 
 The two most common edge rules are one action each — no second server
-needed in front of a load balancer to answer them:
+needed in front of a load balancer to answer them. Both belong on the
+plaintext `:80` listener: a request that already arrived over TLS sent
+back to `https://` is a loop, and since the scheme is what the rule
+states rather than what the hop was, only the config can keep the two
+apart.
 
 ```json
 "request_filters": [
-    { "actions": [{ "redirect": { "status": 301, "scheme": "https" } }] },
     { "match": { "host": "www.example.com" },
       "actions": [{ "redirect": { "status": 308, "scheme": "https",
-                                  "host": "example.com" } }] }
+                                  "host": "example.com" } }] },
+    { "actions": [{ "redirect": { "status": 301, "scheme": "https" } }] }
 ]
 ```
+
+The apex rule is written first because the rule under it matches
+*everything*: reversed, `www.example.com` takes the catch-all's 301 to its
+own name and never reaches the 308. A bare catch-all shadows every rule
+beneath it, which is why a listener that redirects is usually a listener
+that does nothing else — it still needs a `cluster` or `routes` the loader
+can check, but filters run before routing, so nothing is ever dialed.
 
 A composed target replaces the scheme (required — zoxy never guesses it,
 since behind a TLS terminator every hop it sees is plaintext) and


### PR DESCRIPTION
The Redirects block in `docs/README.md` wrote a bare catch-all above the apex rule:

```json
"request_filters": [
    { "actions": [{ "redirect": { "status": 301, "scheme": "https" } }] },
    { "match": { "host": "www.example.com" },
      "actions": [{ "redirect": { "status": 308, "scheme": "https",
                                  "host": "example.com" } }] }
]
```

A rule with no `match` states nothing, so `matches` (`src/http/filter.zig:530`) admits every request and `firstVerdict` (`src/http/filter.zig:374`) returns on its first terminal action. The 308 is unreachable.

Ran both orders against the binary:

| Host | apex first (this PR) | catch-all first (old README) |
|---|---|---|
| `www.example.com` | `308 → https://example.com/a/b?q=1` | `301 → https://www.example.com/a/b?q=1` |
| `example.com` | `301 → https://example.com/a/b?q=1` | `301 → https://example.com/a/b?q=1` |
| `other.example.com` | `301 → https://other.example.com/…` | `301 → https://other.example.com/…` |

`www.example.com` took the catch-all's 301 to its own name and never reached the apex rule.

## What changed

**The ordering rule moves into the Filters intro.** The README only ever said filters are "evaluated top-down" — never that the first terminal action wins and stops the walk. That governs `reject` and `respond` as much as `redirect`, and the `/admin` allow-then-reject example was already leaning on it silently. Stated there against #302's route table, which sorts at load precisely so config order *cannot* decide it: the two tables now behave oppositely, and the docs should say which is which.

**The redirect example is reordered**, with a line on why the order is load-bearing.

**The example names its listener.** A scheme-to-`https` redirect belongs on the plaintext leg — the scheme is what the rule states rather than what the hop was, so the same rule on a terminating listener is an infinite redirect. `resolveRedirect` (`src/config.zig:4797`) validates the status, target form and scheme name, and knows nothing about the listener's `tls`.

## Not addressed

Nothing rejects a shadowed filter rule. The route table has a dead-rule refusal (`error.RouteSniIsAddress`), filters have no counterpart, so both configs above pass `--check` identically — this only ever surfaced in traffic. Whether a catch-all above a specific rule should be refused at load is a real design question (it is sometimes deliberate), so I left it alone rather than invent a policy. Worth an issue if you want it caught earlier.

Docs only; no Zig touched. `zig build ci` and `zig fmt --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)