### PR TITLE
docs: the client allowlist was never expressible (#331)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1497,9 +1497,17 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   owning phase module at compile time.
 - **A filter can match on who is connecting** (#177, settled
   2026-08-03). `match.client` is a CIDR list, any-of across the list
-  and conjoined with the rest — "/admin from the office range and
-  nowhere else" is one rule with a reject beneath it. It matches the
-  connection's client address, which is §6's settled principle rather
+  and conjoined with the rest. What shipped is the **denylist**
+  direction — a `client` list on a `reject` rule refuses that range —
+  and the tagging one, a header edit naming the range for the origin to
+  judge. The issue's own framing, "/admin from the office range and
+  nowhere else", is *not* what a reject beneath an allow rule spells:
+  edits are non-terminal (§7's own rule), so the walk reaches the reject
+  and the allowed range is refused with everyone else. Expressing it
+  needs either a terminal `allow` or a negated predicate, neither of
+  which the closed enum and the positive-conjunction `Match` carry;
+  #331 holds the decision, and the doc states the gap rather than the
+  promise. It matches the connection's client address, which is §6's settled principle rather
   than a new trust decision: the observed peer, or the PROXY-announced
   client on a `proxy_protocol` listener — never an `X-Forwarded-For`
   chain, because an allowlist keyed on client-supplied text is not an

--- a/docs/README.md
+++ b/docs/README.md
@@ -1115,7 +1115,7 @@ decide them; a filter table is read in exactly that sequence.
         "actions": [{ "header_set": { "name": "X-Role", "value": "admin" } }]
     },
     {
-        "match": { "path_prefix": "/admin" },
+        "match": { "path_prefix": "/admin", "client": ["203.0.113.0/24"] },
         "actions": [{ "reject": 403 }]
     },
     {
@@ -1131,6 +1131,13 @@ connection's address must fall inside. Actions are `reject` with a status,
 `redirect`, `respond` (answer from a configured body),
 `header_set` / `header_add` / `header_remove`, and `rewrite_prefix`.
 
+Only `reject`, `redirect` and `respond` are terminal. A rule whose actions
+are all edits — `header_set` above, or a `rewrite_prefix` — records what
+the render should do and evaluation carries on, so an edit never shields a
+request from a `reject` written beneath it. That is why the reject above
+names the range it refuses rather than sitting under an "allow" rule; see
+[matching the client address](#matching-the-client-address).
+
 Rules compile into immutable tables at load time and are interpreted with
 bounded loops — no plugins, no scripting, nothing that can allocate or run
 unbounded. A rewrite changes only what is *forwarded*: routing already chose
@@ -1138,17 +1145,37 @@ the cluster from the original path, so a rewrite never re-routes.
 
 #### Matching the client address
 
-The standard rule — `/admin` from the office range and nowhere else — is a
-`client` list on the allow rule and a reject beneath it:
+`client` is a list of CIDR ranges the connection's address must fall
+inside — any-of across the list, conjoined with the rest of the match. It
+refuses a range:
+
+```json
+"request_filters": [
+    { "match": { "path_prefix": "/admin", "client": ["203.0.113.0/24"] },
+      "actions": [{ "reject": 403 }] }
+]
+```
+
+and it tags traffic for the origin to judge, which costs the request
+nothing and stops nothing:
 
 ```json
 "request_filters": [
     { "match": { "path_prefix": "/admin",
                  "client": ["10.0.0.0/8", "192.168.1.0/24"] },
-      "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] },
-    { "match": { "path_prefix": "/admin" }, "actions": [{ "reject": 403 }] }
+      "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] }
 ]
 ```
+
+> [!IMPORTANT]
+> The inverse — `/admin` from the office range **and nowhere else** — is
+> not expressible today. A header edit is not terminal, so an "allow" rule
+> does not stop the walk: write a `reject` for `/admin` beneath the tagging
+> rule above and it answers `403` for the office range too, which is the
+> opposite of an allowlist. There is no `allow` action to stop on and no
+> way to negate a `client` list, so an allowlist belongs at the origin —
+> which is what the `X-Internal` tag is for — or in a firewall.
+> Tracked in [#331](https://github.com/zoxy-io/zoxy/issues/331).
 
 The address matched is the one zoxy actually believes: the TCP peer, or the
 [PROXY-protocol-announced client](#learning-it-behind-another-proxy-proxy-protocol)
@@ -1359,7 +1386,10 @@ number here when you want zoxy to give up before your platform does.
 
 Optional. The compiled constants are hard ceilings; this block sizes the
 actual pools anywhere from 1 up to them, so a small deployment neither
-reserves nor demands the ceiling's resources.
+reserves nor demands the ceiling's resources. The two conditional keys,
+`tls_engines` and `tunnels`, are absent below on purpose: each is refused
+unless the feature it sizes is configured, so neither belongs in a block
+copied as a starting shape. Both are described further down.
 
 ```json
 "limits": {
@@ -1368,8 +1398,7 @@ reserves nor demands the ceiling's resources.
     "upstream_slots": 4096,
     "head_buffers": 1024,
     "upstream_head_buffers": 512,
-    "head_buffer_bytes": 16384,
-    "tunnels": 512
+    "head_buffer_bytes": 16384
 }
 ```
 


### PR DESCRIPTION
Replaces #332, which GitHub closed when its base branch was deleted on #330's merge. Same commit, rebased onto `main`.

Found by extracting every JSON block in `docs/README.md` and running each through `--check`. 35 config examples, one of which could not load; the more serious finding needed running the proxy, not just loading it.

## 1. The allowlist idiom is inverted (README:1109, README:1132)

The README called this "the standard rule — `/admin` from the office range and nowhere else":

```json
{ "match": { "path_prefix": "/admin", "client": ["10.0.0.0/8", "192.168.1.0/24"] },
  "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] },
{ "match": { "path_prefix": "/admin" }, "actions": [{ "reject": 403 }] }
```

Against the binary, from an address **inside** the rule's own list:

| request | before | after |
|---|---|---|
| `/admin`, client in the allow list | `403` | reaches origin, tagged |
| `/admin`, header variant, `X-Internal` present | `403` | `X-Role: admin` at the origin |
| `/admin`, client in a rejected range | `403` | `403` |

`header_set` is not terminal, so `firstVerdict` (`src/http/filter.zig:374`) walks past the allow rule into the reject and refuses the office range with everyone else.

**Reordering does not fix it, and neither does any other spelling.** The terminal set is `reject`/`redirect`/`respond` — no `allow` to stop on — and `Match` is a positive conjunction with no negation, so "client *not* in R" cannot be written. The denylist direction (a `client` list on the reject rule) works correctly and is what the docs now lead with.

`src/http/filter.zig:912` already covers this shape. Its comment says "Everyone hits the 403 rule on /admin", and it asserts which header edits were collected — never the verdict — so it passes under both behaviors. Left as-is; #331 should add a verdict-level test alongside whatever it settles.

Docs now describe the two directions that work and state the gap outright, pointing an allowlist at the origin or a firewall. The DESIGN.md #177 entry is corrected the same way, since it carried the original claim.

## 2. The `limits` sample could not load (README:1365)

`"tunnels": 512` is refused with `LimitTunnelsWithoutUpgrades` (`src/config.zig:1680`) unless a listener also names an `upgrades` allowlist. `tls_engines`, the other conditionally-required key, was already omitted for exactly that reason — so the block was inconsistent as well as unloadable. Dropped it, and said in the intro why both are absent. The WebSocket section already shows `tunnels` beside the `upgrades` that makes it legal.

## Checked and correct

Routes (host/header/prefix incl. #302 ordering), sticky and hash picks, health checks, passive ejection, `max_inflight`, PROXY protocol both directions, `forwarded`, unix sockets, TLS termination, bodies/`error_pages`, `respond`, timeouts, admin, access log. Response filters were verified live too — `Server` stripped, HSTS on every response, `Retry-After` only on 5xx — the mirror case, where nothing is terminal and every matched rule accumulates.

Docs only; no Zig touched. `zig build ci` and `zig fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)