### PR TITLE
§7: a terminal `allow`, so the allowlist is expressible (#331)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1497,21 +1497,20 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   owning phase module at compile time.
 - **A filter can match on who is connecting** (#177, settled
   2026-08-03). `match.client` is a CIDR list, any-of across the list
-  and conjoined with the rest. What shipped is the **denylist**
-  direction — a `client` list on a `reject` rule refuses that range —
-  and the tagging one, a header edit naming the range for the origin to
-  judge. The issue's own framing, "/admin from the office range and
-  nowhere else", is *not* what a reject beneath an allow rule spells:
-  edits are non-terminal (§7's own rule), so the walk reaches the reject
-  and the allowed range is refused with everyone else. Expressing it
-  needs either a terminal `allow` or a negated predicate, neither of
-  which the closed enum and the positive-conjunction `Match` carry;
-  #331 holds the decision, and the doc states the gap rather than the
-  promise. It matches the connection's client address, which is §6's settled principle rather
-  than a new trust decision: the observed peer, or the PROXY-announced
-  client on a `proxy_protocol` listener — never an `X-Forwarded-For`
-  chain, because an allowlist keyed on client-supplied text is not an
-  allowlist. The prefix is mandatory and bounded per family — /32 for
+  and conjoined with the rest. It refuses a range — the list on a
+  `reject` rule — and it tags one, a header edit naming the range for
+  the origin to judge. The issue's own framing, "/admin from the office
+  range and nowhere else", is the third direction and needed a terminal
+  to stop the walk on, which #177 did not ship: it is the list on an
+  `allow` rule with a reject beneath (#331 below), because edits are
+  non-terminal (§7's own rule) and an "allow" spelled as one lets the
+  walk reach the reject.
+  It matches the connection's client address, which is §6's settled
+  principle rather than a new trust decision: the observed peer, or the
+  PROXY-announced client on a `proxy_protocol` listener — never an
+  `X-Forwarded-For` chain, because an allowlist keyed on
+  client-supplied text is not an allowlist.
+  The prefix is mandatory and bounded per family — /32 for
   IPv4, **/64 for IPv6**, the same client identity a `source_ip`-keyed
   hash pick keys on, so two features cannot disagree about what a
   client is — and host bits past the prefix are refused: `10.0.0.1/8`
@@ -1519,6 +1518,29 @@ accept → admit → recv head → parse (zero-copy) → route (host/path → cl
   which. Containment is a masked-prefix compare over the compiled
   table, family-strict; the accept and PROXY paths both normalize
   mapped v6 forms before storage.
+- **A filter can stop the walk without answering** (#331, settled
+  2026-09-01). `allow` is the fourth terminal action and the only one
+  that is not a response: the request forwards, and no rule beneath the
+  matched one is read. Both interpreters honour it — `firstVerdict` at
+  routing and `collectForward` at the render — and they must, or a rule
+  below an allow would edit a head the verdict walk had already stopped
+  reading rules for; the two ending the table at the same rule is the
+  invariant, not an optimization.
+  It exists because the allowlist was not expressible. The terminal set
+  was reject/redirect/respond, so the admitting rule could only carry an
+  edit, edits do not stop the walk, and the reject beneath refused the
+  admitted range along with everyone else — which the docs promised as
+  the standard shape from #177 until #333 corrected them, and which the
+  in-tree test covering that shape could not catch, asserting the edits
+  it collected rather than the verdict. The alternative was negation on `client`: rejected
+  because `Match` is a positive conjunction, and a second axis there
+  asks the same question of every other predicate, where one more member
+  of an already-closed action enum asks nothing. `allow`/`deny` is also
+  the vocabulary an operator arrives with.
+  Spelled `{"allow": true}`: an action object carries exactly one field
+  naming its kind, so a payload-free action still needs a value, and
+  `true` is the only one it may hold — `allow: false` names an action
+  and unsays it, refused at load like `present: false`.
 - **A filter can answer with a redirect** (#176, settled 2026-08-03).
   `redirect` beside `reject`, closed status set `301/302/307/308` —
   the four with distinct permanent/temporary × method-preserving

--- a/docs/README.md
+++ b/docs/README.md
@@ -1099,9 +1099,10 @@ match anything — and actions applied in order. As with routes, nothing caps
 the list but the file you write.
 
 Order is the rule here, not a tie-break: the first terminal action a
-matching rule carries — `reject`, `redirect` or `respond` — answers the
-request, and no rule beneath it is read. Write the specific rule above the
-general one. That is the opposite of [routes](#routing), which are sorted
+matching rule carries — `reject`, `redirect`, `respond` or `allow` — ends
+the walk, and no rule beneath it is read. The first three answer the
+request; `allow` forwards it. Write the specific rule above the general
+one. That is the opposite of [routes](#routing), which are sorted
 by specificity at load precisely so the sequence you wrote them in cannot
 decide them; a filter table is read in exactly that sequence.
 
@@ -1128,14 +1129,15 @@ decide them; a filter table is read in exactly that sequence.
 Match on `method`, `host`, `path_prefix`, header predicates
 (`present` / `equals` / `contains`), and `client` — CIDR ranges the
 connection's address must fall inside. Actions are `reject` with a status,
-`redirect`, `respond` (answer from a configured body),
-`header_set` / `header_add` / `header_remove`, and `rewrite_prefix`.
+`redirect`, `respond` (answer from a configured body), `allow` (forward and
+stop reading rules), `header_set` / `header_add` / `header_remove`, and
+`rewrite_prefix`.
 
-Only `reject`, `redirect` and `respond` are terminal. A rule whose actions
-are all edits — `header_set` above, or a `rewrite_prefix` — records what
-the render should do and evaluation carries on, so an edit never shields a
-request from a `reject` written beneath it. That is why the reject above
-names the range it refuses rather than sitting under an "allow" rule; see
+Only `reject`, `redirect`, `respond` and `allow` end the walk. A rule whose
+actions are all edits — `header_set` above, or a `rewrite_prefix` — records
+what the render should do and evaluation carries on, so an edit never
+shields a request from a `reject` written beneath it. An `allow` does, which
+is what an allowlist is written with; see
 [matching the client address](#matching-the-client-address).
 
 Rules compile into immutable tables at load time and are interpreted with
@@ -1156,26 +1158,36 @@ refuses a range:
 ]
 ```
 
-and it tags traffic for the origin to judge, which costs the request
-nothing and stops nothing:
+and, with `allow`, it admits one and refuses everyone else — `/admin` from
+the office ranges **and nowhere else**, which is two rules whose order is
+the whole rule:
 
 ```json
 "request_filters": [
     { "match": { "path_prefix": "/admin",
                  "client": ["10.0.0.0/8", "192.168.1.0/24"] },
-      "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] }
+      "actions": [{ "allow": true }] },
+    { "match": { "path_prefix": "/admin" }, "actions": [{ "reject": 403 }] }
 ]
 ```
 
+`allow` answers nothing and edits nothing: it forwards the request and
+stops the walk, so the office ranges never reach the `reject` beneath and
+everyone else does. `true` is the only value it takes.
+
 > [!IMPORTANT]
-> The inverse — `/admin` from the office range **and nowhere else** — is
-> not expressible today. A header edit is not terminal, so an "allow" rule
-> does not stop the walk: write a `reject` for `/admin` beneath the tagging
-> rule above and it answers `403` for the office range too, which is the
-> opposite of an allowlist. There is no `allow` action to stop on and no
-> way to negate a `client` list, so an allowlist belongs at the origin —
-> which is what the `X-Internal` tag is for — or in a firewall.
-> Tracked in [#331](https://github.com/zoxy-io/zoxy/issues/331).
+> The rule that admits must be terminal. A `header_set` in its place —
+> tagging the office range for the origin to judge — is an edit, and edits
+> do not stop the walk, so the `reject` beneath still answers `403` to the
+> office too. Tagging is its own idiom and a useful one, but it is a rule
+> with no rule beneath it:
+>
+> ```json
+> "request_filters": [
+>     { "match": { "path_prefix": "/admin", "client": ["10.0.0.0/8"] },
+>       "actions": [{ "header_set": { "name": "X-Internal", "value": "1" } }] }
+> ]
+> ```
 
 The address matched is the one zoxy actually believes: the TCP peer, or the
 [PROXY-protocol-announced client](#learning-it-behind-another-proxy-proxy-protocol)
@@ -1240,8 +1252,9 @@ routine edge work an origin you do not control cannot do for you: add
 A response rule matches on `status` (exact codes), `status_class`
 (`"1xx"` through `"5xx"`), and response-header predicates — the same
 `present` / `equals` / `contains` vocabulary. Its actions are the three
-header verbs only: `reject` and `rewrite_prefix` are request-side ideas,
-and the loader says so by name if you reach for them here.
+header verbs only: `reject`, `allow` and `rewrite_prefix` are request-side
+ideas — whether to forward at all, and what to forward — and the loader
+says so by name if you reach for them here.
 
 The same guardrails hold in both directions: filters may not touch the
 headers zoxy owns (`Content-Length`, `Transfer-Encoding`, `Connection`

--- a/sim/Harness.zig
+++ b/sim/Harness.zig
@@ -119,7 +119,7 @@ weights_http: [2]u16,
 clusters: [2]zoxy.config.Config.Cluster,
 routes_l4: [1]zoxy.http.router.Route,
 routes_http: [1]zoxy.http.router.Route,
-request_filters_http: [5]zoxy.http.filter.Rule,
+request_filters_http: [7]zoxy.http.filter.Rule,
 /// The #175 response rules beside them: the always-on stamp the client
 /// oracle requires on every proxied 200, and the 5xx rule whose edit
 /// must never appear (the scripted origin answers no 5xx).
@@ -1374,6 +1374,20 @@ fn wireFilters(harness: *Harness) void {
         .{
             .match = .{ .path_prefix = "/rewrite" },
             .actions = &.{.{ .rewrite_prefix = .{ .from = "/rewrite", .to = "/sim" } }},
+        },
+        // #331's pair, and the only rules here whose meaning is in their
+        // *order*: the allow stops the walk, so the reject beneath it
+        // never fires — and a sweep where it did would answer 403 to a
+        // script whose golden outcome is the origin's 200. The reject is
+        // what makes the allow observable at all; without it the first
+        // rule would be indistinguishable from no rule.
+        .{
+            .match = .{ .path_prefix = "/allow" },
+            .actions = &.{.allow},
+        },
+        .{
+            .match = .{ .path_prefix = "/allow" },
+            .actions = &.{.{ .reject = 403 }},
         },
     };
     // #175 response rules, always on: every response the render forwards

--- a/sim/l7/scripts.zig
+++ b/sim/l7/scripts.zig
@@ -126,6 +126,13 @@ pub const Script = enum(u8) {
     /// *neither* response-side stamp, which is how the sweep proves
     /// from outside that a page bypasses the response render.
     filter_respond,
+    /// A GET under `/allow`: a §7 `allow` rule stops the filter walk
+    /// before the 403 written beneath it (#331), so the request routes
+    /// and the origin answers it like any other. The golden outcome is
+    /// a plain GET's 200 — which is exactly the point: an allow that
+    /// failed to stop the walk would answer 403 here, and a reject that
+    /// leaked past one would too.
+    filter_allow,
     /// A GET under `/edit`: a §7 filter adds a header to the forwarded
     /// request. It routes and succeeds (200); the origin's §7 oracle proves
     /// the edited head still forwards canonical.
@@ -676,6 +683,19 @@ const specs = std.enums.EnumArray(Script, Spec).init(.{
         .allowed_statuses = &.{ 200, 408, 503 },
         .respond_page = true,
     },
+    .filter_allow = .{
+        // Routes and forwards like a plain GET — the allow answers
+        // nothing — so the §8 rungs and a killed dial can precede the
+        // 200, and 403 is *not* in the legal set: the reject beneath the
+        // allow is unreachable for this target, under every schedule.
+        .request = "GET /allow HTTP/1.1\r\nHost: sim\r\n\r\n",
+        .expected_responses = 1,
+        .transcript_cap = 1,
+        .golden_status = 200,
+        .method = .get,
+        .allowed_statuses = statuses_routed,
+        .routed_canonical = true,
+    },
     .filter_edit = .{
         // Routes and forwards like a plain GET, so the §8 rungs and a
         // killed dial can precede the 200.
@@ -819,6 +839,7 @@ pub const terminating_scripts = [_]Script{
     .filter_reject,
     .filter_redirect,
     .filter_respond,
+    .filter_allow,
     .filter_edit,
     .filter_rewrite,
     .forwarded_inbound,

--- a/smoke/main.zig
+++ b/smoke/main.zig
@@ -194,11 +194,34 @@ const sticky_exchanges: u32 = 3;
 /// describing a run whose every request was routed.
 const body_exchanges: u32 = 2;
 
+/// The #331 leg: two exchanges on one connection, both under rules that
+/// match the path they name — a request under the prefix an `allow` rule
+/// admits this host's own address on, which must reach the origin, and
+/// one under a prefix whose `allow` names a range this host is not in,
+/// which must be refused by the reject beneath it. What a live gate adds
+/// over the directed tests is that the *order* decides on the real
+/// binary: an allow that stopped nothing answers 403 to the first
+/// request, and a reject reached past a matched allow answers it to
+/// both. Runs after the scrapes above like the two legs before it.
+const allowlist_exchanges: u32 = 2;
+/// The one of those the proxy answers itself. Named apart because the
+/// log partition below counts what the *origin* served, and this line
+/// carries a policy status no origin sent.
+const allowlist_refused: u32 = 1;
+/// The two prefixes that leg drives, each carrying an `allow` rule over
+/// a `reject`. They differ only in the range the allow names: the first
+/// is this host's own loopback /8, the second a documentation range no
+/// client here can be in — so one request is admitted and the other is
+/// refused by rules of identical shape, which is what makes the verdict
+/// a property of the client match and not of the path.
+const allowed_path = "/allowed";
+const refused_path = "/refused";
+
 const exchanges_per_pass: u32 =
     @as(u32, keep_alive_connections) * requests_per_connection + large_requests;
 const http_exchanges: u32 = load_passes * exchanges_per_pass;
-const access_log_lines_expected: u32 =
-    http_exchanges + sticky_exchanges + body_exchanges + tls_requests + l4_connections;
+const access_log_lines_expected: u32 = http_exchanges + sticky_exchanges +
+    body_exchanges + allowlist_exchanges + tls_requests + l4_connections;
 
 /// What the resident set may grow by between the two passes. Measured at
 /// exactly zero, run after run — the tolerance is headroom for page
@@ -221,10 +244,11 @@ const rss_growth_kb_max: u64 = 64;
 /// connections nobody made.
 const sticky_connections: u32 = 1;
 const body_connections: u32 = 1;
+const allowlist_connections: u32 = 1;
 const readiness_probes: u32 = 1;
 const connections_expected: u32 = keep_alive_connections +
     load_passes * large_requests + l4_connections + sticky_connections +
-    body_connections + tls_connections + readiness_probes;
+    body_connections + allowlist_connections + tls_connections + readiness_probes;
 
 /// What the harness holds open against the origin at its peak: every live
 /// client connection can have an upstream connection of its own, parked or
@@ -232,7 +256,10 @@ const connections_expected: u32 = keep_alive_connections +
 /// sticky cluster, whose pool parks its own upstream connection (§5
 /// pools key by cluster, so the origin cluster's parked one is not
 /// reused for it).
-const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2 + 1;
+/// One more for the #331 leg, whose allowed request forwards: it reuses
+/// a parked upstream connection whenever one is free, and a dial of its
+/// own is the case this headroom covers.
+const origin_connections_peak: u8 = keep_alive_connections + l4_connections + 2 + 1 + 1;
 
 /// The drain's cap on waiting for the connections left open above. A
 /// drain cannot tell an idle keep-alive connection from one about to send
@@ -419,6 +446,7 @@ const Stage = enum {
     counter_scrape,
     sticky_leg,
     bodies_leg,
+    allowlist_leg,
     https_handshake,
     https_request,
     https_close_notify,
@@ -436,6 +464,7 @@ const Stage = enum {
             .counter_scrape => "the counter scrapes",
             .sticky_leg => "the sticky leg (#178)",
             .bodies_leg => "the bodies leg (#159)",
+            .allowlist_leg => "the allowlist leg (#331)",
             .https_handshake => "the https handshake",
             .watchdog_leg => "the loop-watchdog leg (#311)",
             .https_request => "an https request",
@@ -535,6 +564,10 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const sticky_ok = try stickyPassed(arena, io, &ports);
     enterStage(.bodies_leg);
     const bodies_ok = try bodiesPassed(arena, io, &ports);
+    // Last of the plaintext legs, so its scrape is the one that sees
+    // every filter verdict this run produced.
+    enterStage(.allowlist_leg);
+    const allowlist_ok = try allowlistPassed(arena, io, &ports);
     // Last, so its scrape sees the whole run — and so a wedged handshake
     // cannot cost the legs above their verdicts.
     const tls_ok = try tlsPassed(arena, io, &ports);
@@ -555,7 +588,8 @@ fn run(arena: std.mem.Allocator, io: Io, flags: *const Flags) !u8 {
     const memory_ok = memoryPassed(&memory);
     const drain_ok = drainPassed(drained_cleanly);
     const passed = log_ok and counters.passed and sticky_ok and bodies_ok and
-        tls_ok and memory_ok and drain_ok and check_ok and watchdog_ok;
+        allowlist_ok and tls_ok and memory_ok and drain_ok and check_ok and
+        watchdog_ok;
     return report(io, &lines, &counters, &memory, passed);
 }
 
@@ -680,9 +714,10 @@ const LogCounts = struct {
     /// HTTP lines that both completed and carried the origin's status —
     /// the outcome every request in this load is owed.
     http_ok: u32 = 0,
-    /// The #159 leg's lines: one page-wearing `404` and one `respond`
-    /// answer. Neither is `ok` — no origin served them — so they are
-    /// counted apart rather than weakening the ok-equality.
+    /// The lines no origin served: the #159 leg's page-wearing `404` and
+    /// its `respond` answer, and the #331 leg's `403` from outside the
+    /// allowed range. None is `ok`, so they are counted apart rather
+    /// than weakening the ok-equality.
     http_rejected: u32 = 0,
     http_responded: u32 = 0,
     /// The #140 headers as the log actually spelled them.
@@ -701,8 +736,8 @@ fn accessLogPassed(lines: *const LogCounts) bool {
     // The https leg's requests land here with every other L7 one: a
     // terminated request is an ordinary request by the time it is logged,
     // and a log that told them apart would be the defect.
-    const http_lines_expected =
-        http_exchanges + sticky_exchanges + body_exchanges + tls_requests;
+    const http_lines_expected = http_exchanges + sticky_exchanges +
+        body_exchanges + allowlist_exchanges + tls_requests;
     assert(access_log_lines_expected == http_lines_expected + l4_connections);
     var passed = true;
     if (lines.http != http_lines_expected) {
@@ -723,20 +758,23 @@ fn accessLogPassed(lines: *const LogCounts) bool {
         std.debug.print("FAIL: {d} access-log lines of no known kind\n", .{lines.other});
         passed = false;
     }
-    // Every line but the #159 leg's two carries the origin's 200; those
-    // two carry the outcomes only a configured page produces, so the
-    // three counts partition the http lines exactly.
-    if (lines.http_ok + body_exchanges != lines.http) {
+    // Every line but the #159 leg's two and the #331 leg's refusal
+    // carries the origin's 200; those three carry outcomes only this
+    // proxy produces, so the counts partition the http lines exactly.
+    if (lines.http_ok + body_exchanges + allowlist_refused != lines.http) {
         std.debug.print(
             "FAIL: {d} of {d} http lines did not complete with the origin's 200\n",
             .{ lines.http - lines.http_ok, lines.http },
         );
         passed = false;
     }
-    if (lines.http_rejected != 1 or lines.http_responded != 1) {
+    // Two refusals: the #159 leg's unroutable request, wearing the
+    // configured page, and the #331 leg's request from outside the
+    // allowed range. One `responded`, from the `respond` action.
+    if (lines.http_rejected != 1 + allowlist_refused or lines.http_responded != 1) {
         std.debug.print(
-            "FAIL: {d} rejected and {d} responded lines, not 1 each (#159)\n",
-            .{ lines.http_rejected, lines.http_responded },
+            "FAIL: {d} rejected and {d} responded lines, not {d} and 1 (#159, #331)\n",
+            .{ lines.http_rejected, lines.http_responded, 1 + allowlist_refused },
         );
         passed = false;
     }
@@ -764,15 +802,16 @@ fn loggedHeadersPassed(lines: *const LogCounts) bool {
         passed = false;
     }
     // The origin's tag rides only the lines whose exchange reached it —
-    // never the page or the respond answer, which no origin served.
-    // Asserted rather than assumed: a near-empty log would otherwise
-    // underflow this subtraction into a panic, where the whole point of
-    // this function is to print a verdict.
-    assert(lines.http >= body_exchanges);
-    if (lines.http_with_origin_tag != lines.http - body_exchanges) {
+    // never the page, the respond answer or the #331 leg's refusal,
+    // which no origin served. Asserted rather than assumed: a near-empty
+    // log would otherwise underflow this subtraction into a panic, where
+    // the whole point of this function is to print a verdict.
+    const origin_served = body_exchanges + allowlist_refused;
+    assert(lines.http >= origin_served);
+    if (lines.http_with_origin_tag != lines.http - origin_served) {
         std.debug.print(
             "FAIL: {d} of {d} origin-served lines carried the logged X-Origin-Tag (#140)\n",
-            .{ lines.http_with_origin_tag, lines.http - body_exchanges },
+            .{ lines.http_with_origin_tag, lines.http - origin_served },
         );
         passed = false;
     }
@@ -973,11 +1012,12 @@ fn identitiesPassed(first: *const scrape_module.Scrape) bool {
         );
         passed = false;
     }
-    // Minus the three legs that deliberately run after this scrape (see
-    // `sticky_exchanges`, `body_exchanges` and `tls_requests`); the
-    // whole-run equality is asserted on the last of their scrapes.
-    const opened_so_far = connections_expected -
-        sticky_connections - body_connections - tls_connections;
+    // Minus the four legs that deliberately run after this scrape (see
+    // `sticky_exchanges`, `body_exchanges`, `allowlist_exchanges` and
+    // `tls_requests`); the whole-run equality is asserted on the last of
+    // their scrapes.
+    const opened_so_far = connections_expected - sticky_connections -
+        body_connections - allowlist_connections - tls_connections;
     if (accepted != opened_so_far) {
         std.debug.print(
             "FAIL: {d} connections accepted, not the {d} opened before this scrape\n",
@@ -1246,7 +1286,8 @@ fn stickyPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
     // The accept count with this leg in, but still short the connections
     // the #159 and TLS legs open after it — the whole-run equality lands
     // on the last scrape of the run.
-    const opened_by_here = connections_expected - body_connections - tls_connections;
+    const opened_by_here = connections_expected - body_connections -
+        allowlist_connections - tls_connections;
     const accepted = counterOf(&scrape, "accepted") orelse return false;
     if (accepted != opened_by_here) {
         std.debug.print(
@@ -1295,15 +1336,89 @@ fn bodiesPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
         std.debug.print("FAIL: l7_no_route reads {d}, not 1\n", .{no_route});
         passed = false;
     }
-    // Short only the TLS leg's connection, which opens after this scrape
-    // and carries the whole-run equality.
-    const opened_by_here = connections_expected - tls_connections;
+    // Short the #331 and TLS legs' connections, which open after this
+    // scrape; the last of them carries the whole-run equality.
+    const opened_by_here = connections_expected - allowlist_connections - tls_connections;
     const accepted = counterOf(&scrape, "accepted") orelse return false;
     if (accepted != opened_by_here) {
         std.debug.print(
             "FAIL: {d} connections accepted, not the {d} opened by here\n",
             .{ accepted, opened_by_here },
         );
+        passed = false;
+    }
+    return passed;
+}
+
+/// The #331 leg against the live binary: the allowlist, both directions,
+/// on one connection. `allowed_path` carries an `allow` rule naming the
+/// loopback range this harness connects from, over a `reject`;
+/// `refused_path` carries that same pair with a range no client here can
+/// be in. So one request must reach the origin and the other must be
+/// refused — and the build this issue was filed against, where an
+/// "allow" rule was a header edit and stopped nothing, answers 403 to
+/// both. That is the whole of what a live gate adds here: the two
+/// verdicts come off the real binary's own walk over a real config.
+///
+/// Runs after the legs above and takes its own scrape, so `l7_filtered`
+/// reads exactly the one refusal — a reject reached past a matched allow
+/// would count two, which no assertion on the *responses* alone could
+/// tell from a client that asked twice.
+fn allowlistPassed(arena: std.mem.Allocator, io: Io, ports: *const Ports) !bool {
+    assert(ports.http != 0);
+    assert(ports.admin != 0);
+    var host_buffer: [32]u8 = undefined;
+    const host = try std.fmt.bufPrint(&host_buffer, "127.0.0.1:{d}", .{ports.http});
+    try single_client.connect(io, ports.http);
+    defer single_client.close();
+
+    // Admitted: the allow stopped the walk before the reject beneath it,
+    // so what follows is an ordinary proxied exchange — the origin's
+    // body and the listener's #175 stamp, judged as the load's are.
+    const allowed = try single_client.get(host, allowed_path, .keep_alive, null);
+    try expectResponse(allowed, origin_module.body.len, .http);
+
+    // Refused: the allow above this rule named a range this client is
+    // not in, so it never matched and the reject decides.
+    const refused = try single_client.get(host, refused_path, .close, null);
+    var passed = expectRefusedResponse(refused);
+    if (!expectProxyDate(refused, "allowlist reject")) passed = false;
+
+    const scrape = try scrape_module.parse(try scrape_module.fetch(arena, io, ports.admin));
+    const filtered = counterOf(&scrape, "l7_filtered") orelse return false;
+    if (filtered != allowlist_refused) {
+        std.debug.print(
+            "FAIL: l7_filtered reads {d}, not the {d} request this run refused (#331)\n",
+            .{ filtered, allowlist_refused },
+        );
+        passed = false;
+    }
+    return passed;
+}
+
+/// The #331 leg's refusal, judged on what a policy reject *is*: the
+/// status the rule named, an empty body — no `error_pages` entry claims
+/// `403` in this config — and no response-side stamp, because a static
+/// never crosses the render the #175 rule lives in.
+fn expectRefusedResponse(response: client_module.Response) bool {
+    assert(response.status >= 100);
+    var passed = true;
+    if (response.status != 403) {
+        std.debug.print(
+            "FAIL: the allowlist refused a request with {d}, not 403\n",
+            .{response.status},
+        );
+        passed = false;
+    }
+    if (response.body_bytes != 0) {
+        std.debug.print(
+            "FAIL: the allowlist reject carried {d} body bytes, not 0\n",
+            .{response.body_bytes},
+        );
+        passed = false;
+    }
+    if (response.edited) {
+        std.debug.print("FAIL: the allowlist reject carried the response-filter stamp\n", .{});
         passed = false;
     }
     return passed;
@@ -1875,6 +1990,10 @@ fn writeConfig(arena: std.mem.Allocator, io: Io, ports: *const Ports, origin_por
     assert(ports.http != 0);
     const config_json = try std.fmt.allocPrint(arena, config_template, .{
         ports.http,
+        allowed_path,
+        allowed_path,
+        refused_path,
+        refused_path,
         ports.l4,
         ports.tls,
         tls_cert_path,
@@ -1912,7 +2031,13 @@ const config_template =
     \\          ],
     \\          "request_filters": [
     \\              {{ "match": {{ "path_prefix": "/robots.txt" }},
-    \\                "actions": [{{ "respond": {{ "status": 200, "body": "robots" }} }}] }}
+    \\                "actions": [{{ "respond": {{ "status": 200, "body": "robots" }} }}] }},
+    \\              {{ "match": {{ "path_prefix": "{s}", "client": ["127.0.0.0/8"] }},
+    \\                "actions": [{{ "allow": true }}] }},
+    \\              {{ "match": {{ "path_prefix": "{s}" }}, "actions": [{{ "reject": 403 }}] }},
+    \\              {{ "match": {{ "path_prefix": "{s}", "client": ["203.0.113.0/24"] }},
+    \\                "actions": [{{ "allow": true }}] }},
+    \\              {{ "match": {{ "path_prefix": "{s}" }}, "actions": [{{ "reject": 403 }}] }}
     \\          ],
     \\          "response_filters": [
     \\              {{ "actions": [{{ "header_set": {{ "name": "X-Zoxy-Smoke", "value": "1" }} }}] }}

--- a/src/config.zig
+++ b/src/config.zig
@@ -2428,10 +2428,11 @@ pub const HeaderMatchJson = struct {
 /// cluster/routes fork uses — no JSON union parsing.
 /// What a #175 response rule may do: edit headers, and nothing else.
 ///
-/// A type of its own rather than `ActionJson` with four of its members
-/// refused at load (#305). The four are request-side answers — `reject`,
+/// A type of its own rather than `ActionJson` with five of its members
+/// refused at load (#305). The five are request-side decisions — `reject`,
 /// `redirect` and `respond` decide what to send *instead* of asking the
-/// origin, and `rewrite_prefix` changes what is asked — while a response
+/// origin, `allow` decides to ask it after all (#331), and
+/// `rewrite_prefix` changes what is asked — while a response
 /// rule runs when the origin has already answered. Sharing the request's
 /// union made those states representable and then rejected them one at
 /// a time; here they cannot be written down, which is the same verdict
@@ -2445,8 +2446,9 @@ pub const ResponseActionJson = struct {
     pub const schema_doc =
         "One response-filter action. Exactly one field is set — the edit's " ++
         "kind. Response rules edit headers only: the request-side actions " ++
-        "(reject, redirect, respond, rewrite_prefix) answer instead of " ++
-        "forwarding, and by the time these rules run the origin already has.";
+        "(reject, redirect, respond, allow, rewrite_prefix) decide whether " ++
+        "to forward at all, and by the time these rules run the origin " ++
+        "already has answered.";
     pub const schema_one_of = [_][]const u8{
         "header_set",
         "header_add",
@@ -2480,6 +2482,12 @@ pub const ActionJson = struct {
     reject: ?u16 = null,
     redirect: ?RedirectJson = null,
     respond: ?RespondJson = null,
+    /// #331's terminal, spelled `{"allow": true}`: an action with no
+    /// payload still needs a value in this "struct of optionals, exactly
+    /// one set" shape, and `true` is the only one it may carry —
+    /// `allow: false` names no action, exactly as `present: false` names
+    /// no predicate.
+    allow: ?bool = null,
     header_set: ?HeaderEditJson = null,
     header_add: ?HeaderEditJson = null,
     header_remove: ?[]const u8 = null,
@@ -2491,6 +2499,7 @@ pub const ActionJson = struct {
         "reject",
         "redirect",
         "respond",
+        "allow",
         "header_set",
         "header_add",
         "header_remove",
@@ -2507,6 +2516,13 @@ pub const ActionJson = struct {
         .respond = .{
             .desc = "Answer the request from a configured body instead of " ++
                 "forwarding it — this proxy as the origin.",
+        },
+        .allow = .{
+            .desc = "Forward the request and stop reading rules — no answer, no " ++
+                "edit. What an allowlist is written with: an allow rule naming " ++
+                "the admitted traffic, a reject beneath it for everything else " ++
+                "(allow: false is rejected).",
+            .const_true = true,
         },
         .header_set = .{ .desc = "Set (replace) a request header." },
         .header_add = .{ .desc = "Append a request header." },
@@ -4367,6 +4383,9 @@ fn resolveRequestFilters(
 
 /// The number of header-edit actions (set/add/remove) in a rule — the
 /// reject and rewrite actions contribute no render-time header edit.
+/// An `allow` contributes none either, and only ever *shortens* a
+/// request's walk (#331), so the whole-table sum this feeds stays an
+/// upper bound on what one render can materialize.
 fn countHeaderEdits(actions: []const filter.Action) u32 {
     // Reached only through `resolveActions`, which rejects an empty
     // action list — so the caps this function once asserted against are
@@ -4376,7 +4395,7 @@ fn countHeaderEdits(actions: []const filter.Action) u32 {
     for (actions) |action| {
         switch (action) {
             .header_set, .header_add, .header_remove => count += 1,
-            .reject, .redirect, .respond, .rewrite_prefix => {},
+            .reject, .redirect, .respond, .allow, .rewrite_prefix => {},
         }
     }
     assert(count <= actions.len); // Edits are a subset of the actions.
@@ -4713,10 +4732,10 @@ fn resolveActions(
 }
 
 /// Exactly one action field may carry the kind — the "exactly one of"
-/// fork both action resolvers share, so a seventh kind cannot be
+/// fork both action resolvers share, so an eighth kind cannot be
 /// counted in one table and forgotten in the other.
 /// The response table's kind fork (#305). Three members rather than the
-/// request's seven, and the same verdict — a rule naming none or two
+/// request's eight, and the same verdict — a rule naming none or two
 /// has no single action to apply.
 fn requireOneResponseActionKind(action_json: *const ResponseActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.header_set != null)) +
@@ -4733,11 +4752,12 @@ fn requireOneActionKind(action_json: *const ActionJson) ParseError!void {
     const set: u8 = @as(u8, @intFromBool(action_json.reject != null)) +
         @intFromBool(action_json.redirect != null) +
         @intFromBool(action_json.respond != null) +
+        @intFromBool(action_json.allow != null) +
         @intFromBool(action_json.header_set != null) +
         @intFromBool(action_json.header_add != null) +
         @intFromBool(action_json.header_remove != null) +
         @intFromBool(action_json.rewrite_prefix != null);
-    assert(set <= 7); // The action object has seven kind fields.
+    assert(set <= 8); // The action object has eight kind fields.
     if (set != 1) {
         return error.FilterActionKind;
     }
@@ -4773,6 +4793,15 @@ fn resolveAction(
         // than on the serving path.
         assert(shed.isPageStatus(page.status));
         return .{ .respond = page };
+    }
+    if (action_json.allow) |allow| {
+        // `allow: false` is the same non-predicate `present: false` is:
+        // a key that names an action and then unsays it. Refused rather
+        // than read as "not allow", which is not an action either.
+        if (!allow) {
+            return error.FilterActionKind;
+        }
+        return .allow;
     }
     if (action_json.header_set) |edit| {
         return .{ .header_set = try resolveHeaderEdit(&edit) };
@@ -6499,6 +6528,46 @@ test "config: filters compile into rules with matches and actions" {
     try std.testing.expectEqualStrings("/new", rule1.actions[1].rewrite_prefix.to);
 }
 
+test "config: an allow rule compiles into the terminal that answers nothing" {
+    // The #331 allowlist, in the spelling the README carries: the rule
+    // that admits, then the reject the admitted range never reaches.
+    var arena_state: std.heap.ArenaAllocator = undefined;
+    defer arena_state.deinit();
+    const parsed = try expectParseOk(&arena_state,
+        \\{"listeners":[{"bind":"127.0.0.1:1","http":{"cluster":"a","request_filters":[
+        \\   {"match":{"path_prefix":"/admin","client":["203.0.113.0/24"]},
+        \\    "actions":[{"allow":true}]},
+        \\   {"match":{"path_prefix":"/admin"},"actions":[{"reject":403}]}]}}],
+        \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
+        \\ "timeouts":{"connect_ms":1,"idle_ms":2,"drain_deadline_ms":1}}
+    );
+    const rules = parsed.listeners[0].request_filters;
+    try std.testing.expectEqual(@as(usize, 2), rules.len);
+    try std.testing.expectEqual(@as(usize, 1), rules[0].actions.len);
+    try std.testing.expectEqual(filter.Action.allow, rules[0].actions[0]);
+    try std.testing.expectEqual(@as(u8, 24), rules[0].match.clients[0].prefix_len);
+    try std.testing.expectEqual(@as(u16, 403), rules[1].actions[0].reject);
+    // The compiled table is what the interpreter reads, so assert the
+    // verdict rather than only the shape: the named range forwards, and
+    // everyone else is refused by the rule beneath.
+    const admitted = std.Io.net.IpAddress.parseLiteral("203.0.113.7:40000") catch unreachable;
+    const stranger = std.Io.net.IpAddress.parseLiteral("198.51.100.7:40000") catch unreachable;
+    try std.testing.expectEqual(@as(?filter.Verdict, null), filter.firstVerdict(rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = &.{},
+        .client = &admitted,
+    }));
+    try std.testing.expectEqual(@as(u16, 403), filter.firstVerdict(rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = &.{},
+        .client = &stranger,
+    }).?.reject);
+}
+
 test "config: filter schema rejects malformed rules" {
     const tail =
         \\ "clusters":{"a":{"endpoints":["127.0.0.1:2"]}},
@@ -6518,6 +6587,11 @@ test "config: filter schema rejects malformed rules" {
     try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{}]}]}}]," ++ tail);
     // An action object with two kinds set.
     try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"reject\":403,\"header_remove\":\"X\"}]}]}}]," ++ tail);
+    // `allow` carries a value only because this shape needs one, and
+    // `true` is the whole of it: `false` names an action and unsays it
+    // (#331), the way `present: false` names no predicate.
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"allow\":false}]}]}}]," ++ tail);
+    try expectParseError(error.FilterActionKind, head ++ "{\"actions\":[{\"allow\":true,\"reject\":403}]}]}}]," ++ tail);
     // A reject status outside the policy set.
     try expectParseError(error.FilterRejectStatus, head ++ "{\"actions\":[{\"reject\":503}]}]}}]," ++ tail);
     // An unknown / lowercase method token.
@@ -6734,6 +6808,7 @@ test "config: response filter schema rejects what has no meaning on the way out"
     // the same thing, where before it could only be discovered at load.
     inline for (.{
         "{\"reject\":403}",
+        "{\"allow\":true}",
         "{\"rewrite_prefix\":{\"from\":\"/a\",\"to\":\"/b\"}}",
         "{\"redirect\":{\"status\":301,\"location\":\"/x\"}}",
         "{\"respond\":{\"status\":200,\"body\":\"b\"}}",
@@ -7926,7 +8001,8 @@ var fuzz_arena_buffer: [1 << 20]u8 = undefined;
 /// `drain_deadline_ms` gives it no path to that branch of the parser.
 const fuzz_seed_json =
     \\{"listeners":[{"bind":"127.0.0.1:8080","http":{"routes":[{"prefix":"/","cluster":"o"}],
-    \\ "request_filters":[{"match":{"client":["10.0.0.0/8"]},"actions":[{"reject":403}]},
+    \\ "request_filters":[{"match":{"path_prefix":"/admin","client":["10.0.0.0/8"]},"actions":[{"allow":true}]},
+    \\ {"match":{"path_prefix":"/admin"},"actions":[{"reject":403}]},
     \\ {"match":{"path_prefix":"/old"},"actions":[{"redirect":{"status":301,"scheme":"https"}}]},
     \\ {"match":{"path_prefix":"/robots.txt"},"actions":[{"respond":{"status":200,"body":"oops"}}]}]}},
     \\ {"bind":"127.0.0.1:8443","tls":{"cert":"/c.pem","key":"/k.pem"},"l4":{"cluster":"t"}}],
@@ -7948,7 +8024,8 @@ const fuzz_seed_json =
 // `path` key only one of them may carry — both endpoint spellings
 // (#174), both pick spellings (#178: the object form with its key/name
 // grammar here, the bare string in the example), and every terminal
-// filter action (`reject`, `redirect` #176, `respond` #159) — so each
+// filter action (`reject`, `redirect` #176, `respond` #159, `allow`
+// #331, whose `true` is the one value it may carry) — so each
 // grammar is a starting point rather than a shape the mutator must
 // blindly discover. The `inline` body arm is the one it can reach:
 // `parse` refuses `file` sources outright, since the fuzzer has no
@@ -7973,10 +8050,13 @@ test "config: the fuzz seed carrying every block parses" {
     try std.testing.expectEqual(@as(usize, 1), parsed.error_pages.len);
     try std.testing.expectEqual(@as(u16, 503), parsed.error_pages[0].status);
     const rules = parsed.listeners[0].request_filters;
-    try std.testing.expectEqual(@as(usize, 3), rules.len);
-    try std.testing.expectEqual(@as(u16, 403), rules[0].actions[0].reject);
-    try std.testing.expectEqual(@as(u16, 301), rules[1].actions[0].redirect.status);
-    try std.testing.expectEqual(@as(u16, 200), rules[2].actions[0].respond.status);
+    try std.testing.expectEqual(@as(usize, 4), rules.len);
+    // The #331 allowlist pair leads: the terminal that answers nothing,
+    // over the reject it shields the named range from.
+    try std.testing.expectEqual(filter.Action.allow, rules[0].actions[0]);
+    try std.testing.expectEqual(@as(u16, 403), rules[1].actions[0].reject);
+    try std.testing.expectEqual(@as(u16, 301), rules[2].actions[0].redirect.status);
+    try std.testing.expectEqual(@as(u16, 200), rules[3].actions[0].respond.status);
     // The #125 grammar and the limit that follows it: both in the seed, so
     // the mutator has the vocabulary for either branch.
     try std.testing.expectEqualStrings("/c.pem", parsed.listeners[1].tls.?.cert_path);

--- a/src/http/filter.zig
+++ b/src/http/filter.zig
@@ -182,6 +182,20 @@ pub const Action = union(enum) {
     /// other reference to the same body and status, so the action
     /// carries a pointer, and serving it is the static path's one send.
     respond: *const shed.StaticPage,
+    /// Stop the walk and forward, answering nothing (#331). The fourth
+    /// terminal, and the only one that is not a response: `reject` stops
+    /// with a status, `redirect` with a `Location`, `respond` with a
+    /// body, and this one stops with the request intact.
+    ///
+    /// It is what makes an *allowlist* expressible — an `allow` rule
+    /// naming the admitted range, a `reject` beneath it for everyone
+    /// else. Without it that shape refused the admitted range too: a
+    /// header edit is not terminal (§7's own rule), so the walk carried
+    /// on into the reject, and the only expressible direction was the
+    /// denylist. Nothing below a matched `allow` runs — not a reject,
+    /// not an edit, not a rewrite — which is what "stops the walk"
+    /// means in both interpreters here.
+    allow,
     /// Set (replacing any existing), add (append), or remove a header on
     /// the forwarded request, applied during the head render.
     header_set: HeaderEdit,
@@ -371,6 +385,12 @@ pub const Verdict = union(enum) {
 /// header/rewrite edits are then moot (they apply only to a request
 /// that forwards, handled at the render). Bounded loops over immutable
 /// arena data; no allocation.
+///
+/// Null covers two different histories — no rule matched, and an
+/// `allow` stopped the walk (#331) — because the caller does the same
+/// thing with both: forward. What separates them is what runs *after*,
+/// and `collectForward` stops at that same `allow`, so the two walks
+/// agree on where the table ended for this request.
 pub fn firstVerdict(rules: []const Rule, view: RequestView) ?Verdict {
     assert(view.path.len >= 1);
     assert(view.path[0] == '/');
@@ -392,6 +412,10 @@ pub fn firstVerdict(rules: []const Rule, view: RequestView) ?Verdict {
                     assert(shed.isPageStatus(page.status));
                     return .{ .respond = page };
                 },
+                // The terminal that answers nothing (#331): the request
+                // forwards, and no rule beneath this one is read — here
+                // or in `collectForward`.
+                .allow => return null,
                 // Edits apply at the render, only when the request
                 // forwards; a terminal anywhere in a matched rule stops it.
                 .header_set, .header_add, .header_remove, .rewrite_prefix => {},
@@ -427,6 +451,13 @@ pub const Forward = struct {
 /// immutable arena data; no allocation. Called at render (a matched reject
 /// would already have stopped the request at routing, so here every matched
 /// rule forwards).
+///
+/// A matched `allow` ends the scan (#331), because it ended the routing
+/// one: the two interpreters must agree about where this request's table
+/// stopped, or a rule beneath an allow would edit a head that `firstVerdict`
+/// had already decided never to read. Actions before it in the same rule
+/// are collected first — action order inside a rule is the same order
+/// there.
 pub fn collectForward(
     rules: []const Rule,
     view: RequestView,
@@ -437,7 +468,7 @@ pub fn collectForward(
     assert(out.len <= constants.header_edits_max);
     var rewrite: ?Rewrite = null;
     var count: usize = 0;
-    for (rules) |rule| {
+    scan: for (rules) |rule| {
         if (!matches(rule.match, view)) {
             continue;
         }
@@ -452,6 +483,7 @@ pub fn collectForward(
                     rewrite = candidate;
                 }
             },
+            .allow => break :scan,
             .reject, .redirect, .respond => {},
         };
     }
@@ -466,7 +498,7 @@ fn appliedEdit(action: Action) AppliedHeaderEdit {
         .header_set => |e| .{ .kind = .set, .name = e.name, .value = e.value },
         .header_add => |e| .{ .kind = .add, .name = e.name, .value = e.value },
         .header_remove => |name| .{ .kind = .remove, .name = name, .value = "" },
-        .reject, .redirect, .respond, .rewrite_prefix => unreachable,
+        .reject, .redirect, .respond, .allow, .rewrite_prefix => unreachable,
     };
 }
 
@@ -918,9 +950,11 @@ test "filter: a client predicate is any-of, conjoined with the rest" {
         .address = std.Io.net.IpAddress.parse("192.168.1.0", 0) catch unreachable,
         .prefix_len = 24,
     };
-    // The issue's own rule: /admin from the office ranges and nowhere
-    // else — spelled as a reject of everything the allowlist misses,
-    // conjoined with the path.
+    // The *tagging* direction (#177): a rule that names the office
+    // ranges and edits a header for the origin to judge, over a blanket
+    // reject of /admin. Not an allowlist — an edit is not terminal, so
+    // the office reaches the reject too, which the verdict below pins
+    // now that `allow` is what an allowlist is written with (#331).
     const rules = [_]Rule{
         .{
             .match = .{ .path_prefix = "/admin", .clients = &.{ office, lab } },
@@ -971,6 +1005,123 @@ test "filter: a client predicate is any-of, conjoined with the rest" {
         .client = &office_client,
     }, &buffer);
     try std.testing.expectEqual(@as(usize, 0), off_path.edits.len);
+    // The verdict the edits above cannot see, and the whole of #331: the
+    // tag rule matched the office and stopped nothing, so the office is
+    // refused with the stranger. This shape is a denylist with a label
+    // on it, never an allowlist.
+    try std.testing.expectEqual(@as(u16, 403), firstVerdict(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &office_client,
+    }).?.reject);
+}
+
+test "filter: an allow rule stops the walk before the reject beneath it" {
+    // #331's shape, the one the tagging rule above cannot spell: /admin
+    // from the office range and nowhere else, as an `allow` naming the
+    // range over a reject of the rest.
+    const office: Cidr = .{
+        .address = std.Io.net.IpAddress.parse("10.0.0.0", 0) catch unreachable,
+        .prefix_len = 8,
+    };
+    const rules = [_]Rule{
+        .{
+            .match = .{ .path_prefix = "/admin", .clients = &.{office} },
+            .actions = &.{.allow},
+        },
+        .{ .match = .{ .path_prefix = "/admin" }, .actions = &.{.{ .reject = 403 }} },
+    };
+    const empty: []const parser.Header = &.{};
+    const office_client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:40000") catch unreachable;
+    const stranger = std.Io.net.IpAddress.parseLiteral("203.0.113.9:40000") catch unreachable;
+
+    // The admitted range forwards: the allow answered nothing and the
+    // reject beneath it was never read.
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &office_client,
+    }));
+    // Everyone else reaches the reject.
+    try std.testing.expectEqual(@as(u16, 403), firstVerdict(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &stranger,
+    }).?.reject);
+    // Off the guarded path neither rule matches, so an allowlist on
+    // /admin refuses nothing anywhere else.
+    try std.testing.expectEqual(@as(?Verdict, null), firstVerdict(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/public",
+        .headers = empty,
+        .client = &stranger,
+    }));
+}
+
+test "filter: an allow stops the render walk exactly where it stopped the verdict" {
+    // The two interpreters must end the table at the same rule (#331):
+    // edits above the allow apply, edits below it — and the rewrite
+    // below it — do not, or the render would edit a head the verdict
+    // walk had already stopped reading rules for.
+    const rules = [_]Rule{
+        .{
+            .match = .{},
+            .actions = &.{.{ .header_set = .{ .name = "X-Above", .value = "1" } }},
+        },
+        .{
+            .match = .{ .path_prefix = "/admin" },
+            .actions = &.{
+                .{ .header_set = .{ .name = "X-Same-Rule", .value = "1" } },
+                .allow,
+                // Past the allow in its own rule: unreachable, on the
+                // same action-order rule the verdict walk applies.
+                .{ .header_set = .{ .name = "X-After-Allow", .value = "1" } },
+            },
+        },
+        .{
+            .match = .{},
+            .actions = &.{
+                .{ .header_set = .{ .name = "X-Below", .value = "1" } },
+                .{ .rewrite_prefix = .{ .from = "/admin", .to = "/private" } },
+            },
+        },
+    };
+    const empty: []const parser.Header = &.{};
+    const client = std.Io.net.IpAddress.parseLiteral("10.1.2.3:40000") catch unreachable;
+    var buffer: [constants.header_edits_max]AppliedHeaderEdit = undefined;
+
+    const allowed = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/admin",
+        .headers = empty,
+        .client = &client,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 2), allowed.edits.len);
+    try std.testing.expectEqualStrings("X-Above", allowed.edits[0].name);
+    try std.testing.expectEqualStrings("X-Same-Rule", allowed.edits[1].name);
+    try std.testing.expectEqual(@as(?Rewrite, null), allowed.rewrite);
+
+    // A path the allow rule misses walks the whole table, which is what
+    // makes the truncation above a property of the allow and not of the
+    // match.
+    const untouched = collectForward(&rules, .{
+        .method = .get,
+        .host = null,
+        .path = "/public",
+        .headers = empty,
+        .client = &client,
+    }, &buffer);
+    try std.testing.expectEqual(@as(usize, 2), untouched.edits.len);
+    try std.testing.expectEqualStrings("X-Above", untouched.edits[0].name);
+    try std.testing.expectEqualStrings("X-Below", untouched.edits[1].name);
 }
 
 test "filter: response rules match on status, class and headers" {

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -2311,6 +2311,65 @@ test "l7: filter header edits reach the origin, applied once" {
     try bed.expectDrained();
 }
 
+test "l7: an allow rule forwards and stops every rule beneath it" {
+    // #331's allowlist, end to end: the first rule admits `/ok` and
+    // answers nothing, so the reject beneath it never fires and the edit
+    // beside that reject never reaches the origin. A path the allow rule
+    // misses still walks into the reject, which is what makes the first
+    // half a property of the allow rather than of the table.
+    const rules = [_]filter.Rule{
+        .{ .match = .{ .path_prefix = "/ok" }, .actions = &.{.allow} },
+        .{ .match = .{}, .actions = &.{
+            .{ .header_set = .{ .name = "X-Below", .value = "1" } },
+            .{ .reject = 403 },
+        } },
+    };
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 31,
+            .request_filters = &rules,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /ok HTTP/1.1\r\nHost: o\r\nConnection: close\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 0), bed.server.counters.get("l7_filtered"));
+        try std.testing.expectEqual(@as(u32, 1), bed.origin.requests_served);
+        var storage: parser.HeaderStorage = undefined;
+        const forwarded = try forwardedRequest(&bed, &storage);
+        try std.testing.expectEqual(
+            @as(?[]const u8, null),
+            parser.headerValue(forwarded.headers, "x-below"),
+        );
+        try bed.expectDrained();
+    }
+    {
+        var bed: Http1Bed = undefined;
+        try bed.setUp(std.testing.allocator, .{
+            .seed = 32,
+            .request_filters = &rules,
+            .origin_response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        });
+        defer bed.tearDown();
+
+        try bed.exchange("GET /other HTTP/1.1\r\nHost: o\r\n\r\n");
+
+        try std.testing.expectEqualStrings(
+            "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n" ++ expected_date ++ "\r\n",
+            bed.client.response(),
+        );
+        try std.testing.expectEqual(@as(u64, 1), bed.server.counters.get("l7_filtered"));
+        try std.testing.expectEqual(@as(u32, 0), bed.origin.requests_served);
+        try bed.expectDrained();
+    }
+}
+
 test "l7: a filter rewrite changes only the forwarded path, not the route" {
     // Routing keys off the original path (/old matches the route); the
     // rewrite swaps that prefix for /new on the way out, so the origin sees


### PR DESCRIPTION
Closes #331.

`match.client` could refuse a range and tag one; it could not admit one and refuse everything else — the shape #177 led with, and the one the README carried as "the standard rule" until #333 corrected it. The admitting rule had no terminal to carry: reject/redirect/respond all *answer*, so an "allow" could only be a header edit, edits do not stop the walk, and the reject beneath refused the admitted range along with everyone else.

This takes the issue's option 1.

## What `allow` is

The fourth terminal action, and the only one that is not a response: the request forwards, and no rule beneath the matched one is read.

```json
"request_filters": [
    { "match": { "path_prefix": "/admin", "client": ["10.0.0.0/8", "192.168.1.0/24"] },
      "actions": [{ "allow": true }] },
    { "match": { "path_prefix": "/admin" }, "actions": [{ "reject": 403 }] }
]
```

Both interpreters honour it — `firstVerdict` at routing, `collectForward` at the render — and they must end the table at the same rule, or a rule below an allow would edit a head the verdict walk had already stopped reading rules for. Actions before it in its own rule still apply; action order inside a rule is the same order in both walks.

Spelled `{"allow": true}`: an action object carries exactly one field naming its kind, so a payload-free action still needs a value, and `true` is the only one it may hold — `allow: false` names an action and unsays it, refused at load like `present: false`.

The alternative, negation on `client`, was rejected because `Match` is a positive conjunction: a second axis there asks the same question of every other predicate, where one more member of an already-closed enum asks nothing.

## Tested where the gap was

The gap was untested at the verdict level — the #177 test asserted which edits were collected, and its own comment already said "everyone hits the 403 rule on /admin", so it would have passed under either behaviour.

- **`filter.zig`** — that test now pins the tagging shape's 403 for the office too (the denylist-with-a-label it actually is), beside new tests for the allow pair's verdicts and for the two walks stopping at the same rule.
- **`http_proxy_test.zig`** — end to end: the allowed path forwards with the edit below the allow absent from the origin's head; a path the allow rule misses still reaches the reject.
- **sim** — a `filter_allow` script across the adversarial schedules, with `403` deliberately *not* in its legal status set.
- **fuzz corpus** — the seed carries the token, so the mutator has the grammar.
- **live gate** — a leg with two prefixes whose allow rules are identical in shape, one naming the loopback range the harness connects from and one a range it cannot be in, so both directions come off the real binary; `l7_filtered` must read exactly one, so a reject leaking past a matched allow counts two. The binary at `f1e4346` answers 403 to both and fails this leg.

## Gates

`zig build ci` green (unit tests + fuzz corpus, boundary lint, 4096 sim seeds, both smoke runs), `zig fmt --check` clean, `tiger-style-reviewer` clean.

Docs stop describing the gap and describe the feature: a settled #331 entry in DESIGN.md §7, the #177 entry's "not expressible" text dropped, and the README's IMPORTANT note flipped to why the admitting rule must be terminal. The tagging idiom stays, as a rule with no rule beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)