### PR TITLE
§4/§8: the exchange path pays no clock and no lock (#299)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -330,12 +330,19 @@ primitives trusted institutionally.
 - **Clock.** `Io.now_ns` is refreshed once per loop tick (the previous
   iteration measured per-callback `clock_gettime` at ~3% of data-path CPU)
   and is the seam the simulator's virtual clock replaces. The refresh
-  reads the *coarse* monotonic clock — every consumer is a second-scale
-  deadline, and the precise read was measured at ~7% of on-CPU
+  reads the *precise* monotonic clock, through libxev's own `update_now`
+  — which is the read it already makes to arm a timer, so a tick that
+  touches a deadline pays nothing extra. It read `CLOCK_MONOTONIC_COARSE`
+  until #299 gave the clock a second kind of consumer: deadlines are
+  second-scale and a ~ms granule was ample for them, but the §8 latency
+  histogram and the access log's duration measure tens of microseconds,
+  and one precise read per *tick* is far cheaper than the two per
+  *request* that measuring them any other way costs
   (`IMPLEMENTATION_NOTES.md`). Anything
   computed from it may be stale by up to one tick's completion batch —
-  deadline logic must stay correct under that bound, and the simulator
-  makes the staleness adversarial (§9).
+  deadline logic must stay correct under that bound, durations are only
+  taken across intervals that span ticks, and the simulator makes the
+  staleness adversarial (§9).
 - **Deadlines.** One timer per connection holding an *absolute* deadline.
   A state transition only *stores* the new deadline value — the armed op
   is never touched. When the timer fires, the callback compares the
@@ -356,12 +363,13 @@ primitives trusted institutionally.
   reader that stalls cannot stall the loop. `peerAddress` is asked once
   per admitted connection rather than at log time, when the socket may
   already be closed and the fd number reused. `nowWallNs` is a *second*
-  clock: precise and uncached, where `now_ns` is coarse and refreshed once
-  per tick. Both of those properties are wrong for a log — a line needs a
-  date, which a monotonic clock cannot give, and a duration measured
-  against the tick would read 0 µs for every request served inside one
-  completion batch. It costs two vDSO reads per logged request, against
-  `now_ns`'s one per tick, and only when a deployment turns the log on.
+  clock, and it exists for one thing `now_ns` cannot do: name a moment on
+  the operator's calendar. A line needs a date, which no monotonic clock
+  can give. The *duration* beside it is not this clock's job — that is
+  `now_ns`, which is monotonic (so an NTP step cannot land inside a
+  measured interval) and free (the tick has already read it). So a logged
+  request costs one vDSO read, not two, and a deployment with the log off
+  — the default — costs none.
 - **Plain ops only.** Multishot accept/recv, `send_zc`, `splice` stay
   behind measurement — the previous iteration never became CPU-bound
   without them, and this one is latency-bound with CPU headroom. Each
@@ -2261,11 +2269,14 @@ origin, not one this proxy can pick for them.
   timeout could evict; its flag and engage counter exist for the
   operator, who sizes `limits.head_buffers` by the crossings before the
   wall starts refusing.
-- **Metrics witness every shed.** Every rung has a counter, written only
-  by the loop thread as a relaxed atomic — one writer, any number of
-  readers. The admin plane reads them on the loop itself (§3: there is no
-  second thread); the relaxed atomic costs nothing on the write side and
-  keeps any out-of-loop reader race-free by construction. The simulator
+- **Metrics witness every shed.** Every rung has a counter, written and
+  read only by the loop thread, as a plain `u64`. The admin plane reads
+  them on the loop itself (§3: there is no second thread), so the writer
+  and every reader are the same thread and there is no race for an
+  ordering to rule out. They were relaxed atomics until the §9 profile
+  priced the `lock` prefix on the #299 exchange path, which put four
+  read-modify-writes on every response; a metrics or admin *thread* is
+  the decision that would bring them back. The simulator
   asserts counters reconcile (admitted = completed + shed + in-flight)
   under every seed. Counters live in `counters.zig` (§10); exposure is
   the admin/metrics listener's Prometheus rendering (`admin.zig`, one
@@ -2877,7 +2888,7 @@ src/
     libcrypto_heap.zig // libcrypto's mallocs into one fixed startup buffer (§4, §5)
   balancer.zig        // upstream endpoint pick: rr | p2c | hash (§7)
   shed.zig            // exhaustion ladder: decisions + static responses (incl. configured pages, #159)
-  counters.zig        // per-rung counters: loop-written, relaxed-atomic reads
+  counters.zig        // per-rung counters: loop-written, loop-read, plain u64
   admin.zig           // admin/metrics listener: one reserved scrape slot (§8)
   access_log.zig      // JSON access log: double-buffered sink, drop rung, named headers (§8)
 sim/                  // simulator harness + invariants

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -787,14 +787,94 @@ Verify it is active: `perf -e io_uring:io_uring_create` → flags
 `0x3100`. Kernels < 6.1 reject the flags; `XevIo.init` degrades to a
 plain ring on EINVAL rather than refusing to start.
 
-## Coarse deadline clock — landed (#39)
+## Coarse deadline clock — landed (#39), superseded (#299)
 
 The idle-deadline refresh's `CLOCK_MONOTONIC` read was ~7% of on-CPU
-under load. `XevIo.nowNs` now reads `CLOCK_MONOTONIC_COARSE` (a
-vvar-page vDSO load, no TSC access): <1%. Sound because every consumer
-of that clock is a second-scale deadline, so ~ms resolution is ample.
-No fork change; `nowNs` documents the field-layout reach-in that the
-hash pin fixes.
+under load. `XevIo.nowNs` read `CLOCK_MONOTONIC_COARSE` (a vvar-page
+vDSO load, no TSC access) from #39: <1%. Sound at the time, because
+every consumer of that clock was a second-scale deadline, so ~ms
+resolution was ample. No fork change; `nowNs` documents the
+field-layout reach-in that the hash pin fixes.
+
+**`nowNs` is precise again.** Not a reversal of #39's measurement — a
+change in what the clock is for. #39 priced a precise read taken on
+every *deadline refresh*; the read is now taken once per *tick*, and it
+is libxev's own `update_now`, which already runs on any tick that arms a
+timer. What forced the question was #299 giving the clock a consumer
+that is not a deadline: a latency histogram over ~45 µs exchanges, for
+which a millisecond granule is the whole measurement rather than a
+rounding error. The alternative — measuring durations off the wall
+clock, uncached — is what #299 actually shipped, and what the note below
+priced. Cost of the swap: one coarse read per tick becomes one precise
+read per tick. Benefit: two `clock_gettime`s per request become zero.
+
+The staleness this buys is bounded by one completion batch and is only
+ever spent on intervals that *span* ticks — an exchange with an upstream
+round trip in it cannot begin and end inside one batch, and the sites
+that could (a filter `reject`, a `respond`) never reach `observeExchange`,
+which asserts an upstream. The access log's duration rides the same
+clock; only its *date* still reads `nowWallNs`, once per logged request
+and only when a sink is configured.
+
+## The RED triad put a wall clock on the exchange path (#299)
+
+Found by A/B-profiling v0.7.0 against v0.8.1 (§9, `--protocol http`,
+both ReleaseSafe, fixed 100 k req/s, three reps): **+384 userspace
+cycles per request, +11.6%**, with ring ops per request identical at
+4.01 — pure compute, no new I/O. p50 rose from 36/39/45 µs to 47/48/52 µs
+across the reps. The L4 control showed no regression (32 → 29 µs), which
+is what localized it: L4 runs no HTTP exchange.
+
+Attribution, in cycles per request: `__vdso_clock_gettime` 0 → 99.9,
+`observeExchange` 0 → 30.1, plus ~13 of `nowWallNs`/glue — **~143, or
+37% of the total regression, from #299 alone**. The rest was diffuse:
+`assert` +58 (ReleaseSafe assertion growth across the #274 stream split),
+`arm`/`beginNextRequest`/`delivered` ~+84 (the split itself), routing
+~+34 (#302's header matching). `foldHeader` +28.7 against `analyzeHeaders`
+−21.0 is not new work — it is the TIGER_STYLE function split (d3eaf7d)
+losing an inline, and it very nearly cancels.
+
+The mechanism: #299 removed the `access_log.sink == null` guard from the
+request-start stamp and added a second unguarded `nowWallNs` in
+`finishExchange`, taking a path that read the clock **zero** times with
+the log off — the default — to **two** `CLOCK_REALTIME` reads per
+request. Its own comment priced this as "one `CLOCK_REALTIME` read per
+request … against the ~25 us of loop time a request already costs". Two
+corrections: it was two reads, and the denominator is wrong — the
+relevant base is zoxy's *own* userspace work (~3300 cycles/request), not
+the wall latency, which is mostly kernel and network. Against that, ~100
+cycles is ~3%, not ~0.1%.
+
+Worth keeping in mind for any future clock on a hot path: this box has
+`clocksource=tsc`, so `clock_gettime` takes the vDSO fast path at ~50
+cycles. Where the clocksource falls back to `acpi_pm`, or on a VM without
+a stable TSC, the same call is a real syscall at ~1 µs — the same code
+would have cost ~2 µs per request, 30× worse. The cost of a clock read is
+a property of the deployment, not of the source.
+
+Fixed by taking the duration off `nowNs` (see #39 above), restoring the
+sink guard on the wall-clock date, and dropping the counter atomics
+(below).
+
+## Counters are not atomic (#299 follow-on)
+
+`Counters.Value` was `std.atomic.Value(u64)`, so every `increment` was a
+`lock`-prefixed RMW — ~20 cycles apiece uncontended on x86, and #299 put
+*four* of them on each exchange (`observeExchange`: status class, bucket,
+sum, count). The §9 profile priced `observeExchange` plus the `fetchAdd`
+line at ~45 cycles per request.
+
+They bought nothing. `src/` spawns no thread — DESIGN.md §4 is one thread
+owning one ring and every pool, and scale-out is N processes behind
+`SO_REUSEPORT` — the Prometheus render runs on the same loop that writes
+the counters, and SIGUSR1 stopped reading them in #310, which was the one
+asynchronous reader they ever had. An ordering is a promise between
+threads, and there is only one. `Value` is now a plain `u64` behind
+`add`/`get`/`set`; the names deliberately do not borrow the atomic
+spelling, because a `fetchAdd` that is not atomic reads as one that is.
+
+Reopen this only if a metrics or admin *thread* is ever proposed — that,
+not the counter type, is the decision that would change the answer.
 
 ## CQE reaping — profiled and shelved (#40)
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -243,9 +243,9 @@ pub fn Server(comptime IoType: type) type {
         /// keeps the wall clock *off* the per-response path (§9).
         ///
         /// `nowWallNs` is deliberately precise and deliberately uncached —
-        /// it exists for access-log durations, where a coarse granule
-        /// would report 0 µs and a per-tick cache would give every request
-        /// in one batch the same start. Neither property is worth paying
+        /// it exists to date an access-log line, and a line names the
+        /// moment its own request began, not the moment whichever earlier
+        /// request shared its batch did. Neither property is worth paying
         /// for here: a `Date` is a *second*, and a shed storm answers a
         /// whole completion batch from this one line. So the wall clock is
         /// read at most once per tick — §4 guarantees `nowNs` returns one
@@ -951,7 +951,7 @@ pub fn Server(comptime IoType: type) type {
         /// has not. Without it a shed storm — the load this path exists
         /// for (§8) — would pay one precise `CLOCK_REALTIME` read per
         /// response, on the path that is otherwise one send from memory
-        /// that is neither assembled nor copied. `nowNs` is the coarse,
+        /// that is neither assembled nor copied. `nowNs` is the
         /// tick-cached clock §4 already refreshes once per tick, so the
         /// gate costs a load and a compare and a whole completion batch
         /// reads the wall clock once between them.
@@ -2058,15 +2058,15 @@ pub fn Server(comptime IoType: type) type {
             // capture at all, and its line would otherwise report
             // whatever the slot's *previous* occupant sent.
             server.resetLogHeaders(conn);
-            // An L4 connection is its own log unit and starts its line
+            // An L4 connection is its own log unit and starts its clocks
             // here — the first point at which a listener has said it is
             // one. An L7 exchange starts only when its first head byte
             // lands, so an idle keep-alive connection reaped without ever
-            // being asked anything owes no line. Both are gated on the log
-            // being on, so a deployment without one reads no clock here.
-            if (listener.protocol == .l4 and server.access_log.sink != null) {
-                conn.stream.log.started_wall_ns = server.io.nowWallNs();
-            }
+            // being asked anything owes no line. The stamping itself is
+            // `beginRequest`'s, called rather than repeated: two copies of
+            // "which clock is conditional on what" is exactly the shape
+            // that drifted once already (#237).
+            if (listener.protocol == .l4) server.beginRequest(conn);
             assert(conn.routes.len >= 1);
             assert(conn.stream.conn == conn);
         }
@@ -3478,22 +3478,40 @@ pub fn Server(comptime IoType: type) type {
             server.maybeStopAfterDrain();
         }
 
-        /// Start this connection's access-log clock, if it owes a line and
-        /// has not started one (§8). The L7 path calls it when a request's
-        /// first head byte lands — which is when the request begins, not
-        /// when its head finishes parsing, so a slowloris's line reports
-        /// the whole time it spent dribbling.
+        /// Start this log unit's clocks, if it has not started them (§8).
+        /// The L7 path calls it when a request's first head byte lands —
+        /// which is when the request begins, not when its head finishes
+        /// parsing, so a slowloris's line reports the whole time it spent
+        /// dribbling. The L4 path calls it at admission, where the unit is
+        /// the whole connection rather than a request on it; the two
+        /// clocks and the guard between them are the same either way,
+        /// which is why there is one function and not two.
         ///
-        /// Stamped whether or not an access log is configured, and that
-        /// is #299's doing: the §8 latency histogram measures the same
-        /// interval this starts, so gating the stamp on a sink would have
-        /// left every deployment without an access log — the default —
-        /// reporting no latency at all, or worse, a duration measured
-        /// from zero. The cost is one `CLOCK_REALTIME` read per request
-        /// where there was none: a vDSO call, against the ~25 us of loop
-        /// time a request already costs at the Tier-1 band.
+        /// Two stamps, on two clocks, for two different questions, and
+        /// only the first is unconditional:
+        ///
+        ///   - `started_ns` is the monotonic per-tick clock (§4) and the
+        ///     interval every duration is measured over — the #299
+        ///     histogram's and the log's alike. Always taken, because the
+        ///     histogram is always on and the read is free: the tick has
+        ///     already refreshed the clock.
+        ///   - `started_wall_ns` is the calendar date a log line prints,
+        ///     and it is a real `CLOCK_REALTIME` read, so it is taken only
+        ///     when a sink is configured to print it.
+        ///
+        /// That split is what #299 was missing. It needed a duration in
+        /// every deployment, correctly rejected gating the stamp on a sink
+        /// (which would have left the default deployment reporting no
+        /// latency at all), and reached for the wall clock it already had —
+        /// putting two `CLOCK_REALTIME` reads per request on a path that
+        /// had none, log or no log. §9 priced them at ~100 cycles per
+        /// request. The duration never needed a wall clock; it needed a
+        /// stopwatch, and §4's tick clock had been one all along.
         pub fn beginRequest(server: *Self, conn: *ConnType) void {
-            if (conn.stream.log.started_wall_ns != 0) return;
+            if (conn.stream.log.started_ns != 0) return;
+            conn.stream.log.started_ns = server.io.nowNs();
+            assert(conn.stream.log.started_ns != 0);
+            if (server.access_log.sink == null) return;
             conn.stream.log.started_wall_ns = server.io.nowWallNs();
             assert(conn.stream.log.started_wall_ns != 0);
         }
@@ -3512,9 +3530,23 @@ pub fn Server(comptime IoType: type) type {
             if (conn.stream.log.emitted) return;
             // Nothing was asked of this connection: an L7 slot that idled
             // out between requests, or one reaped before its first byte.
-            if (conn.stream.log.started_wall_ns == 0) return;
+            // The monotonic stamp is the one that answers this, because it
+            // is the one taken unconditionally; the wall stamp beside it
+            // says only whether a date was wanted.
+            if (conn.stream.log.started_ns == 0) return;
             conn.stream.log.emitted = true;
-            const now_wall_ns = server.io.nowWallNs();
+            // Reached only past the `sink == null` return above, and the
+            // sink is fixed at startup — `init` is its one writer, and
+            // SIGHUP reopens the file behind it without ever clearing it.
+            // So a stamp taken under "the log is on" cannot be missing by
+            // the time the line is written.
+            assert(conn.stream.log.started_wall_ns != 0);
+            // One clock for the interval, and it is not this line's date
+            // clock. `nowNs` is monotonic and cannot step backwards, so
+            // the subtraction below needs no saturation — where the wall
+            // clock this used to read needed it against NTP.
+            const now_ns = server.io.nowNs();
+            assert(now_ns >= conn.stream.log.started_ns);
             // Both indices are pool/config positions this connection has
             // carried since routing; a stale one would name another
             // operator's backend in the line, so they are checked here
@@ -3533,10 +3565,7 @@ pub fn Server(comptime IoType: type) type {
                 },
                 .outcome = conn.stream.log.outcome,
                 .started_wall_ns = conn.stream.log.started_wall_ns,
-                // Saturating: the wall clock can step backwards under NTP,
-                // and a duration that wrapped to eighteen quintillion
-                // microseconds would be read as a stall that never happened.
-                .duration_ns = now_wall_ns -| conn.stream.log.started_wall_ns,
+                .duration_ns = now_ns - conn.stream.log.started_ns,
                 .client = conn.client_address,
                 .upstream = if (conn.stream.log.endpoint_index == stream_module.LogState.endpoint_none)
                     null
@@ -3558,7 +3587,6 @@ pub fn Server(comptime IoType: type) type {
             // always names a start: both are what `renderLine` prints
             // without checking, so they are checked here.
             assert(entry.started_wall_ns != 0);
-            assert(entry.duration_ns <= now_wall_ns);
             server.access_log.record(&entry);
         }
 

--- a/src/access_log.zig
+++ b/src/access_log.zig
@@ -315,9 +315,12 @@ fn writeNamedHeaders(
 }
 
 /// RFC 3339 UTC to the millisecond, the spelling every log pipeline reads
-/// without configuration. Milliseconds because that is the resolution of
-/// the coarse clock the stamp comes from (§4) — printing more digits would
-/// be inventing them.
+/// without configuration. Milliseconds because that is the useful
+/// resolution of a *date*: the stamp comes from `nowWallNs`, which is a
+/// precise `CLOCK_REALTIME` read, but a wall clock is NTP-disciplined and
+/// its extra digits describe the daemon's steering, not the request. The
+/// duration beside it is where sub-millisecond detail lives, and that is
+/// measured on the monotonic clock (§4).
 fn writeTimestamp(writer: *std.Io.Writer, wall_ns: u64) std.Io.Writer.Error!void {
     const epoch: std.time.epoch.EpochSeconds = .{
         .secs = @divFloor(wall_ns, std.time.ns_per_s),

--- a/src/counters.zig
+++ b/src/counters.zig
@@ -1,8 +1,12 @@
-//! Per-rung and lifecycle counters (DESIGN.md §8): written only by the
-//! loop thread as relaxed atomics — one writer, any number of readers —
-//! so a future metrics/admin thread reads without a data race and
-//! single-writer stays intact. The simulator asserts `reconcile` under
-//! every seed: work is never lost, every shed is witnessed.
+//! Per-rung and lifecycle counters (DESIGN.md §8): written and read only
+//! by the loop thread, as plain `u64` — one writer, and every reader is
+//! that same writer, so there is no race for an ordering to rule out.
+//! These were relaxed atomics until the §9 profile priced the `lock`
+//! prefix on the #299 exchange path; `Value` carries the full reasoning.
+//! A metrics or admin *thread* would change that answer, and nothing in
+//! §4's one-thread-one-ring model proposes one. The simulator asserts
+//! `reconcile` under every seed: work is never lost, every shed is
+//! witnessed.
 
 const std = @import("std");
 
@@ -570,7 +574,52 @@ pub const Counters = struct {
     /// Drain deadline tore down stragglers (§8).
     drained_at_deadline: Value = Value.init(0),
 
-    const Value = std.atomic.Value(u64);
+    /// One counter cell. A plain `u64`, not `std.atomic.Value(u64)`.
+    ///
+    /// Nothing here is shared between threads, so nothing here needs a
+    /// locked read-modify-write. `src/` spawns no thread — scale-out is N
+    /// processes behind `SO_REUSEPORT`, never threads sharing memory
+    /// (DESIGN.md §4) — the Prometheus render runs on the event loop that
+    /// writes these, and SIGUSR1 stopped reading them in #310, which was
+    /// the one asynchronous reader they ever had. The `.monotonic` orders
+    /// these carried bought nothing on x86 either: an ordering is a
+    /// promise between threads, and there is only one.
+    ///
+    /// It was not free. `fetchAdd` lowers to a `lock`-prefixed RMW — ~20
+    /// cycles apiece, uncontended — and #299 put four of them on every
+    /// exchange. The §9 profile priced the pair of them (`observeExchange`
+    /// plus the `fetchAdd` line) at ~45 cycles per request.
+    ///
+    /// The method names say what they do rather than borrowing the atomic
+    /// spelling: a `fetchAdd` that is not atomic would read as one that is.
+    const Value = struct {
+        /// `total`, not `count`: most of these cells tally events, but
+        /// `cluster_duration_sum_ns` holds a sum of nanoseconds, and a
+        /// field named `count` would say the wrong thing about it.
+        total: u64,
+
+        pub fn init(initial: u64) Value {
+            return .{ .total = initial };
+        }
+
+        /// Add `delta` and answer the total *before* it — the shape every
+        /// caller wants, because each one asserts the counter did not wrap.
+        pub fn add(value: *Value, delta: u64) u64 {
+            const previous = value.total;
+            assert(previous <= std.math.maxInt(u64) - delta);
+            value.total = previous + delta;
+            assert(value.total >= previous);
+            return previous;
+        }
+
+        pub fn get(value: *const Value) u64 {
+            return value.total;
+        }
+
+        pub fn set(value: *Value, to: u64) void {
+            value.total = to;
+        }
+    };
 
     /// Every counter's field name, in declaration order — the one place
     /// the set is enumerated. `render` walks it, `render_bytes_max` sizes
@@ -673,12 +722,12 @@ pub const Counters = struct {
 
     /// Loop thread only — the single writer (§8).
     pub fn increment(counters: *Counters, comptime name: []const u8) void {
-        const previous = @field(counters, name).fetchAdd(1, .monotonic);
+        const previous = @field(counters, name).add(1);
         assert(previous < std.math.maxInt(u64));
     }
 
     pub fn get(counters: *const Counters, comptime name: []const u8) u64 {
-        return @field(counters, name).load(.monotonic);
+        return @field(counters, name).get();
     }
 
     /// The metric-name prefix for the Prometheus exposition rendering
@@ -910,8 +959,8 @@ pub const Counters = struct {
 };
 
 /// The per-cluster and per-endpoint breakdown of the exposition (§8,
-/// #179): which backend, not only how many. Same single-writer
-/// relaxed-atomic discipline as `Counters`, in tables sized by the loaded
+/// #179): which backend, not only how many. Same single-writer,
+/// single-reader discipline as `Counters`, in tables sized by the loaded
 /// config's endpoint index space (`EndpointKeys`) rather than by a field
 /// list — the first counter tables among the §7 endpoint-keyed state.
 ///
@@ -981,7 +1030,7 @@ pub const Labeled = struct {
     /// (buckets + 1)`, indexed `cluster * stride + bucket`, with the
     /// final slot the `+Inf` overflow. Counts are per bucket, not
     /// cumulative — the render accumulates, so an observation is one
-    /// atomic add rather than a walk.
+    /// add rather than a walk.
     cluster_duration_buckets: []Value,
     /// Nanoseconds observed and observations made, per cluster: the
     /// `_sum` and `_count` a Prometheus histogram owes. `_count` equals
@@ -1329,7 +1378,7 @@ pub const Labeled = struct {
         assert(key < labeled.keys.count);
         assert(labeled.endpoint_labels[key].len >= 1);
         const table = @field(labeled, @tagName(family));
-        const previous = table[key].fetchAdd(1, .monotonic);
+        const previous = table[key].add(1);
         assert(previous < std.math.maxInt(u64));
     }
 
@@ -1353,7 +1402,7 @@ pub const Labeled = struct {
         const class = StatusClass.of(status);
         const class_at = @as(usize, cluster_index) * StatusClass.count + @intFromEnum(class);
         assert(class_at < labeled.cluster_responses.len);
-        const class_previous = labeled.cluster_responses[class_at].fetchAdd(1, .monotonic);
+        const class_previous = labeled.cluster_responses[class_at].add(1);
         assert(class_previous < std.math.maxInt(u64));
 
         // The first bound this duration does not exceed, or the `+Inf`
@@ -1371,15 +1420,15 @@ pub const Labeled = struct {
         assert(bucket < duration_bucket_count);
         const bucket_at = @as(usize, cluster_index) * duration_bucket_count + bucket;
         assert(bucket_at < labeled.cluster_duration_buckets.len);
-        const bucket_previous = labeled.cluster_duration_buckets[bucket_at].fetchAdd(1, .monotonic);
+        const bucket_previous = labeled.cluster_duration_buckets[bucket_at].add(1);
         assert(bucket_previous < std.math.maxInt(u64));
         // The one counter here that does not add one: it takes a whole
         // duration, so it is the only place in this file where the
         // guard is about the *addend* as much as the total.
         const sum_previous =
-            labeled.cluster_duration_sum_ns[cluster_index].fetchAdd(duration_ns, .monotonic);
+            labeled.cluster_duration_sum_ns[cluster_index].add(duration_ns);
         assert(sum_previous <= std.math.maxInt(u64) - duration_ns);
-        const count_previous = labeled.cluster_duration_count[cluster_index].fetchAdd(1, .monotonic);
+        const count_previous = labeled.cluster_duration_count[cluster_index].add(1);
         assert(count_previous < std.math.maxInt(u64));
     }
 
@@ -1390,7 +1439,7 @@ pub const Labeled = struct {
     ) void {
         assert(cluster_index < labeled.cluster_labels.len);
         const table = @field(labeled, @tagName(family));
-        const previous = table[cluster_index].fetchAdd(1, .monotonic);
+        const previous = table[cluster_index].add(1);
         assert(previous < std.math.maxInt(u64));
     }
 
@@ -1443,7 +1492,7 @@ pub const Labeled = struct {
                     metric_prefix,
                     comptime family.name(),
                     labeled.endpoint_labels[key],
-                    table[key].load(.monotonic),
+                    table[key].get(),
                 }) catch unreachable;
             }
         }
@@ -1465,7 +1514,7 @@ pub const Labeled = struct {
                 metric_prefix,
                 comptime family.name(),
                 label,
-                value.load(.monotonic),
+                value.get(),
             }) catch unreachable;
         }
     }
@@ -1492,7 +1541,7 @@ pub const Labeled = struct {
                     metric_prefix,
                     label[0 .. label.len - 1],
                     comptime class.label(),
-                    labeled.cluster_responses[at].load(.monotonic),
+                    labeled.cluster_responses[at].get(),
                 }) catch unreachable;
             }
         }
@@ -1503,7 +1552,7 @@ pub const Labeled = struct {
     ///
     /// Buckets are stored per-bucket and accumulated here, because
     /// Prometheus wants cumulative `le` counts and an observation should
-    /// be one atomic add rather than a walk over the ladder.
+    /// be one add rather than a walk over the ladder.
     fn renderDuration(labeled: *const Labeled, writer: *std.Io.Writer) void {
         assert(labeled.cluster_duration_buckets.len ==
             labeled.cluster_labels.len * duration_bucket_count);
@@ -1518,7 +1567,7 @@ pub const Labeled = struct {
             var cumulative: u64 = 0;
             const base = cluster_index * duration_bucket_count;
             inline for (constants.duration_buckets_ns, 0..) |bound, index| {
-                cumulative += labeled.cluster_duration_buckets[base + index].load(.monotonic);
+                cumulative += labeled.cluster_duration_buckets[base + index].get();
                 // Seconds, as Prometheus base units require, rendered from
                 // the integer nanoseconds the ladder is written in so the
                 // boundary text cannot drift from the comparison.
@@ -1531,11 +1580,11 @@ pub const Labeled = struct {
                 }) catch unreachable;
             }
             cumulative += labeled.cluster_duration_buckets[base + constants.duration_buckets_ns.len]
-                .load(.monotonic);
+                .get();
             writer.print("{s}cluster_duration_seconds_bucket{s},le=\"+Inf\"}} {d}\n", .{
                 metric_prefix, inner, cumulative,
             }) catch unreachable;
-            const sum_ns = labeled.cluster_duration_sum_ns[cluster_index].load(.monotonic);
+            const sum_ns = labeled.cluster_duration_sum_ns[cluster_index].get();
             writer.print("{s}cluster_duration_seconds_sum{s} {d}.{d:0>9}\n", .{
                 metric_prefix,
                 label,
@@ -1545,12 +1594,12 @@ pub const Labeled = struct {
             writer.print("{s}cluster_duration_seconds_count{s} {d}\n", .{
                 metric_prefix,
                 label,
-                labeled.cluster_duration_count[cluster_index].load(.monotonic),
+                labeled.cluster_duration_count[cluster_index].get(),
             }) catch unreachable;
             // The `+Inf` bucket is every observation, which is what
             // `_count` reports — a histogram whose two disagreed would be
             // rejected by a scraper rather than merely wrong.
-            assert(cumulative == labeled.cluster_duration_count[cluster_index].load(.monotonic));
+            assert(cumulative == labeled.cluster_duration_count[cluster_index].get());
         }
     }
 
@@ -1711,7 +1760,7 @@ pub const Labeled = struct {
         assert(values.len >= 1);
         var total: u64 = 0;
         for (values) |*value| {
-            total += value.load(.monotonic);
+            total += value.get();
         }
         return total;
     }
@@ -1857,7 +1906,7 @@ test "counters: render bound holds at the maximum value" {
     var counters: Counters = .{};
     inline for (@typeInfo(Counters).@"struct".fields) |field| {
         if (field.type == Counters.Value) {
-            @field(counters, field.name).store(std.math.maxInt(u64), .monotonic);
+            @field(counters, field.name).set(std.math.maxInt(u64));
         }
     }
     var gauges: Counters.Gauges = undefined;
@@ -2161,7 +2210,7 @@ test "counters: labeled render bound is exact at the maximum values" {
         labeled.l4_shed_inflight,        labeled.cluster_responses,
         labeled.cluster_duration_sum_ns, labeled.cluster_duration_count,
     }) |table| {
-        for (table) |*value| value.store(std.math.maxInt(u64), .monotonic);
+        for (table) |*value| value.set(std.math.maxInt(u64));
     }
     // The histogram is the one table that cannot be saturated slot by
     // slot: its rows render *cumulatively*, so a maximal reading is the
@@ -2170,7 +2219,7 @@ test "counters: labeled render bound is exact at the maximum values" {
     // what the bound prices and the only way it can be reached.
     for (labeled.cluster_duration_buckets, 0..) |*value, index| {
         const first = index % Labeled.duration_bucket_count == 0;
-        value.store(if (first) std.math.maxInt(u64) else 0, .monotonic);
+        value.set(if (first) std.math.maxInt(u64) else 0);
     }
     // The widest live view either owner can produce: both u16 tables
     // saturated (the inflight bound is their sum, not a u32's), and a

--- a/src/http/proxy.zig
+++ b/src/http/proxy.zig
@@ -3375,15 +3375,22 @@ pub fn Proxy(comptime IoType: type) type {
             // `reconciles` noticed the histogram had drifted.
             assert(conn.stream.log.status != 0);
             {
+                // The §4 per-tick clock, monotonic and already refreshed
+                // by the tick that delivered this completion — so the
+                // measurement costs no syscall. It cannot step backwards
+                // either, which is why the subtraction is plain: the wall
+                // clock this used to read had to saturate against an NTP
+                // step, or a wrapped duration would land the exchange in
+                // `+Inf` and add eighteen quintillion nanoseconds to the
+                // sum. `started_ns` is set by `beginRequest`, which every
+                // path to a response has passed through.
+                const now_ns = server.io.nowNs();
+                assert(conn.stream.log.started_ns != 0);
+                assert(now_ns >= conn.stream.log.started_ns);
                 server.labeled.observeExchange(
                     conn.stream.upstream.?.cluster_index,
                     conn.stream.log.status,
-                    // Saturating on `logExchange`'s reasoning: the wall
-                    // clock can step backwards under NTP, and a wrapped
-                    // duration would land every such exchange in the
-                    // `+Inf` bucket and add eighteen quintillion
-                    // nanoseconds to the sum.
-                    server.io.nowWallNs() -| conn.stream.log.started_wall_ns,
+                    now_ns - conn.stream.log.started_ns,
                 );
             }
             // The whole response reached the client: the line goes out
@@ -3495,14 +3502,16 @@ pub fn Proxy(comptime IoType: type) type {
             // gate every read, and this zeroes those.
             // Either the line went out, or there was no sink for it to go
             // to, or nothing was asked of this connection. The middle arm
-            // is #299's: the request's start is stamped whether or not an
-            // access log is configured, because the §8 latency histogram
-            // measures that same interval — so "started" no longer
-            // implies "will be logged", and this assert used to read the
-            // two as one fact.
+            // is #299's: the §8 latency histogram measures every exchange,
+            // so the *monotonic* start is stamped whether or not an access
+            // log is configured — "started" does not imply "will be
+            // logged", and this assert used to read the two as one fact.
+            // The third arm asks the unconditional stamp, because that is
+            // the one that answers "was anything asked"; `started_wall_ns`
+            // would fold it into the middle arm and assert nothing.
             assert(conn.stream.log.emitted or
                 conn.server.access_log.sink == null or
-                conn.stream.log.started_wall_ns == 0);
+                conn.stream.log.started_ns == 0);
             // The request's head buffer goes back to the ring before the
             // idle wait begins — an idle connection holds no head bytes
             // (§5). Conditional because the static-response path already

--- a/src/http_proxy_test.zig
+++ b/src/http_proxy_test.zig
@@ -547,7 +547,7 @@ fn endpointCounter(
     endpoint_index: u16,
 ) u64 {
     const table = @field(server.labeled, @tagName(family));
-    return table[server.upstreams.keys.key(cluster_index, endpoint_index)].load(.monotonic);
+    return table[server.upstreams.keys.key(cluster_index, endpoint_index)].get();
 }
 
 const Http1Bed = struct {

--- a/src/io/XevIo.zig
+++ b/src/io/XevIo.zig
@@ -1646,57 +1646,69 @@ pub fn fillRandom(io: *XevIo, buffer: []u8) void {
     }
 }
 
+/// Monotonic nanoseconds, refreshed at most once per tick (DESIGN.md §4):
+/// every `nowNs` inside one tick answers with the same value.
+///
+/// The io_uring backend does NOT refresh `cached_now` each tick — the tick
+/// only marks it `now_outdated` and refreshes lazily (in `loop.now()`, or
+/// when a timer is armed). Reading the field raw would return the time of
+/// the last timer submission, arbitrarily stale, so deadlines set on
+/// activity would never actually move. Refresh here when stale, through
+/// libxev's own `update_now` — which only assigns on a successful read, so
+/// a failed one leaves the flag set and the next caller retries.
+///
+/// **Precise**, where this read `CLOCK_MONOTONIC_COARSE` until now (#39).
+/// That choice was right for the consumers it had: every one was a
+/// second-scale deadline (idle/connect/drain/max-lifetime), ~ms resolution
+/// was ample, and the coarse read is a vvar-page load with no TSC access.
+/// #299 gave the clock a consumer of a different kind — the §8 latency
+/// histogram, and the access log's duration beside it — and for a 45 µs
+/// exchange a millisecond granule is not a rounding error, it is the whole
+/// measurement. Paying the precise read *here* is what buys those two the
+/// right to be free: one read per tick, amortized across the completion
+/// batch, in place of the two `clock_gettime`s per *request* that #299
+/// first put on the exchange path. §9 measured the swap.
+///
+/// The added cost is small and partly already spent: `update_now` is the
+/// same call libxev makes whenever it arms a timer, so a tick that touches
+/// any deadline pays nothing new. It also retires the coarse/precise split
+/// that let one tick's `cached_now` be coarse and the next one's precise —
+/// one clock, one resolution, and a timeline that cannot step backwards,
+/// which is what lets the duration sites subtract without saturating.
+///
+/// The hash pin (build.zig.zon) fixes the field layout reached into here.
+/// The kqueue backend (macOS bench runs) has no `now_outdated` flag: its
+/// tick refreshes `cached_now` itself, so the raw read is already current.
 pub fn nowNs(io: *XevIo) u64 {
-    // The io_uring backend does NOT refresh cached_now each tick — the tick
-    // only marks it `now_outdated` and refreshes lazily (in loop.now() or
-    // when a timer is armed). Reading the field raw would return the time
-    // of the last timer submission, arbitrarily stale, so deadlines set on
-    // activity would never actually move (DESIGN.md §4). Refresh here when
-    // stale — but with CLOCK_MONOTONIC_COARSE, not update_now()'s plain
-    // CLOCK_MONOTONIC. Every consumer of this clock is a second-scale
-    // deadline (idle/connect/drain/max-lifetime), so ~ms resolution is ample,
-    // and the coarse read is a vvar-page vDSO load with no TSC access — the
-    // flamegraph (§9) showed the monotonic read at ~7% of on-CPU under load,
-    // and coarse is several times cheaper. Writing cached_now + clearing the
-    // flag mirrors update_now() exactly, so the §4 once-per-tick invariant
-    // still holds (every nowNs within a tick returns the same value) and
-    // libxev's own timer_next shares this value for the rest of the tick; the
-    // hash pin (build.zig.zon) fixes the field layout reached into. Coarse and
-    // precise are the same monotonic timeline, so a tick that arms a timer
-    // before any nowNs (update_now writes precise) then reads nowNs differs by
-    // at most one coarse granule (~ms) — absorbed by second-scale deadlines
-    // and the §4 lazy re-arm. The kqueue backend (macOS bench runs) has no
-    // now_outdated flag: its tick refreshes cached_now, so raw is safe.
     if (comptime @hasField(@FieldType(xev.Loop, "flags"), "now_outdated")) {
-        if (io.loop.flags.now_outdated) {
-            var ts: linux.timespec = undefined;
-            if (posix.errno(linux.clock_gettime(linux.CLOCK.MONOTONIC_COARSE, &ts)) == .SUCCESS) {
-                io.loop.cached_now = ts;
-                io.loop.flags.now_outdated = false;
-            }
-        }
+        if (io.loop.flags.now_outdated) io.loop.update_now();
     }
     const cached = io.loop.cached_now;
+    // `update_now` reads CLOCK_MONOTONIC, which is non-negative on a
+    // running kernel; the casts below would panic rather than wrap, so the
+    // invariant is stated where it is relied on.
+    assert(cached.sec >= 0);
+    assert(cached.nsec >= 0);
     return @as(u64, @intCast(cached.sec)) * std.time.ns_per_s +
         @as(u64, @intCast(cached.nsec));
 }
 
-/// Wall-clock nanoseconds since the Unix epoch, for the access log (§8) —
-/// both a line's timestamp and, read again at the end, its duration.
+/// Wall-clock nanoseconds since the Unix epoch: the *date* an access-log
+/// line carries (§8), and nothing else.
 ///
-/// A second clock beside `nowNs`, deliberately, and on the opposite side of
-/// both of that one's trade-offs. It is *precise*, not coarse: `nowNs`
-/// feeds second-scale deadlines where a millisecond granule is free, while
-/// a duration quantized to the coarse granule would report 0 µs for every
-/// request a loopback or LAN hop actually serves. And it is *not* cached
-/// per tick: a cached read would give every request in one completion batch
-/// the same start and end, which is the same failure a second time.
+/// A second clock beside `nowNs` because the two answer different
+/// questions. `nowNs` is a monotonic stopwatch — it says how far apart two
+/// moments are and is immune to an NTP step, which is what a duration
+/// wants and what every duration now uses. This one names a moment on the
+/// operator's calendar, which no monotonic clock can do; a line has to say
+/// *when*, not only *how long*.
 ///
-/// The cost is bounded by being rare — two vDSO reads per *logged request*,
-/// against `nowNs`'s one per tick — and it is paid only when an operator
-/// turned the log on. Deriving durations from a wall clock does mean an NTP
-/// step lands in whichever line spans it; the saturating subtraction at the
-/// call site keeps that a wrong number rather than a wrapped one.
+/// Read once per logged request, and only when a sink is configured — the
+/// callers restore that guard, so a deployment with the log off (the
+/// default) reads this clock zero times per request. It used to be read
+/// twice per exchange whether or not anyone had asked for a log, because
+/// #299 borrowed it for the histogram's duration; that borrowing is what
+/// the swap to `nowNs` undid.
 pub fn nowWallNs(io: *XevIo) u64 {
     _ = io;
     var ts: posix.timespec = undefined;

--- a/src/io/contract_test.zig
+++ b/src/io/contract_test.zig
@@ -898,10 +898,10 @@ test "xevio: nowNs refreshes a stale clock instead of returning a frozen value" 
     // Regression for the stale-cached_now bug (review finding 1): the
     // io_uring backend only marks the clock outdated per tick and refreshes
     // it lazily, so nowNs must refresh when the flag is set rather than
-    // returning the time of the last timer arm. The monotonic clock strictly
-    // advances between two update_now syscalls, so a correct nowNs returns a
-    // larger value on the second read; the buggy version returned the frozen
-    // cached_now unchanged.
+    // returning the time of the last timer arm. A correct nowNs answers from
+    // a reading taken since the flag was set; the buggy version returned the
+    // frozen cached_now unchanged, which the poison below makes unmistakable
+    // without having to assume the clock advanced between two reads.
     //
     // io_uring-only: other backends (kqueue on macOS) refresh cached_now
     // every tick and have no now_outdated flag to simulate staleness with.
@@ -914,16 +914,17 @@ test "xevio: nowNs refreshes a stale clock instead of returning a frozen value" 
     try initTestIo(&xev_io, arena_state.allocator(), 0);
     defer xev_io.deinit();
 
-    // Force a coarse refresh for the baseline too — init() seeds cached_now
-    // with a precise read, and the coarse clock lags precise by up to a tick,
-    // so comparing across the two sources would spuriously fail.
+    // Take the baseline through the same refresh path the assertion below
+    // exercises. Both are precise reads of one monotonic timeline now, so
+    // this no longer has to paper over a coarse-versus-precise mismatch —
+    // it just keeps the two readings comparable by construction.
     xev_io.loop.flags.now_outdated = true;
     const first = xev_io.nowNs();
     // Poison the cache with an obviously-stale value and mark it outdated —
     // exactly the relay-activity case where the old code left the clock
-    // frozen. A correct nowNs must refresh *past* the poison; asserting the
-    // poison is gone (rather than strict advancement between two reads) also
-    // holds for the coarse clock, whose two rapid reads can read equal.
+    // frozen. A correct nowNs must refresh *past* the poison. The assertion
+    // is `>=` rather than strict advancement because two reads this close
+    // together may legitimately land on the same nanosecond.
     xev_io.loop.cached_now = .{ .sec = 0, .nsec = 0 };
     xev_io.loop.flags.now_outdated = true;
     const second = xev_io.nowNs();

--- a/src/net/Stream.zig
+++ b/src/net/Stream.zig
@@ -188,16 +188,34 @@ pub const ClientWrite = struct {
 /// clearing 500-odd bytes per request would be work for an invariant that
 /// already holds — the same argument `Conn.head` makes.
 pub const LogState = struct {
-    /// Wall-clock nanoseconds at which this request — or, on L4, this
-    /// connection — began. Zero means nothing is in flight, which is what
-    /// keeps an idle keep-alive connection reaped by its deadline from
-    /// emitting a line about a request nobody made; it is also why nothing
-    /// sets it while the log is off, so a disabled log reads no clock.
+    /// Monotonic nanoseconds at which this request — or, on L4, this
+    /// connection — began: `Io.nowNs`, the per-tick clock (§4). Zero means
+    /// nothing is in flight, which is what keeps an idle keep-alive
+    /// connection reaped by its deadline from emitting a line about a
+    /// request nobody made, and what `logExchange` and `observeExchange`
+    /// both check before they measure anything.
     ///
-    /// Wall-clock rather than the monotonic deadline clock because a line
-    /// needs both a date and a duration, and one precise read at each end
-    /// answers both — where `Io.now_ns` is coarse and cached per tick (§4),
-    /// which would report 0 µs for every request served inside one batch.
+    /// This is the stamp every *duration* is taken from — the §8 histogram
+    /// (#299) and the access log alike. Monotonic, so an NTP step cannot
+    /// land inside a measured interval, and per-tick, so it is free: the
+    /// tick has already read the clock by the time any exchange asks. That
+    /// it is shared across a completion batch is the one thing it gives up,
+    /// and it is affordable here because both consumers measure an interval
+    /// that *spans* ticks — an exchange with an upstream round trip in it
+    /// cannot begin and end inside one batch. The set of sites that could
+    /// answer in one tick is exactly the set that never reaches these two:
+    /// `finishExchange` asserts an upstream, and a locally-answered reject
+    /// or `respond` has none.
+    ///
+    /// Always set, unlike `started_wall_ns` — reading it costs no syscall,
+    /// so there is nothing for a guard to save.
+    started_ns: u64 = 0,
+    /// Wall-clock nanoseconds at which the same moment fell on the
+    /// operator's calendar — the *date* a log line prints, and nothing
+    /// else. Set only when a sink is configured, so a deployment with the
+    /// log off reads no wall clock; `logExchange` returns early in that
+    /// case, which is what keeps "a line is being written" and "this is
+    /// non-zero" the same condition.
     started_wall_ns: u64 = 0,
     /// Bytes read from the client and written to it, for this request.
     bytes_in: u64 = 0,
@@ -238,6 +256,7 @@ pub const LogState = struct {
     /// Start a fresh request's accounting. Only the scalars: the three
     /// captures are read through their lengths, which this zeroes.
     pub fn reset(state: *LogState) void {
+        state.started_ns = 0;
         state.started_wall_ns = 0;
         state.bytes_in = 0;
         state.bytes_out = 0;
@@ -674,6 +693,7 @@ pub fn Stream(comptime IoType: type, comptime ConnType: type) type {
             assert(stream.l7.request_leg == .idle);
             assert(!stream.log.emitted);
             assert(stream.log.bytes_in == 0);
+            assert(stream.log.started_ns == 0);
             assert(stream.log.started_wall_ns == 0);
         }
 

--- a/src/net/health.zig
+++ b/src/net/health.zig
@@ -81,7 +81,7 @@ pub fn Checker(comptime IoType: type) type {
         /// and a cluster may configure either without the other.
         passive_streaks: []u8,
         /// When a passively ejected endpoint may be let back, on the §4
-        /// coarse clock; zero for an endpoint that is not passively
+        /// tick clock; zero for an endpoint that is not passively
         /// ejected. Recorded at the ejection and consumed by the
         /// re-admission sweep — recovery cannot itself be passive,
         /// because an ejected endpoint receives no traffic to learn from.


### PR DESCRIPTION
## What

A/B profile of `v0.7.0` against `v0.8.1` (§9, `--protocol http`, ReleaseSafe both sides, fixed 100 k req/s, 3 reps) found the L7 path had grown **~380 userspace cycles per request** with ring ops unchanged at 4.01 — compute, not I/O. The L4 control showed nothing, which localized it: L4 runs no HTTP exchange.

Root cause is #299. It needed a duration for every exchange, correctly refused to gate it on an access-log sink, and reached for the wall clock it already had — removing the `sink == null` guard from the request-start stamp and adding a second unguarded `nowWallNs` in `finishExchange`. A path that read **no** clock with the log off (the default) began reading `CLOCK_REALTIME` **twice per request**.

## How

- **§4's tick clock is precise.** `nowNs` refreshes through libxev's own `update_now` instead of a hand-rolled `CLOCK_MONOTONIC_COARSE` read. That is the same read libxev already makes to arm a timer, so a tick touching any deadline pays nothing new. Revises #39's verdict without contradicting its measurement — #39 priced a precise read per *deadline refresh*; this is one per *tick*, against two per *request*.
- **The stamps split by what they answer.** `started_ns` (monotonic, per-tick, always taken) is the interval every duration is measured over, and the "was anything asked" sentinel. `started_wall_ns` (real `CLOCK_REALTIME`) is now only the date a log line prints, taken only when a sink exists. Monotonic durations retire the saturating subtraction the wall clock needed against NTP steps.
- **Counters are not atomic.** `src/` spawns no thread (§4: one thread, one ring; scale-out is N processes behind `SO_REUSEPORT`), the Prometheus render runs on the loop that writes them, and SIGUSR1 stopped reading them in #310. Every `increment` was paying a `lock` prefix for nothing — four per exchange through `observeExchange`.

## Verification

Re-profiled, per request:

| symbol | v0.8.1 | this branch |
|---|---|---|
| `__vdso_clock_gettime` | 99.9 | **0.0** |
| `fetchAdd` | 38.1 | **0.0** |
| `assert` | 187.6 | 102.7 (below v0.7.0's 129.5) |

Both gone from the request path with no callers left in the call graph. The replacement clock costs +7 cycles net for the ~100 it removes.

The histogram still resolves what it exists for — 57% of exchanges under 25 µs, 87% under 50 µs, mean 38.3 µs. A proxied exchange spans ticks by construction, and the sites that could answer inside one (a filter `reject`, a `respond`) never reach `observeExchange`, which asserts an upstream.

**What this does not claim:** a precise figure for the residue against v0.7.0. Four runs of this branch span 3400–3601 cycles/request — a spread comparable to the difference being measured, so no aggregate percentage is quoted as though it were solid. The per-symbol numbers are exact because a symbol is present or it is not. What the symbol table does show is that none of the residue is leftover #299 clock cost: it is #274's stream-split indirection, #302's header matching, and the histogram's own bucket scan.

## Gates

`zig build ci` (4096 sim seeds, both smoke legs, counters reconcile), `zig build test`, `zig fmt --check`, `zig build lint` — all green locally. `tiger-style-reviewer` run on the diff; its four doc-staleness violations and three judgement calls are fixed in this commit.

Docs: `IMPLEMENTATION_NOTES` records the finding, marks #39 superseded rather than reversed, and notes that a clock read's cost is a property of the deployment — this box is `clocksource=tsc` (vDSO, ~50 cycles); where it falls back to `acpi_pm` the same call is a syscall at ~1 µs, and this code would have cost ~2 µs/request instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)