### PR TITLE
docs: refresh the `--check` banner in the manual

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ does up to the banner, then exits without binding a port:
 $ zoxy --check config.json
 zoxy 0.8.2
 budgets (DESIGN.md §5/§8; closed-form except where marked):
-  memory  total 48142 KiB = conn slots 1386 x 720 B + stream slots 1386 x 1968 B
+  memory  total 47297 KiB = conn slots 1386 x 512 B + stream slots 1386 x 1552 B
           + relay buffers 1386 x 32808 B
           + upstream slots 1311 x 48 B + head buffers 0 x 8192 B (+ ring 0 B)
           + upstream head buffers 0 x 8216 B + head scratch 8192 B
@@ -59,7 +59,7 @@ budgets (DESIGN.md §5/§8; closed-form except where marked):
   fds     4093 required (asserted against RLIMIT_NOFILE)
   ring    4096 entries, completion queue 8192, in-flight ops <= 6869
   config  1 listener(s), 1 cluster(s), 0 error page(s), access log off
-  rlimit  RLIMIT_NOFILE 1048576 soft, unlimited hard (a start raises the soft limit to the fd budget)
+  rlimit  RLIMIT_NOFILE 1024 soft, 524288 hard (a start raises the soft limit to the fd budget)
   check   config.json: valid, and this box can start it
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,14 +44,22 @@ does up to the banner, then exits without binding a port:
 
 ```console
 $ zoxy --check config.json
-zoxy 0.0.9
+zoxy 0.8.2
 budgets (DESIGN.md §5/§8; closed-form except where marked):
-  memory  total 47127 KiB = conn slots 1386 x 440 B + stream slots 1386 x 1448 B
-          …
-  fds     4094 required (asserted against RLIMIT_NOFILE)
-  ring    4096 entries, completion queue 8192, in-flight ops <= 6871
-  config  1 listener(s), 1 cluster(s), 0 error page(s), access log stdout
-  rlimit  RLIMIT_NOFILE 524288 soft, 524288 hard (a start raises the soft limit to the fd budget)
+  memory  total 48142 KiB = conn slots 1386 x 720 B + stream slots 1386 x 1968 B
+          + relay buffers 1386 x 32808 B
+          + upstream slots 1311 x 48 B + head buffers 0 x 8192 B (+ ring 0 B)
+          + upstream head buffers 0 x 8216 B + head scratch 8192 B
+          + access log 0 KiB (+ logged headers 0 B)
+          + endpoint tables 29 B (1 cluster(s) x 1 wide)
+          + labeled metrics 26450 B (tables, labels and render buffers)
+          + tunnels 0 x 0 B (their own relay buffers, never HTTP's)
+          + tls engines 0 x 0 B (+ plaintext 0 B each, libcrypto heap 0 KiB)
+          + config arena 2 KiB (measured, not closed-form)
+  fds     4093 required (asserted against RLIMIT_NOFILE)
+  ring    4096 entries, completion queue 8192, in-flight ops <= 6869
+  config  1 listener(s), 1 cluster(s), 0 error page(s), access log off
+  rlimit  RLIMIT_NOFILE 1048576 soft, unlimited hard (a start raises the soft limit to the fd budget)
   check   config.json: valid, and this box can start it
 ```
 


### PR DESCRIPTION
The sample report in `docs/README.md` still showed 0.0.9 output: a version four releases old, a memory line elided to a single `…` from before the per-plane breakdown existed, an `access log stdout` field for a config that never turns it on, and stale `fds`/`ring` numbers.

Regenerated against the current binary for the minimal config the section below documents. The numbers are Linux ones — cross-compiled to `aarch64-linux-musl` and run under a distro-typical `RLIMIT_NOFILE` (1024 soft, 524288 hard), since the conn and stream slot widths differ from a macOS build and the manual describes the io_uring path. The version line is the bare release form the same page documents, so it does not go stale on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)